### PR TITLE
ci: Push core images to our container repository.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -197,9 +197,8 @@ jobs:
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/gadget-${{ matrix.type }}.Dockerfile
         build-args: |
           ENABLE_BTFGEN=true
-        # At the moment, we only build core image and do not publish them.
-        push: ${{ matrix.type != 'core' }}
-        tags: ${{ steps.choose-repo-determine-image-tag.outputs.container-repo }}:${{ steps.choose-repo-determine-image-tag.outputs.image-tag }}
+        push: true
+        tags: ${{ steps.choose-repo-determine-image-tag.outputs.container-repo }}:${{ steps.choose-repo-determine-image-tag.outputs.image-tag }}${{ matrix.type == 'core' && '-core' || ''}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
         # For the moment, we only support these two platforms.


### PR DESCRIPTION
Hi.


In this PR, I enabled pushing for CO-RE only container image.
CO-RE only container images are pushed with ["-core" concatenated to their image tag](https://github.com/orgs/kinvolk/packages/container/inspektor-gadget-dev/36530150?tag=francis-push-core-image-core), this avoid creating a new repository for this image type.
It fixes #807.


Best regards.