### PR TITLE
ci: Fix step name.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -236,7 +236,7 @@ jobs:
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/Dockerfiles/gadget-${{ matrix.type }}.Dockerfile
         build-args: |
           ENABLE_BTFGEN=true
-        outputs: type=registry,name=${{ steps.choose-repo-determine-image-tag.outputs.container-repo }},push=true,push-by-digest=true
+        outputs: type=registry,name=${{ steps.set-repo-determine-image-tag.outputs.image-tag.outputs.container-repo }},push=true,push-by-digest=true
         cache-from: type=local,src=/tmp/.buildx-cache-docker
         cache-to: type=local,dest=/tmp/.buildx-cache-registry
         platforms: ${{ matrix.os }}/${{ matrix.platform }}


### PR DESCRIPTION
Commit 83de71183f00 ("ci: Remove references to development container repository.") modified one action name.
Sadly, with some rebase, the name was forgotten to be changed in one place.

Fixes: 83de71183f00 ("ci: Remove references to development container repository.")
Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>