### PR TITLE
cmd: Fix biotop path

### DIFF
--- a/cmd/kubectl-gadget/bcck8s.go
+++ b/cmd/kubectl-gadget/bcck8s.go
@@ -34,10 +34,14 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+// create the commands for the different gadgets. The gadgets that have CO-RE
+// support should use "/bin/gadgets/" as the path for the binary. Otherwise
+// "/usr/share/bcc/tools/" should be used.
+
 var biotopCmd = &cobra.Command{
 	Use:   "biotop",
 	Short: "Trace block device I/O",
-	Run:   bccCmd("biotop", "/bin/gadgets/biotop"),
+	Run:   bccCmd("biotop", "/usr/share/bcc/tools/biotop"),
 }
 
 var execsnoopCmd = &cobra.Command{


### PR DESCRIPTION
biotop doesn't have a libbpf-based version, then it should use
/usr/share/bcc/tools/ instead of /bin/gadgets/.

## How to reproduce 

```
# deploy IG using co-re tools 
./kubectl-gadget deploy --traceloop=false --tools-mode=core | kubectl apply -f -

# run biotop 
$ ./kubectl-gadget biotop --node ubuntu-hirsute
/opt/bcck8s/bcc-wrapper.sh: line 141: /bin/gadgets/biotop: No such file or directory

Error running command: command terminated with exit code 127
```

