### PR TITLE
turn bpf_trace_printk into comments

### DIFF
--- a/gadget-ds/files/bcck8s/execsnoop-edge
+++ b/gadget-ds/files/bcck8s/execsnoop-edge
@@ -76,6 +76,8 @@ bpf_text = """
 #include <linux/sched.h>
 #include <linux/fs.h>
 
+#define DEBUG_PRINT 0
+
 #define ARGSIZE  128
 
 enum event_type {
@@ -196,21 +198,21 @@ if args.label:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgrouplabelsmap.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            text64 textkey = {%s};
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &textkey[0]);
            if (textvalue == NULL) {
-             bpf_trace_printk("no such label\\n");
+             DEBUG_PRINT && bpf_trace_printk("no such label\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("label with different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("label with different value\\n");
              return 0;
            }
         }
@@ -229,21 +231,21 @@ if args.namespace:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 0; /* namespace */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no namespace defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no namespace defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("namespace has different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("namespace has different value\\n");
              return 0;
            }
         }
@@ -261,21 +263,21 @@ if args.podname:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 1; /* podname */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no podname defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no podname defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("pod has different name\\n");
+             DEBUG_PRINT && bpf_trace_printk("pod has different name\\n");
              return 0;
            }
         }

--- a/gadget-ds/files/bcck8s/opensnoop-edge
+++ b/gadget-ds/files/bcck8s/opensnoop-edge
@@ -93,6 +93,8 @@ bpf_text = """
 #include <uapi/linux/limits.h>
 #include <linux/sched.h>
 
+#define DEBUG_PRINT 0
+
 struct val_t {
     u64 id;
     char comm[TASK_COMM_LEN];
@@ -188,21 +190,21 @@ if args.label:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgrouplabelsmap.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            text64 textkey = {%s};
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &textkey[0]);
            if (textvalue == NULL) {
-             bpf_trace_printk("no such label\\n");
+             DEBUG_PRINT && bpf_trace_printk("no such label\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("label with different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("label with different value\\n");
              return 0;
            }
         }
@@ -221,21 +223,21 @@ if args.namespace:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 0; /* namespace */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no namespace defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no namespace defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("namespace has different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("namespace has different value\\n");
              return 0;
            }
         }
@@ -253,21 +255,21 @@ if args.podname:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 1; /* podname */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no podname defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no podname defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("pod has different name\\n");
+             DEBUG_PRINT && bpf_trace_printk("pod has different name\\n");
              return 0;
            }
         }

--- a/gadget-ds/files/bcck8s/tcpconnect
+++ b/gadget-ds/files/bcck8s/tcpconnect
@@ -72,6 +72,8 @@ bpf_text = """
 #include <net/sock.h>
 #include <bcc/proto.h>
 
+#define DEBUG_PRINT 0
+
 BPF_HASH(cgrouplabelsmap, u64, u32);        // DEFINE_CGROUPLABELSMAP  // EXTERNAL_MAP:cgrouplabelsmap,/sys/fs/bpf/cgrouplabelsmap,92
 BPF_HASH(cgroupmetadatas, u64, u32);        // DEFINE_CGROUPMETADATAS  // EXTERNAL_MAP:cgroupmetadatas,/sys/fs/bpf/cgroupmetadatas,93
 BPF_HASH(currsock, u32, struct sock *);
@@ -217,21 +219,21 @@ if args.label:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgrouplabelsmap.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            text64 textkey = {%s};
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &textkey[0]);
            if (textvalue == NULL) {
-             bpf_trace_printk("no such label\\n");
+             DEBUG_PRINT && bpf_trace_printk("no such label\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("label with different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("label with different value\\n");
              return 0;
            }
         }
@@ -250,21 +252,21 @@ if args.namespace:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 0; /* namespace */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no namespace defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no namespace defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("namespace has different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("namespace has different value\\n");
              return 0;
            }
         }
@@ -282,21 +284,21 @@ if args.podname:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 1; /* podname */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no podname defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no podname defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("pod has different name\\n");
+             DEBUG_PRINT && bpf_trace_printk("pod has different name\\n");
              return 0;
            }
         }

--- a/gadget-ds/files/bcck8s/tcptop-edge
+++ b/gadget-ds/files/bcck8s/tcptop-edge
@@ -86,6 +86,8 @@ bpf_text = """
 #include <net/sock.h>
 #include <bcc/proto.h>
 
+#define DEBUG_PRINT 0
+
 struct ipv4_key_t {
     u32 pid;
     u32 saddr;
@@ -207,21 +209,21 @@ if args.label:
     bpf_text = bpf_text.replace('LABEL_FILTER',
         '''
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgrouplabelsmap.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            text64 textkey = {%s};
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &textkey[0]);
            if (textvalue == NULL) {
-             bpf_trace_printk("no such label\\n");
+             DEBUG_PRINT && bpf_trace_printk("no such label\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("label with different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("label with different value\\n");
              return 0;
            }
         ''' % (
@@ -239,21 +241,21 @@ if args.namespace:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 0; /* namespace */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no namespace defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no namespace defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("namespace has different value\\n");
+             DEBUG_PRINT && bpf_trace_printk("namespace has different value\\n");
              return 0;
            }
         }
@@ -271,21 +273,21 @@ if args.podname:
         '''
         {
            u64 cgroupid = bpf_get_current_cgroup_id();
-           bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
+           DEBUG_PRINT && bpf_trace_printk("checking cgroupid: %%llu\\n", cgroupid);
            u32 *innermap = cgroupmetadatas.lookup(&cgroupid);
            if (innermap == NULL) {
-             bpf_trace_printk("no innermap\\n");
+             DEBUG_PRINT && bpf_trace_printk("no innermap\\n");
              return 0;
            }
 
            u32 key = 1; /* podname */
            text64 *textvalue = bpf_map_lookup_elem_((uintptr_t)innermap, &key);
            if (textvalue == NULL) {
-             bpf_trace_printk("no podname defined\\n");
+             DEBUG_PRINT && bpf_trace_printk("no podname defined\\n");
              return 0;
            }
            if (%s) {
-             bpf_trace_printk("pod has different name\\n");
+             DEBUG_PRINT && bpf_trace_printk("pod has different name\\n");
              return 0;
            }
         }


### PR DESCRIPTION
The use of `bpf_trace_printk` causes a warning in the kernel log (dmesg).

Turn them into comments to preserve them for debugging but don't use
them in production.