### PR TITLE
trace/open: Use columns library

### DIFF
--- a/cmd/common/trace/open.go
+++ b/cmd/common/trace/open.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewOpenCmd(runCmd func(*cobra.Command, []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   "open",
+		Short: "Trace open system calls",
+		RunE:  runCmd,
+	}
+}

--- a/cmd/kubectl-gadget/trace/open.go
+++ b/cmd/kubectl-gadget/trace/open.go
@@ -15,107 +15,34 @@
 package trace
 
 import (
-	"fmt"
-	"strings"
+	"github.com/spf13/cobra"
 
 	commontrace "github.com/inspektor-gadget/inspektor-gadget/cmd/common/trace"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/types"
-
-	"github.com/spf13/cobra"
+	openTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/types"
 )
 
-type OpenParser struct {
-	commonutils.BaseParser[types.Event]
-}
-
 func newOpenCmd() *cobra.Command {
-	commonFlags := &utils.CommonFlags{
-		OutputConfig: commonutils.OutputConfig{
-			// The columns that will be used in case the user does not specify
-			// which specific columns they want to print.
-			CustomColumns: []string{
-				"node",
-				"namespace",
-				"pod",
-				"container",
-				"pid",
-				"comm",
-				"fd",
-				"err",
-				"path",
-			},
-		},
-	}
+	var commonFlags utils.CommonFlags
 
-	cmd := &cobra.Command{
-		Use:   "open",
-		Short: "Trace open system calls",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			openGadget := &TraceGadget[types.Event]{
-				name:        "opensnoop",
-				commonFlags: commonFlags,
-				parser:      NewOpenParser(&commonFlags.OutputConfig),
-			}
-
-			return openGadget.Run()
-		},
-	}
-
-	utils.AddCommonFlags(cmd, commonFlags)
-
-	return cmd
-}
-
-func NewOpenParser(outputConfig *commonutils.OutputConfig) commontrace.TraceParser[types.Event] {
-	columnsWidth := map[string]int{
-		"node":      -16,
-		"namespace": -16,
-		"pod":       -30,
-		"container": -16,
-		"pid":       -7,
-		"comm":      -16,
-		"fd":        -3,
-		"err":       -3,
-		"path":      -24,
-	}
-
-	return &OpenParser{
-		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
-	}
-}
-
-func (p *OpenParser) TransformIntoColumns(event *types.Event) string {
-	var sb strings.Builder
-
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "container":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Container))
-		case "pid":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Pid))
-		case "comm":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Comm))
-		case "fd":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Fd))
-		case "err":
-			sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], event.Err))
-		case "path":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Path))
-		default:
-			continue
+	runCmd := func(cmd *cobra.Command, args []string) error {
+		parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonFlags.OutputConfig, openTypes.GetColumns())
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
 		}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+		openGadget := &TraceGadget[openTypes.Event]{
+			name:        "opensnoop",
+			commonFlags: &commonFlags,
+			parser:      parser,
+		}
+
+		return openGadget.Run()
 	}
 
-	return sb.String()
+	cmd := commontrace.NewOpenCmd(runCmd)
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
 }

--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -15,20 +15,25 @@
 package types
 
 import (
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type Event struct {
 	eventtypes.Event
 
-	MountNsID uint64 `json:"mountnsid,omitempty"`
-	Pid       uint32 `json:"pid,omitempty"`
-	UID       uint32 `json:"uid,omitempty"`
-	Comm      string `json:"pcomm,omitempty"`
-	Fd        int    `json:"fd,omitempty"`
-	Ret       int    `json:"ret,omitempty"`
-	Err       int    `json:"err,omitempty"`
-	Path      string `json:"path,omitempty"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
+	UID       uint32 `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
+	Comm      string `json:"pcomm,omitempty" column:"comm,maxWidth:16"`
+	Fd        int    `json:"fd,omitempty" column:"fd,minWidth:2,width:3"`
+	Ret       int    `json:"ret,omitempty" column:"ret,width:3,fixed,hide"`
+	Err       int    `json:"err,omitempty" column:"err,width:3,fixed"`
+	Path      string `json:"path,omitempty" column:"path,minWidth:24,width:32"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	return columns.MustCreateColumns[Event]()
 }
 
 func Base(ev eventtypes.Event) Event {


### PR DESCRIPTION
# trace/open: Use columns library

The trace open gadget now uses the columns library

See https://github.com/kinvolk/inspektor-gadget/issues/1003

## Testing done
![image](https://user-images.githubusercontent.com/113581185/195110088-f310fc66-f835-432a-85e8-70a5673f09f4.png)