### PR TITLE
Makefile: Add lint target.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -51,6 +51,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
+        # This version number must be kept in sync with Makefile lint one.
         version: v1.46.2
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ integration-tests: kubectl-gadget
 generate-documentation:
 	go run -tags docs cmd/gen-doc/gen-doc.go -repo $(shell pwd)
 
+lint:
+	# This version number must be kept in sync with CI workflow lint one.
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.46.2 golangci-lint run --fix
+
 # minikube
 LIVENESS_PROBE_INITIAL_DELAY_SECONDS ?= 10
 .PHONY: minikube-install


### PR DESCRIPTION
Hi.


In this PR I added a `lint` target to our Makefile.
It uses `golangci-lint`, like our CI, as suggested in this [comment](https://github.com/kinvolk/inspektor-gadget/issues/599#issuecomment-1105191713).
Hopefully, it takes less time than when tested in above comment:

```bash
$ make lint
docker run --rm -v /home/francis/Codes/kinvolk/inspektor-gadget:/app -w /app golangci/golangci-lint:v1.46.2 golangci-lint run --fix -v
...
level=info msg="Execution took 54.433329501s"
```


Best regards and thank you in advance.