### PR TITLE
Makefile: Use Makefile stem to make gadget container targets more generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,21 +112,18 @@ install/kubectl-gadget: kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
 	mkdir -p ~/.local/bin/
 	cp kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) ~/.local/bin/kubectl-gadget
 
-# gadget BCC container image
-.PHONY: gadget-default-container
-gadget-default-container:
-	docker buildx build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f Dockerfiles/gadget-default.Dockerfile \
+GADGET_CONTAINERS = \
+	gadget-default-container \
+	gadget-core-container
+
+gadget-container-all: $(GADGET_CONTAINERS)
+
+gadget-%-container:
+	docker buildx build -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) -f Dockerfiles/gadget-$*.Dockerfile \
 		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
 
-# gadget CO-RE container image
-.PHONY: gadget-core-container
-gadget-core-container:
-	docker buildx build -t $(CONTAINER_REPO):$(IMAGE_TAG) -f Dockerfiles/gadget-core.Dockerfile \
-		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
-
-.PHONY: push-gadget-container
-push-gadget-container:
-	docker push $(CONTAINER_REPO):$(IMAGE_TAG)
+push-gadget-%-container:
+	docker push $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,)
 
 # kubectl-gadget container image
 .PHONY: kubectl-gadget-container

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,7 +46,7 @@ You can build and push the container gadget image by running the following comma
 
 ```bash
 $ make gadget-default-container # or make gadget-core-container
-$ make push-gadget-container
+$ make push-gadget-default-container
 ```
 
 The eBPF code is built using a Docker container, so you don't have to worry


### PR DESCRIPTION
Hi.


In this PR, I used Makefile stem to make the targets related to gadget containers more generic.


Best regards.