### PR TITLE
pkg/gadgets: Move GenSelector into gadget's helper functions

### DIFF
--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -58,22 +58,6 @@ type TraceReconciler struct {
 //+kubebuilder:rbac:groups=gadget.kinvolk.io,resources=traces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=gadget.kinvolk.io,resources=traces/finalizers,verbs=update
 
-func genSelector(f *gadgetv1alpha1.ContainerFilter) *pb.ContainerSelector {
-	if f == nil {
-		return &pb.ContainerSelector{}
-	}
-	labels := []*pb.Label{}
-	for k, v := range f.Labels {
-		labels = append(labels, &pb.Label{Key: k, Value: v})
-	}
-	return &pb.ContainerSelector{
-		Namespace: f.Namespace,
-		Podname:   f.Podname,
-		Labels:    labels,
-		Name:      f.ContainerName,
-	}
-}
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
@@ -157,7 +141,7 @@ func (r *TraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		_, err = r.TracerManager.AddTracer(ctx,
 			&pb.AddTracerRequest{
 				Id:       gadgets.TraceNameFromNamespacedName(req.NamespacedName),
-				Selector: genSelector(trace.Spec.Filter),
+				Selector: gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
 			})
 		if err != nil && !errors.Is(err, os.ErrExist) {
 			log.Errorf("Failed to add tracer BPF map: %s", err)

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	gadgetv1alpha1 "github.com/kinvolk/inspektor-gadget/pkg/api/v1alpha1"
+	pb "github.com/kinvolk/inspektor-gadget/pkg/gadgettracermanager/api"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -50,4 +51,20 @@ func SetStatusError(trace *gadgetv1alpha1.Trace, err string) {
 	trace.Status.OperationError = err
 	trace.Status.Output = ""
 	trace.Status.State = "Stopped"
+}
+
+func ContainerSelectorFromContainerFilter(f *gadgetv1alpha1.ContainerFilter) *pb.ContainerSelector {
+	if f == nil {
+		return &pb.ContainerSelector{}
+	}
+	labels := []*pb.Label{}
+	for k, v := range f.Labels {
+		labels = append(labels, &pb.Label{Key: k, Value: v})
+	}
+	return &pb.ContainerSelector{
+		Namespace: f.Namespace,
+		Podname:   f.Podname,
+		Labels:    labels,
+		Name:      f.ContainerName,
+	}
 }


### PR DESCRIPTION
# pkg/gadgets: Move GenSelector into gadget's helper functions

This commit makes GenSelector function accessible from gadgets given that they frequently need to convert a gadgetv1alpha1.ContainerFilter into a pb.ContainerSelector to communicate with the gadgettracermanager.