### PR TITLE
Add an image-pull-policy parameter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ minikube-install: gadget-container kubectl-gadget
 	./kubectl-gadget deploy | kubectl delete -f - || true
 	time kubectl wait --for=delete namespace gadget 2>/dev/null || true
 	time kubectl wait --for=delete daemonset -n kube-system gadget 2>/dev/null || true
-	./kubectl-gadget deploy --traceloop=false --hook-mode=fanotify | \
-		sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \
+	./kubectl-gadget deploy --traceloop=false --hook-mode=fanotify \
+		--image-pull-policy=Never | \
 		sed 's/initialDelaySeconds: 10/initialDelaySeconds: '$(LIVENESS_PROBE_INITIAL_DELAY_SECONDS)'/g' | \
 		kubectl apply -f -

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -35,6 +35,7 @@ var gadgetimage = "undefined"
 
 var (
 	image             string
+	imagePullPolicy   string
 	traceloop         bool
 	traceloopLoglevel string
 	hookMode          string
@@ -48,6 +49,11 @@ func init() {
 		"image", "",
 		gadgetimage,
 		"container image")
+	deployCmd.PersistentFlags().StringVarP(
+		&imagePullPolicy,
+		"image-pull-policy", "",
+		"Always",
+		"pull policy for the container image")
 	deployCmd.PersistentFlags().BoolVarP(
 		&traceloop,
 		"traceloop", "",
@@ -127,7 +133,7 @@ spec:
       containers:
       - name: gadget
         image: {{.Image}}
-        imagePullPolicy: Always
+        imagePullPolicy: {{.ImagePullPolicy}}
         command: [ "/entrypoint.sh" ]
         lifecycle:
           preStop:
@@ -225,6 +231,7 @@ spec:
 
 type parameters struct {
 	Image             string
+	ImagePullPolicy   string
 	Version           string
 	Traceloop         bool
 	TraceloopLoglevel string
@@ -253,6 +260,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	p := parameters{
 		image,
+		imagePullPolicy,
 		version,
 		traceloop,
 		traceloopLoglevel,


### PR DESCRIPTION
# Add an image-pull-policy parameter

As discussed in #343, we want to have a parameter to set the image pull policy and avoid having to use `sed` commands when using local images. This change adds this parameter to the code, and also uses it in the `Makefile`, that was using `sed` before.

Defaults to Always and is free-form. We could check the content and only allow valid values, but it seemed overkill.

## How to use

`make kubectl-gadget`
`./kubectl-gadget deploy | grep imagePullPolicy`
`./kubectl-gadget deploy --image-pull-policy Never | grep imagePullPolicy`

## Testing done

I tried the above mentioned commands:
```
$ ./kubectl-gadget deploy | grep imagePullPolicy
        imagePullPolicy: Always
$ ./kubectl-gadget deploy --image-pull-policy Never | grep imagePullPolicy
        imagePullPolicy: Never
```