### PR TITLE
trace/network: Use columns library

### DIFF
--- a/cmd/common/trace/network.go
+++ b/cmd/common/trace/network.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewNetworkCmd(runCmd func(*cobra.Command, []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   "network",
+		Short: "Trace network streams",
+		RunE:  runCmd,
+	}
+}

--- a/docs/guides/trace/network.md
+++ b/docs/guides/trace/network.md
@@ -1,9 +1,9 @@
 ---
-title: 'The "network-graph" gadget'
+title: 'The "network" gadget'
 weight: 10
 ---
 
-The network-graph gadget monitors the network activity in the specified pods
+The network gadget monitors the network activity in the specified pods
 and records the list of TCP connections and UDP streams.
 
 ### On Kubernetes

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -1047,7 +1047,6 @@ func TestNetworkGraph(t *testing.T) {
 				e.PodHostIP = ""
 				e.PodIP = ""
 				e.PodOwner = ""
-				e.Debug = ""
 				e.RemoteSvcNamespace = ""
 				e.RemoteSvcName = ""
 				e.RemoteSvcLabelSelector = nil


### PR DESCRIPTION
# trace/network: Use columns library

The trace network gadget now uses the columns library

See https://github.com/kinvolk/inspektor-gadget/issues/1003

## Questions
### Naming of gadgets
The names of the gadget is `network` but the gadgetname of the deployed pod is `network-graph` (See modified `network.md`). This is also true for other gadgets like `mount` <-> `mountsnoop`. 

Is this by design or should i open a separate issue for this to discuss it?

### Annotating every variable in the `Event` struct with `column:`
This is the first PR where i did not anootate every variable with a `column:...`
Do we want to do that or are we leaving these hidden fields without an annotation?

## Testing done
![image](https://user-images.githubusercontent.com/113581185/195828569-2cd9d3f2-2015-41e0-b713-90e1377218ee.png)