### PR TITLE
ci: Use GITHUB_HEAD_REF to craft image tag.

### DIFF
--- a/.github/actions/choose-container-repo-and-determine-image-tag/action.yml
+++ b/.github/actions/choose-container-repo-and-determine-image-tag/action.yml
@@ -53,9 +53,17 @@ runs:
       id: craft-image-tag
       shell: bash
       run: |
-        # If GITHUB_REF_NAME is 'foo/bar', image_tag will be 'foo-bar', we need
-        # this because it is not possible to have slash in image tag.
-        image_tag=${GITHUB_REF_NAME/\//-}
+        # GITHUB_HEAD_REF is set only when workflow is related to a PR.
+        # So, in case of push to main or a tag, we need to use GITHUB_REF_NAME.
+        if [ -z "${GITHUB_HEAD_REF}" ]; then
+          ref=$GITHUB_REF_NAME
+        else
+          ref=$GITHUB_HEAD_REF
+        fi
+
+        # If ref is 'foo/bar', image_tag will be 'foo-bar', we need this because
+        # it is forbidden to have slash in image tag.
+        image_tag=${ref/\//-}
         if [ "$image_tag" = "main" ]; then
             image_tag="latest"
         fi


### PR DESCRIPTION
GITHUB_HEAD_REF only exists when the workflow was triggered by a pull request.
In this case, we get the branch name from this variable.
When pushing a tag or to main, we continue to use GITHUB_REF_NAME.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
