### PR TITLE
RFC: publish streams as Kubernetes events

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -136,6 +136,9 @@ rules:
   resources: ["seccompprofiles"]
   # Required for integration with the Kubernetes Security Profiles Operator
   verbs: ["list", "watch", "create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create"]
 - apiGroups: ["security.openshift.io"]
   # It is necessary to use the 'privileged' security context constraints to be
   # able mount host directories as volumes, use the host networking, among others.

--- a/pkg/controllers/trace_controller.go
+++ b/pkg/controllers/trace_controller.go
@@ -25,6 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -46,9 +47,10 @@ const (
 
 // TraceReconciler reconciles a Trace object
 type TraceReconciler struct {
-	Client client.Client
-	Scheme *runtime.Scheme
-	Node   string
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Node     string
 
 	// TraceFactories contains the trace factories keyed by the gadget name
 	TraceFactories map[string]gadgets.TraceFactory

--- a/pkg/gadgets/execsnoop/gadget.go
+++ b/pkg/gadgets/execsnoop/gadget.go
@@ -31,7 +31,8 @@ import (
 )
 
 type Trace struct {
-	resolver gadgets.Resolver
+	resolver  gadgets.Resolver
+	publisher gadgets.FuncPublisher
 
 	started bool
 	tracer  tracer.Tracer
@@ -67,7 +68,8 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[string]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			resolver: f.Resolver,
+			resolver:  f.Resolver,
+			publisher: f.Publisher,
 		}
 	}
 
@@ -103,6 +105,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			return
 		}
 		t.resolver.PublishEvent(traceName, string(r))
+		t.publisher(trace, event)
 	}
 
 	var err error

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -296,7 +296,7 @@ func NewManager() (*LocalGadgetManager, error) {
 	}
 
 	for _, factory := range l.traceFactories {
-		factory.Initialize(l, nil)
+		factory.Initialize(l, nil, nil)
 	}
 
 	return l, nil


### PR DESCRIPTION
This can be useful for fetching the results in a Headlamp plugin without using a `kubectl exec` API.

Example:

* Starting the execsnoop gadget
```
./kubectl-gadget execsnoop
```

* Watching the logs via Kubernetes events:
```
$ kubectl get events -w -n gadget
LAST SEEN   TYPE     REASON             OBJECT             MESSAGE
0s          Normal   GadgetEvent        trace/execsnoop-bxlgq   {"type":"normal","node":"albantyphoon-worker000000","namespace":"default","pod":"shell1","container":"shell1","pid":1113559,"ppid":1105330,"mountnsid":4026532865,"pcomm":"ls","args":["/bin/ls"]}
```

In this example, the event is attached to the "trace" resource. But it could be useful for other gadgets to attach an event on a pod, e.g. a gadget detects that a pod runs a syscall that is blocked by seccomp, and an event is attached to that pod.