### PR TITLE
ci: Use repository_owner instead of actor.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -186,7 +186,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Choose container repository and determine image tag
       id: choose-repo-determine-image-tag
@@ -226,7 +226,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Choose container repository and determine image tag
       id: choose-repo-determine-image-tag
@@ -406,7 +406,7 @@ jobs:
         registry: ${{ env.REGISTRY }}
         container_repo: ${{ steps.choose-repo-determine-image-tag.outputs.container-repo }}
         image_tag: ${{ steps.choose-repo-determine-image-tag.outputs.image-tag }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
   test-integration:
@@ -437,7 +437,7 @@ jobs:
         registry: ${{ env.REGISTRY }}
         container_repo: ${{ steps.choose-repo-determine-image-tag.outputs.container-repo }}
         image_tag: ${{ steps.choose-repo-determine-image-tag.outputs.image-tag }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
   release:


### PR DESCRIPTION
Hi.


In this PR, I replaced all mentions of `${{ github.actor }}` by `${{ github.repository_owner }}`.
The goal of this is to permit external contributor to push to `inspetor-gadget-dev` by having their image pushed by `kinvolk`.

**We should be really careful to not click too quickly on the button to run the CI for external contributor to avoid having an image full of cryptominers pushed to our `dev` package.**


Best regards. 