### PR TITLE
cmd/local-gadget: Add Kubernetes metadata

### DIFF
--- a/cmd/common/audit/seccomp.go
+++ b/cmd/common/audit/seccomp.go
@@ -71,13 +71,13 @@ func (p *SeccompParser) TransformEvent(e *types.Event) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.KubernetesNode))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Namespace))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.KubernetesNamespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Pod))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.KubernetesPodName))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.Container))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], e.KubernetesContainerName))
 			case "pid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], e.Pid))
 			case "comm":

--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -91,13 +91,13 @@ func (p *ProcessParser) TransformToColumns(e *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%s", e.Node))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%s", e.Namespace))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%s", e.Pod))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%s", e.Container))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesContainerName))
 		case "comm":
 			sb.WriteString(fmt.Sprintf("%s", e.Command))
 		case "tgid":
@@ -127,14 +127,14 @@ func (p *ProcessParser) SortEvents(allProcesses *[]types.Event) {
 	sort.Slice(*allProcesses, func(i, j int) bool {
 		pi, pj := (*allProcesses)[i], (*allProcesses)[j]
 		switch {
-		case pi.Node != pj.Node:
-			return pi.Node < pj.Node
-		case pi.Namespace != pj.Namespace:
-			return pi.Namespace < pj.Namespace
-		case pi.Pod != pj.Pod:
-			return pi.Pod < pj.Pod
-		case pi.Container != pj.Container:
-			return pi.Container < pj.Container
+		case pi.KubernetesNode != pj.KubernetesNode:
+			return pi.KubernetesNode < pj.KubernetesNode
+		case pi.KubernetesNamespace != pj.KubernetesNamespace:
+			return pi.KubernetesNamespace < pj.KubernetesNamespace
+		case pi.KubernetesPodName != pj.KubernetesPodName:
+			return pi.KubernetesPodName < pj.KubernetesPodName
+		case pi.KubernetesContainerName != pj.KubernetesContainerName:
+			return pi.KubernetesContainerName < pj.KubernetesContainerName
 		case pi.Command != pj.Command:
 			return pi.Command < pj.Command
 		case pi.Tgid != pj.Tgid:

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -82,11 +82,11 @@ func (s *SocketParser) TransformToColumns(e *types.Event) string {
 	for _, col := range s.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%s", e.Node))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%s", e.Namespace))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%s", e.Pod))
+			sb.WriteString(fmt.Sprintf("%s", e.KubernetesPodName))
 		case "protocol":
 			sb.WriteString(fmt.Sprintf("%s", e.Protocol))
 		case "local":
@@ -110,12 +110,12 @@ func (s *SocketParser) SortEvents(allSockets *[]types.Event) {
 	sort.Slice(*allSockets, func(i, j int) bool {
 		si, sj := (*allSockets)[i], (*allSockets)[j]
 		switch {
-		case si.Node != sj.Node:
-			return si.Node < sj.Node
-		case si.Namespace != sj.Namespace:
-			return si.Namespace < sj.Namespace
-		case si.Pod != sj.Pod:
-			return si.Pod < sj.Pod
+		case si.KubernetesNode != sj.KubernetesNode:
+			return si.KubernetesNode < sj.KubernetesNode
+		case si.KubernetesNamespace != sj.KubernetesNamespace:
+			return si.KubernetesNamespace < sj.KubernetesNamespace
+		case si.KubernetesPodName != sj.KubernetesPodName:
+			return si.KubernetesPodName < sj.KubernetesPodName
 		case si.Protocol != sj.Protocol:
 			return si.Protocol < sj.Protocol
 		case si.Status != sj.Status:

--- a/cmd/common/trace/tcpconnect.go
+++ b/cmd/common/trace/tcpconnect.go
@@ -69,13 +69,13 @@ func (p *TcpconnectParser) TransformIntoColumns(event *tcpconnectTypes.Event) st
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesContainerName))
 		case "pid":
 			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
 		case "comm":

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -37,10 +37,10 @@ func ManageSpecialEvent(e eventtypes.Event, verbose bool) {
 		fallthrough
 	case eventtypes.INFO:
 		podMsgSuffix := ""
-		if e.Namespace != "" && e.Pod != "" {
-			podMsgSuffix = ", pod " + e.Namespace + "/" + e.Pod
+		if e.KubernetesNamespace != "" && e.KubernetesPodName != "" {
+			podMsgSuffix = ", pod " + e.KubernetesNamespace + "/" + e.KubernetesPodName
 		}
 
-		fmt.Fprintf(os.Stderr, "%s: node %s%s: %s\n", e.Type, e.Node, podMsgSuffix, e.Message)
+		fmt.Fprintf(os.Stderr, "%s: node %s%s: %s\n", e.Type, e.KubernetesNode, podMsgSuffix, e.Message)
 	}
 }

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -190,13 +190,13 @@ func (p *CPUParser) TransformReport(report *types.Report) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.KubernetesNode))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.Namespace))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.KubernetesNamespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.Pod))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.KubernetesPodName))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.Container))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], report.KubernetesContainerName))
 			case "pid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], report.Pid))
 			case "comm":

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -234,13 +234,13 @@ func (p *BlockIOParser) TransformStats(stats *types.Stats) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNode))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Namespace))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNamespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Pod))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesPodName))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Container))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesContainerName))
 			case "pid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
 			case "comm":

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -230,7 +230,7 @@ func (p *EbpfParser) PrintStats() {
 	stats := []types.Stats{}
 	for node, stat := range p.nodeStats {
 		for i := range stat {
-			stat[i].Node = node
+			stat[i].KubernetesNode = node
 		}
 		stats = append(stats, stat...)
 	}
@@ -255,7 +255,7 @@ func (p *EbpfParser) TransformStats(stats *types.Stats) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNode))
 			case "progid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.ProgramID))
 			case "type":

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -239,13 +239,13 @@ func (p *FileParser) TransformStats(stats *types.Stats) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNode))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Namespace))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNamespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Pod))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesPodName))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Container))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesContainerName))
 			case "pid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
 			case "tid":

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -259,13 +259,13 @@ func (p *TCPParser) TransformStats(stats *types.Stats) string {
 		for _, col := range p.OutputConfig.CustomColumns {
 			switch col {
 			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNode))
 			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Namespace))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesNamespace))
 			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Pod))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesPodName))
 			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Container))
+				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.KubernetesContainerName))
 			case "pid":
 				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
 			case "comm":

--- a/cmd/kubectl-gadget/trace/fsslower.go
+++ b/cmd/kubectl-gadget/trace/fsslower.go
@@ -144,13 +144,13 @@ func (p *FsslowerParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesContainerName))
 		case "pid":
 			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
 		case "comm":

--- a/cmd/kubectl-gadget/trace/mount.go
+++ b/cmd/kubectl-gadget/trace/mount.go
@@ -114,13 +114,13 @@ func (p *MountParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesContainerName))
 		case "pid":
 			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
 		case "tid":

--- a/cmd/kubectl-gadget/trace/network.go
+++ b/cmd/kubectl-gadget/trace/network.go
@@ -85,7 +85,7 @@ func NewNetworkParser(outputConfig *commonutils.OutputConfig) commontrace.TraceP
 func (p *NetworkParser) TransformIntoColumns(event *types.Event) string {
 	var sb strings.Builder
 
-	if event.Pod == "" {
+	if event.KubernetesPodName == "" {
 		// ignore events on host netns for now
 		return ""
 	}
@@ -105,11 +105,11 @@ func (p *NetworkParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "type":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.PktType))
 		case "proto":

--- a/cmd/kubectl-gadget/trace/oomkill.go
+++ b/cmd/kubectl-gadget/trace/oomkill.go
@@ -92,13 +92,13 @@ func (p *OOMKillParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesContainerName))
 		case "kpid":
 			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.KilledPid))
 		case "kcomm":

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -92,13 +92,13 @@ func (p *OpenParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesContainerName))
 		case "pid":
 			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
 		case "comm":

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -82,11 +82,11 @@ func (p *SNIParser) TransformIntoColumns(event *types.Event) string {
 	for _, col := range p.OutputConfig.CustomColumns {
 		switch col {
 		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNode))
 		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesNamespace))
 		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
+			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.KubernetesPodName))
 		case "name":
 			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Name))
 		default:

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -45,7 +45,7 @@ func NewListContainersCmd() *cobra.Command {
 			}
 
 			containers := localGadgetManager.GetContainersBySelector(&containercollection.ContainerSelector{
-				KubernetesContainerName: commonFlags.Containername,
+				RuntimeContainerName: commonFlags.Containername,
 			})
 
 			parser.Sort(containers, []string{"runtime", "name"})

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -39,7 +39,11 @@ func NewListContainersCmd() *cobra.Command {
 			}
 			defer localGadgetManager.Close()
 
-			parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, containercollection.GetColumns())
+			parser, err := commonutils.NewGadgetParserWithRuntimeInfo(
+				&commonFlags.OutputConfig,
+				containercollection.GetColumns(),
+				commonFlags.ShowK8sMetadata,
+			)
 			if err != nil {
 				return commonutils.WrapInErrParserCreate(err)
 			}
@@ -48,7 +52,7 @@ func NewListContainersCmd() *cobra.Command {
 				RuntimeContainerName: commonFlags.Containername,
 			})
 
