### PR TITLE
pkg/gadgets/...: replace column information with template where applicable

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -35,7 +35,7 @@ type Container struct {
 	ID string `json:"id,omitempty" column:"id,width:13,maxWidth:64" columnTags:"runtime"`
 
 	// Pid is the process id of the container
-	Pid uint32 `json:"pid,omitempty" column:"pid,minWidth:7,hide"`
+	Pid uint32 `json:"pid,omitempty" column:"pid,template:pid,hide"`
 
 	// Container's configuration is the config.json from the OCI runtime
 	// spec
@@ -47,8 +47,8 @@ type Container struct {
 	Bundle string `json:"bundle,omitempty"`
 
 	// Linux metadata can be derived from the pid via /proc/$pid/...
-	Mntns      uint64 `json:"mntns,omitempty" column:"mntns,width:12,hide"`
-	Netns      uint64 `json:"netns,omitempty" column:"netns,width:12,hide"`
+	Mntns      uint64 `json:"mntns,omitempty" column:"mntns,template:ns"`
+	Netns      uint64 `json:"netns,omitempty" column:"netns,template:ns"`
 	CgroupPath string `json:"cgroupPath,omitempty"`
 	CgroupID   uint64 `json:"cgroupID,omitempty"`
 	// Data required to find the container to Pod association in the

--- a/pkg/gadgets/trace/bind/types/types.go
+++ b/pkg/gadgets/trace/bind/types/types.go
@@ -22,14 +22,14 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	Protocol  string `json:"proto,omitempty" column:"proto,width:5,fixed"`
-	Addr      string `json:"addr,omitempty" column:"addr,width:16"`
-	Port      uint16 `json:"port,omitempty" column:"port,minWidth:type"`
+	Addr      string `json:"addr,omitempty" column:"addr,template:ipaddr"`
+	Port      uint16 `json:"port,omitempty" column:"port,template:ipport"`
 	Options   string `json:"opts,omitempty" column:"opts,width:5,fixed"`
 	Interface string `json:"if,omitempty" column:"if,width:12"`
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -34,15 +34,15 @@ const (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	UID       uint32 `json:"uid,omitempty" column:"uid,minWidth:6"`
 	Cap       int    `json:"cap,omitempty" column:"cap,width:3,fixed"`
 	CapName   string `json:"capName,omitempty" column:"capName,width:18,fixed"`
 	Audit     int    `json:"audit,omitempty" column:"audit,minWidth:5"`
 	Verdict   string `json:"verdict,omitempty" column:"verdict,width:7,fixed"`
 	InsetID   *bool  `json:"insetid,omitempty" column:"insetid,width:7,fixed,hide"`
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -24,13 +24,13 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32   `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Ppid      uint32   `json:"ppid,omitempty" column:"ppid,minWidth:7"`
-	Comm      string   `json:"pcomm,omitempty" column:"comm,maxWidth:16"`
+	Pid       uint32   `json:"pid,omitempty" column:"pid,template:pid"`
+	Ppid      uint32   `json:"ppid,omitempty" column:"ppid,template:pid"`
+	Comm      string   `json:"pcomm,omitempty" column:"comm,template:comm"`
 	Retval    int      `json:"ret,omitempty" column:"ret,width:3,fixed"`
 	Args      []string `json:"args,omitempty" column:"args,width:40"`
 	UID       uint32   `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
-	MountNsID uint64   `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	MountNsID uint64   `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/fsslower/types/types.go
+++ b/pkg/gadgets/trace/fsslower/types/types.go
@@ -26,9 +26,9 @@ const (
 type Event struct {
 	eventtypes.Event
 
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
-	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	Op        string `json:"op,omitempty" column:"T,width:1,fixed"`
 	Bytes     uint64 `json:"bytes,omitempty" column:"bytes,width:10,align:right"`
 	Offset    int64  `json:"offset,omitempty" column:"offset,width:10,align:right"`

--- a/pkg/gadgets/trace/mount/types/types.go
+++ b/pkg/gadgets/trace/mount/types/types.go
@@ -25,10 +25,10 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Comm      string   `json:"comm,omitempty" column:"comm,maxWidth:16"`
-	Pid       uint32   `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Tid       uint32   `json:"tid,omitempty" column:"tid,minWidth:7"`
-	MountNsID uint64   `json:"mntnsid,omitempty" column:"mntns,width:12"`
+	Comm      string   `json:"comm,omitempty" column:"comm,template:comm"`
+	Pid       uint32   `json:"pid,omitempty" column:"pid,template:pid"`
+	Tid       uint32   `json:"tid,omitempty" column:"tid,template:pid"`
+	MountNsID uint64   `json:"mntnsid,omitempty" column:"mntns,template:ns"`
 	Operation string   `json:"operation,omitempty" column:"op,minWidth:5,maxWidth:7,hide"`
 	Retval    int      `json:"ret,omitempty" column:"ret,width:3,fixed,hide"`
 	Latency   uint64   `json:"latency,omitempty" column:"latency,minWidth:3,hide"`

--- a/pkg/gadgets/trace/oomkill/types/types.go
+++ b/pkg/gadgets/trace/oomkill/types/types.go
@@ -22,12 +22,12 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	KilledPid     uint32 `json:"kpid,omitempty" column:"kpid,minWidth:7"`
-	KilledComm    string `json:"kcomm,omitempty" column:"kcomm,maxWidth:16"`
+	KilledPid     uint32 `json:"kpid,omitempty" column:"kpid,template:pid"`
+	KilledComm    string `json:"kcomm,omitempty" column:"kcomm,template:comm"`
 	Pages         uint64 `json:"pages,omitempty" column:"pages,width:6"`
-	TriggeredPid  uint32 `json:"tpid,omitempty" column:"tpid,minWidth:7"`
-	TriggeredComm string `json:"tcomm,omitempty" column:"tcomm,maxWidth:16"`
-	MountNsID     uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	TriggeredPid  uint32 `json:"tpid,omitempty" column:"tpid,template:pid"`
+	TriggeredComm string `json:"tcomm,omitempty" column:"tcomm,template:comm"`
+	MountNsID     uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/signal/types/types.go
+++ b/pkg/gadgets/trace/signal/types/types.go
@@ -22,14 +22,14 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid  uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Comm string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	Pid  uint32 `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm string `json:"comm,omitempty" column:"comm,template:comm"`
 	// The most common signals are SIGKILL, SIGTERM, SIGINT (6 chars) and the
 	// longest is SIGRTMIN+XX (11 chars).
 	Signal    string `json:"signal,omitempty" column:"signal,minWidth:6,maxWidth:11,ellipsis:start"`
-	TargetPid uint32 `json:"tpid,omitempty" column:"tpid,minWidth:7"`
+	TargetPid uint32 `json:"tpid,omitempty" column:"tpid,template:pid"`
 	Retval    int    `json:"ret,omitempty" column:"ret,width:3,fixed"`
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/tcp/types/types.go
+++ b/pkg/gadgets/trace/tcp/types/types.go
@@ -23,17 +23,14 @@ type Event struct {
 	eventtypes.Event
 
 	Operation string `json:"operation,omitempty" column:"t,width:1,fixed"`
-	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	IPVersion int    `json:"ipversion,omitempty" column:"ip,width:2,fixed"`
-	// For Saddr and Daddr:
-	// Min: XXX.XXX.XXX.XXX (IPv4) = 15
-	// Max: 0000:0000:0000:0000:0000:ffff:XXX.XXX.XXX.XXX (IPv4-mapped IPv6 address) = 45
-	Saddr     string `json:"saddr,omitempty" column:"saddr,minWidth:15,maxWidth:45"`
-	Daddr     string `json:"daddr,omitempty" column:"daddr,minWidth:15,maxWidth:45"`
-	Sport     uint16 `json:"sport,omitempty" column:"sport,minWidth:type"`
-	Dport     uint16 `json:"dport,omitempty" column:"dport,minWidth:type"`
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr"`
+	Daddr     string `json:"daddr,omitempty" column:"daddr,template:ipaddr"`
+	Sport     uint16 `json:"sport,omitempty" column:"sport,template:ipport"`
+	Dport     uint16 `json:"dport,omitempty" column:"dport,template:ipport"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -22,17 +22,14 @@ import (
 type Event struct {
 	eventtypes.Event
 
-	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
+	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
 	UID       uint32 `json:"uid,omitempty" column:"uid,minWidth:6,hide"`
-	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	IPVersion int    `json:"ipversion,omitempty" column:"ip,width:2,fixed"`
-	// For Saddr and Daddr:
-	// Min: XXX.XXX.XXX.XXX (IPv4) = 15
-	// Max: 0000:0000:0000:0000:0000:ffff:XXX.XXX.XXX.XXX (IPv4-mapped IPv6 address) = 45
-	Saddr     string `json:"saddr,omitempty" column:"saddr,minWidth:15,maxWidth:45"`
-	Daddr     string `json:"daddr,omitempty" column:"daddr,minWidth:15,maxWidth:45"`
-	Dport     uint16 `json:"dport,omitempty" column:"dport,minWidth:type"`
-	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
+	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr"`
+	Daddr     string `json:"daddr,omitempty" column:"daddr,template:ipaddr"`
+	Dport     uint16 `json:"dport,omitempty" column:"dport,template:ipport"`
+	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,template:ns"`
 }
 
 func GetColumns() *columns.Columns[Event] {


### PR DESCRIPTION
In this PR, I changed the column information of all already to columns converted gadgets to use templates (where possible).