### PR TITLE
local-gadget: Add signal trace gadget

### DIFF
--- a/cmd/local-gadget/trace/signal.go
+++ b/cmd/local-gadget/trace/signal.go
@@ -1,0 +1,64 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/spf13/cobra"
+
+	commontrace "github.com/inspektor-gadget/inspektor-gadget/cmd/common/trace"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/local-gadget/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	signalTracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/tracer"
+	signalTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/types"
+)
+
+func newSignalCmd() *cobra.Command {
+	var commonFlags utils.CommonFlags
+	var flags commontrace.SignalFlags
+
+	runCmd := func(*cobra.Command, []string) error {
+		parser, err := commonutils.NewGadgetParserWithRuntimeInfo(
+			&commonFlags.OutputConfig,
+			signalTypes.GetColumns(),
+		)
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
+		}
+
+		signalGadget := &TraceGadget[signalTypes.Event]{
+			commonFlags: &commonFlags,
+			parser:      parser,
+			createAndRunTracer: func(mountnsmap *ebpf.Map, enricher gadgets.DataEnricher, eventCallback func(signalTypes.Event)) (trace.Tracer, error) {
+				return signalTracer.NewTracer(&signalTracer.Config{
+					MountnsMap:   mountnsmap,
+					TargetSignal: flags.Sig,
+					TargetPid:    int32(flags.Pid),
+					FailedOnly:   flags.Failed,
+				}, enricher, eventCallback)
+			},
+		}
+
+		return signalGadget.Run()
+	}
+
+	cmd := commontrace.NewSignalCmd(runCmd, &flags)
+
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
+}

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -115,6 +115,7 @@ func NewTraceCmd() *cobra.Command {
 	traceCmd.AddCommand(newOOMKillCmd())
 	traceCmd.AddCommand(newTCPCmd())
 	traceCmd.AddCommand(newTcpconnectCmd())
+	traceCmd.AddCommand(newSignalCmd())
 
 	return traceCmd
 }

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -289,6 +289,29 @@ CONTAINER        PID     COMM             IP  SADDR            DADDR            
 test-container   503650  wget             4   172.17.0.3       93.184.216.34    80
 ```
 
+### Trace/Signal
+
+The signal trace gadget is used to trace system signals received by containers.
+
+```bash
+$ docker run -it --rm --name test-container busybox /bin/sh
+/ # sleep 100 &
+/ # echo $!
+7
+/ # kill -kill $!
+/ # exit
+```
+
+```bash
+$ sudo local-gadget trace signal --containername test-container
+WARN[0000] Runtime enricher (containerd): couldn't get current containers
+WARN[0000] Runtime enricher (cri-o): couldn't get current containers
+CONTAINER                  PID        COMM          SIGNAL      TPID       RET
+test-container             11131      sh            SIGKILL     11162      0
+test-container             11131      sh            SIGKILL     7          0
+test-container             11131      sh            SIGHUP      11131      0
+```
+
 ## Using the interactive mode
 
 The interactive mode allows us to create multiple traces at the same time.

--- a/pkg/gadget-collection/gadget-collection.go
+++ b/pkg/gadget-collection/gadget-collection.go
@@ -82,5 +82,6 @@ func TraceFactoriesForLocalGadget() map[string]gadgets.TraceFactory {
 		"socket-collector":  socketcollector.NewFactory(),
 		"seccomp":           seccomp.NewFactory(),
 		"snisnoop":          snisnoop.NewFactory(),
+		"sigsnoop":          sigsnoop.NewFactory(),
 	}
 }


### PR DESCRIPTION
This is a fix for https://github.com/inspektor-gadget/inspektor-gadget/issues/892 .

`local-gadget` doesn't support tracing signal, like `kubectl-gadget` do. Use the common functionality available to add the same support to `local-gadget`.

## Testing Done

- Ran `local-gadget` integration test on `minikube` cluster
- Build and run `local-gadget`
```
sudo ./local-gadget trace signal
CONTAINER                                          PID        COMM             SIGNAL      TPID       RET
minikube-docker                                    47618      cri-dockerd      SIGURG      51004      0
minikube-docker                                    47618      cri-dockerd      SIGURG      3073       0
minikube-docker                                    49410      kubelet          SIGURG      85749      0
...
```
