### PR TITLE
Improve standard tracer message when JSON unmarshalling failed

### DIFF
--- a/pkg/gadgets/bindsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/bindsnoop/tracer/standard/tracer.go
@@ -40,7 +40,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		event.Type = eventtypes.NORMAL
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/capabilities/tracer/standard/tracer.go
+++ b/pkg/gadgets/capabilities/tracer/standard/tracer.go
@@ -41,7 +41,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		event.Type = eventtypes.NORMAL
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/execsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/execsnoop/tracer/standard/tracer.go
@@ -42,7 +42,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		event.Type = eventtypes.NORMAL
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/mountsnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/mountsnoop/tracer/standard/tracer.go
@@ -47,7 +47,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		line = strings.ReplaceAll(line, `"tgid"`, `"tid"`)
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/opensnoop/tracer/standard/tracer.go
+++ b/pkg/gadgets/opensnoop/tracer/standard/tracer.go
@@ -41,7 +41,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		event.Type = eventtypes.NORMAL
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/tcpconnect/tracer/standard/tracer.go
+++ b/pkg/gadgets/tcpconnect/tracer/standard/tracer.go
@@ -45,7 +45,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		line = strings.ReplaceAll(line, `"ip"`, `"ipversion"`)
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}

--- a/pkg/gadgets/tcptracer/tracer/standard/tracer.go
+++ b/pkg/gadgets/tcptracer/tracer/standard/tracer.go
@@ -47,7 +47,7 @@ func NewTracer(config *tracer.Config, resolver containercollection.ContainerReso
 		line = strings.ReplaceAll(line, `"type"`, `"operation"`)
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			msg := fmt.Sprintf("failed to unmarshal event: %s", err)
+			msg := fmt.Sprintf("failed to unmarshal event '%s': %s", line, err)
 			eventCallback(types.Base(eventtypes.Warn(msg, node)))
 			return
 		}


### PR DESCRIPTION
Hi.


In this PR, I added the problematic line when unmarshalling failed for standard tracer.
So, before this commit the following was printed:

```
failed to unmarshal event: invalid character 'U' looking for beginning of value
```

Now, the output is the following:

```
failed to unmarshal event: invalid character 'U' looking for beginning of value
    Unable to find kernel headers. Try rebuilding kernel with CONFIG_IKHEADERS=m (module) or installing the kernel development package for your running kernel version.
```

It is not perfect but should quickly fix #711 while not needed modifications to bcc code.


Best regards.