### PR TITLE
containers map: add BTF info

### DIFF
--- a/pkg/gadgettracermanager/containers-map/bpf/Makefile
+++ b/pkg/gadgettracermanager/containers-map/bpf/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+all: containers-map.o
+
+PKG_DIR=../../..
+
+containers-map.o: containers-map.c
+	clang -Werror -I$(PKG_DIR) -target bpf -O2 -g -c -x c $< -o $@
+
+clean:
+	rm -f containers-map.o

--- a/pkg/gadgettracermanager/containers-map/bpf/containers-map.c
+++ b/pkg/gadgettracermanager/containers-map/bpf/containers-map.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0 WITH Linux-syscall-note) OR Apache-2.0
+/* Copyright (c) 2021 The Inspektor Gadget authors */
+
+#include <vmlinux/vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+
+#include "gadgettracermanager/common.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u64);
+	__type(value, struct container);
+	__uint(max_entries, MAX_CONTAINERS_PER_NODE);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} containers SEC(".maps");
+
+char _license[] SEC("license") = "GPL";

--- a/pkg/gadgettracermanager/containers-map/embed-ebpf.go
+++ b/pkg/gadgettracermanager/containers-map/embed-ebpf.go
@@ -1,0 +1,24 @@
+// +build withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containersmap
+
+import (
+	_ "embed"
+)
+
+//go:embed bpf/containers-map.o
+var ebpfProg []byte

--- a/pkg/gadgettracermanager/containers-map/embed-none.go
+++ b/pkg/gadgettracermanager/containers-map/embed-none.go
@@ -1,0 +1,19 @@
+// +build !withebpf
+
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containersmap
+
+var ebpfProg []byte

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -1,0 +1,43 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containersmap
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+const (
+	BPF_MAP_NAME = "containers"
+)
+
+func CreateContainersMap(pinPath string) (*ebpf.Map, error) {
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(ebpfProg))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load asset: %w", err)
+	}
+
+	coll, err := ebpf.NewCollectionWithOptions(spec,
+		ebpf.CollectionOptions{
+			Maps: ebpf.MapOptions{PinPath: pinPath},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
+	}
+	return coll.Maps[BPF_MAP_NAME], nil
+}


### PR DESCRIPTION
The Gadget Tracer Manager creates a map pinned at `/sys/fs/bpf/gadget/containers` with container metadata. This PR adds BTF information to the map so it can be dumped in this way:

```
$ sudo bpftool map dump name containers
[{
        "key": 4026533170,
        "value": {
            "container_id": "docker://f5b15fade69241f9c4af32d1a85348062608111d52e0b9f7d2496cfbabec8469",
            "namespace": "kube-system",
            "pod": "coredns-66bff467f8-28q9s",
            "container": "coredns"
        }
    }...
```

Unfortunately, `ebpf.NewMapWithOptions()` (cilium/ebpf) does not expose a way to add BTF info to maps, so I reverted to use an intermediary ELF file.
