### PR TITLE
btfgen: Check BTF file exists before calling btfgen.

### DIFF
--- a/Makefile.btfgen
+++ b/Makefile.btfgen
@@ -38,7 +38,7 @@ $(MIN_CORE_BTF_FILES): $(BPF_PROGS_O_FILES)
 $(OUTPUT)/%.btf: $(BTFHUB_ARCHIVE)/%.btf
 	$(call msg,BTFGEN,$@)
 	$(Q)mkdir -p "$(@D)"
-	$(Q)$(BPFTOOL) gen min_core_btf $< $@ $(BPF_PROGS_O_FILES)
+	$(Q)if [ -f $< ]; then $(BPFTOOL) gen min_core_btf $< $@ $(BPF_PROGS_O_FILES); else echo "$< does not exist!" >&2; fi
 
 # delete failed targets
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Hi.


This PR adds a check to verify BTF directory is not empty before calling btfgen.
It is related to aquasecurity/btfhub-archive#6.


Best regards.