### PR TITLE
ci: Use ghcr.io as image registry.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1,6 +1,6 @@
 name: Inspektor Gadget CI
 env:
-  CONTAINER_REPO: ${{ secrets.CONTAINER_REPO }}
+  CONTAINER_REPO: ghcr.io/${{ github.repository }}
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -180,9 +180,9 @@ jobs:
     - name: Login to Container Registry
       uses: docker/login-action@v1
       with:
-        registry: ${{ secrets.CONTAINER_REGISTRY }}
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -204,7 +204,7 @@ jobs:
         # push to final registry
         # At the moment, we only build core image and do not publish them.
         push: ${{ matrix.type != 'core' }}
-        tags: ${{ secrets.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
+        tags: ${{ env.CONTAINER_REPO }}:${{ env.IMAGE_TAG }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
         # For the moment, we only support these two platforms.
@@ -226,9 +226,9 @@ jobs:
     - name: Login to Container Registry
       uses: docker/login-action@v1
       with:
-        registry: ${{ secrets.CONTAINER_REGISTRY }}
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Set IMAGE_TAG
       run: |
         TMP1=${GITHUB_REF#*/}
@@ -244,7 +244,7 @@ jobs:
         context: /home/runner/work/inspektor-gadget/inspektor-gadget
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/examples/${{ matrix.example }}/Dockerfile
         push: ${{ secrets.PUSH_EXAMPLES == 'ENABLE_PUSH_EXAMPLES' }}
-        tags: ${{ secrets.CONTAINER_REPO }}-${{ matrix.example }}:${{ env.IMAGE_TAG }}
+        tags: ${{ env.CONTAINER_REPO }}-${{ matrix.example }}:${{ env.IMAGE_TAG }}
 
   test-unit:
     name: Unit tests
@@ -382,9 +382,9 @@ jobs:
       env:
         KUBERNETES_DISTRIBUTION: "aro"
       with:
-        registry: ${{ secrets.CONTAINER_REGISTRY }}
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
   test-integration:
     name: Integration tests
@@ -404,9 +404,9 @@ jobs:
       env:
         KUBERNETES_DISTRIBUTION: "minikube-github"
       with:
-        registry: ${{ secrets.CONTAINER_REGISTRY }}
-        username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-        password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Release

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG := `git describe --tags --always`
 VERSION :=
 
-CONTAINER_REPO ?= docker.io/kinvolk/gadget
+CONTAINER_REPO ?= ghcr.io/kinvolk/inspektor-gadget
 IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
 MINIKUBE ?= minikube

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Inspektor Gadget provides two different container images:
 **Note**: Using a locally built container image requires pushing it to a container
 repository, either local or remote. The default repository can be
 overridden by changing the value of the `CONTAINER_REPO` env variable,
-which defaults to `docker.io/kinvolk/gadget` if not defined.
+which defaults to `ghcr.io/kinvolk/inspektor-gadget` if not defined.
 
 You can build and push the container gadget image by running the following commands:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,19 +23,9 @@ To run the integration tests, it is necessary to have the gadget container image
 available on a container repository so that it can be installed in the
 Kubernetes cluster where the tests will run.
 
-After adding the following secrets, the workflow is already configured to use
-them to login to the container registry and push the generated images:
-
-- `CONTAINER_REPO`: The container repository to use. Example:
-  docker.io/kinvolk/gadget
-- `CONTAINER_REGISTRY`: The registry containing the repo above. Leave empty for
-  Docker Hub. Example: ghcr.io, foo.azurecr.io, gcr.io
-- `CONTAINER_REGISTRY_USERNAME` & `CONTAINER_REGISTRY_PASSWORD`: Authentication
-  information for the the registry above.
-
-Notice that either the provided container repository allows anonymous pull or
-the cluster used to run the integration tests is properly configured to be able
-to pull images from it.
+As a default, `ghcr.io/${{ github.repository }}` is used to store images created
+in the CI pipeline.
+Note that, you need to [set repository packages as public](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#configuring-visibility-of-container-images-for-your-personal-account) to allow anonymous pull.
 
 ## Run integration tests on an ARO cluster
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,7 +77,7 @@ This will deploy the gadget DaemonSet along with its RBAC rules.
 If you wish to install an alternative gadget image, you could use the following commands:
 
 ```bash
-$ kubectl gadget deploy --image=docker.io/myfork/gadget:tag | kubectl apply -f -
+$ kubectl gadget deploy --image=ghcr.io/myfork/inspektor-gadget:tag | kubectl apply -f -
 ```
 
 ### Hook Mode

--- a/examples/kube-container-collection/Makefile
+++ b/examples/kube-container-collection/Makefile
@@ -1,4 +1,4 @@
-CONTAINER_REPO ?= docker.io/kinvolk/gadget
+CONTAINER_REPO ?= ghcr.io/kinvolk/inspektor-gadget
 IMAGE_TAG ?= $(shell ../../tools/image-tag branch)
 
 kube-container-collection: main.go

--- a/examples/runc-hook/Makefile
+++ b/examples/runc-hook/Makefile
@@ -1,4 +1,4 @@
-CONTAINER_REPO ?= docker.io/kinvolk/gadget
+CONTAINER_REPO ?= ghcr/kinvolk/inspektor-gadget
 IMAGE_TAG ?= $(shell ../../tools/image-tag branch)
 
 runc-hook: main.go

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,4 +1,4 @@
-CONTAINER_REPO ?= docker.io/kinvolk/gadget
+CONTAINER_REPO ?= ghcr.io/kinvolk/inspektor-gadget
 IMAGE_TAG ?= $(shell ../tools/image-tag branch)
 
 TESTS_DOCKER_ARGS ?= -e KUBECONFIG=/opt/kubeconfig/config -v $(HOME)/.kube:/opt/kubeconfig

--- a/integration/gadget-integration-tests-job.yaml
+++ b/integration/gadget-integration-tests-job.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccount: gadget-test
       containers:
       - name: gadget-test
-        image: docker.io/kinvolk/gadgettest:latest
+        image: ghcr.io/kinvolk/inspektor-gadgettest:latest
         imagePullPolicy: Always
       restartPolicy: Never
   backoffLimit: 0

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -40,7 +40,7 @@ var (
 var (
 	integration = flag.Bool("integration", false, "run integration tests")
 
-	// image such as docker.io/kinvolk/gadget:latest
+	// image such as ghcr.io/kinvolk/inspektor-gadget:latest
 	image = flag.String("image", "", "gadget container image")
 
 	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")

--- a/kubectl-gadget.Dockerfile
+++ b/kubectl-gadget.Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum /gadget/
 RUN cd /gadget && go mod download
 
 # default image that will be used in the deploy command
-ARG CONTAINER_REPO="docker.io/kinvolk/gadget"
+ARG CONTAINER_REPO="ghcr.io/kinvolk/inspektor-gadget"
 ENV CONTAINER_REPO=${CONTAINER_REPO}
 
 ARG IMAGE_TAG


### PR DESCRIPTION
Hi.


In this PR, I switched image registry from `docker.io` to `ghcr.io`.
The images can be found [there](https://github.com/kinvolk/inspektor-gadget/pkgs/container/inspektor-gadget).


Best regards.