### PR TITLE
Dockerfiles: Bump bcc image tag.

### DIFF
--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -6,7 +6,7 @@ ARG BUILDER_IMAGE=debian:bullseye
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/CONTRIBUTING.md for further details.
-ARG BCC="quay.io/kinvolk/bcc:7d56a6f6920826a62a3cc0dc7fc302bf3cdf2618-focal-release"
+ARG BCC="quay.io/kinvolk/bcc:b3b9bd12109fefce4dc31314cecdaeac5bf0d83e-focal-release"
 
 FROM ${BCC} as bcc
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder


### PR DESCRIPTION
We recently merged a commit in our bcc's fork to synchronize the JSON key with recent modifications in Inspektor Gadget [1].
This commit uses the last flavour of our fork image.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1] https://github.com/kinvolk/bcc/commit/1e1bb3fe4bac