-			parser.Sort(containers, []string{"runtime", "name"})
+			parser.Sort(containers, []string{"runtime", "container"})
 
 			switch commonFlags.OutputMode {
 			case commonutils.OutputModeJSON:

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -45,7 +45,7 @@ func NewListContainersCmd() *cobra.Command {
 			}
 
 			containers := localGadgetManager.GetContainersBySelector(&containercollection.ContainerSelector{
-				Name: commonFlags.Containername,
+				KubernetesContainerName: commonFlags.Containername,
 			})
 
 			parser.Sort(containers, []string{"runtime", "name"})

--- a/cmd/local-gadget/snapshot/snapshot.go
+++ b/cmd/local-gadget/snapshot/snapshot.go
@@ -44,7 +44,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 	// TODO: Improve filtering, see further details in
 	// https://github.com/kinvolk/inspektor-gadget/issues/644.
 	containerSelector := &containercollection.ContainerSelector{
-		Name: g.commonFlags.Containername,
+		KubernetesContainerName: g.commonFlags.Containername,
 	}
 
 	allEvents, err := g.runTracer(localGadgetManager, containerSelector)

--- a/cmd/local-gadget/snapshot/snapshot.go
+++ b/cmd/local-gadget/snapshot/snapshot.go
@@ -44,7 +44,7 @@ func (g *SnapshotGadget[Event]) Run() error {
 	// TODO: Improve filtering, see further details in
 	// https://github.com/kinvolk/inspektor-gadget/issues/644.
 	containerSelector := &containercollection.ContainerSelector{
-		KubernetesContainerName: g.commonFlags.Containername,
+		RuntimeContainerName: g.commonFlags.Containername,
 	}
 
 	allEvents, err := g.runTracer(localGadgetManager, containerSelector)

--- a/cmd/local-gadget/snapshot/socket.go
+++ b/cmd/local-gadget/snapshot/socket.go
@@ -55,7 +55,7 @@ func newSocketCmd() *cobra.Command {
 					// to be notified.
 					if container.Pid == 0 {
 						return nil, fmt.Errorf("container %q does not have PID",
-							container.Name)
+							container.KubernetesContainerName)
 					}
 
 					if _, ok := visitedNetNs[container.Netns]; ok {
@@ -66,8 +66,8 @@ func newSocketCmd() *cobra.Command {
 
 					netNsSockets, err := tracer.RunCollector(
 						container.Pid,
-						container.Podname,
-						container.Namespace,
+						container.KubernetesPodName,
+						container.KubernetesNamespace,
 						"",
 						flags.ParsedProtocol,
 					)

--- a/cmd/local-gadget/trace/bind.go
+++ b/cmd/local-gadget/trace/bind.go
@@ -32,7 +32,11 @@ func newBindCmd() *cobra.Command {
 	var flags commontrace.BindFlags
 
 	runCmd := func(*cobra.Command, []string) error {
-		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, bindTypes.GetColumns())
+		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(
+			&commonFlags.OutputConfig,
+			bindTypes.GetColumns(),
+			commonFlags.ShowK8sMetadata,
+		)
 		if err != nil {
 			return commonutils.WrapInErrParserCreate(err)
 		}

--- a/cmd/local-gadget/trace/exec.go
+++ b/cmd/local-gadget/trace/exec.go
@@ -31,7 +31,11 @@ func newExecCmd() *cobra.Command {
 	var commonFlags utils.CommonFlags
 
 	runCmd := func(*cobra.Command, []string) error {
-		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, execTypes.GetColumns())
+		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(
+			&commonFlags.OutputConfig,
+			execTypes.GetColumns(),
+			commonFlags.ShowK8sMetadata,
+		)
 		if err != nil {
 			return commonutils.WrapInErrParserCreate(err)
 		}

--- a/cmd/local-gadget/trace/tcp.go
+++ b/cmd/local-gadget/trace/tcp.go
@@ -31,7 +31,11 @@ func newTCPCmd() *cobra.Command {
 	var commonFlags utils.CommonFlags
 
 	runCmd := func(*cobra.Command, []string) error {
-		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, tcpTypes.GetColumns())
+		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(
+			&commonFlags.OutputConfig,
+			tcpTypes.GetColumns(),
+			commonFlags.ShowK8sMetadata,
+		)
 		if err != nil {
 			return commonutils.WrapInErrParserCreate(err)
 		}

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -53,7 +53,7 @@ func (g *TraceGadget[Event]) Run() error {
 	// TODO: Improve filtering, see further details in
 	// https://github.com/kinvolk/inspektor-gadget/issues/644.
 	containerSelector := containercollection.ContainerSelector{
-		Name: g.commonFlags.Containername,
+		KubernetesContainerName: g.commonFlags.Containername,
 	}
 
 	// Create mount namespace map to filter by containers

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -53,7 +53,7 @@ func (g *TraceGadget[Event]) Run() error {
 	// TODO: Improve filtering, see further details in
 	// https://github.com/kinvolk/inspektor-gadget/issues/644.
 	containerSelector := containercollection.ContainerSelector{
-		KubernetesContainerName: g.commonFlags.Containername,
+		RuntimeContainerName: g.commonFlags.Containername,
 	}
 
 	// Create mount namespace map to filter by containers

--- a/cmd/local-gadget/utils/flags.go
+++ b/cmd/local-gadget/utils/flags.go
@@ -36,6 +36,9 @@ type CommonFlags struct {
 	// Containername allows to filter containers by name.
 	Containername string
 
+	// Show Kubernetes metadata
+	ShowK8sMetadata bool
+
 	// The name of the container runtimes to be used separated by comma.
 	Runtimes string
 
@@ -121,6 +124,14 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		"c",
 		"",
 		"Show only data from containers with that name",
+	)
+
+	command.PersistentFlags().BoolVarP(
+		&commonFlags.ShowK8sMetadata,
+		"k8s-metadata",
+		"k",
+		false,
+		"Show Kubernetes metadata",
 	)
 
 	command.PersistentFlags().StringVarP(

--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -34,10 +34,10 @@ func main() {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
 			fmt.Printf("Container added: %q pid %d\n",
-				event.Container.Name, event.Container.Pid)
+				event.Container.KubernetesContainerName, event.Container.Pid)
 		case containercollection.EventTypeRemoveContainer:
 			fmt.Printf("Container removed: %q pid %d\n",
-				event.Container.Name, event.Container.Pid)
+				event.Container.KubernetesContainerName, event.Container.Pid)
 		}
 	}
 

--- a/examples/gadgets/formatter/trace/exec/exec.go
+++ b/examples/gadgets/formatter/trace/exec/exec.go
@@ -107,7 +107,7 @@ func main() {
 	// Create a tracer instance. This is the glue piece that allows
 	// this example to filter events by containers.
 	containerSelector := containercollection.ContainerSelector{
-		Name: containerName,
+		KubernetesContainerName: containerName,
 	}
 
 	if err := tracerCollection.AddTracer(traceName, containerSelector); err != nil {

--- a/examples/gadgets/withfilter/trace/exec/exec.go
+++ b/examples/gadgets/withfilter/trace/exec/exec.go
@@ -91,7 +91,7 @@ func main() {
 	// Define a callback to be called each time there is an event.
 	eventCallback := func(event types.Event) {
 		fmt.Printf("A new %q process with pid %d was executed in container %q\n",
-			event.Comm, event.Pid, event.Container)
+			event.Comm, event.Pid, event.KubernetesContainerName)
 	}
 
 	// Create a tracer instance. This is the glue piece that allows

--- a/examples/gadgets/withfilter/trace/exec/exec.go
+++ b/examples/gadgets/withfilter/trace/exec/exec.go
@@ -97,7 +97,7 @@ func main() {
 	// Create a tracer instance. This is the glue piece that allows
 	// this example to filter events by containers.
 	containerSelector := containercollection.ContainerSelector{
-		Name: containerName,
+		KubernetesContainerName: containerName,
 	}
 
 	if err := tracerCollection.AddTracer(traceName, containerSelector); err != nil {

--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -46,8 +46,8 @@ func publishEvent(c *containercollection.Container, reason, message string) {
 	eventTime := metav1.NewTime(time.Now())
 	event := &api.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v.%x", c.Podname, time.Now().UnixNano()),
-			Namespace: c.Namespace,
+			Name:      fmt.Sprintf("%v.%x", c.KubernetesPodName, time.Now().UnixNano()),
+			Namespace: c.KubernetesNamespace,
 		},
 		Source: api.EventSource{
 			Component: "KubeContainerCollection",
@@ -60,9 +60,9 @@ func publishEvent(c *containercollection.Container, reason, message string) {
 		LastTimestamp:       eventTime,
 		InvolvedObject: api.ObjectReference{
 			Kind:      "Pod",
-			Namespace: c.Namespace,
-			Name:      c.Podname,
-			UID:       types.UID(c.PodUID),
+			Namespace: c.KubernetesNamespace,
+			Name:      c.KubernetesPodName,
+			UID:       types.UID(c.KubernetesPodUID),
 		},
 		Type:    api.EventTypeNormal,
 		Reason:  reason,
@@ -72,7 +72,7 @@ func publishEvent(c *containercollection.Container, reason, message string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if _, err := client.CoreV1().Events(c.Namespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+	if _, err := client.CoreV1().Events(c.KubernetesNamespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create event: %s\n", err)
 	}
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -97,10 +97,10 @@ func BuildBaseEvent(namespace string) eventtypes.Event {
 	return eventtypes.Event{
 		Type: eventtypes.NORMAL,
 		CommonData: eventtypes.CommonData{
-			Namespace: namespace,
+			KubernetesNamespace: namespace,
 			// Pod and Container name are defined by BusyboxPodCommand.
-			Pod:       "test-pod",
-			Container: "test-pod",
+			KubernetesPodName:       "test-pod",
+			KubernetesContainerName: "test-pod",
 			// TODO: Include the Node
 		},
 	}

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -331,7 +331,7 @@ func TestBindsnoop(t *testing.T) {
 			}
 
 			normalize := func(e *bindTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.MountNsID = 0
 			}
@@ -416,7 +416,7 @@ func TestCapabilities(t *testing.T) {
 			}
 
 			normalize := func(e *capabilitiesTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.UID = 0
 				e.MountNsID = 0
@@ -466,11 +466,11 @@ func TestDns(t *testing.T) {
 
 			// DNS gadget doesn't provide container data. Remove it.
 			for _, entry := range expectedEntries {
-				entry.Container = ""
+				entry.KubernetesContainerName = ""
 			}
 
 			normalize := func(e *dnsTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
@@ -549,7 +549,7 @@ func TestExecsnoop(t *testing.T) {
 			}
 
 			normalize := func(e *execTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.Ppid = 0
 				e.UID = 0
@@ -823,7 +823,7 @@ func TestOpensnoop(t *testing.T) {
 			}
 
 			normalize := func(e *openTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.MountNsID = 0
 				e.Pid = 0
 				e.UID = 0
@@ -929,7 +929,7 @@ func TestSigsnoop(t *testing.T) {
 			}
 
 			normalize := func(e *signalTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.TargetPid = 0
 				e.Retval = 0
@@ -1063,7 +1063,7 @@ func TestTcptracer(t *testing.T) {
 			}
 
 			normalize := func(e *tcpTypes.Event) {
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.Saddr = ""
 				e.Sport = 0

--- a/integration/local-gadget/list_containers_test.go
+++ b/integration/local-gadget/list_containers_test.go
@@ -33,15 +33,12 @@ func TestListContainers(t *testing.T) {
 		Cmd:  fmt.Sprintf("local-gadget list-containers -o json --runtimes=%s", *containerRuntime),
 		ExpectedOutputFn: func(output string) error {
 			expectedContainer := &containercollection.Container{
-				Podname:   "test-pod",
-				Runtime:   *containerRuntime,
-				Namespace: ns,
+				KubernetesPodName:   "test-pod",
+				KubernetesNamespace: ns,
+				Runtime:             *containerRuntime,
 			}
 
 			normalize := func(c *containercollection.Container) {
-				// TODO: Handle it once we support getting K8s container name for docker
-				// Issue: https://github.com/kinvolk/inspektor-gadget/issues/737
-				c.Name = ""
 				c.ID = ""
 				c.Pid = 0
 				c.OciConfig = nil
@@ -52,8 +49,8 @@ func TestListContainers(t *testing.T) {
 				c.CgroupID = 0
 				c.CgroupV1 = ""
 				c.CgroupV2 = ""
-				c.Labels = nil
-				c.PodUID = ""
+				c.KubernetesLabels = nil
+				c.KubernetesPodUID = ""
 			}
 
 			var containers []*containercollection.Container
@@ -90,10 +87,8 @@ func TestListSingleContainer(t *testing.T) {
 	cn := fmt.Sprintf("%s-container", prefix)
 	ns := GenerateTestNamespaceName(fmt.Sprintf("%s-namespace", prefix))
 
-	// TODO: Handle it once we support getting K8s container name for docker
-	// Issue: https://github.com/kinvolk/inspektor-gadget/issues/737
 	if *containerRuntime == ContainerRuntimeDocker {
-		t.Skip("Skip TestListSingleContainer on docker since we don't propagate the Kubernetes pod container name")
+		t.Skip("Skip TestListSingleContainer on docker since it uses a different notation for naming Kubernetes containers")
 	}
 
 	TestPodYaml := fmt.Sprintf(`
@@ -118,10 +113,10 @@ spec:
 		Cmd:  fmt.Sprintf("local-gadget list-containers -o json --runtimes=%s --containername=%s", *containerRuntime, cn),
 		ExpectedOutputFn: func(output string) error {
 			expectedContainer := &containercollection.Container{
-				Name:      cn,
-				Podname:   po,
-				Runtime:   *containerRuntime,
-				Namespace: ns,
+				KubernetesContainerName: cn,
+				KubernetesPodName:       po,
+				KubernetesNamespace:     ns,
+				Runtime:                 *containerRuntime,
 			}
 
 			normalize := func(c *containercollection.Container) {
@@ -135,8 +130,8 @@ spec:
 				c.CgroupID = 0
 				c.CgroupV1 = ""
 				c.CgroupV2 = ""
-				c.Labels = nil
-				c.PodUID = ""
+				c.KubernetesLabels = nil
+				c.KubernetesPodUID = ""
 			}
 
 			var containers []*containercollection.Container

--- a/integration/local-gadget/trace_bind_test.go
+++ b/integration/local-gadget/trace_bind_test.go
@@ -41,9 +41,6 @@ func TestTraceBind(t *testing.T) {
 			}
 
 			normalize := func(e *bindTypes.Event) {
-				// TODO: Handle it once we support getting K8s container name for docker
-				// Issue: https://github.com/kinvolk/inspektor-gadget/issues/737
-				e.Container = "test-pod"
 				e.KubernetesNode = ""
 				e.Pid = 0
 				e.MountNsID = 0

--- a/integration/local-gadget/trace_bind_test.go
+++ b/integration/local-gadget/trace_bind_test.go
@@ -44,7 +44,7 @@ func TestTraceBind(t *testing.T) {
 				// TODO: Handle it once we support getting K8s container name for docker
 				// Issue: https://github.com/kinvolk/inspektor-gadget/issues/737
 				e.Container = "test-pod"
-				e.Node = ""
+				e.KubernetesNode = ""
 				e.Pid = 0
 				e.MountNsID = 0
 			}

--- a/pkg/columns/columns.go
+++ b/pkg/columns/columns.go
@@ -150,6 +150,24 @@ func (c ColumnMap[T]) VerifyColumnNames(columnNames []string) (valid []string, i
 	return
 }
 
+func (c ColumnMap[T]) RenameColumn(columnName string, newColumnName string) error {
+	column, ok := c[strings.ToLower(columnName)]
+	if !ok {
+		return fmt.Errorf("unknown column: %q", columnName)
+	}
+
+	_, ok = c[strings.ToLower(newColumnName)]
+	if ok {
+		return fmt.Errorf("column name already in use: %q", columnName)
+	}
+
+	column.Name = newColumnName
+	c[newColumnName] = column
+	delete(c, strings.ToLower(columnName))
+
+	return nil
+}
+
 func (c *Columns[T]) iterateFields(t reflect.Type, sub []int) error {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
@@ -177,7 +195,7 @@ func (c *Columns[T]) iterateFields(t reflect.Type, sub []int) error {
 			Visible:      true,
 			Precision:    2,
 
-			Order: len(c.ColumnMap) * 10,
+			Order: (len(c.ColumnMap) + 1) * 10,
 		}
 
 		if sub == nil {

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -308,6 +308,8 @@ func (cc *ContainerCollection) Enrich(event *eventtypes.CommonData, mountnsid ui
 		event.KubernetesContainerName = container.KubernetesContainerName
 		event.KubernetesPodName = container.KubernetesPodName
 		event.KubernetesNamespace = container.KubernetesNamespace
+		event.Runtime = container.Runtime
+		event.RuntimeContainerName = container.RuntimeContainerName
 	}
 }
 

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -156,7 +156,7 @@ func (cc *ContainerCollection) AddContainer(container *Container) {
 func (cc *ContainerCollection) LookupMntnsByContainer(namespace, pod, container string) (mntns uint64) {
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
-		if namespace == c.Namespace && pod == c.Podname && container == c.Name {
+		if namespace == c.KubernetesNamespace && pod == c.KubernetesPodName && container == c.KubernetesContainerName {
 			mntns = c.Mntns
 			// container found, stop iterating
 			return false
@@ -190,8 +190,8 @@ func (cc *ContainerCollection) LookupMntnsByPod(namespace, pod string) map[strin
 	ret := make(map[string]uint64)
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
-		if namespace == c.Namespace && pod == c.Podname {
-			ret[c.Name] = c.Mntns
+		if namespace == c.KubernetesNamespace && pod == c.KubernetesPodName {
+			ret[c.KubernetesContainerName] = c.Mntns
 		}
 		return true
 	})
@@ -203,7 +203,7 @@ func (cc *ContainerCollection) LookupMntnsByPod(namespace, pod string) map[strin
 func (cc *ContainerCollection) LookupPIDByContainer(namespace, pod, container string) (pid uint32) {
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
-		if namespace == c.Namespace && pod == c.Podname && container == c.Name {
+		if namespace == c.KubernetesNamespace && pod == c.KubernetesPodName && container == c.KubernetesContainerName {
 			pid = c.Pid
 			// container found, stop iterating
 			return false
@@ -220,8 +220,8 @@ func (cc *ContainerCollection) LookupPIDByPod(namespace, pod string) map[string]
 	ret := make(map[string]uint32)
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
-		if namespace == c.Namespace && pod == c.Podname {
-			ret[c.Name] = c.Pid
+		if namespace == c.KubernetesNamespace && pod == c.KubernetesPodName {
+			ret[c.KubernetesContainerName] = c.Pid
 		}
 		return true
 	})
@@ -239,7 +239,7 @@ func (cc *ContainerCollection) LookupOwnerReferenceByMntns(mntns uint64) *metav1
 			ownerRef, err = c.GetOwnerReference()
 			if err != nil {
 				log.Warnf("Failed to get owner reference of %s/%s/%s: %s",
-					c.Namespace, c.Podname, c.Name, err)
+					c.KubernetesNamespace, c.KubernetesPodName, c.KubernetesContainerName, err)
 			}
 			// container found, stop iterating
 			return false
@@ -305,9 +305,9 @@ func (cc *ContainerCollection) Enrich(event *eventtypes.CommonData, mountnsid ui
 
 	container := cc.LookupContainerByMntns(mountnsid)
 	if container != nil {
-		event.Container = container.Name
-		event.Pod = container.Podname
-		event.Namespace = container.Namespace
+		event.Container = container.KubernetesContainerName
+		event.Pod = container.KubernetesPodName
+		event.Namespace = container.KubernetesNamespace
 	}
 }
 

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -301,13 +301,13 @@ func (cc *ContainerCollection) ContainerRangeWithSelector(
 }
 
 func (cc *ContainerCollection) Enrich(event *eventtypes.CommonData, mountnsid uint64) {
-	event.Node = cc.nodeName
+	event.KubernetesNode = cc.nodeName
 
 	container := cc.LookupContainerByMntns(mountnsid)
 	if container != nil {
-		event.Container = container.KubernetesContainerName
-		event.Pod = container.KubernetesPodName
-		event.Namespace = container.KubernetesNamespace
+		event.KubernetesContainerName = container.KubernetesContainerName
+		event.KubernetesPodName = container.KubernetesPodName
+		event.KubernetesNamespace = container.KubernetesNamespace
 	}
 }
 

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -57,11 +57,11 @@ type Container struct {
 	CgroupV2 string `json:"cgroupV2,omitempty"`
 
 	// Kubernetes metadata
-	Namespace string            `json:"namespace,omitempty"`
-	Podname   string            `json:"podname,omitempty"`
-	Name      string            `json:"name,omitempty" column:"name,width:30" columnTags:"runtime"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	PodUID    string            `json:"podUID,omitempty"`
+	KubernetesNamespace     string            `json:"kubernetesNamespace,omitempty"`
+	KubernetesPodName       string            `json:"kubernetesPodName,omitempty"`
+	KubernetesPodUID        string            `json:"kubernetesPodUID,omitempty"`
+	KubernetesContainerName string            `json:"kubernetesContainerName,omitempty" column:"name,width:30" columnTags:"runtime"`
+	KubernetesLabels        map[string]string `json:"kubernetesLabels,omitempty"`
 
 	ownerReference *metav1.OwnerReference
 }
@@ -108,8 +108,8 @@ func ownerReferenceEnrichment(
 ) error {
 	resGroupVersion := "v1"
 	resKind := "pods"
-	resName := container.Podname
-	resNamespace := container.Namespace
+	resName := container.KubernetesPodName
+	resNamespace := container.KubernetesNamespace
 
 	var highestOwnerRef *metav1.OwnerReference
 

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -67,10 +67,10 @@ type Container struct {
 }
 
 type ContainerSelector struct {
-	Namespace string
-	Podname   string
-	Labels    map[string]string
-	Name      string
+	KubernetesNamespace     string
+	KubernetesPodName       string
+	KubernetesLabels        map[string]string
+	KubernetesContainerName string
 }
 
 // GetOwnerReference returns the owner reference information of the

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -31,6 +31,9 @@ type Container struct {
 	// Container Runtime
 	Runtime string `json:"runtime,omitempty" column:"runtime,minWidth:5,maxWidth:10" columnTags:"runtime"`
 
+	// RuntimeContainerName is the container name given by the Container Runtime
+	RuntimeContainerName string `json:"runtimeContainerName,omitempty" column:"name,width:30" columnTags:"runtime"`
+
 	// ID is the container id, typically a 64 hexadecimal string
 	ID string `json:"id,omitempty" column:"id,width:13,maxWidth:64" columnTags:"runtime"`
 
@@ -60,7 +63,7 @@ type Container struct {
 	KubernetesNamespace     string            `json:"kubernetesNamespace,omitempty"`
 	KubernetesPodName       string            `json:"kubernetesPodName,omitempty"`
 	KubernetesPodUID        string            `json:"kubernetesPodUID,omitempty"`
-	KubernetesContainerName string            `json:"kubernetesContainerName,omitempty" column:"name,width:30" columnTags:"runtime"`
+	KubernetesContainerName string            `json:"kubernetesContainerName,omitempty"`
 	KubernetesLabels        map[string]string `json:"kubernetesLabels,omitempty"`
 
 	ownerReference *metav1.OwnerReference
@@ -71,6 +74,7 @@ type ContainerSelector struct {
 	KubernetesPodName       string
 	KubernetesLabels        map[string]string
 	KubernetesContainerName string
+	RuntimeContainerName    string
 }
 
 // GetOwnerReference returns the owner reference information of the

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -32,7 +32,7 @@ type Container struct {
 	Runtime string `json:"runtime,omitempty" column:"runtime,minWidth:5,maxWidth:10" columnTags:"runtime"`
 
 	// RuntimeContainerName is the container name given by the Container Runtime
-	RuntimeContainerName string `json:"runtimeContainerName,omitempty" column:"name,width:30" columnTags:"runtime"`
+	RuntimeContainerName string `json:"runtimeContainerName,omitempty" column:"runtimeContainerName,width:30" columnTags:"runtime"`
 
 	// ID is the container id, typically a 64 hexadecimal string
 	ID string `json:"id,omitempty" column:"id,width:13,maxWidth:64" columnTags:"runtime"`
@@ -60,10 +60,10 @@ type Container struct {
 	CgroupV2 string `json:"cgroupV2,omitempty"`
 
 	// Kubernetes metadata
-	KubernetesNamespace     string            `json:"kubernetesNamespace,omitempty"`
-	KubernetesPodName       string            `json:"kubernetesPodName,omitempty"`
-	KubernetesPodUID        string            `json:"kubernetesPodUID,omitempty"`
-	KubernetesContainerName string            `json:"kubernetesContainerName,omitempty"`
+	KubernetesNamespace     string            `json:"kubernetesNamespace,omitempty" column:"namespace,width:30" columnTags:"kubernetes"`
+	KubernetesPodName       string            `json:"kubernetesPodName,omitempty" column:"pod,width:30,ellipsis:middle" columnTags:"kubernetes"`
+	KubernetesPodUID        string            `json:"kubernetesPodUID,omitempty" column:"poduid,width:30,hide" columnTags:"kubernetes"`
+	KubernetesContainerName string            `json:"kubernetesContainerName,omitempty" column:"container,width:30" columnTags:"kubernetes"`
 	KubernetesLabels        map[string]string `json:"kubernetesLabels,omitempty"`
 
 	ownerReference *metav1.OwnerReference

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -125,12 +125,12 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []Container {
 		}
 
 		containerDef := Container{
-			ID:        idParts[1],
-			Namespace: pod.GetNamespace(),
-			Podname:   pod.GetName(),
-			Name:      s.Name,
-			Labels:    labels,
-			Pid:       uint32(containerData.Pid),
+			ID:                      idParts[1],
+			KubernetesNamespace:     pod.GetNamespace(),
+			KubernetesPodName:       pod.GetName(),
+			KubernetesContainerName: s.Name,
+			KubernetesLabels:        labels,
+			Pid:                     uint32(containerData.Pid),
 		}
 		containers = append(containers, containerDef)
 	}

--- a/pkg/container-collection/match.go
+++ b/pkg/container-collection/match.go
@@ -32,6 +32,9 @@ func ContainerSelectorMatches(s *ContainerSelector, c *Container) bool {
 	if s.KubernetesContainerName != "" && s.KubernetesContainerName != c.KubernetesContainerName {
 		return false
 	}
+	if s.RuntimeContainerName != "" && s.RuntimeContainerName != c.RuntimeContainerName {
+		return false
+	}
 	for sk, sv := range s.KubernetesLabels {
 		if cv, ok := c.KubernetesLabels[sk]; !ok || cv != sv {
 			return false

--- a/pkg/container-collection/match.go
+++ b/pkg/container-collection/match.go
@@ -23,17 +23,17 @@ import (
 // ContainerSelectorMatches tells if a container matches the criteria in a
 // container selector.
 func ContainerSelectorMatches(s *ContainerSelector, c *Container) bool {
-	if s.Namespace != "" && !slices.Contains(strings.Split(s.Namespace, ","), c.Namespace) {
+	if s.Namespace != "" && !slices.Contains(strings.Split(s.Namespace, ","), c.KubernetesNamespace) {
 		return false
 	}
-	if s.Podname != "" && s.Podname != c.Podname {
+	if s.Podname != "" && s.Podname != c.KubernetesPodName {
 		return false
 	}
-	if s.Name != "" && s.Name != c.Name {
+	if s.Name != "" && s.Name != c.KubernetesContainerName {
 		return false
 	}
 	for sk, sv := range s.Labels {
-		if cv, ok := c.Labels[sk]; !ok || cv != sv {
+		if cv, ok := c.KubernetesLabels[sk]; !ok || cv != sv {
 			return false
 		}
 	}

--- a/pkg/container-collection/match.go
+++ b/pkg/container-collection/match.go
@@ -23,16 +23,16 @@ import (
 // ContainerSelectorMatches tells if a container matches the criteria in a
 // container selector.
 func ContainerSelectorMatches(s *ContainerSelector, c *Container) bool {
-	if s.Namespace != "" && !slices.Contains(strings.Split(s.Namespace, ","), c.KubernetesNamespace) {
+	if s.KubernetesNamespace != "" && !slices.Contains(strings.Split(s.KubernetesNamespace, ","), c.KubernetesNamespace) {
 		return false
 	}
-	if s.Podname != "" && s.Podname != c.KubernetesPodName {
+	if s.KubernetesPodName != "" && s.KubernetesPodName != c.KubernetesPodName {
 		return false
 	}
-	if s.Name != "" && s.Name != c.KubernetesContainerName {
+	if s.KubernetesContainerName != "" && s.KubernetesContainerName != c.KubernetesContainerName {
 		return false
 	}
-	for sk, sv := range s.Labels {
+	for sk, sv := range s.KubernetesLabels {
 		if cv, ok := c.KubernetesLabels[sk]; !ok || cv != sv {
 			return false
 		}

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -35,9 +35,9 @@ func TestSelector(t *testing.T) {
 			match:       true,
 			selector:    &ContainerSelector{},
 			container: &Container{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
 			},
 		},
 		{
@@ -53,10 +53,10 @@ func TestSelector(t *testing.T) {
 				},
 			},
 			container: &Container{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
-				Labels: map[string]string{
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
+				KubernetesLabels: map[string]string{
 					"unrelated-label": "here",
 					"key1":            "value1",
 					"key2":            "value2",
@@ -71,9 +71,9 @@ func TestSelector(t *testing.T) {
 				Podname:   "this-pod",
 			},
 			container: &Container{
-				Namespace: "this-namespace",
-				Podname:   "a-misnamed-pod",
-				Name:      "this-container",
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "a-misnamed-pod",
+				KubernetesContainerName: "this-container",
 			},
 		},
 		{
@@ -89,10 +89,10 @@ func TestSelector(t *testing.T) {
 				},
 			},
 			container: &Container{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
-				Labels: map[string]string{
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
+				KubernetesLabels: map[string]string{
 					"key1": "value1",
 					"key2": "something-else",
 				},
@@ -106,9 +106,9 @@ func TestSelector(t *testing.T) {
 				Podname:   "this-pod",
 			},
 			container: &Container{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
 			},
 		},
 		{
@@ -119,9 +119,9 @@ func TestSelector(t *testing.T) {
 				Podname:   "this-pod",
 			},
 			container: &Container{
-				Namespace: "ns2",
-				Podname:   "this-pod",
-				Name:      "this-container",
+				KubernetesNamespace:     "ns2",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
 			},
 		},
 	}
@@ -147,14 +147,14 @@ func TestContainerResolver(t *testing.T) {
 	// Add 3 Containers
 	for i := 0; i < 3; i++ {
 		cc.AddContainer(&Container{
-			ID:         fmt.Sprintf("abcde%d", i),
-			Namespace:  "this-namespace",
-			Podname:    "my-pod",
-			Name:       fmt.Sprintf("container%d", i),
-			Mntns:      55555 + uint64(i),
-			Pid:        uint32(100 + i),
-			CgroupPath: "/none",
-			CgroupID:   1,
+			ID:                      fmt.Sprintf("abcde%d", i),
+			KubernetesNamespace:     "this-namespace",
+			KubernetesPodName:       "my-pod",
+			KubernetesContainerName: fmt.Sprintf("container%d", i),
+			Mntns:                   55555 + uint64(i),
+			Pid:                     uint32(100 + i),
+			CgroupPath:              "/none",
+			CgroupID:                1,
 			ownerReference: &metav1.OwnerReference{
 				UID: types.UID(fmt.Sprintf("abcde%d", i)),
 			},
@@ -245,16 +245,16 @@ func TestContainerResolver(t *testing.T) {
 
 	// Check LookupContainerByMntns
 	containerByMntns0 := cc.LookupContainerByMntns(55555)
-	if containerByMntns0.Name != "container0" {
+	if containerByMntns0.KubernetesContainerName != "container0" {
 		t.Fatalf("Error in LookupContainerByMntns: expected %s, found %s", "container0",
-			containerByMntns0.Name)
+			containerByMntns0.KubernetesContainerName)
 	}
 
 	// Check LookupContainerByMntns
 	containerByMntns2 := cc.LookupContainerByMntns(55555 + 2)
-	if containerByMntns2.Name != "container2" {
+	if containerByMntns2.KubernetesContainerName != "container2" {
 		t.Fatalf("Error in LookupContainerByMntns: expected %s, found %s", "container2",
-			containerByMntns2.Name)
+			containerByMntns2.KubernetesContainerName)
 	}
 
 	containerByMntnsNotFound := cc.LookupContainerByMntns(989898)
@@ -264,11 +264,11 @@ func TestContainerResolver(t *testing.T) {
 
 	// Add new container with same pod and container name of container0 but in different namespace
 	cc.AddContainer(&Container{
-		ID:        "abcde0-different",
-		Namespace: "another-namespace",
-		Podname:   "my-pod",
-		Name:      "container0",
-		Labels: map[string]string{
+		ID:                      "abcde0-different",
+		KubernetesNamespace:     "another-namespace",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container0",
+		KubernetesLabels: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -283,7 +283,7 @@ func TestContainerResolver(t *testing.T) {
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up containers by one label: invalid number of matches")
 	}
-	if v, found := selectedContainers[0].Labels["key1"]; !found || v != "value1" {
+	if v, found := selectedContainers[0].KubernetesLabels["key1"]; !found || v != "value1" {
 		t.Fatalf("Error while looking up containers by one label: unexpected container %+v",
 			selectedContainers[0])
 	}
@@ -300,7 +300,7 @@ func TestContainerResolver(t *testing.T) {
 		t.Fatalf("Error while looking up containers by multiple labels: invalid number of matches")
 	}
 	for sk, sv := range selector.Labels {
-		if v, found := selectedContainers[0].Labels[sk]; !found || v != sv {
+		if v, found := selectedContainers[0].KubernetesLabels[sk]; !found || v != sv {
 			t.Fatalf("Error while looking up containers by multiple labels: unexpected container %+v",
 				selectedContainers[0])
 		}
@@ -314,7 +314,7 @@ func TestContainerResolver(t *testing.T) {
 		t.Fatalf("Error while looking up containers by namespace: invalid number of matches")
 	}
 	for _, container := range selectedContainers {
-		if container.Namespace != "this-namespace" {
+		if container.KubernetesNamespace != "this-namespace" {
 			t.Fatalf("Error while looking up containers by namespace: unexpected container %+v",
 				container)
 		}
@@ -329,7 +329,7 @@ func TestContainerResolver(t *testing.T) {
 		t.Fatalf("Error while looking up containers by namespace and pod: invalid number of matches")
 	}
 	for _, container := range selectedContainers {
-		if container.Namespace != "this-namespace" || container.Podname != "my-pod" {
+		if container.KubernetesNamespace != "this-namespace" || container.KubernetesPodName != "my-pod" {
 			t.Fatalf("Error while looking up containers by namespace and pod: unexpected container %+v",
 				container)
 		}
@@ -343,7 +343,7 @@ func TestContainerResolver(t *testing.T) {
 		t.Fatalf("Error while looking up containers by name: invalid number of matches")
 	}
 	for _, container := range selectedContainers {
-		if container.Name != "container0" {
+		if container.KubernetesContainerName != "container0" {
 			t.Fatalf("Error while looking up containers by name: unexpected container %+v",
 				container)
 		}
@@ -358,7 +358,7 @@ func TestContainerResolver(t *testing.T) {
 		t.Fatalf("Error while looking up containers by name and pod: invalid number of matches")
 	}
 	for _, container := range selectedContainers {
-		if container.Podname != "my-pod" || container.Name != "container0" {
+		if container.KubernetesPodName != "my-pod" || container.KubernetesContainerName != "container0" {
 			t.Fatalf("Error while looking up containers by name and pod: unexpected container %+v",
 				container)
 		}
@@ -373,7 +373,7 @@ func TestContainerResolver(t *testing.T) {
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
 	}
-	if selectedContainers[0].Namespace != "this-namespace" || selectedContainers[0].Podname != "my-pod" || selectedContainers[0].Name != "container0" {
+	if selectedContainers[0].KubernetesNamespace != "this-namespace" || selectedContainers[0].KubernetesPodName != "my-pod" || selectedContainers[0].KubernetesContainerName != "container0" {
 		t.Fatalf("Error while looking up specific container: unexpected container %+v",
 			selectedContainers[0])
 	}
@@ -387,7 +387,7 @@ func TestContainerResolver(t *testing.T) {
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
 	}
-	if selectedContainers[0].Namespace != "another-namespace" || selectedContainers[0].Podname != "my-pod" || selectedContainers[0].Name != "container0" {
+	if selectedContainers[0].KubernetesNamespace != "another-namespace" || selectedContainers[0].KubernetesPodName != "my-pod" || selectedContainers[0].KubernetesContainerName != "container0" {
 		t.Fatalf("Error while looking up specific container: unexpected container %+v",
 			selectedContainers[0])
 	}
@@ -401,7 +401,7 @@ func TestContainerResolver(t *testing.T) {
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
 	}
-	if selectedContainers[0].Namespace != "this-namespace" || selectedContainers[0].Podname != "my-pod" || selectedContainers[0].Name != "container2" {
+	if selectedContainers[0].KubernetesNamespace != "this-namespace" || selectedContainers[0].KubernetesPodName != "my-pod" || selectedContainers[0].KubernetesContainerName != "container2" {
 		t.Fatalf("Error while looking up specific container: unexpected container %+v",
 			selectedContainers[0])
 	}

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -44,10 +44,10 @@ func TestSelector(t *testing.T) {
 			description: "Selector with all filters",
 			match:       true,
 			selector: &ContainerSelector{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
-				Labels: map[string]string{
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
+				KubernetesLabels: map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 				},
@@ -67,8 +67,8 @@ func TestSelector(t *testing.T) {
 			description: "Podname does not match",
 			match:       false,
 			selector: &ContainerSelector{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
+				KubernetesNamespace: "this-namespace",
+				KubernetesPodName:   "this-pod",
 			},
 			container: &Container{
 				KubernetesNamespace:     "this-namespace",
@@ -80,10 +80,10 @@ func TestSelector(t *testing.T) {
 			description: "One label doesn't match",
 			match:       false,
 			selector: &ContainerSelector{
-				Namespace: "this-namespace",
-				Podname:   "this-pod",
-				Name:      "this-container",
-				Labels: map[string]string{
+				KubernetesNamespace:     "this-namespace",
+				KubernetesPodName:       "this-pod",
+				KubernetesContainerName: "this-container",
+				KubernetesLabels: map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 				},
@@ -102,8 +102,8 @@ func TestSelector(t *testing.T) {
 			description: "Several namespaces without match",
 			match:       false,
 			selector: &ContainerSelector{
-				Namespace: "ns1,ns2,ns3",
-				Podname:   "this-pod",
+				KubernetesNamespace: "ns1,ns2,ns3",
+				KubernetesPodName:   "this-pod",
 			},
 			container: &Container{
 				KubernetesNamespace:     "this-namespace",
@@ -115,8 +115,8 @@ func TestSelector(t *testing.T) {
 			description: "Several namespaces with match",
 			match:       true,
 			selector: &ContainerSelector{
-				Namespace: "ns1,ns2,ns3",
-				Podname:   "this-pod",
+				KubernetesNamespace: "ns1,ns2,ns3",
+				KubernetesPodName:   "this-pod",
 			},
 			container: &Container{
 				KubernetesNamespace:     "ns2",
@@ -276,7 +276,7 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers with label 'key1=value1'
 	selectedContainers := cc.GetContainersBySelector(&ContainerSelector{
-		Labels: map[string]string{
+		KubernetesLabels: map[string]string{
 			"key1": "value1",
 		},
 	})
@@ -290,7 +290,7 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers with label 'key1=value1' and 'key2=value2'
 	selector := ContainerSelector{
-		Labels: map[string]string{
+		KubernetesLabels: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
 		},
@@ -299,7 +299,7 @@ func TestContainerResolver(t *testing.T) {
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up containers by multiple labels: invalid number of matches")
 	}
-	for sk, sv := range selector.Labels {
+	for sk, sv := range selector.KubernetesLabels {
 		if v, found := selectedContainers[0].KubernetesLabels[sk]; !found || v != sv {
 			t.Fatalf("Error while looking up containers by multiple labels: unexpected container %+v",
 				selectedContainers[0])
@@ -308,7 +308,7 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in 'this-namespace'
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
+		KubernetesNamespace: "this-namespace",
 	})
 	if len(selectedContainers) != 2 {
 		t.Fatalf("Error while looking up containers by namespace: invalid number of matches")
@@ -322,8 +322,8 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in 'this-namespace' and 'my-pod'
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "my-pod",
+		KubernetesNamespace: "this-namespace",
+		KubernetesPodName:   "my-pod",
 	})
 	if len(selectedContainers) != 2 {
 		t.Fatalf("Error while looking up containers by namespace and pod: invalid number of matches")
@@ -337,7 +337,7 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers named 'container0' anywhere
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Name: "container0",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 2 {
 		t.Fatalf("Error while looking up containers by name: invalid number of matches")
@@ -351,8 +351,8 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers named 'container0' in 'my-pod' but any namespace
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Podname: "my-pod",
-		Name:    "container0",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 2 {
 		t.Fatalf("Error while looking up containers by name and pod: invalid number of matches")
@@ -366,9 +366,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up container0 in 'this-namespace' and 'my-pod'
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "my-pod",
-		Name:      "container0",
+		KubernetesNamespace:     "this-namespace",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
@@ -380,9 +380,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up container0 in 'another-namespace' and 'my-pod'
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "another-namespace",
-		Podname:   "my-pod",
-		Name:      "container0",
+		KubernetesNamespace:     "another-namespace",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
@@ -394,9 +394,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up container2 in 'this-namespace' and 'my-pod'
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "my-pod",
-		Name:      "container2",
+		KubernetesNamespace:     "this-namespace",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container2",
 	})
 	if len(selectedContainers) != 1 {
 		t.Fatalf("Error while looking up specific container: invalid number of matches")
@@ -408,9 +408,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up a non-existent container
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "my-pod",
-		Name:      "non-existent",
+		KubernetesNamespace:     "this-namespace",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "non-existent",
 	})
 	if len(selectedContainers) != 0 {
 		t.Fatalf("Error while looking up a non-existent container")
@@ -418,8 +418,8 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in a non-existent pod
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "non-existent",
+		KubernetesNamespace: "this-namespace",
+		KubernetesPodName:   "non-existent",
 	})
 	if len(selectedContainers) != 0 {
 		t.Fatalf("Error while looking up containers in a non-existent pod")
@@ -427,9 +427,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in a non-existent pod
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "this-namespace",
-		Podname:   "non-existent",
-		Name:      "container0",
+		KubernetesNamespace:     "this-namespace",
+		KubernetesPodName:       "non-existent",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 0 {
 		t.Fatalf("Error while looking up containers in a non-existent namespace")
@@ -437,7 +437,7 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in a non-existent namespace
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "non-existent",
+		KubernetesNamespace: "non-existent",
 	})
 	if len(selectedContainers) != 0 {
 		t.Fatalf("Error while looking up containers in a non-existent namespace")
@@ -445,9 +445,9 @@ func TestContainerResolver(t *testing.T) {
 
 	// Look up containers in a non-existent namespace
 	selectedContainers = cc.GetContainersBySelector(&ContainerSelector{
-		Namespace: "non-existent",
-		Podname:   "my-pod",
-		Name:      "container0",
+		KubernetesNamespace:     "non-existent",
+		KubernetesPodName:       "my-pod",
+		KubernetesContainerName: "container0",
 	})
 	if len(selectedContainers) != 0 {
 		t.Fatalf("Error while looking up containers in a non-existent namespace")

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -42,14 +42,14 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	container.Runtime = containerData.Runtime
 
 	// Kubernetes
-	container.KubernetesNamespace = containerData.PodNamespace
-	container.KubernetesPodName = containerData.PodName
-	container.KubernetesPodUID = containerData.PodUID
+	container.KubernetesNamespace = containerData.KubernetesNamespace
+	container.KubernetesPodName = containerData.KubernetesPodName
+	container.KubernetesPodUID = containerData.KubernetesPodUID
 
 	// Notice we are temporarily using the runtime container name as the
 	// Kubernetes container name because the Container struct doesn't have that
 	// field, and we don't support filtering by runtime container name yet.
-	container.KubernetesContainerName = containerData.Name
+	container.KubernetesContainerName = containerData.RuntimeContainerName
 
 	// Some gadgets using the Trace CRD approach in local-gadget require the
 	// namespace and pod name to be set.
@@ -57,7 +57,7 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 		container.KubernetesNamespace = "default"
 	}
 	if container.KubernetesPodName == "" {
-		container.KubernetesPodName = containerData.Name
+		container.KubernetesPodName = containerData.RuntimeContainerName
 	}
 }
 
@@ -151,14 +151,14 @@ func WithContainerRuntimeEnrichment(runtime *containerutils.RuntimeConfig) Conta
 		for _, container := range containers {
 			if container.State != runtimeclient.StateRunning {
 				log.Debugf("Runtime enricher(%s): Skip container %q (ID: %s): not running",
-					runtime.Name, container.Name, container.ID)
+					runtime.Name, container.RuntimeContainerName, container.ID)
 				continue
 			}
 
 			containerDetails, err := runtimeClient.GetContainerDetails(container.ID)
 			if err != nil {
 				log.Debugf("Runtime enricher (%s): Skip container %q (ID: %s): couldn't find container: %s",
-					runtime.Name, container.Name, container.ID, err)
+					runtime.Name, container.RuntimeContainerName, container.ID, err)
 				continue
 			}
 

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -40,16 +40,13 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	// Runtime
 	container.ID = containerData.ID
 	container.Runtime = containerData.Runtime
+	container.RuntimeContainerName = containerData.RuntimeContainerName
 
 	// Kubernetes
 	container.KubernetesNamespace = containerData.KubernetesNamespace
 	container.KubernetesPodName = containerData.KubernetesPodName
 	container.KubernetesPodUID = containerData.KubernetesPodUID
-
-	// Notice we are temporarily using the runtime container name as the
-	// Kubernetes container name because the Container struct doesn't have that
-	// field, and we don't support filtering by runtime container name yet.
-	container.KubernetesContainerName = containerData.RuntimeContainerName
+	container.KubernetesContainerName = containerData.KubernetesContainerName
 
 	// Some gadgets using the Trace CRD approach in local-gadget require the
 	// namespace and pod name to be set.

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -48,14 +48,17 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	container.KubernetesPodUID = containerData.KubernetesPodUID
 	container.KubernetesContainerName = containerData.KubernetesContainerName
 
-	// Some gadgets using the Trace CRD approach in local-gadget require the
-	// namespace and pod name to be set.
-	if container.KubernetesNamespace == "" {
-		container.KubernetesNamespace = "default"
-	}
-	if container.KubernetesPodName == "" {
-		container.KubernetesPodName = containerData.RuntimeContainerName
-	}
+	// IMPORTANT: Temporary disabling this workaround to avoid showing wrong
+	// information for non-k8s containers. It implies that filtering feature
+	// will not work on local-gadget interactive mode.
+	// Some gadgets using the Trace CRD approach (interactive mode) in
+	// local-gadget require the namespace and pod name to be set.
+	// if container.KubernetesNamespace == "" {
+	// 	container.KubernetesNamespace = "default"
+	// }
+	// if container.KubernetesPodName == "" {
+	// 	container.KubernetesPodName = containerData.RuntimeContainerName
+	// }
 }
 
 func containerRuntimeEnricher(

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -146,10 +146,10 @@ func parseContainerDetailsData(runtimeName string, containerStatus *pb.Container
 	// Create container details structure to be filled.
 	containerDetailsData := &runtimeclient.ContainerDetailsData{
 		ContainerData: runtimeclient.ContainerData{
-			ID:      containerStatus.Id,
-			Name:    strings.TrimPrefix(containerStatus.GetMetadata().Name, "/"),
-			State:   containerStatusStateToRuntimeClientState(containerStatus.GetState()),
-			Runtime: runtimeName,
+			ID:                   containerStatus.Id,
+			RuntimeContainerName: strings.TrimPrefix(containerStatus.GetMetadata().Name, "/"),
+			State:                containerStatusStateToRuntimeClientState(containerStatus.GetState()),
+			Runtime:              runtimeName,
 		},
 	}
 
@@ -281,10 +281,10 @@ func containerStatusStateToRuntimeClientState(containerStatusState pb.ContainerS
 
 func CRIContainerToContainerData(runtimeName string, container *pb.Container) *runtimeclient.ContainerData {
 	containerData := &runtimeclient.ContainerData{
-		ID:      container.Id,
-		Name:    strings.TrimPrefix(container.GetMetadata().Name, "/"),
-		State:   containerStatusStateToRuntimeClientState(container.GetState()),
-		Runtime: runtimeName,
+		ID:                   container.Id,
+		RuntimeContainerName: strings.TrimPrefix(container.GetMetadata().Name, "/"),
+		State:                containerStatusStateToRuntimeClientState(container.GetState()),
+		Runtime:              runtimeName,
 	}
 
 	// Fill K8S information.

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -146,10 +146,10 @@ func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.C
 
 	containerDetailsData := runtimeclient.ContainerDetailsData{
 		ContainerData: runtimeclient.ContainerData{
-			ID:      containerJSON.ID,
-			Name:    strings.TrimPrefix(containerJSON.Name, "/"),
-			State:   containerStatusStateToRuntimeClientState(containerJSON.State.Status),
-			Runtime: Name,
+			ID:                   containerJSON.ID,
+			RuntimeContainerName: strings.TrimPrefix(containerJSON.Name, "/"),
+			State:                containerStatusStateToRuntimeClientState(containerJSON.State.Status),
+			Runtime:              Name,
 		},
 		Pid:         containerJSON.State.Pid,
 		CgroupsPath: string(containerJSON.HostConfig.Cgroup),
@@ -218,10 +218,10 @@ func containerStatusStateToRuntimeClientState(containerState string) (runtimeCli
 
 func DockerContainerToContainerData(container *dockertypes.Container) *runtimeclient.ContainerData {
 	containerData := &runtimeclient.ContainerData{
-		ID:      container.ID,
-		Name:    strings.TrimPrefix(container.Names[0], "/"),
-		State:   containerStatusStateToRuntimeClientState(container.State),
-		Runtime: Name,
+		ID:                   container.ID,
+		RuntimeContainerName: strings.TrimPrefix(container.Names[0], "/"),
+		State:                containerStatusStateToRuntimeClientState(container.State),
+		Runtime:              Name,
 	}
 
 	// Fill K8S information.

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -39,6 +39,9 @@ type ContainerData struct {
 	// Current state of the container.
 	State string
 
+	// Name of container in Kubernetes.
+	KubernetesContainerName string
+
 	// Unique identifier of pod running the container.
 	KubernetesPodUID string
 
@@ -90,9 +93,10 @@ const (
 )
 
 const (
-	containerLabelK8sPodName      = "io.kubernetes.pod.name"
-	containerLabelK8sPodNamespace = "io.kubernetes.pod.namespace"
-	containerLabelK8sPodUID       = "io.kubernetes.pod.uid"
+	containerLabelK8sContainerName = "io.kubernetes.container.name"
+	containerLabelK8sPodName       = "io.kubernetes.pod.name"
+	containerLabelK8sPodNamespace  = "io.kubernetes.pod.namespace"
+	containerLabelK8sPodUID        = "io.kubernetes.pod.uid"
 )
 
 // ContainerRuntimeClient defines the interface to communicate with the
@@ -130,6 +134,9 @@ func ParseContainerID(expectedRuntime, containerID string) (string, error) {
 }
 
 func EnrichWithK8sMetadata(container *ContainerData, labels map[string]string) {
+	if name, ok := labels[containerLabelK8sContainerName]; ok {
+		container.KubernetesContainerName = name
+	}
 	if podName, ok := labels[containerLabelK8sPodName]; ok {
 		container.KubernetesPodName = podName
 	}

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -22,30 +22,31 @@ import (
 // ContainerData contains container information returned from the container
 // runtime clients.
 type ContainerData struct {
-	// ID is the container ID without the container runtime prefix. For
-	// instance, "cri-o://" for CRI-O.
-	ID string
-
-	// Name is the container name. In the case the container runtime response
-	// with multiples, Name contains only the first element.
-	Name string
-
-	// Current state of the container.
-	State string
-
 	// Runtime is the name of the runtime (e.g. docker, cri-o, containerd). It
 	// is useful to distinguish who is the "owner" of each container in a list
 	// of containers collected from multiples runtimes.
 	Runtime string
 
+	// ID is the container ID without the container runtime prefix. For
+	// instance, "cri-o://" for CRI-O.
+	ID string
+
+	// RuntimeContainerName is the container name. In the case the container
+	// runtime response with multiples, RuntimeContainerName contains only the
+	// first element.
+	RuntimeContainerName string
+
+	// Current state of the container.
+	State string
+
 	// Unique identifier of pod running the container.
-	PodUID string
+	KubernetesPodUID string
 
 	// Name of the pod running the container.
-	PodName string
+	KubernetesPodName string
 
 	// Namespace of the pod running the container.
-	PodNamespace string
+	KubernetesNamespace string
 }
 
 // ContainerDetailsData contains container extra information returned from the
@@ -130,12 +131,12 @@ func ParseContainerID(expectedRuntime, containerID string) (string, error) {
 
 func EnrichWithK8sMetadata(container *ContainerData, labels map[string]string) {
 	if podName, ok := labels[containerLabelK8sPodName]; ok {
-		container.PodName = podName
+		container.KubernetesPodName = podName
 	}
 	if podNamespace, ok := labels[containerLabelK8sPodNamespace]; ok {
-		container.PodNamespace = podNamespace
+		container.KubernetesNamespace = podNamespace
 	}
 	if podUID, ok := labels[containerLabelK8sPodUID]; ok {
-		container.PodUID = podUID
+		container.KubernetesPodUID = podUID
 	}
 }

--- a/pkg/gadget-collection/gadgets/advise/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/advise/seccomp/gadget.go
@@ -345,13 +345,13 @@ func (t *Trace) containerTerminated(trace *gadgetv1alpha1.Trace, event container
 	// The container has terminated. Cleanup the BPF hash map
 	traceSingleton.tracer.Delete(event.Container.Mntns)
 
-	namespacedName := fmt.Sprintf("%s/%s", event.Container.Namespace, event.Container.Podname)
+	namespacedName := fmt.Sprintf("%s/%s", event.Container.KubernetesNamespace, event.Container.KubernetesPodName)
 
 	// This field was fetched when the container was created
 	ownerReference := getContainerOwnerReference(event.Container)
 
-	r, err := generateSeccompPolicy(t.client, trace, b, event.Container.Podname,
-		event.Container.Name, namespacedName, ownerReference)
+	r, err := generateSeccompPolicy(t.client, trace, b, event.Container.KubernetesPodName,
+		event.Container.KubernetesContainerName, namespacedName, ownerReference)
 	if err != nil {
 		log.Errorf("Trace %s: %v", traceName, err)
 		return
@@ -388,7 +388,7 @@ func getContainerOwnerReference(c *containercollection.Container) *metav1.OwnerR
 	// the cluster.
 	if err != nil && !errors.Is(err, rest.ErrNotInCluster) {
 		log.Warnf("Failed to get owner reference of %s/%s/%s: %s",
-			c.Namespace, c.Podname, c.Name, err)
+			c.KubernetesNamespace, c.KubernetesPodName, c.KubernetesContainerName, err)
 	}
 
 	return ownerRef

--- a/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
@@ -98,7 +98,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
 	eventCallback := func(event types.Event) {
-		event.Node = trace.Spec.Node
+		event.KubernetesNode = trace.Spec.Node
 
 		t.helpers.PublishEvent(
 			traceName,

--- a/pkg/gadget-collection/gadgets/helpers.go
+++ b/pkg/gadget-collection/gadgets/helpers.go
@@ -37,9 +37,9 @@ func ContainerSelectorFromContainerFilter(f *gadgetv1alpha1.ContainerFilter) *co
 		labels[k] = v
 	}
 	return &containercollection.ContainerSelector{
-		Namespace: f.Namespace,
-		Podname:   f.Podname,
-		Labels:    labels,
-		Name:      f.ContainerName,
+		KubernetesNamespace:     f.Namespace,
+		KubernetesPodName:       f.Podname,
+		KubernetesLabels:        labels,
+		KubernetesContainerName: f.ContainerName,
 	}
 }

--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -89,7 +89,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 	visitedPods := make(map[string]struct{})
 
 	for _, container := range filteredContainers {
-		key := container.Namespace + "/" + container.Podname
+		key := container.KubernetesNamespace + "/" + container.KubernetesPodName
 		if _, ok := visitedPods[key]; !ok {
 			// Make the whole gadget fail if there is a container without PID
 			// because it would be an inconsistency that has to be notified
@@ -103,7 +103,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 			visitedPods[key] = struct{}{}
 
 			log.Debugf("Gadget %s: Using PID %d to retrieve network namespace of Pod %q in Namespace %q",
-				trace.Spec.Gadget, container.Pid, container.Podname, container.Namespace)
+				trace.Spec.Gadget, container.Pid, container.KubernetesPodName, container.KubernetesNamespace)
 
 			protocol := socketcollectortypes.ALL
 
@@ -118,8 +118,8 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 				}
 			}
 
-			podSockets, err := tracer.RunCollector(container.Pid, container.Podname,
-				container.Namespace, trace.Spec.Node, protocol)
+			podSockets, err := tracer.RunCollector(container.Pid, container.KubernetesPodName,
+				container.KubernetesNamespace, trace.Spec.Node, protocol)
 			if err != nil {
 				trace.Status.OperationError = err.Error()
 				return

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -170,7 +170,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if container.Netns == t.netnsHost {
 			return "host"
 		}
-		return container.Namespace + "/" + container.Podname
+		return container.KubernetesNamespace + "/" + container.KubernetesPodName
 	}
 
 	attachContainerFunc := func(container *containercollection.Container) error {

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -116,7 +116,7 @@ func (t *Trace) publishMessage(
 		Event: eventtypes.Event{
 			Type: eventType,
 			CommonData: eventtypes.CommonData{
-				Node: trace.Spec.Node,
+				KubernetesNode: trace.Spec.Node,
 			},
 			Message: msg,
 		},
@@ -130,11 +130,11 @@ func (t *Trace) publishEvent(
 	event *types.Event,
 	key string,
 ) {
-	event.Node = trace.Spec.Node
+	event.KubernetesNode = trace.Spec.Node
 	keyParts := strings.SplitN(key, "/", 2)
 	if len(keyParts) == 2 {
-		event.Namespace = keyParts[0]
-		event.Pod = keyParts[1]
+		event.KubernetesNamespace = keyParts[0]
+		event.KubernetesPodName = keyParts[1]
 	} else if key != "host" {
 		event.Type = eventtypes.ERR
 		event.Message = fmt.Sprintf("unknown key %s", key)

--- a/pkg/gadget-collection/gadgets/trace/network/enricher.go
+++ b/pkg/gadget-collection/gadgets/trace/network/enricher.go
@@ -70,9 +70,9 @@ func (e *Enricher) convertEvent(
 		Event: eventtypes.Event{
 			Type: eventtypes.NORMAL,
 			CommonData: eventtypes.CommonData{
-				Node:      e.node,
-				Namespace: namespace,
-				Pod:       name,
+				KubernetesNode:      e.node,
+				KubernetesNamespace: namespace,
+				KubernetesPodName:   name,
 			},
 			Message: "",
 		},
@@ -120,7 +120,7 @@ func (e *Enricher) convertEvent(
 	// shorter name without the random suffix. That will be used to
 	// generate the network policy name.
 	if pods.Items[localPodIndex].OwnerReferences != nil {
-		nameItems := strings.Split(out.Pod, "-")
+		nameItems := strings.Split(out.KubernetesPodName, "-")
 		if len(nameItems) > 2 {
 			out.PodOwner = strings.Join(nameItems[:len(nameItems)-2], "-")
 		}

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -126,7 +126,7 @@ func (t *Trace) publishMessage(
 		Event: eventtypes.Event{
 			Type: eventType,
 			CommonData: eventtypes.CommonData{
-				Node: trace.Spec.Node,
+				KubernetesNode: trace.Spec.Node,
 			},
 			Message: msg,
 		},
@@ -134,8 +134,8 @@ func (t *Trace) publishMessage(
 
 	keyParts := strings.SplitN(key, "/", 2)
 	if len(keyParts) == 2 {
-		event.Namespace = keyParts[0]
-		event.Pod = keyParts[1]
+		event.KubernetesNamespace = keyParts[0]
+		event.KubernetesPodName = keyParts[1]
 	} else if key != "host" {
 		event.Type = eventtypes.ERR
 		event.Message = fmt.Sprintf("unknown key %s", key)
@@ -288,7 +288,7 @@ func (t *Trace) update(trace, traceBeforePatch *gadgetv1alpha1.Trace) bool {
 
 	for _, event := range newEvents {
 		// for now, ignore events on the host netns
-		if event.Pod != "" {
+		if event.KubernetesPodName != "" {
 			t.publishEvent(trace, &event)
 		}
 	}

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -178,7 +178,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if container.Netns == t.netnsHost {
 			return "host"
 		}
-		return container.Namespace + "/" + container.Podname
+		return container.KubernetesNamespace + "/" + container.KubernetesPodName
 	}
 
 	attachContainerFunc := func(container *containercollection.Container) error {

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -184,7 +184,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if container.Netns == t.netnsHost {
 			return "host"
 		}
-		return container.Namespace + "/" + container.Podname
+		return container.KubernetesNamespace + "/" + container.KubernetesPodName
 	}
 
 	attachContainerFunc := func(container *containercollection.Container) error {

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -121,11 +121,11 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 	}
 
 	fillEvent := func(event *types.Event, key string) {
-		event.Node = trace.Spec.Node
+		event.KubernetesNode = trace.Spec.Node
 		keyParts := strings.SplitN(key, "/", 2)
 		if len(keyParts) == 2 {
-			event.Namespace = keyParts[0]
-			event.Pod = keyParts[1]
+			event.KubernetesNamespace = keyParts[0]
+			event.KubernetesPodName = keyParts[1]
 		} else if key != "host" {
 			event.Type = eventtypes.ERR
 			event.Message = fmt.Sprintf("unknown key %s", key)
@@ -136,7 +136,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			Event: eventtypes.Event{
 				Type: t,
 				CommonData: eventtypes.CommonData{
-					Node: trace.Spec.Node,
+					KubernetesNode: trace.Spec.Node,
 				},
 				Message: message,
 			},
@@ -155,7 +155,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
 				CommonData: eventtypes.CommonData{
-					Node: trace.Spec.Node,
+					KubernetesNode: trace.Spec.Node,
 				},
 			},
 			Name: name,

--- a/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
+++ b/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
@@ -144,7 +144,7 @@ func (a *NetworkPolicyAdvisor) labelKeyString(labels map[string]string) (ret str
  * namespace:label1=value1,label2=value2
  */
 func (a *NetworkPolicyAdvisor) localPodKey(e types.Event) (ret string) {
-	return e.Namespace + ":" + a.labelKeyString(e.PodLabels)
+	return e.KubernetesNamespace + ":" + a.labelKeyString(e.PodLabels)
 }
 
 func (a *NetworkPolicyAdvisor) networkPeerKey(e types.Event) (ret string) {
@@ -173,7 +173,7 @@ func (a *NetworkPolicyAdvisor) eventToRule(e types.Event) (ports []networkingv1.
 				PodSelector: &metav1.LabelSelector{MatchLabels: a.labelFilter(e.RemotePodLabels)},
 			},
 		}
-		if e.Namespace != e.RemotePodNamespace {
+		if e.KubernetesNamespace != e.RemotePodNamespace {
 			peers[0].NamespaceSelector = &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					// Kubernetes 1.22 is guaranteed to add the following label on namespaces:
@@ -190,7 +190,7 @@ func (a *NetworkPolicyAdvisor) eventToRule(e types.Event) (ports []networkingv1.
 				PodSelector: &metav1.LabelSelector{MatchLabels: e.RemoteSvcLabelSelector},
 			},
 		}
-		if e.Namespace != e.RemoteSvcNamespace {
+		if e.KubernetesNamespace != e.RemoteSvcNamespace {
 			peers[0].NamespaceSelector = &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					// Kubernetes 1.22 is guaranteed to add the following label on namespaces:
@@ -341,7 +341,7 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 			}
 		}
 
-		name := events[0].Pod
+		name := events[0].KubernetesPodName
 		if events[0].PodOwner != "" {
 			name = events[0].PodOwner
 		}
@@ -353,7 +353,7 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: events[0].Namespace,
+				Namespace: events[0].KubernetesNamespace,
 				Labels:    map[string]string{},
 			},
 			Spec: networkingv1.NetworkPolicySpec{

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -151,9 +151,9 @@ func (t *Tracer) run() {
 					// ring buffer, we might not be able to get the
 					// Kubernetes metadata from the mount namespace
 					// id.
-					Namespace: C.GoString(&eventC.container.namespace[0]),
-					Pod:       C.GoString(&eventC.container.pod[0]),
-					Container: C.GoString(&eventC.container.container[0]),
+					KubernetesNamespace:     C.GoString(&eventC.container.namespace[0]),
+					KubernetesPodName:       C.GoString(&eventC.container.pod[0]),
+					KubernetesContainerName: C.GoString(&eventC.container.container[0]),
 				},
 			},
 			Pid:       uint32(eventC.pid),

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -165,9 +165,9 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 					Event: eventtypes.Event{
 						Type: eventtypes.NORMAL,
 						CommonData: eventtypes.CommonData{
-							Node:      node,
-							Namespace: namespace,
-							Pod:       podname,
+							KubernetesNode:      node,
+							KubernetesNamespace: namespace,
+							KubernetesPodName:   podname,
 						},
 					},
 					Protocol:      proto,

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -72,8 +72,8 @@ func Unique(edges []Event) []Event {
 
 func (e *Event) Key() string {
 	return fmt.Sprintf("%s/%s/%s/%s/%s/%d",
-		e.Namespace,
-		e.Pod,
+		e.KubernetesNamespace,
+		e.KubernetesPodName,
 		e.PktType,
 		e.Proto,
 		e.IP,

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -112,9 +112,9 @@ func (cm *ContainersMap) addContainerInMap(c *containercollection.Container) {
 	val := Container{}
 
 	copyToC(&val.container_id, c.ID)
-	copyToC(&val.namespace, c.Namespace)
-	copyToC(&val.pod, c.Podname)
-	copyToC(&val.container, c.Name)
+	copyToC(&val.namespace, c.KubernetesNamespace)
+	copyToC(&val.pod, c.KubernetesPodName)
+	copyToC(&val.container, c.KubernetesContainerName)
 
 	cm.containersMap.Put(mntnsC, val)
 }
@@ -131,7 +131,7 @@ func (cm *ContainersMap) ContainersMapUpdater() containercollection.FuncNotify {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
 			// Skip the pause container
-			if event.Container.Name == "" {
+			if event.Container.KubernetesContainerName == "" {
 				return
 			}
 

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -155,15 +155,15 @@ func (g *GadgetTracerManager) AddContainer(_ context.Context, containerDefinitio
 	}
 
 	container := containercollection.Container{
-		ID:        containerDefinition.Id,
-		Pid:       containerDefinition.Pid,
-		Namespace: containerDefinition.Namespace,
-		Podname:   containerDefinition.Podname,
-		Name:      containerDefinition.Name,
-		Labels:    map[string]string{},
+		ID:                      containerDefinition.Id,
+		Pid:                     containerDefinition.Pid,
+		KubernetesNamespace:     containerDefinition.Namespace,
+		KubernetesPodName:       containerDefinition.Podname,
+		KubernetesContainerName: containerDefinition.Name,
+		KubernetesLabels:        map[string]string{},
 	}
 	for _, l := range containerDefinition.Labels {
-		container.Labels[l.Key] = l.Value
+		container.KubernetesLabels[l.Key] = l.Value
 	}
 	if containerDefinition.OciConfig != "" {
 		containerConfig := &ocispec.Spec{}

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -92,7 +92,7 @@ func (g *GadgetTracerManager) ReceiveStream(tracerID *pb.TracerID, stream pb.Gad
 			ev := eventtypes.Event{
 				Type: eventtypes.ERR,
 				CommonData: eventtypes.CommonData{
-					Node: g.nodeName,
+					KubernetesNode: g.nodeName,
 				},
 				Message: "events lost in gadget tracer manager",
 			}

--- a/pkg/gadgettracermanager/gadgettracermanager_test.go
+++ b/pkg/gadgettracermanager/gadgettracermanager_test.go
@@ -32,7 +32,7 @@ func TestTracer(t *testing.T) {
 		err := g.AddTracer(
 			fmt.Sprintf("my_tracer_id%d", i),
 			containercollection.ContainerSelector{
-				Namespace: fmt.Sprintf("this-namespace%d", i),
+				KubernetesNamespace: fmt.Sprintf("this-namespace%d", i),
 			},
 		)
 		if err != nil {
@@ -48,7 +48,7 @@ func TestTracer(t *testing.T) {
 	err = g.AddTracer(
 		fmt.Sprintf("my_tracer_id%d", 0),
 		containercollection.ContainerSelector{
-			Namespace: fmt.Sprintf("this-namespace%d", 0),
+			KubernetesNamespace: fmt.Sprintf("this-namespace%d", 0),
 		},
 	)
 	if err == nil {

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -103,7 +103,7 @@ func (l *LocalGadgetManager) ListTraceResources() []string {
 func (l *LocalGadgetManager) ListContainers() []string {
 	containers := []string{}
 	l.ContainerCollection.ContainerRange(func(c *containercollection.Container) {
-		containers = append(containers, c.KubernetesContainerName)
+		containers = append(containers, c.RuntimeContainerName)
 	})
 	sort.Strings(containers)
 	return containers

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -103,7 +103,7 @@ func (l *LocalGadgetManager) ListTraceResources() []string {
 func (l *LocalGadgetManager) ListContainers() []string {
 	containers := []string{}
 	l.ContainerCollection.ContainerRange(func(c *containercollection.Container) {
-		containers = append(containers, c.Name)
+		containers = append(containers, c.KubernetesContainerName)
 	})
 	sort.Strings(containers)
 	return containers

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -420,9 +420,9 @@ func TestDNS(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.DEBUG,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-dns001",
 			},
 			Message: "tracer attached",
 		},
@@ -443,9 +443,9 @@ func TestDNS(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.NORMAL,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-dns001",
 			},
 		},
 		DNSName: "microsoft.com.",
@@ -468,9 +468,9 @@ func TestDNS(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.DEBUG,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-dns001",
 			},
 			Message: "tracer detached",
 		},
@@ -542,9 +542,9 @@ func TestNetworkGraph(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.DEBUG,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-network-graph001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-network-graph001",
 			},
 			Message: "tracer attached",
 		},
@@ -565,9 +565,9 @@ func TestNetworkGraph(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.NORMAL,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-network-graph001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-network-graph001",
 			},
 		},
 		PktType: "OUTGOING",
@@ -591,9 +591,9 @@ func TestNetworkGraph(t *testing.T) {
 		Event: eventtypes.Event{
 			Type: eventtypes.DEBUG,
 			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-network-graph001",
+				KubernetesNode:      "local",
+				KubernetesNamespace: "default",
+				KubernetesPodName:   "test-local-gadget-network-graph001",
 			},
 			Message: "tracer detached",
 		},

--- a/pkg/tracer-collection/tracer-collection.go
+++ b/pkg/tracer-collection/tracer-collection.go
@@ -71,7 +71,7 @@ func (tc *TracerCollection) TracerMapsUpdater() containercollection.FuncNotify {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
 			// Skip the pause container
-			if event.Container.Name == "" {
+			if event.Container.KubernetesContainerName == "" {
 				return
 			}
 
@@ -178,7 +178,7 @@ func (tc *TracerCollection) TracerDump() (out string) {
 		}
 		out += "        Matches:\n"
 		tc.containerCollection.ContainerRangeWithSelector(&t.containerSelector, func(c *containercollection.Container) {
-			out += fmt.Sprintf("        - %s/%s [Mntns=%v CgroupID=%v]\n", c.Namespace, c.Podname, c.Mntns, c.CgroupID)
+			out += fmt.Sprintf("        - %s/%s [Mntns=%v CgroupID=%v]\n", c.KubernetesNamespace, c.KubernetesPodName, c.Mntns, c.CgroupID)
 		})
 	}
 	return

--- a/pkg/tracer-collection/tracer-collection.go
+++ b/pkg/tracer-collection/tracer-collection.go
@@ -170,10 +170,10 @@ func (tc *TracerCollection) TracerDump() (out string) {
 	for i, t := range tc.tracers {
 		out += fmt.Sprintf("%v -> %q/%q (%s) Labels: \n",
 			i,
-			t.containerSelector.Namespace,
-			t.containerSelector.Podname,
-			t.containerSelector.Name)
-		for k, v := range t.containerSelector.Labels {
+			t.containerSelector.KubernetesNamespace,
+			t.containerSelector.KubernetesPodName,
+			t.containerSelector.KubernetesContainerName)
+		for k, v := range t.containerSelector.KubernetesLabels {
 			out += fmt.Sprintf("                  %v: %v\n", k, v)
 		}
 		out += "        Matches:\n"

--- a/pkg/tracer-collection/tracer-collection.go
+++ b/pkg/tracer-collection/tracer-collection.go
@@ -70,8 +70,9 @@ func (tc *TracerCollection) TracerMapsUpdater() containercollection.FuncNotify {
 	return func(event containercollection.PubSubEvent) {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
-			// Skip the pause container
-			if event.Container.KubernetesContainerName == "" {
+			// Skip the pause container, only if it is not a standalone
+			// container (local-gadget use case).
+			if event.Container.RuntimeContainerName == "" && event.Container.KubernetesContainerName == "" {
 				return
 			}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -29,18 +29,18 @@ func Init(nodeName string) {
 
 type CommonData struct {
 	// Node where the event comes from
-	Node string `json:"node,omitempty" column:"node,width:30,ellipsis:middle" columnTags:"kubernetes"`
+	KubernetesNode string `json:"kubernetesNode,omitempty" column:"node,width:30,ellipsis:middle" columnTags:"kubernetes"`
 
 	// Pod namespace where the event comes from, or empty for host-level
 	// event
-	Namespace string `json:"namespace,omitempty" column:"namespace,width:30" columnTags:"kubernetes"`
+	KubernetesNamespace string `json:"kubernetesNamespace,omitempty" column:"namespace,width:30" columnTags:"kubernetes"`
 
 	// Pod where the event comes from, or empty for host-level event
-	Pod string `json:"pod,omitempty" column:"pod,width:30,ellipsis:middle" columnTags:"kubernetes"`
+	KubernetesPodName string `json:"kubernetesPodName,omitempty" column:"pod,width:30,ellipsis:middle" columnTags:"kubernetes"`
 
-	// Container where the event comes from, or empty for host-level or
-	// pod-level event
-	Container string `json:"container,omitempty" column:"container,width:30" columnTags:"kubernetes,runtime"`
+	// Container where the event comes from. It could be empty for host-level or
+	// pod-level event. Or, when the tracer is not running in a Kubernetes env.
+	KubernetesContainerName string `json:"kubernetesContainerName,omitempty" column:"container,width:30" columnTags:"kubernetes"`
 }
 
 const (
@@ -77,7 +77,7 @@ type Event struct {
 func Err(msg string) Event {
 	return Event{
 		CommonData: CommonData{
-			Node: node,
+			KubernetesNode: node,
 		},
 		Type:    ERR,
 		Message: msg,
@@ -87,7 +87,7 @@ func Err(msg string) Event {
 func Warn(msg string) Event {
 	return Event{
 		CommonData: CommonData{
-			Node: node,
+			KubernetesNode: node,
 		},
 		Type:    WARN,
 		Message: msg,
@@ -97,7 +97,7 @@ func Warn(msg string) Event {
 func Debug(msg string) Event {
 	return Event{
 		CommonData: CommonData{
-			Node: node,
+			KubernetesNode: node,
 		},
 		Type:    DEBUG,
 		Message: msg,
@@ -107,7 +107,7 @@ func Debug(msg string) Event {
 func Info(msg string) Event {
 	return Event{
 		CommonData: CommonData{
-			Node: node,
+			KubernetesNode: node,
 		},
 		Type:    INFO,
 		Message: msg,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -41,6 +41,16 @@ type CommonData struct {
 	// Container where the event comes from. It could be empty for host-level or
 	// pod-level event. Or, when the tracer is not running in a Kubernetes env.
 	KubernetesContainerName string `json:"kubernetesContainerName,omitempty" column:"container,width:30" columnTags:"kubernetes"`
+
+	// Container Runtime managing the container where the event comes from. It
+	// could be empty if the enricher doesn't use the Container Runtime as
+	// source for enrichment.
+	Runtime string `json:"runtime,omitempty" column:"runtime,width:10,fixed,hide" columnTags:"runtime"`
+
+	// It refers to the same container of KubernetesContainerName, it is just
+	// that some Container Runtimes use a different naming notation. As Runtime,
+	// it could be empty in some cases.
+	RuntimeContainerName string `json:"runtimeContainerName,omitempty" column:"runtimeContainerName,width:30" columnTags:"runtime"`
 }
 
 const (


### PR DESCRIPTION
Fixes #737

```bash
$ sudo local-gadget list-containers -k
RUNTIME    ID                                                               CONTAINER               K8S-NAMESPACE K8S-POD                                  K8S-CONTAINER
containerd d6cb7fc9a2187b02c63e0acf1b56786a8fed2399a701afc53fae76c1f8bd4905 calico-kube-controllers kube-system   calico-kube-controllers-685b65ddf9-9qksq calico-kube-controllers
containerd 52d36f9343e10ce278b02eec71b31a4f805584e24698b9f98884b1cda2157d64 calico-node             kube-system   calico-node-ws7fz                        calico-node
containerd 5ba3dc488f40c4adcad01fd6de19124c9dfcbfd236132affe46b2d6bbef72ae9 coredns                 kube-system   coredns-78fcd69978-x47zw                 coredns
containerd df0d57be79e203f2b2f1f9814e03522f764be7e021f29da3bd437001e0804f4f kube-controller-manager kube-system   kube-controller-manager-master           kube-controller-manager
containerd 64c8f3e2bafe62605b19cf26ca780127a06c7be76aa1737aff5ec92f27588249 etcd                    kube-system   etcd-master                              etcd
containerd 848c201142fa369231531fd624958d4a320a6ed8ecb37bf069e9624a544c7e3a coredns                 kube-system   coredns-78fcd69978-rj79d                 coredns
containerd 412d20166e80a0119b063d0eb29416b6809a13acb972e68a96178cb3372b2d46 kube-proxy              kube-system   kube-proxy-f8mkm                         kube-proxy
containerd 9c8b80f55e00084daba8c04bfb03fed8b03bc2aadf384fdec68a4f8ecadbf2d9 kube-apiserver          kube-system   kube-apiserver-master                    kube-apiserver
containerd 0dee184c65ccdb5232617f1ff0219962f2ad8b1920ed72d761b9e62835a5e278 kube-scheduler          kube-system   kube-scheduler-master                    kube-scheduler
docker     c97fac86dcb402b3ab7c9715cacba7192567395370f8eb48023097f0836f26bd test-container
```


```bash
$ sudo local-gadget trace exec -k
CONTAINER                            PID        PPID       COMM             RET ARGS                                             K8S-NAMESPACE                        K8S-POD                              K8S-CONTAINER
calico-node                          307172     307161     calico-node      0   /bin/calico-node -felix-live -bird-live          kube-system                          calico-node-ws7fz                    calico-node
calico-node                          307187     307172     sv               0   /usr/local/bin/sv status /etc/service/enabled/c… kube-system                          calico-node-ws7fz                    calico-node
calico-node                          307188     307172     sv               0   /usr/local/bin/sv status /etc/service/enabled/b… kube-system                          calico-node-ws7fz                    calico-node
calico-node                          307189     3887       ipset            0   /usr/sbin/ipset list                             kube-system                          calico-node-ws7fz                    calico-node
calico-kube-controllers              307202     307190     check-status     0   /usr/bin/check-status -r                         kube-system                          calico-kube-contro…-685b65ddf9-9qksq calico-kube-controllers
test-container                       307327     307318     sh               0   /bin/sh
test-container                       307437     307327     cat              0   /bin/cat /dev/null
calico-node                          307352     307339     calico-node      0   /bin/calico-node -felix-live -bird-live          kube-system                          calico-node-ws7fz                    calico-node
calico-node                          307449     307438     calico-node      0   /bin/calico-node -felix-ready -bird-ready        kube-system                          calico-node-ws7fz                    calico-node
```

```bash
$ sudo /inspektor-gadget/local-gadget snapshot socket -c kube-apiserver -k
PROTO LOCAL              REMOTE             STATUS      K8S-NAMESPACE K8S-POD
TCP   127.0.0.1:56302    127.0.0.1:2379     ESTABLISHED kube-system   kube-apiserver-master
TCP   172.28.128.4:44142 172.28.128.4:6443  ESTABLISHED kube-system   kube-apiserver-master
TCP   127.0.0.1:2379     127.0.0.1:56302    ESTABLISHED kube-system   kube-apiserver-master
TCP   172.28.128.4:2379  172.28.128.4:49588 ESTABLISHED kube-system   kube-apiserver-master
TCP   127.0.0.1:2379     127.0.0.1:56304    ESTABLISHED kube-system   kube-apiserver-master
[...]
```

```bash
$ sudo /inspektor-gadget/local-gadget trace tcpconnect -k
CONTAINER               PID        COMM          IP SADDR           DADDR           DPORT K8S-NAMESPACE          K8S-POD                K8S-CONTAINER
coredns                 3467       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-rj79d coredns
calico-node             245175     calico-node   4  127.0.0.1       127.0.0.1       9099  kube-system            calico-node-ws7fz      calico-node
coredns                 5198       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-x47zw coredns
coredns                 3467       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-rj79d coredns
coredns                 5198       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-x47zw coredns
coredns                 3467       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-rj79d coredns
coredns                 5198       coredns       4  127.0.0.1       127.0.0.1       8080  kube-system            coredns-78f…9978-x47zw coredns
```
