### PR TITLE
pkg/gadgets/trace/{block-io, tcpconnect}: Remove BPF_F_NO_PREALLOC.

### DIFF
--- a/pkg/gadgets/profile/block-io/tracer/bpf/biolatency.bpf.c
+++ b/pkg/gadgets/profile/block-io/tracer/bpf/biolatency.bpf.c
@@ -33,7 +33,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct request *);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } start SEC(".maps");
 
 static struct hist initial_hist;
@@ -43,7 +42,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct hist_key);
 	__type(value, struct hist);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } hists SEC(".maps");
 
 static __always_inline

--- a/pkg/gadgets/trace/tcpconnect/tracer/bpf/tcpconnect.bpf.c
+++ b/pkg/gadgets/trace/tcpconnect/tracer/bpf/tcpconnect.bpf.c
@@ -27,7 +27,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, u32);
 	__type(value, struct sock *);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } sockets SEC(".maps");
 
 struct {
@@ -35,7 +34,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct ipv4_flow_key);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } ipv4_count SEC(".maps");
 
 struct {
@@ -43,7 +41,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct ipv6_flow_key);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } ipv6_count SEC(".maps");
 
 struct {


### PR DESCRIPTION
biolatency.bpf.c and tcpconnect.bpf.c were taken from iovisor/bcc. These two tools were updated upstream to remove the use of this specific flag, as it can cause deadlock according a kernel commit [1, 2].

This commit synchronizes with the recent upstream change.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1] https://github.com/iovisor/bcc/commit/45f5df4c5942 [2] https://github.com/torvalds/linux/commit/94dacdbd5d2d
