### PR TITLE
pkg/snapshotcombiner: introduce SnapshotCombiner to handle combining and caching stats

### DIFF
--- a/pkg/snapshotcombiner/snapshotcombiner.go
+++ b/pkg/snapshotcombiner/snapshotcombiner.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshotcombiner
+
+import (
+	"sync"
+	"time"
+)
+
+// Stats contains the status of the SnapshotCombiner when calling GetSnapshots()
+type Stats struct {
+	Epochs           int // Number of calls to GetSnapshots()
+	CurrentSnapshots int // Number of wrappedSnapshots that have been updated since the previous call to GetSnapshots()
+	ExpiredSnapshots int // Number of wrappedSnapshots that have a ttl of 0
+	TotalSnapshots   int // Number of wrappedSnapshots known
+}
+
+type snapshotWrapper[T any] struct {
+	snapshot   []*T
+	ttl        int
+	count      int
+	lastUpdate time.Time
+}
+
+type SnapshotCombiner[T any] struct {
+	lock             sync.Mutex
+	defaultTTL       int
+	wrappedSnapshots map[string]*snapshotWrapper[T]
+	epoch            int
+}
+
+// NewSnapshotCombiner creates a new wrappedSnapshots combiner that stores structs of type T using a key. Each key is
+// given a time-to-live (ttl) and only valid for ttl calls of GetSnapshots(). Whenever a key is refreshed using
+// AddSnapshot(), the ttl will be reset to the initial value.
+func NewSnapshotCombiner[T any](ttl int) *SnapshotCombiner[T] {
+	return &SnapshotCombiner[T]{
+		defaultTTL:       ttl,
+		wrappedSnapshots: make(map[string]*snapshotWrapper[T]),
+	}
+}
+
+// AddSnapshot adds the given snapshot to the given key (e.g. a node name) and set its ttl to the defaultTTL of the
+// SnapshotCombiner
+func (sc *SnapshotCombiner[T]) AddSnapshot(key string, snapshot []*T) {
+	now := time.Now()
+
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	if entry, ok := sc.wrappedSnapshots[key]; ok {
+		entry.snapshot = snapshot
+		entry.ttl = sc.defaultTTL
+		entry.count++
+		entry.lastUpdate = now
+		return
+	}
+	sc.wrappedSnapshots[key] = &snapshotWrapper[T]{
+		snapshot:   snapshot,
+		ttl:        sc.defaultTTL,
+		count:      1,
+		lastUpdate: now,
+	}
+}
+
+// GetSnapshots combines all stored wrappedSnapshots from all keys and decreases each keys defaultTTL by one.
+// If the ttl of an entry is less than zero, it will not be returned anymore.
+func (sc *SnapshotCombiner[T]) GetSnapshots() ([]*T, Stats) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	// increase epoch
+	sc.epoch++
+
+	stats := Stats{
+		Epochs: sc.epoch,
+	}
+
+	result := make([]*T, 0, len(sc.wrappedSnapshots))
+	for _, wrapper := range sc.wrappedSnapshots {
+		if wrapper.ttl == sc.defaultTTL {
+			stats.CurrentSnapshots++
+		}
+		if wrapper.ttl > 0 {
+			result = append(result, wrapper.snapshot...)
+			wrapper.ttl--
+		} else {
+			stats.ExpiredSnapshots++
+		}
+	}
+
+	stats.TotalSnapshots = len(sc.wrappedSnapshots)
+
+	return result, stats
+}

--- a/pkg/snapshotcombiner/snapshotcombiner_test.go
+++ b/pkg/snapshotcombiner/snapshotcombiner_test.go
@@ -1,0 +1,108 @@
+// Copyright 2022-2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshotcombiner
+
+import "testing"
+
+func TestSnapshotCombiner(t *testing.T) {
+	ttl := 2
+	sc := NewSnapshotCombiner[int](ttl)
+
+	type testRun struct {
+		Name            string
+		IntervalStats   map[string][]*int
+		ExpectedEntries int
+	}
+
+	data1 := 1
+	data2 := 2
+	data3 := 3
+	data4 := 4
+
+	testSteps := []testRun{
+		{
+			Name: "No snapshots sent, should return an empty result",
+		},
+		{
+			Name: "one node sends a snapshot",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1},
+			},
+			ExpectedEntries: 1,
+		},
+		{
+			Name:            "no node sends snapshots, old snapshots should still be there",
+			ExpectedEntries: 1,
+		},
+		{
+			Name: "no node sends snapshots, old snapshots should have gotten deleted",
+		},
+
+		{
+			Name: "one node sends a snapshot",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1},
+			},
+			ExpectedEntries: 1,
+		},
+		{
+			Name: "same node sends a snapshot (defaultTTL refresh), still one result",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1},
+			},
+			ExpectedEntries: 1,
+		},
+		{
+			Name:            "no node sends snapshots, old snapshots should still be there",
+			ExpectedEntries: 1,
+		},
+		{
+			Name: "no node sends snapshots, old snapshots should have gotten deleted",
+		},
+
+		{
+			Name: "two nodes send snapshots with two entries each",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1, &data2},
+				"node2": {&data3, &data4},
+			},
+			ExpectedEntries: 4,
+		},
+		{
+			Name: "only one of the two nodes sends a snapshot in the next interval, still all 4 entries should show",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1, &data2},
+			},
+			ExpectedEntries: 4,
+		},
+		{
+			Name: "still only one of the two nodes sends a snapshot, two entries from node2 should be lost now",
+			IntervalStats: map[string][]*int{
+				"node1": {&data1, &data2},
+			},
+			ExpectedEntries: 2,
+		},
+	}
+
+	for _, step := range testSteps {
+		for nodeName, nodeStats := range step.IntervalStats {
+			sc.AddSnapshot(nodeName, nodeStats)
+		}
+		res, _ := sc.GetSnapshots()
+		if len(res) != step.ExpectedEntries {
+			t.Errorf("expected %d, got %d", step.ExpectedEntries, len(res))
+		}
+	}
+}


### PR DESCRIPTION
# Add SnapshotCombiner to handle combining and caching stats for multiple nodes

This PR adds a new and simple SnapshotCombiner library that takes stats of nodes and returns them combined on request. 
It adds a caching mechanism, so that when no stats get reported for a node and a certain amount of intervals, "old" stats will be used. This should increase user experience by not "flickering" if a node doesn't report its stats in time. The tradeoff in doing this, is that for one interval (or the ttl given in the settings), the results will not be 100% accurate (but they won't accurate as well if results are missing).

## How to use

You create a new SnapshotCombiner and add stats via `AddSnapshot()` for each node once the node reports stats. Periodically, you request the combined stats using `GetSnapshots()`.

Every time stats get added, a `ttl` (time-to-live) timer is reset for the reporting node and everytime stats are requested, all `ttl` values of all nodes will be decreased by one. Once a node reaches a ttl of zero, it won't be returned anymore.

Fixes #852 