### PR TITLE
gadgets/network: Align name and type notation with the rest of gadgets

### DIFF
--- a/docs/guides/trace/network-graph.md
+++ b/docs/guides/trace/network-graph.md
@@ -47,6 +47,6 @@ State: Started
 
 ```json
 {"type":"debug","message":"tracer attached","node":"local","namespace":"default","pod":"demo"}
-{"type":"normal","namespace":"default","pod":"demo","pktType":"OUTGOING","proto":"tcp","ip":"1.1.1.1","port":80}
-{"type":"normal","namespace":"default","pod":"demo","pktType":"OUTGOING","proto":"udp","ip":"192.168.0.1","port":53}
+{"type":"normal","namespace":"default","pod":"demo","pktType":"OUTGOING","proto":"tcp","addr":"1.1.1.1","port":80}
+{"type":"normal","namespace":"default","pod":"demo","pktType":"OUTGOING","proto":"udp","addr":"192.168.0.1","port":53}
 ```

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -716,7 +716,7 @@ func TestNetworkpolicy(t *testing.T) {
 					sleep 10
 					kill $!
 					head networktrace-client.log | sort | uniq`, nsClient),
-			ExpectedRegexp: fmt.Sprintf(`{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pktType":"OUTGOING","proto":"tcp","ip":".*","port":9090,"remoteKind":"svc","podHostIP":".*","podIP":".*","podLabels":{"run":"test-pod"},"remoteServiceNamespace":"%s","remoteServiceName":"test-pod","remoteServiceLabelSelector":{"run":"test-pod"}}`, nsClient, nsServer),
+			ExpectedRegexp: fmt.Sprintf(`{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pktType":"OUTGOING","proto":"tcp","addr":".*","port":9090,"remoteKind":"svc","podHostIP":".*","podIP":".*","podLabels":{"run":"test-pod"},"remoteServiceNamespace":"%s","remoteServiceName":"test-pod","remoteServiceLabelSelector":{"run":"test-pod"}}`, nsClient, nsServer),
 		},
 		{
 			// Docker bridge does not preserve source IP :-(
@@ -728,7 +728,7 @@ func TestNetworkpolicy(t *testing.T) {
 					kill $!
 					head networktrace-server.log | sort | uniq
 					kubectl get node -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}'|grep -q docker && echo SKIP_TEST || true`, nsServer),
-			ExpectedRegexp: fmt.Sprintf(`SKIP_TEST|{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pktType":"HOST","proto":"tcp","ip":".*","port":9090,"remoteKind":"pod","podHostIP":".*","podIP":".*","podLabels":{"run":"test-pod"},"remotePodNamespace":"%s","remotePodName":"test-pod","remotePodLabels":{"run":"test-pod"}}`, nsServer, nsClient),
+			ExpectedRegexp: fmt.Sprintf(`SKIP_TEST|{"node":".*","namespace":"%s","pod":"test-pod","type":"normal","pktType":"HOST","proto":"tcp","addr":".*","port":9090,"remoteKind":"pod","podHostIP":".*","podIP":".*","podLabels":{"run":"test-pod"},"remotePodNamespace":"%s","remotePodName":"test-pod","remotePodLabels":{"run":"test-pod"}}`, nsServer, nsClient),
 		},
 		{
 			Name: "RunNetworkPolicyReportClient",

--- a/pkg/gadget-collection/gadgets/trace/network/enricher.go
+++ b/pkg/gadget-collection/gadgets/trace/network/enricher.go
@@ -79,7 +79,7 @@ func (e *Enricher) convertEvent(
 
 		PktType: edge.PktType,
 		Proto:   edge.Proto,
-		IP:      edge.IP.String(),
+		Addr:    edge.Addr.String(),
 		Port:    edge.Port,
 	}
 
@@ -104,7 +104,7 @@ func (e *Enricher) convertEvent(
 		if pod.Spec.HostNetwork {
 			continue
 		}
-		if pod.Status.PodIP == edge.IP.String() {
+		if pod.Status.PodIP == edge.Addr.String() {
 			out.RemoteKind = "pod"
 			out.RemotePodNamespace = pod.Namespace
 			out.RemotePodName = pod.Name
@@ -128,7 +128,7 @@ func (e *Enricher) convertEvent(
 
 	if out.RemoteKind == "" {
 		for _, svc := range svcs.Items {
-			if svc.Spec.ClusterIP == edge.IP.String() {
+			if svc.Spec.ClusterIP == edge.Addr.String() {
 				out.RemoteKind = "svc"
 				out.RemoteSvcNamespace = svc.Namespace
 				out.RemoteSvcName = svc.Name
@@ -139,7 +139,7 @@ func (e *Enricher) convertEvent(
 	}
 	if out.RemoteKind == "" {
 		out.RemoteKind = "other"
-		out.RemoteOther = edge.IP.String()
+		out.RemoteOther = edge.Addr.String()
 	}
 
 	return out

--- a/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
+++ b/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
@@ -287,7 +287,7 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 		// Kubernetes Network Policies can't block traffic from a pod's
 		// own resident node. Therefore we must not generate a network
 		// policy in that case.
-		if e.PktType == "HOST" && e.PodHostIP == e.IP {
+		if e.PktType == "HOST" && e.PodHostIP == e.Addr {
 			continue
 		}
 

--- a/pkg/gadgets/trace/network/tracer/tracer.go
+++ b/pkg/gadgets/trace/network/tracer/tracer.go
@@ -42,7 +42,7 @@ const (
 type Edge struct {
 	Key     string
 	PktType string
-	IP      net.IP
+	Addr    net.IP
 	Proto   string
 	Port    uint16
 }
@@ -212,7 +212,7 @@ func (t *Tracer) Pop() ([]Edge, error) {
 		return Edge{
 			Key:     t.containerQuarkToKey(uint64(key.ContainerQuark)),
 			PktType: pktTypeString(int(key.PktType)),
-			IP:      ip,
+			Addr:    ip,
 			Proto:   protoString(int(key.Proto)),
 			Port:    uint16(C.htons(C.ushort(key.Port))),
 		}

--- a/pkg/gadgets/trace/network/tracer/tracer.go
+++ b/pkg/gadgets/trace/network/tracer/tracer.go
@@ -44,7 +44,7 @@ type Edge struct {
 	PktType string
 	IP      net.IP
 	Proto   string
-	Port    int
+	Port    uint16
 }
 
 type link struct {
@@ -214,7 +214,7 @@ func (t *Tracer) Pop() ([]Edge, error) {
 			PktType: pktTypeString(int(key.PktType)),
 			IP:      ip,
 			Proto:   protoString(int(key.Proto)),
-			Port:    int(C.htons(C.ushort(key.Port))),
+			Port:    uint16(C.htons(C.ushort(key.Port))),
 		}
 	}
 

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -26,7 +26,7 @@ type Event struct {
 
 	PktType string `json:"pktType,omitempty"`
 	Proto   string `json:"proto,omitempty"`
-	IP      string `json:"ip,omitempty"`
+	Addr    string `json:"addr,omitempty"`
 	Port    uint16 `json:"port,omitempty"`
 
 	/* pod, svc or other */
@@ -76,7 +76,7 @@ func (e *Event) Key() string {
 		e.Pod,
 		e.PktType,
 		e.Proto,
-		e.IP,
+		e.Addr,
 		e.Port)
 }
 

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -27,7 +27,7 @@ type Event struct {
 	PktType string `json:"pktType,omitempty"`
 	Proto   string `json:"proto,omitempty"`
 	IP      string `json:"ip,omitempty"`
-	Port    int    `json:"port,omitempty"`
+	Port    uint16 `json:"port,omitempty"`
 
 	/* pod, svc or other */
 	RemoteKind string `json:"remoteKind,omitempty"`

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -572,7 +572,7 @@ func TestNetworkGraph(t *testing.T) {
 		},
 		PktType: "OUTGOING",
 		Proto:   "tcp",
-		IP:      "1.1.1.1",
+		Addr:    "1.1.1.1",
 		Port:    443,
 	}
 


### PR DESCRIPTION
This PR introduces two changes to the network trace gadget:

1. Use `unint16` for the port field.
2. Currently, we are using `ip` to describe if it is IPv4 or IPv6 in tcp and tcpconnect gadget. Instead, we use `saddr`, `daddr` or `addr` for the IP addresses, e.g. in bind, tcp and tcpconnect. This commit aligns the network gadget to bind, tcp and tcpconnect gadgets.