### PR TITLE
gadgettracermanager: pubsub: implement filtering

### DIFF
--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -83,7 +83,7 @@ type Resolver interface {
 	// Subscribe returns the list of existing containers and registers a
 	// callback for notifications about additions and deletions of
 	// containers
-	Subscribe(key interface{}, f pubsub.FuncNotify) []pb.ContainerDefinition
+	Subscribe(key interface{}, s pb.ContainerSelector, f pubsub.FuncNotify) []pb.ContainerDefinition
 
 	// Unsubscribe undoes a previous call to Subscribe
 	Unsubscribe(key interface{})


### PR DESCRIPTION
# gadgettracermanager: pubsub: implement filtering

This patch allows gadgets such as "dns" (#225) to subscribe to notifications about container creations and terminations with a filter based on TraceSpec.Filter.

## How to use

Gadgets can use pubsub with a filter:
```
    existingContainers := t.resolver.Subscribe(
            genPubSubKey(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name),
            *gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
            containerEventCallback,
    )
```

## Testing done

Tested in #225: Only the selected pods are traced (here I execute `kubectl exec -ti normal-pod-ks8hs -- ping -c 1 kinvolk.io`):

```
$ ./kubectl-gadget-linux-amd64 dns -n default -l name=normal-pod
POD                            TYPE      NAME
normal-pod-ks8hs               OUTGOING  kinvolk.io.
normal-pod-ks8hs               OUTGOING  kinvolk.io.
^C
```

It also works when pods are created/deleted with `kubectl delete pod normal-pod-ks8hs`:
```
$ ./kubectl-gadget-linux-amd64 dns -n default -l name=normal-pod --verbose
POD                            TYPE      NAME
Notice on node minikube: attaching dns tracer
Notice on node minikube: detaching dns tracer
Notice on node minikube: attaching dns tracer
normal-pod-ngtcf               OUTGOING  kinvolk.io.
normal-pod-ngtcf               OUTGOING  kinvolk.io.
```