### PR TITLE
Consider existing kubernetes containers for other hooks

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -385,6 +385,8 @@ func newServer(nodeName string, hookMode string, testonly bool) (*GadgetTracerMa
 				}
 
 			case pubsub.EVENT_TYPE_REMOVE_CONTAINER:
+				log.Infof("pubsub: REMOVE_CONTAINER: %s/%s/%s", event.Container.Namespace, event.Container.Podname, event.Container.Name)
+
 				g.deleteContainerFromMap(&event.Container)
 
 				for _, t := range g.tracers {
@@ -413,6 +415,9 @@ func newServer(nodeName string, hookMode string, testonly bool) (*GadgetTracerMa
 		// Nothing to do: grpc calls will be enough
 		// Used by nri and crio
 		log.Infof("GadgetTracerManager: hook mode: none")
+		if !testonly {
+			opts = append(opts, containercollection.WithInitialKubernetesContainers(nodeName))
+		}
 	case "auto":
 		if runcfanotify.Supported() {
 			log.Infof("GadgetTracerManager: hook mode: fanotify (auto)")


### PR DESCRIPTION
When the hook parameter in the gadget tracer manager is "none" it means
an external executable will use the grpc interface to add/remove
containers. Those executables are usually triggered by the container
runtime when creating/removing a container, hence those hooks won't
notify about already existing containers. This commit uses
WithInitialKubernetesContainers() to take into consideration containers
that are already running.
