### PR TITLE
[RFC] Generate documentation for json types returned by gadgets

### DIFF
--- a/cmd/gen-doc/gadget.template
+++ b/cmd/gen-doc/gadget.template
@@ -27,5 +27,9 @@ $ kubectl annotate -n gadget trace/{{$.Name}} \
 
 {{range $i, $outputMode := .OutputModes -}}
 * {{$outputMode}}
-{{end -}}
+{{- end}}
 
+### Types
+
+```go
+{{ godoc (printf "pkg/gadgets/%s/types" .Pkg) }}```

--- a/docs/gadgets/audit-seccomp.md
+++ b/docs/gadgets/audit-seccomp.md
@@ -52,3 +52,25 @@ $ kubectl annotate -n gadget trace/audit-seccomp \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Syscall   string `json:"syscall,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	MountNsID uint64 `json:"mntns,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+```

--- a/docs/gadgets/bindsnoop.md
+++ b/docs/gadgets/bindsnoop.md
@@ -45,3 +45,30 @@ $ kubectl annotate -n gadget trace/bindsnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/bind/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Pid       uint32 `json:"pid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	Protocol  string `json:"proto,omitempty"`
+	Addr      string `json:"addr,omitempty"`
+	Port      uint16 `json:"port,omitempty"`
+	Options   string `json:"opts,omitempty"`
+	Interface string `json:"if,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/biolatency.md
+++ b/docs/gadgets/biolatency.md
@@ -45,3 +45,25 @@ $ kubectl annotate -n gadget trace/biolatency \
 ### Output Modes
 
 * Status
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/profile/block-io/types"
+
+
+TYPES
+
+type Data struct {
+	Count         uint64 `json:"count"`
+	IntervalStart uint64 `json:"intervalStart"`
+	IntervalEnd   uint64 `json:"intervalEnd,omitempty"`
+}
+
+type Report struct {
+	ValType string `json:"valType,omitempty"`
+	Data    []Data `json:"data,omitempty"`
+	Time    string `json:"ts,omitempty"`
+}
+
+```

--- a/docs/gadgets/capabilities.md
+++ b/docs/gadgets/capabilities.md
@@ -45,3 +45,30 @@ $ kubectl annotate -n gadget trace/capabilities \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	UID       uint32 `json:"uid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	CapName   string `json:"capName,omitempty"`
+	Cap       int    `json:"cap,omitempty"`
+	Audit     int    `json:"audit,omitempty"`
+	InsetID   string `json:"insetid,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/dns.md
+++ b/docs/gadgets/dns.md
@@ -46,3 +46,25 @@ $ kubectl annotate -n gadget trace/dns \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/dns/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	DNSName string `json:"name,omitempty"`
+	PktType string `json:"pktType,omitempty"`
+	QType   string `json:"qtype,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/ebpftop.md
+++ b/docs/gadgets/ebpftop.md
@@ -52,3 +52,81 @@ $ kubectl annotate -n gadget trace/ebpftop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/ebpf/types"
+
+
+CONSTANTS
+
+const (
+	MaxRowsDefault  = 20
+	IntervalDefault = 1
+	SortByDefault   = ALL
+)
+const (
+	IntervalParam = "interval"
+	MaxRowsParam  = "max_rows"
+	SortByParam   = "sort_by"
+)
+
+VARIABLES
+
+var SortBySlice = []string{
+	"all",
+	"runtime",
+	"runcount",
+	"progid",
+	"totalruntime",
+	"totalruncount",
+}
+
+FUNCTIONS
+
+func SortStats(stats []Stats, sortBy SortBy)
+
+TYPES
+
+type Event struct {
+	Error string `json:"error,omitempty"`
+
+	// Node where the event comes from.
+	Node string `json:"node,omitempty"`
+
+	Stats []Stats `json:"stats,omitempty"`
+}
+
+type PidInfo struct {
+	Pid  uint32 `json:"pid,omitempty"`
+	Comm string `json:"comm,omitempty"`
+}
+
+type SortBy int
+
+const (
+	ALL SortBy = iota
+	RUNTIME
+	RUNCOUNT
+	PROGRAMID
+	TOTALRUNTIME
+	TOTALRUNCOUNT
+)
+func ParseSortBy(sortby string) (SortBy, error)
+
+func (s SortBy) String() string
+
+type Stats struct {
+	eventtypes.CommonData
+	ProgramID       uint32     `json:"progid"`
+	Pids            []*PidInfo `json:"pids,omitempty"`
+	Name            string     `json:"name,omitempty"`
+	Type            string     `json:"type,omitempty"`
+	CurrentRuntime  int64      `json:"currentRuntime,omitempty"`
+	CurrentRunCount uint64     `json:"currentRuncount,omitempty"`
+	TotalRuntime    int64      `json:"totalRuntime,omitempty"`
+	TotalRunCount   uint64     `json:"totalRuncount,omitempty"`
+}
+
+```

--- a/docs/gadgets/execsnoop.md
+++ b/docs/gadgets/execsnoop.md
@@ -45,3 +45,29 @@ $ kubectl annotate -n gadget trace/execsnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/exec/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Pid       uint32   `json:"pid,omitempty"`
+	Ppid      uint32   `json:"ppid,omitempty"`
+	UID       uint32   `json:"uid,omitempty"`
+	MountNsID uint64   `json:"mountnsid,omitempty"`
+	Retval    int      `json:"ret,omitempty"`
+	Comm      string   `json:"pcomm,omitempty"`
+	Args      []string `json:"args,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/filetop.md
+++ b/docs/gadgets/filetop.md
@@ -51,3 +51,82 @@ $ kubectl annotate -n gadget trace/filetop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/top/file/types"
+
+
+CONSTANTS
+
+const (
+	MaxRowsDefault  = 20
+	IntervalDefault = 1
+	SortByDefault   = ALL
+	AllFilesDefault = false
+)
+const (
+	IntervalParam = "interval"
+	MaxRowsParam  = "max_rows"
+	SortByParam   = "sort_by"
+	AllFilesParam = "pid"
+)
+
+VARIABLES
+
+var SortBySlice = []string{
+	"all",
+	"reads",
+	"writes",
+	"rbytes",
+	"wbytes",
+}
+
+FUNCTIONS
+
+func SortStats(stats []Stats, sortBy SortBy)
+
+TYPES
+
+type Event struct {
+	Error string `json:"error,omitempty"`
+
+	// Node where the event comes from.
+	Node string `json:"node,omitempty"`
+
+	Stats []Stats `json:"stats,omitempty"`
+}
+    Event is the information the gadget sends to the client each capture
+    interval
+
+type SortBy int
+
+const (
+	ALL SortBy = iota
+	READS
+	WRITES
+	RBYTES
+	WBYTES
+)
+func ParseSortBy(sortby string) (SortBy, error)
+
+func (s SortBy) String() string
+
+type Stats struct {
+	eventtypes.CommonData
+
+	Reads      uint64 `json:"reads,omitempty"`
+	Writes     uint64 `json:"writes,omitempty"`
+	ReadBytes  uint64 `json:"rbytes,omitempty"`
+	WriteBytes uint64 `json:"wbytes,omitempty"`
+	Pid        uint32 `json:"pid,omitempty"`
+	Tid        uint32 `json:"tid,omitempty"`
+	MountNsID  uint64 `json:"mountnsid,omitempty"`
+	Filename   string `json:"filename,omitempty"`
+	Comm       string `json:"comm,omitempty"`
+	FileType   byte   `json:"fileType,omitempty"`
+}
+    Stats represents the operations performed on a single file
+
+```

--- a/docs/gadgets/fsslower.md
+++ b/docs/gadgets/fsslower.md
@@ -49,3 +49,36 @@ $ kubectl annotate -n gadget trace/fsslower \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/fsslower/types"
+
+
+CONSTANTS
+
+const (
+	MinLatencyDefault = uint(10)
+)
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	Op        string `json:"op,omitempty"`
+	Bytes     uint64 `json:"bytes,omitempty"`
+	Offset    int64  `json:"offset,omitempty"`
+	Latency   uint64 `json:"latency,omitempty"`
+	File      string `json:"file,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/mountsnoop.md
+++ b/docs/gadgets/mountsnoop.md
@@ -45,3 +45,35 @@ $ kubectl annotate -n gadget trace/mountsnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/mount/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64   `json:"mntnsid,omitempty"`
+	Pid       uint32   `json:"pid,omitempty"`
+	Tid       uint32   `json:"tid,omitempty"`
+	Comm      string   `json:"comm,omitempty"`
+	Operation string   `json:"operation,omitempty"`
+	Retval    int      `json:"ret,omitempty"`
+	Latency   uint64   `json:"latency,omitempty"`
+	Fs        string   `json:"fs,omitempty"`
+	Source    string   `json:"source,omitempty"`
+	Target    string   `json:"target,omitempty"`
+	Data      string   `json:"data,omitempty"`
+	Flags     []string `json:"flags,omitempty"`
+	FlagsRaw  uint64   `json:"flagsRaw,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/network-graph.md
+++ b/docs/gadgets/network-graph.md
@@ -45,3 +45,55 @@ $ kubectl annotate -n gadget trace/network-graph \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/network/types"
+
+
+FUNCTIONS
+
+func EventsString(edges []Event) string
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	PktType string `json:"pktType,omitempty"`
+	Proto   string `json:"proto,omitempty"`
+	IP      string `json:"ip,omitempty"`
+	Port    int    `json:"port,omitempty"`
+
+	/* pod, svc or other */
+	RemoteKind string `json:"remoteKind,omitempty"`
+
+	PodHostIP string            `json:"podHostIP,omitempty"`
+	PodIP     string            `json:"podIP,omitempty"`
+	PodOwner  string            `json:"podOwner,omitempty"`
+	PodLabels map[string]string `json:"podLabels,omitempty"`
+
+	/* if RemoteKind = svc */
+	RemoteSvcNamespace     string            `json:"remoteServiceNamespace,omitempty"`
+	RemoteSvcName          string            `json:"remoteServiceName,omitempty"`
+	RemoteSvcLabelSelector map[string]string `json:"remoteServiceLabelSelector,omitempty"`
+
+	/* if RemoteKind = pod */
+	RemotePodNamespace string            `json:"remotePodNamespace,omitempty"`
+	RemotePodName      string            `json:"remotePodName,omitempty"`
+	RemotePodLabels    map[string]string `json:"remotePodLabels,omitempty"`
+
+	/* if RemoteKind = other */
+	RemoteOther string `json:"remoteOther,omitempty"`
+
+	Debug string `json:"debug,omitempty"`
+}
+
+func Unique(edges []Event) []Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+func (e *Event) Key() string
+
+```

