### PR TITLE
ci: Add dependabot.yml to automatically update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Several of the actions we use, like actions/cache@v2, were reported as warning  due to them using Node.js 12 which was deprecated in favor of Node.js 16 [1].

So, this commit enables dependabot to automatically opens pull request when a  new version of an action is available.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12