### PR TITLE
cmd/deploy: Add container socketpath configuration

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -20,6 +20,9 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
 const (
@@ -40,6 +43,23 @@ type OutputConfig struct {
 
 	// Verbose prints additional information
 	Verbose bool
+}
+
+func AddOutputFlags(command *cobra.Command, outputConfig *OutputConfig) {
+	command.PersistentFlags().StringVarP(
+		&outputConfig.OutputMode,
+		"output",
+		"o",
+		OutputModeColumns,
+		fmt.Sprintf("Output format (%s).", strings.Join(SupportedOutputModes, ", ")),
+	)
+
+	command.PersistentFlags().BoolVarP(
+		&outputConfig.Verbose,
+		"verbose", "v",
+		false,
+		"Print debug information",
+	)
 }
 
 func (config *OutputConfig) ParseOutputConfig() error {
@@ -74,4 +94,33 @@ func (config *OutputConfig) ParseOutputConfig() error {
 		return WrapInErrInvalidArg("--output / -o",
 			fmt.Errorf("%q is not a valid output format", config.OutputMode))
 	}
+}
+
+type RuntimesSocketPathConfig struct {
+	Docker     string
+	Containerd string
+	Crio       string
+}
+
+func AddRuntimesSocketPathFlags(command *cobra.Command, config *RuntimesSocketPathConfig) {
+	command.PersistentFlags().StringVarP(
+		&config.Docker,
+		"docker-socketpath", "",
+		runtimeclient.DockerDefaultSocketPath,
+		"Docker Engine API Unix socket path",
+	)
+
+	command.PersistentFlags().StringVarP(
+		&config.Containerd,
+		"containerd-socketpath", "",
+		runtimeclient.ContainerdDefaultSocketPath,
+		"containerd CRI Unix socket path",
+	)
+
+	command.PersistentFlags().StringVarP(
+		&config.Crio,
+		"crio-socketpath", "",
+		runtimeclient.CrioDefaultSocketPath,
+		"CRI-O CRI Unix socket path",
+	)
 }

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -74,9 +74,12 @@ var (
 	quiet               bool
 	debug               bool
 	wait                bool
+	runtimesConfig      commonutils.RuntimesSocketPathConfig
 )
 
 func init() {
+	commonutils.AddRuntimesSocketPathFlags(deployCmd, &runtimesConfig)
+
 	deployCmd.PersistentFlags().StringVarP(
 		&image,
 		"image", "",
@@ -320,6 +323,12 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					gadgetContainer.Env[i].Value = hookMode
 				case "INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER":
 					gadgetContainer.Env[i].Value = strconv.FormatBool(fallbackPodInformer)
+				case utils.GadgetEnvironmentContainerdSocketpath:
+					gadgetContainer.Env[i].Value = runtimesConfig.Containerd
+				case utils.GadgetEnvironmentCRIOSocketpath:
+					gadgetContainer.Env[i].Value = runtimesConfig.Crio
+				case utils.GadgetEnvironmentDockerSocketpath:
+					gadgetContainer.Env[i].Value = runtimesConfig.Docker
 				}
 			}
 

--- a/cmd/kubectl-gadget/utils/consts.go
+++ b/cmd/kubectl-gadget/utils/consts.go
@@ -16,4 +16,8 @@ package utils
 
 const (
 	GadgetNamespace string = "gadget"
+
+	GadgetEnvironmentContainerdSocketpath string = "INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"
+	GadgetEnvironmentCRIOSocketpath       string = "INSPEKTOR_GADGET_CRIO_SOCKETPATH"
+	GadgetEnvironmentDockerSocketpath     string = "INSPEKTOR_GADGET_DOCKER_SOCKETPATH"
 )

--- a/cmd/kubectl-gadget/utils/flags.go
+++ b/cmd/kubectl-gadget/utils/flags.go
@@ -144,6 +144,8 @@ func AddCommonFlags(command *cobra.Command, params *CommonFlags) {
 	// No 'Namespace' flag because it's added automatically by
 	// KubernetesConfigFlags.AddFlags(rootCmd.PersistentFlags())
 
+	commonutils.AddOutputFlags(command, &params.OutputConfig)
+
 	command.PersistentFlags().StringVarP(
 		&params.LabelsRaw,
 		"selector",
@@ -183,26 +185,9 @@ func AddCommonFlags(command *cobra.Command, params *CommonFlags) {
 		"Show data from pods in all namespaces",
 	)
 
-	command.PersistentFlags().StringVarP(
-		&params.OutputMode,
-		"output",
-		"o",
-		commonutils.OutputModeColumns,
-		fmt.Sprintf("Output format (%s).", strings.Join(commonutils.SupportedOutputModes, ", ")),
-	)
-
-	command.PersistentFlags().BoolVarP(
-		&params.Verbose,
-		"verbose",
-		"",
-		false,
-		"Print additional information",
-	)
-
-	command.PersistentFlags().IntVarP(
+	command.PersistentFlags().IntVar(
 		&params.Timeout,
 		"timeout",
-		"",
 		0,
 		"Number of seconds that the gadget will run for",
 	)

--- a/cmd/local-gadget/utils/flags.go
+++ b/cmd/local-gadget/utils/flags.go
@@ -31,20 +31,14 @@ type CommonFlags struct {
 	// OutputConfig describes the way output should be printed.
 	commonutils.OutputConfig
 
+	// Saves all runtime socket paths
+	commonutils.RuntimesSocketPathConfig
+
 	// Containername allows to filter containers by name.
 	Containername string
 
 	// The name of the container runtimes to be used separated by comma.
 	Runtimes string
-
-	// DockerSocketPath is the Docker Engine API Unix socket path.
-	DockerSocketPath string
-
-	// ContainerdSocketPath is the containerd CRI Unix socket path.
-	ContainerdSocketPath string
-
-	// CrioSocketPath is the CRI-O CRI Unix socket path.
-	CrioSocketPath string
 
 	// RuntimeConfigs contains the list of the container runtimes to be used
 	// with their specific socket path.
@@ -63,11 +57,11 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 
 			switch runtimeName {
 			case runtimeclient.DockerName:
-				socketPath = commonFlags.DockerSocketPath
+				socketPath = commonFlags.RuntimesSocketPathConfig.Docker
 			case runtimeclient.ContainerdName:
-				socketPath = commonFlags.ContainerdSocketPath
+				socketPath = commonFlags.RuntimesSocketPathConfig.Containerd
 			case runtimeclient.CrioName:
-				socketPath = commonFlags.CrioSocketPath
+				socketPath = commonFlags.RuntimesSocketPathConfig.Crio
 			default:
 				return commonutils.WrapInErrInvalidArg("--runtime / -r",
 					fmt.Errorf("runtime %q is not supported", p))
@@ -98,20 +92,8 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 	// do not print usage when there is an error
 	command.SilenceUsage = true
 
-	command.PersistentFlags().BoolVarP(
-		&commonFlags.Verbose,
-		"verbose", "v",
-		false,
-		"Print debug information",
-	)
-
-	command.PersistentFlags().StringVarP(
-		&commonFlags.OutputMode,
-		"output",
-		"o",
-		commonutils.OutputModeColumns,
-		fmt.Sprintf("Output format (%s).", strings.Join(commonutils.SupportedOutputModes, ", ")),
-	)
+	commonutils.AddOutputFlags(command, &commonFlags.OutputConfig)
+	commonutils.AddRuntimesSocketPathFlags(command, &commonFlags.RuntimesSocketPathConfig)
 
 	command.PersistentFlags().StringVarP(
 		&commonFlags.Containername,
@@ -127,26 +109,5 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		strings.Join(containerutils.AvailableRuntimes, ","),
 		fmt.Sprintf("Container runtimes to be used separated by comma. Supported values are: %s",
 			strings.Join(containerutils.AvailableRuntimes, ", ")),
-	)
-
-	command.PersistentFlags().StringVarP(
-		&commonFlags.DockerSocketPath,
-		"docker-socketpath", "",
-		runtimeclient.DockerDefaultSocketPath,
-		"Docker Engine API Unix socket path",
-	)
-
-	command.PersistentFlags().StringVarP(
-		&commonFlags.ContainerdSocketPath,
-		"containerd-socketpath", "",
-		runtimeclient.ContainerdDefaultSocketPath,
-		"containerd CRI Unix socket path",
-	)
-
-	command.PersistentFlags().StringVarP(
-		&commonFlags.CrioSocketPath,
-		"crio-socketpath", "",
-		runtimeclient.CrioDefaultSocketPath,
-		"CRI-O CRI Unix socket path",
 	)
 }

--- a/cmd/local-gadget/utils/flags.go
+++ b/cmd/local-gadget/utils/flags.go
@@ -20,9 +20,7 @@ import (
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/containerd"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/crio"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -64,11 +62,11 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 			socketPath := ""
 
 			switch runtimeName {
-			case docker.Name:
+			case runtimeclient.DockerName:
 				socketPath = commonFlags.DockerSocketPath
-			case containerd.Name:
+			case runtimeclient.ContainerdName:
 				socketPath = commonFlags.ContainerdSocketPath
-			case crio.Name:
+			case runtimeclient.CrioName:
 				socketPath = commonFlags.CrioSocketPath
 			default:
 				return commonutils.WrapInErrInvalidArg("--runtime / -r",
@@ -134,21 +132,21 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 	command.PersistentFlags().StringVarP(
 		&commonFlags.DockerSocketPath,
 		"docker-socketpath", "",
-		docker.DefaultSocketPath,
+		runtimeclient.DockerDefaultSocketPath,
 		"Docker Engine API Unix socket path",
 	)
 
 	command.PersistentFlags().StringVarP(
 		&commonFlags.ContainerdSocketPath,
 		"containerd-socketpath", "",
-		containerd.DefaultSocketPath,
+		runtimeclient.ContainerdDefaultSocketPath,
 		"containerd CRI Unix socket path",
 	)
 
 	command.PersistentFlags().StringVarP(
 		&commonFlags.CrioSocketPath,
 		"crio-socketpath", "",
-		crio.DefaultSocketPath,
+		runtimeclient.CrioDefaultSocketPath,
 		"CRI-O CRI Unix socket path",
 	)
 }

--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -22,8 +22,7 @@ import (
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/containerd"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
 func main() {
@@ -55,8 +54,8 @@ func main() {
 		// (It's needed to have the name of the container in this example).
 		containercollection.WithMultipleContainerRuntimesEnrichment(
 			[]*containerutils.RuntimeConfig{
-				{Name: docker.Name},
-				{Name: containerd.Name},
+				{Name: runtimeclient.DockerName},
+				{Name: runtimeclient.ContainerdName},
 			}),
 	}
 

--- a/examples/gadgets/formatter/trace/exec/exec.go
+++ b/examples/gadgets/formatter/trace/exec/exec.go
@@ -26,8 +26,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/formatter/textcolumns"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/containerd"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
@@ -78,8 +77,8 @@ func main() {
 		// runtime. docker and containerd in this case.
 		containercollection.WithMultipleContainerRuntimesEnrichment(
 			[]*containerutils.RuntimeConfig{
-				{Name: docker.Name},
-				{Name: containerd.Name},
+				{Name: runtimeclient.DockerName},
+				{Name: runtimeclient.ContainerdName},
 			}),
 	}
 

--- a/examples/gadgets/withfilter/trace/exec/exec.go
+++ b/examples/gadgets/withfilter/trace/exec/exec.go
@@ -25,8 +25,7 @@ import (
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/containerd"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
@@ -77,8 +76,8 @@ func main() {
 		// runtime. docker and containerd in this case.
 		containercollection.WithMultipleContainerRuntimesEnrichment(
 			[]*containerutils.RuntimeConfig{
-				{Name: docker.Name},
-				{Name: containerd.Name},
+				{Name: runtimeclient.DockerName},
+				{Name: runtimeclient.ContainerdName},
 			}),
 	}
 

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -22,9 +22,7 @@ import (
 )
 
 const (
-	Name              = "containerd"
-	DefaultSocketPath = "/run/containerd/containerd.sock"
-	DefaultTimeout    = 2 * time.Second
+	DefaultTimeout = 2 * time.Second
 )
 
 type ContainerdClient struct {
@@ -33,10 +31,10 @@ type ContainerdClient struct {
 
 func NewContainerdClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
-		socketPath = DefaultSocketPath
+		socketPath = runtimeclient.ContainerdDefaultSocketPath
 	}
 
-	criClient, err := criclient.NewCRIClient(Name, socketPath, DefaultTimeout)
+	criClient, err := criclient.NewCRIClient(runtimeclient.ContainerdName, socketPath, DefaultTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -33,9 +33,9 @@ import (
 )
 
 var AvailableRuntimes = []string{
-	docker.Name,
-	containerd.Name,
-	crio.Name,
+	runtimeclient.DockerName,
+	runtimeclient.ContainerdName,
+	runtimeclient.CrioName,
 }
 
 type RuntimeConfig struct {
@@ -45,11 +45,11 @@ type RuntimeConfig struct {
 
 func NewContainerRuntimeClient(runtime *RuntimeConfig) (runtimeclient.ContainerRuntimeClient, error) {
 	switch runtime.Name {
-	case docker.Name:
+	case runtimeclient.DockerName:
 		return docker.NewDockerClient(runtime.SocketPath)
-	case containerd.Name:
+	case runtimeclient.ContainerdName:
 		return containerd.NewContainerdClient(runtime.SocketPath)
-	case crio.Name:
+	case runtimeclient.CrioName:
 		return crio.NewCrioClient(runtime.SocketPath)
 	default:
 		return nil, fmt.Errorf("unknown container runtime: %s (available %s)",

--- a/pkg/container-utils/crio/crio.go
+++ b/pkg/container-utils/crio/crio.go
@@ -22,9 +22,7 @@ import (
 )
 
 const (
-	Name              = "cri-o"
-	DefaultSocketPath = "/run/crio/crio.sock"
-	DefaultTimeout    = 2 * time.Second
+	DefaultTimeout = 2 * time.Second
 )
 
 type CrioClient struct {
@@ -33,10 +31,10 @@ type CrioClient struct {
 
 func NewCrioClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
-		socketPath = DefaultSocketPath
+		socketPath = runtimeclient.CrioDefaultSocketPath
 	}
 
-	criClient, err := criclient.NewCRIClient(Name, socketPath, DefaultTimeout)
+	criClient, err := criclient.NewCRIClient(runtimeclient.CrioName, socketPath, DefaultTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -30,9 +30,7 @@ import (
 )
 
 const (
-	Name              = "docker"
-	DefaultSocketPath = "/run/docker.sock"
-	DefaultTimeout    = 2 * time.Second
+	DefaultTimeout = 2 * time.Second
 )
 
 // DockerClient implements the ContainerRuntimeClient interface but using the
@@ -47,7 +45,7 @@ type DockerClient struct {
 
 func NewDockerClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
-		socketPath = DefaultSocketPath
+		socketPath = runtimeclient.DockerDefaultSocketPath
 	}
 
 	cli, err := client.NewClientWithOpts(
@@ -121,7 +119,7 @@ func (c *DockerClient) GetContainer(containerID string) (*runtimeclient.Containe
 }
 
 func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.ContainerDetailsData, error) {
-	containerID, err := runtimeclient.ParseContainerID(Name, containerID)
+	containerID, err := runtimeclient.ParseContainerID(runtimeclient.DockerName, containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +147,7 @@ func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.C
 			ID:      containerJSON.ID,
 			Name:    strings.TrimPrefix(containerJSON.Name, "/"),
 			State:   containerStatusStateToRuntimeClientState(containerJSON.State.Status),
-			Runtime: Name,
+			Runtime: runtimeclient.DockerName,
 		},
 		Pid:         containerJSON.State.Pid,
 		CgroupsPath: string(containerJSON.HostConfig.Cgroup),
@@ -221,7 +219,7 @@ func DockerContainerToContainerData(container *dockertypes.Container) *runtimecl
 		ID:      container.ID,
 		Name:    strings.TrimPrefix(container.Names[0], "/"),
 		State:   containerStatusStateToRuntimeClientState(container.State),
-		Runtime: Name,
+		Runtime: runtimeclient.DockerName,
 	}
 
 	// Fill K8S information.

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -24,9 +24,10 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cgroups"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -19,6 +19,17 @@ import (
 	"strings"
 )
 
+const (
+	DockerName              = "docker"
+	DockerDefaultSocketPath = "/run/docker.sock"
+
+	CrioName              = "cri-o"
+	CrioDefaultSocketPath = "/run/crio/crio.sock"
+
+	ContainerdName              = "containerd"
+	ContainerdDefaultSocketPath = "/run/containerd/containerd.sock"
+)
+
 // ContainerData contains container information returned from the container
 // runtime clients.
 type ContainerData struct {

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -20,14 +20,15 @@ import (
 )
 
 const (
-	DockerName              = "docker"
-	DockerDefaultSocketPath = "/run/docker.sock"
-
+	// Make sure to keep these settings in sync with pkg/resources/manifests/deploy.yaml
 	CrioName              = "cri-o"
 	CrioDefaultSocketPath = "/run/crio/crio.sock"
 
 	ContainerdName              = "containerd"
 	ContainerdDefaultSocketPath = "/run/containerd/containerd.sock"
+
+	DockerName              = "docker"
+	DockerDefaultSocketPath = "/run/docker.sock"
 )
 
 // ContainerData contains container information returned from the container

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -162,6 +162,13 @@ spec:
             value: "auto"
           - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
             value: "true"
+          # Make sure to keep these settings in sync with pkg/container-utils/runtime-client/interface.go
+          - name: INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH
+            value: "/run/containerd/containerd.sock"
+          - name: INSPEKTOR_GADGET_CRIO_SOCKETPATH
+            value: "/run/crio/crio.sock"
+          - name: INSPEKTOR_GADGET_DOCKER_SOCKETPATH
+            value: "/run/docker.sock"
           - name: HOST_ROOT
             value: "/host"
         securityContext:


### PR DESCRIPTION
# cmd/deploy: Add container socketpath configuration

When the socketpath of the underlying container runtime is not the default it can be configured through these newly added cmd options of the `deploy` cmd
See #451. This change bases on https://github.com/flyth/inspektor-gadget/tree/michael/socketpaths

The newly added 3 subcommands to the `deploy` command are the following:
`--socketpath-docker`, `socketpath-containerd` and `--socketpath-containerd`

# Usage
`kubectl gadget deploy --socketpath-docker /burak.docker.sock` for docker.
Same for `crio` and `containerd`

# Testing
## When configuring another (but wrong) socket path
```
time="2022-10-07T14:59:46Z" level=warning msg="Skip pod default/kubernetes-bootcamp-75c5d958ff-f2s5l: cannot find container (ID: docker://1fb5a0580223858c8ee7d105be6b74e01472630abaf28c760a29cfef02e340e6): Cannot connect to the Docker daemon at unix:///burak.docker.sock. Is the docker daemon running?"
time="2022-10-07T14:59:46Z" level=warning msg="Skip pod gadget/gadget-tkww7: cannot find container (ID: docker://c316045e652f6059f9015718cad81efc33c3738e055bb86391943e026075802c): Cannot connect to the Docker daemon at unix:///burak.docker.sock. Is the docker daemon running?"
time="2022-10-07T14:59:46Z" level=warning msg="Skip pod kube-system/coredns-565d847f94-vxw6m: cannot find container (ID: docker://368d30eee7c4c7152e12263ff0b071d18e898e1e38c3798402c81cf7827b7912): Cannot connect to the Docker daemon at unix:///burak.docker.sock. Is the docker daemon running?"
time="2022-10-07T14:59:46Z" level=warning msg="Skip pod kube-system/etcd-minikube: cannot find container (ID: docker://617eaa50f09506d55ed29003c274d2e16019182c7f2c6ccc5f0343584515ad90): Cannot connect to the Docker daemon at unix:///burak.docker.sock. Is the docker daemon running?"
```
## Same deployment when the socket `/burak.docker.sock` is there:
```
time="2022-10-07T15:00:29Z" level=info msg="GadgetTracerManager: enabling fallback podinformer"
time="2022-10-07T15:00:59Z" level=info msg="Starting Pod controller"
time="2022-10-07T15:00:59Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2022-10-07T15:00:59Z" level=info msg="Starting trace controller manager"
```
-> IG works