--- a/docs/gadgets/oomkill.md
+++ b/docs/gadgets/oomkill.md
@@ -45,3 +45,28 @@ $ kubectl annotate -n gadget trace/oomkill \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/oomkill/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	TriggeredPid  uint32 `json:"tpid,omitempty"`
+	TriggeredComm string `json:"tcomm,omitempty"`
+	KilledPid     uint32 `json:"kpid,omitempty"`
+	KilledComm    string `json:"kcomm,omitempty"`
+	Pages         uint64 `json:"pages,omitempty"`
+	MountNsID     uint64 `json:"mountnsid,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/opensnoop.md
+++ b/docs/gadgets/opensnoop.md
@@ -45,3 +45,30 @@ $ kubectl annotate -n gadget trace/opensnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/open/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	UID       uint32 `json:"uid,omitempty"`
+	Comm      string `json:"pcomm,omitempty"`
+	Fd        int    `json:"fd,omitempty"`
+	Ret       int    `json:"ret,omitempty"`
+	Err       int    `json:"err,omitempty"`
+	Path      string `json:"path,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/process-collector.md
+++ b/docs/gadgets/process-collector.md
@@ -39,3 +39,23 @@ $ kubectl annotate -n gadget trace/process-collector \
 ### Output Modes
 
 * Status
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/snapshot/process/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+	Tgid      int    `json:"tgid"`
+	Pid       int    `json:"pid"`
+	Command   string `json:"comm"`
+	MountNsID uint64 `json:"mntns"`
+}
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/seccomp.md
+++ b/docs/gadgets/seccomp.md
@@ -108,6 +108,9 @@ $ kubectl annotate -n gadget trace/seccomp \
 
 ### Output Modes
 
