### PR TITLE
makefile: Some changes on `minikube-install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ minikube-install: gadget-default-container kubectl-gadget
 	# features. So we have to keep "docker-save|docker-load" when
 	# available.
 	if $(MINIKUBE) docker-env >/dev/null 2>&1 ; then \
-		docker save $(CONTAINER_REPO):$(IMAGE_TAG) $(PV) | (eval $$($(MINIKUBE) -p minikube docker-env | grep =) && docker load) ; \
+		docker save $(CONTAINER_REPO):$(IMAGE_TAG) $(PV) | (eval $$($(MINIKUBE) docker-env | grep =) && docker load) ; \
 	else \
 		$(MINIKUBE) image load $(CONTAINER_REPO):$(IMAGE_TAG) ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,8 @@ minikube-install: gadget-default-container kubectl-gadget
 		$(MINIKUBE) image load $(CONTAINER_REPO):$(IMAGE_TAG) ; \
 	fi
 	@echo "Image in Minikube:"
-	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || true
+	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
+		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
 	# Remove all resources created by Inspektor Gadget.
 	./kubectl-gadget undeploy || true


### PR DESCRIPTION
# makefile: Some changes on `minikube-install` target

This PR adds the following changes:

1. Remove the hardcoded minikube profile name so that users can run:
```bash
MINIKUBE="minikube -p minikube-containerd" make minikube-install
```

2. If the image is not correctly loaded into Minikube, then we shouldn't go ahead and try to redeploy IG.

