### PR TITLE
kubectl-gadget/version: Use appropiate error message

### DIFF
--- a/cmd/common/utils/errors.go
+++ b/cmd/common/utils/errors.go
@@ -35,6 +35,10 @@ func WrapInErrListNodes(err error) error {
 	return fmt.Errorf("failed to list nodes: %w", err)
 }
 
+func WrapInErrListPods(err error) error {
+	return fmt.Errorf("listing pods: %w", err)
+}
+
 // Manager
 
 func WrapInErrManagerInit(err error) error {

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -132,7 +132,7 @@ func getTracesListPerNode(client *kubernetes.Clientset) (out map[string][]tracem
 	}
 	pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get gadget pods: %w", err)
+		return nil, commonutils.WrapInErrListPods(err)
 	}
 	if len(pods.Items) == 0 {
 		return nil, errors.New("no gadget pods found")

--- a/cmd/kubectl-gadget/utils/exec.go
+++ b/cmd/kubectl-gadget/utils/exec.go
@@ -52,7 +52,7 @@ func ExecPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 	}
 	pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), listOptions)
 	if err != nil {
-		return err
+		return commonutils.WrapInErrListPods(err)
 	}
 	if len(pods.Items) == 0 {
 		return commonutils.ErrGadgetPodNotFound

--- a/cmd/kubectl-gadget/utils/flags.go
+++ b/cmd/kubectl-gadget/utils/flags.go
@@ -120,7 +120,7 @@ func AddCommonFlags(command *cobra.Command, params *CommonFlags) {
 			}
 			pods, err := client.CoreV1().Pods(GadgetNamespace).List(context.TODO(), opts)
 			if err != nil {
-				return commonutils.WrapInErrListNodes(err)
+				return commonutils.WrapInErrListPods(err)
 			}
 
 			if len(pods.Items) == 0 {

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -230,7 +230,7 @@ func createTraces(trace *gadgetv1alpha1.Trace) error {
 	opts := metav1.ListOptions{LabelSelector: "k8s-app=gadget"}
 	pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), opts)
 	if err != nil {
-		return commonutils.WrapInErrListNodes(err)
+		return commonutils.WrapInErrListPods(err)
 	}
 
 	if len(pods.Items) == 0 {

--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -51,7 +51,7 @@ var versionCmd = &cobra.Command{
 		opts := metav1.ListOptions{LabelSelector: "k8s-app=gadget"}
 		pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), opts)
 		if err != nil {
-			return commonutils.WrapInErrListNodes(err)
+			return commonutils.WrapInErrListPods(err)
 		}
 
 		serverVersions := make(map[string]struct{})


### PR DESCRIPTION
Fixes the usage of the wrong error message function in https://github.com/inspektor-gadget/inspektor-gadget/pull/977#discussion_r988874555