### PR TITLE
ci: Fix outdated field name

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -926,7 +926,7 @@ func TestNetworkGraph(t *testing.T) {
 					PktType:     "OUTGOING",
 					Proto:       "tcp",
 					Port:        80,
-					IP:          "1.1.1.1",
+					Addr:        "1.1.1.1",
 					PodLabels:   map[string]string{"run": "test-pod"},
 					RemoteKind:  "other",
 					RemoteOther: "1.1.1.1",
@@ -957,7 +957,7 @@ func TestNetworkGraph(t *testing.T) {
 				e.RemoteSvcLabelSelector = nil
 
 				if e.RemoteKind == "svc" {
-					e.IP = ""
+					e.Addr = ""
 				}
 			}
 


### PR DESCRIPTION
Fixes conflict created by merging #1050 and #1046 without rebasing.