-* ExternalResource
-* Status
-* Stream
+* ExternalResource* Status* Stream
+
+### Types
+
+```go
+None```

--- a/docs/gadgets/sigsnoop.md
+++ b/docs/gadgets/sigsnoop.md
@@ -51,3 +51,28 @@ $ kubectl annotate -n gadget trace/sigsnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/signal/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Pid       uint32 `json:"pid,omitempty"`
+	TargetPid uint32 `json:"tpid,omitempty"`
+	Signal    string `json:"signal,omitempty"`
+	Retval    int    `json:"ret,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/snisnoop.md
+++ b/docs/gadgets/snisnoop.md
@@ -45,3 +45,23 @@ $ kubectl annotate -n gadget trace/snisnoop \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/sni/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Name string `json:"name,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/socket-collector.md
+++ b/docs/gadgets/socket-collector.md
@@ -40,3 +40,45 @@ $ kubectl annotate -n gadget trace/socket-collector \
 ### Output Modes
 
 * Status
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
+
+
+VARIABLES
+
+var ProtocolsMap = map[string]Proto{
+	"all": ALL,
+	"tcp": TCP,
+	"udp": UDP,
+}
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	Protocol      string `json:"protocol"`
+	LocalAddress  string `json:"localAddress"`
+	LocalPort     uint16 `json:"localPort"`
+	RemoteAddress string `json:"remoteAddress"`
+	RemotePort    uint16 `json:"remotePort"`
+	Status        string `json:"status"`
+	InodeNumber   uint64 `json:"inodeNumber"`
+}
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+type Proto int
+
+const (
+	INVALID Proto = iota
+	ALL
+	TCP
+	UDP
+)
+func ParseProtocol(protocol string) (Proto, error)
+
+```

--- a/docs/gadgets/tcpconnect.md
+++ b/docs/gadgets/tcpconnect.md
@@ -45,3 +45,30 @@ $ kubectl annotate -n gadget trace/tcpconnect \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcpconnect/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	UID       uint32 `json:"uid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	IPVersion int    `json:"ipversion,omitempty"`
+	Saddr     string `json:"saddr,omitempty"`
+	Daddr     string `json:"daddr,omitempty"`
+	Dport     uint16 `json:"dport,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/tcptracer.md
+++ b/docs/gadgets/tcptracer.md
@@ -45,3 +45,31 @@ $ kubectl annotate -n gadget trace/tcptracer \
 ### Output Modes
 
 * Stream
+
+### Types
+
+```go
+package types // import "github.com/kinvolk/inspektor-gadget/pkg/gadgets/trace/tcp/types"
+
+
+TYPES
+
+type Event struct {
+	eventtypes.Event
+
+	MountNsID uint64 `json:"mountnsid,omitempty"`
+	Pid       uint32 `json:"pid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	IPVersion int    `json:"ipversion,omitempty"`
+	Saddr     string `json:"saddr,omitempty"`
+	Daddr     string `json:"daddr,omitempty"`
+	Sport     uint16 `json:"sport,omitempty"`
+	Dport     uint16 `json:"dport,omitempty"`
+	Operation string `json:"operation,omitempty"`
+}
+
+func Base(ev eventtypes.Event) Event
+
+func (e Event) GetBaseEvent() eventtypes.Event
+
+```

--- a/docs/gadgets/traceloop.md
+++ b/docs/gadgets/traceloop.md
@@ -51,3 +51,8 @@ $ kubectl annotate -n gadget trace/traceloop \
 ### Output Modes
 
 * ExternalResource
+
+### Types
+
+```go
+None```


### PR DESCRIPTION
# Generate documentation for json returned by gadgets

Each gadget can return a stream of json events of different types and it is not consistently documented.

This PR is an attempt to automatically generate documentation for it.

Related: https://github.com/kinvolk/inspektor-gadget/issues/856
