### PR TITLE
cmd/common: Handle `ManageSpecialEvent` inside `BaseParser.Transform`

### DIFF
--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -111,7 +111,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 			for _, e := range allEvents {
 				baseEvent := e.GetBaseEvent()
 				if baseEvent.Type != eventtypes.NORMAL {
-					commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
+					commonutils.HandleSpecialEvent(baseEvent, outputConfig.Verbose)
 					continue
 				}
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -111,7 +111,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 			for _, e := range allEvents {
 				baseEvent := e.GetBaseEvent()
 				if baseEvent.Type != eventtypes.NORMAL {
-					commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
+					commonutils.ManageSpecialEvent(&baseEvent, outputConfig.Verbose)
 					continue
 				}
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -34,7 +34,7 @@ type SnapshotEvent interface {
 	// x is of type parameter type even if all types in the type parameter's
 	// type set have a field f. We may remove this restriction in Go 1.19. See
 	// https://tip.golang.org/doc/go1.18#generics.
-	GetBaseEvent() eventtypes.Event
+	GetBaseEvent() *eventtypes.Event
 }
 
 // SnapshotParser defines the interface that every snapshot-gadget parser has to
@@ -111,7 +111,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 			for _, e := range allEvents {
 				baseEvent := e.GetBaseEvent()
 				if baseEvent.Type != eventtypes.NORMAL {
-					commonutils.ManageSpecialEvent(&baseEvent, outputConfig.Verbose)
+					commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
 					continue
 				}
 

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -21,10 +21,10 @@ import (
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
-// ManageSpecialEvent prints the special events. Notice it does not receive the
+// HandleSpecialEvent prints the special events. Notice it does not receive the
 // OutputMode so it will always print the special events messages without any
 // specific format to standard error.
-func ManageSpecialEvent(e *eventtypes.Event, verbose bool) {
+func HandleSpecialEvent(e *eventtypes.Event, verbose bool) {
 	switch e.Type {
 	case eventtypes.READY:
 		// TODO

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -21,6 +21,9 @@ import (
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
+// ManageSpecialEvent prints the special events. Notice it does not receive the
+// OutputMode so it will always print the special events messages without any
+// specific format to standard error.
 func ManageSpecialEvent(e *eventtypes.Event, verbose bool) {
 	switch e.Type {
 	case eventtypes.READY:

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -21,7 +21,7 @@ import (
 	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
-func ManageSpecialEvent(e eventtypes.Event, verbose bool) {
+func ManageSpecialEvent(e *eventtypes.Event, verbose bool) {
 	switch e.Type {
 	case eventtypes.READY:
 		// TODO

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -111,7 +111,7 @@ func (p *BaseParser[E]) Transform(element *E, toColumns func(*E) string) string 
 	// cases by themselves, GetBaseEvent() simply needs to return nil.
 	baseEvent := (*element).GetBaseEvent()
 	if baseEvent != nil && baseEvent.Type != eventtypes.NORMAL {
-		ManageSpecialEvent(baseEvent, p.OutputConfig.Verbose)
+		HandleSpecialEvent(baseEvent, p.OutputConfig.Verbose)
 		return ""
 	}
 

--- a/cmd/common/utils/parser_test.go
+++ b/cmd/common/utils/parser_test.go
@@ -16,18 +16,58 @@ package utils
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
+
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 )
 
+// MyElement doesn't need to implement GetBaseEvent because eventtypes.Event
+// already does it.
 type MyElement struct {
+	eventtypes.Event
+
 	Pid  uint32 `json:"pid,omitempty"`
 	Comm string `json:"comm,omitempty"`
 }
 
 var elem = &MyElement{
+	Event: eventtypes.Event{
+		CommonData: eventtypes.CommonData{
+			Node:      "myNode",
+			Namespace: "myNs",
+			Pod:       "myPod",
+		},
+		Type: eventtypes.NORMAL,
+	},
 	Pid:  1234,
 	Comm: "cat",
+}
+
+var errorElem = &MyElement{
+	Event: eventtypes.Event{
+		CommonData: eventtypes.CommonData{
+			Node:      "myNode",
+			Namespace: "myNs",
+			Pod:       "myPod",
+		},
+		Type:    eventtypes.ERR,
+		Message: "Error message",
+	},
+}
+
+var debugElem = &MyElement{
+	Event: eventtypes.Event{
+		CommonData: eventtypes.CommonData{
+			Node:      "myNode",
+			Namespace: "myNs",
+			Pod:       "myPod",
+		},
+		Type:    eventtypes.DEBUG,
+		Message: "Debug message",
+	},
 }
 
 // TODO: Test default columns (OutputModeColumns)
@@ -41,6 +81,7 @@ func TestBaseParser(t *testing.T) {
 		element          *MyElement
 		expectedHeader   string
 		expectedValues   string
+		expectedStdErr   string
 	}{
 		{
 			description: "JSON output mode",
@@ -48,7 +89,7 @@ func TestBaseParser(t *testing.T) {
 				OutputMode: OutputModeJSON,
 			},
 			element:        elem,
-			expectedValues: "{\"pid\":1234,\"comm\":\"cat\"}",
+			expectedValues: "{\"node\":\"myNode\",\"namespace\":\"myNs\",\"pod\":\"myPod\",\"type\":\"normal\",\"pid\":1234,\"comm\":\"cat\"}",
 		},
 		{
 			description: "none valid column using width",
@@ -136,6 +177,56 @@ func TestBaseParser(t *testing.T) {
 			expectedValues: fmt.Sprintf("%d\t%s\t", elem.Pid, elem.Comm),
 		},
 		{
+			description: "error case with columns",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"pid", "comm"},
+				OutputMode:    OutputModeCustomColumns,
+			},
+			columnsWidth: map[string]int{
+				"pid":  -7,
+				"comm": -16,
+			},
+			useTabs:        false,
+			expectedHeader: fmt.Sprintf("%-7s %-16s ", "PID", "COMM"),
+			element:        errorElem,
+			expectedStdErr: fmt.Sprintf("%s: node %s, pod %s/%s: %s\n",
+				errorElem.Type, errorElem.Node, errorElem.Namespace,
+				errorElem.Pod, errorElem.Message),
+		},
+		{
+			description: "error case with JSON",
+			outputConfig: &OutputConfig{
+				OutputMode: OutputModeJSON,
+			},
+			useTabs: false,
+			element: errorElem,
+			/// Notice it is not printed in JSON format but is sent to stderr.
+			expectedStdErr: fmt.Sprintf("%s: node %s, pod %s/%s: %s\n",
+				errorElem.Type, errorElem.Node, errorElem.Namespace,
+				errorElem.Pod, errorElem.Message),
+		},
+		{
+			description: "debug case (no verbose)",
+			outputConfig: &OutputConfig{
+				OutputMode: OutputModeJSON,
+				Verbose:    false,
+			},
+			useTabs: false,
+			element: debugElem,
+		},
+		{
+			description: "debug case (verbose)",
+			outputConfig: &OutputConfig{
+				OutputMode: OutputModeJSON,
+				Verbose:    true,
+			},
+			useTabs: false,
+			element: debugElem,
+			expectedStdErr: fmt.Sprintf("%s: node %s, pod %s/%s: %s\n",
+				debugElem.Type, debugElem.Node, debugElem.Namespace,
+				debugElem.Pod, debugElem.Message),
+		},
+		{
 			description: "normal case using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "comm"},
@@ -220,10 +311,156 @@ func TestBaseParser(t *testing.T) {
 			}
 		}
 
+		// get reference to original stderr and restore on exit
+		originalStderr := os.Stderr
+		defer func() { os.Stderr = originalStderr }()
+
+		r, w, _ := os.Pipe()
+		os.Stderr = w
 		values := p.Transform(entry.element, toColumns)
 		if values != entry.expectedValues {
 			t.Fatalf("Failed Transform test %q (index %d): result %q expected %q",
 				entry.description, i, values, entry.expectedValues)
+		}
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stderr = originalStderr
+
+		if (entry.expectedStdErr != "" || string(out) != "") && entry.expectedStdErr != string(out) {
+			t.Fatalf("Failed Transform test %q (index %d): stderr %q expected %q",
+				entry.description, i, string(out), entry.expectedStdErr)
+		}
+	}
+}
+
+type MyElementNoBase struct {
+	Pid  uint32 `json:"pid,omitempty"`
+	Comm string `json:"comm,omitempty"`
+}
+
+func (e MyElementNoBase) GetBaseEvent() *eventtypes.Event {
+	return nil
+}
+
+var elemNoBase = &MyElementNoBase{
+	Pid:  1234,
+	Comm: "cat",
+}
+
+func TestTransformWithNoBase(t *testing.T) {
+	table := []struct {
+		description      string
+		columnsWidth     map[string]int
+		availableColumns []string
+		useTabs          bool
+		outputConfig     *OutputConfig
+		element          *MyElementNoBase
+		expectedValues   string
+		expectedStdErr   string
+	}{
+		{
+			description: "JSON output mode",
+			outputConfig: &OutputConfig{
+				OutputMode: OutputModeJSON,
+			},
+			element:        elemNoBase,
+			expectedValues: "{\"pid\":1234,\"comm\":\"cat\"}",
+		},
+		{
+			description: "normal case using width",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"pid", "comm"},
+				OutputMode:    OutputModeCustomColumns,
+			},
+			columnsWidth: map[string]int{
+				"pid":  -7,
+				"comm": -16,
+			},
+			useTabs:        false,
+			element:        elemNoBase,
+			expectedValues: fmt.Sprintf("%-7d %-16s ", elem.Pid, elem.Comm),
+		},
+		{
+			description: "normal case using tabs",
+			outputConfig: &OutputConfig{
+				CustomColumns: []string{"pid", "comm"},
+				OutputMode:    OutputModeCustomColumns,
+			},
+			availableColumns: []string{
+				"pid",
+				"comm",
+			},
+			useTabs:        true,
+			element:        elemNoBase,
+			expectedValues: fmt.Sprintf("%d\t%s\t", elem.Pid, elem.Comm),
+		},
+	}
+
+	for i, entry := range table {
+		var p BaseParser[MyElementNoBase]
+		if entry.useTabs {
+			p = NewBaseTabParser[MyElementNoBase](entry.availableColumns, entry.outputConfig)
+		} else {
+			p = NewBaseWidthParser[MyElementNoBase](entry.columnsWidth, entry.outputConfig)
+		}
+
+		var toColumns func(e *MyElementNoBase) string
+		if entry.useTabs {
+			toColumns = func(e *MyElementNoBase) string {
+				var sb strings.Builder
+
+				for _, col := range p.OutputConfig.CustomColumns {
+					switch col {
+					case "pid":
+						sb.WriteString(fmt.Sprintf("%d", e.Pid))
+					case "comm":
+						sb.WriteString(fmt.Sprintf("%s", e.Comm))
+					default:
+						continue
+					}
+					sb.WriteRune('\t')
+				}
+
+				return sb.String()
+			}
+		} else {
+			toColumns = func(e *MyElementNoBase) string {
+				var sb strings.Builder
+
+				for _, col := range p.OutputConfig.CustomColumns {
+					switch col {
+					case "pid":
+						sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], e.Pid))
+					case "comm":
+						sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Comm))
+					default:
+						continue
+					}
+					sb.WriteRune(' ')
+				}
+
+				return sb.String()
+			}
+		}
+
+		// get reference to original stderr and restore on exit
+		originalStderr := os.Stderr
+		defer func() { os.Stderr = originalStderr }()
+
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+		values := p.Transform(entry.element, toColumns)
+		if values != entry.expectedValues {
+			t.Fatalf("Failed Transform test %q (index %d): result %q expected %q",
+				entry.description, i, values, entry.expectedValues)
+		}
+		w.Close()
+		out, _ := ioutil.ReadAll(r)
+		os.Stderr = originalStderr
+
+		if (entry.expectedStdErr != "" || string(out) != "") && entry.expectedStdErr != string(out) {
+			t.Fatalf("Failed Transform test %q (index %d): stderr %q expected %q",
+				entry.description, i, string(out), entry.expectedStdErr)
 		}
 	}
 }

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -60,7 +60,7 @@ func newSeccompCmd() *cobra.Command {
 				}
 
 				if e.Type != eventtypes.NORMAL {
-					commonutils.ManageSpecialEvent(e.Event, commonFlags.Verbose)
+					commonutils.ManageSpecialEvent(&e.Event, commonFlags.Verbose)
 					return ""
 				}
 

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -23,7 +23,6 @@ import (
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
-	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -56,11 +55,6 @@ func newSeccompCmd() *cobra.Command {
 
 				if err := json.Unmarshal([]byte(line), &e); err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %s", commonutils.WrapInErrUnmarshalOutput(err, line))
-					return ""
-				}
-
-				if e.Type != eventtypes.NORMAL {
-					commonutils.ManageSpecialEvent(&e.Event, commonFlags.Verbose)
 					return ""
 				}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -89,7 +89,7 @@ func (g *TraceGadget[Event]) Run() error {
 
 		baseEvent := e.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -33,7 +33,7 @@ type TraceEvent interface {
 	// of type parameter type even if all types in the type parameter's type set
 	// have a field f. We may remove this restriction in Go 1.19. See
 	// https://tip.golang.org/doc/go1.18#generics.
-	GetBaseEvent() eventtypes.Event
+	GetBaseEvent() *eventtypes.Event
 }
 
 // TraceParser defines the interface that every trace-gadget parser has to
@@ -89,7 +89,7 @@ func (g *TraceGadget[Event]) Run() error {
 
 		baseEvent := e.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -21,19 +21,12 @@ import (
 
 	commonutils "github.com/kinvolk/inspektor-gadget/cmd/common/utils"
 	"github.com/kinvolk/inspektor-gadget/cmd/kubectl-gadget/utils"
-	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 
 	"github.com/spf13/cobra"
 )
 
 type TraceEvent interface {
 	any
-
-	// The Go compiler does not support accessing a struct field x.f where x is
-	// of type parameter type even if all types in the type parameter's type set
-	// have a field f. We may remove this restriction in Go 1.19. See
-	// https://tip.golang.org/doc/go1.18#generics.
-	GetBaseEvent() *eventtypes.Event
 }
 
 // TraceParser defines the interface that every trace-gadget parser has to
@@ -84,12 +77,6 @@ func (g *TraceGadget[Event]) Run() error {
 
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s", commonutils.WrapInErrUnmarshalOutput(err, line))
-			return ""
-		}
-
-		baseEvent := e.GetBaseEvent()
-		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -15,6 +15,7 @@
 package containercollection
 
 import (
+	eventtypes "github.com/kinvolk/inspektor-gadget/pkg/types"
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -71,4 +72,13 @@ type ContainerSelector struct {
 	Podname   string
 	Labels    map[string]string
 	Name      string
+}
+
+// GetBaseEvent is defined to implement the commonutils.BaseElement interface so
+// that we can use the commonutils.BaseParser methods to parse Container. In
+// commonutils.BaseParser.Transform(), we call GetBaseEvent() to check whether
+// the element being parsed is a special event or not. Given that Container is
+// not an event, this method simply returns nil.
+func (e Container) GetBaseEvent() *eventtypes.Event {
+	return nil
 }

--- a/pkg/gadgets/profile/cpu/types/types.go
+++ b/pkg/gadgets/profile/cpu/types/types.go
@@ -32,3 +32,12 @@ type Report struct {
 	KernelStack []string `json:"kernel_stack,omitempty"`
 	Count       uint64   `json:"count,omitempty"`
 }
+
+// GetBaseEvent is defined to implement the commonutils.BaseElement interface so
+// that we can use the commonutils.BaseParser methods to parse Report. In
+// commonutils.BaseParser.Transform(), we call GetBaseEvent() to check whether
+// the element being parsed is a special event or not. Given that the profile
+// cpu gadget is not event-based, this method simply returns nil.
+func (e Report) GetBaseEvent() *eventtypes.Event {
+	return nil
+}

--- a/pkg/gadgets/snapshot/process/types/process-collector.go
+++ b/pkg/gadgets/snapshot/process/types/process-collector.go
@@ -25,7 +25,3 @@ type Event struct {
 	Command   string `json:"comm"`
 	MountNsID uint64 `json:"mntns"`
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -55,7 +55,3 @@ func ParseProtocol(protocol string) (Proto, error) {
 
 	return INVALID, fmt.Errorf("%q is not a valid protocol value", protocol)
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/bind/types/types.go
+++ b/pkg/gadgets/trace/bind/types/types.go
@@ -36,7 +36,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -36,7 +36,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/dns/types/dns.go
+++ b/pkg/gadgets/trace/dns/types/dns.go
@@ -31,7 +31,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -35,7 +35,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/fsslower/types/types.go
+++ b/pkg/gadgets/trace/fsslower/types/types.go
@@ -40,7 +40,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/mount/types/types.go
+++ b/pkg/gadgets/trace/mount/types/types.go
@@ -41,7 +41,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -53,10 +53,6 @@ type Event struct {
 	Debug string `json:"debug,omitempty"`
 }
 
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}
-
 func Unique(edges []Event) []Event {
 	keys := make(map[string]bool)
 	list := []Event{}

--- a/pkg/gadgets/trace/oomkill/types/types.go
+++ b/pkg/gadgets/trace/oomkill/types/types.go
@@ -34,7 +34,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -36,7 +36,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/signal/types/types.go
+++ b/pkg/gadgets/trace/signal/types/types.go
@@ -34,7 +34,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/sni/types/snisnoop.go
+++ b/pkg/gadgets/trace/sni/types/snisnoop.go
@@ -29,7 +29,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/tcp/types/types.go
+++ b/pkg/gadgets/trace/tcp/types/types.go
@@ -37,7 +37,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -36,7 +36,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -74,6 +74,12 @@ type Event struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetBaseEvent is needed to implement commonutils.BaseElement and
+// snapshot.SnapshotEvent interfaces.
+func (e Event) GetBaseEvent() *Event {
+	return &e
+}
+
 func Err(msg string) Event {
 	return Event{
 		CommonData: CommonData{


### PR DESCRIPTION
# Handle `ManageSpecialEvent` inside `BaseParser.Transform`

This PR aims to handle `ManageSpecialEvent` inside `BaseParser.Transform`. The main issue with doing so is that it doesn't need to be done in all cases. Therefore, we need to identify whether `ManageSpecialEvent` needs to be called or not. My proposal in this PR is to base the decision on the value returned by `GetBaseEvent`.

## Implementation details

The gadgets using `BaseParser.Transform` are the ones supporting columns output format:

- The `audit/seccomp` gadget
- The `profile/cpu` gadget
- The `trace` category
- The `top` category is in the process: https://github.com/kinvolk/inspektor-gadget/pull/782. BTW, we need to synchronize these two PRs and rebase once one of them is merged.
- **NOTE**: The `snapshot` category and the `list-container` command of `local-gadget` don't use `BaseParser.Transform` as they print the JSON output format differently (as discussed [here](https://github.com/kinvolk/inspektor-gadget/pull/764#discussion_r930044431)). It means they will need to manage special events (if needed) by themselves. 

However, the `profile/cpu` gadget and the `top` category don't need to handle any "special events" as they are not event-based, but reports, and they manage the errors differently:
- The `profile/cpu` gadget reports errors when starting or stopping the gadget.
- The `top` category reports errors per report (e.g., [here](https://github.com/kinvolk/inspektor-gadget/blob/355f0295cef04a40cdd7df50e6ffaf9036ab8d7f/cmd/kubectl-gadget/top/tcp.go#L198-L201)) and not per stats (which is what we transform in columns using `BaseParser.Transform`).

In addition, moving `ManageSpecialEvent` into `BaseParser.Transform`, implies that whoever wants to use the `BaseParser`, needs to implement `GetBaseEvent`, which is strange but I think is acceptable. 

## How to use

It should now be easier for `BaseParser` users to use it because they don't need to manage these special cases alone. See https://github.com/kinvolk/inspektor-gadget/pull/789#discussion_r934738002.

## Testing done

I enhenced the unit-tests to cover this.
