### PR TITLE
Remove signal KILL when used in signal handler.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,10 +16,6 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
-    # FIXME temporarily suppress. See issue #540
-    - text: "SA1016: (syscall.SIGKILL|os.Kill) cannot be trapped \\(did you mean syscall.SIGTERM\\?\\)"
-      linters:
-      - staticcheck
     # FIXME temporarily suppress. See issue #541
     - text: "SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead."
       linters:

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -649,7 +649,7 @@ var sigIntReceivedNumber = 0
 // kubectl gadget process-collector -A | head -n0
 func sigHandler(traceID *string) {
 	c := make(chan os.Signal)
-	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGILL, syscall.SIGABRT, syscall.SIGFPE, syscall.SIGKILL, syscall.SIGSEGV, syscall.SIGPIPE, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGBUS, syscall.SIGTRAP)
+	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGILL, syscall.SIGABRT, syscall.SIGFPE, syscall.SIGSEGV, syscall.SIGPIPE, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGBUS, syscall.SIGTRAP)
 	go func() {
 		sig := <-c
 

--- a/gadget-container/gadgets/networkpolicyadvisor/main.go
+++ b/gadget-container/gadgets/networkpolicyadvisor/main.go
@@ -213,7 +213,7 @@ func main() {
 	fmt.Printf(`{"type":"ready"}` + "\n")
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, os.Kill)
+	signal.Notify(sig, os.Interrupt)
 
 	<-sig
 


### PR DESCRIPTION
Hi.


This PR removes SIGKILL from handler as it cannot be trapped (this was pointed by static checker).


Best regards.