### PR TITLE
ci: Add integration tests for exec/signal/tcp trace gadgets

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -520,7 +520,8 @@ func TestExecsnoop(t *testing.T) {
 
 	t.Parallel()
 
-	shArgs := []string{"/bin/sh", "-c", "while true; do date ; sleep 0.1; done"}
+	cmd := "while true; do date ; sleep 0.1; done"
+	shArgs := []string{"/bin/sh", "-c", cmd}
 	dateArgs := []string{"/bin/date"}
 	sleepArgs := []string{"/bin/sleep", "0.1"}
 	// on arm64, trace exec uses kprobe and it cannot trace the arguments:
@@ -570,7 +571,7 @@ func TestExecsnoop(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		execsnoopCmd,
-		BusyboxPodRepeatCommand(ns, "date"),
+		BusyboxPodCommand(ns, cmd),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}

--- a/integration/local-gadget/trace_exec_test.go
+++ b/integration/local-gadget/trace_exec_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	execTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
+)
+
+func TestTraceExec(t *testing.T) {
+	t.Parallel()
+	ns := GenerateTestNamespaceName("test-trace-exec")
+
+	cmd := "while true; do date ; sleep 0.1; done"
+	// shArgs := []string{"/bin/sh", "-c", cmd}
+	dateArgs := []string{"/bin/date"}
+	sleepArgs := []string{"/bin/sleep", "0.1"}
+
+	traceExecCmd := &Command{
+		Name:         "TraceExec",
+		Cmd:          fmt.Sprintf("local-gadget trace exec -o json --runtimes=%s", *containerRuntime),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntries := []*execTypes.Event{
+				// TODO: Enable this test once we can trace new cri-o containers.
+				// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
+				// {
+				// 	Event: BuildBaseEvent(ns),
+				// 	Comm:  "sh",
+				// 	Args:  shArgs,
+				// },
+				{
+					Event: BuildBaseEvent(ns),
+					Comm:  "date",
+					Args:  dateArgs,
+				},
+				{
+					Event: BuildBaseEvent(ns),
+					Comm:  "sleep",
+					Args:  sleepArgs,
+				},
+			}
+
+			normalize := func(e *execTypes.Event) {
+				// TODO: Handle it once we support getting K8s container name for docker
+				// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/737
+				if *containerRuntime == ContainerRuntimeDocker {
+					e.Container = "test-pod"
+				}
+
+				e.Pid = 0
+				e.Ppid = 0
+				e.UID = 0
+				e.Retval = 0
+				e.MountNsID = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+		},
+	}
+
+	// TODO: traceExecCmd should moved up the list once we can trace new cri-o containers.
+	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		BusyboxPodCommand(ns, cmd),
+		WaitUntilTestPodReadyCommand(ns),
+		traceExecCmd,
+		DeleteTestNamespaceCommand(ns),
+	}
+
+	RunCommands(commands, t)
+}

--- a/integration/local-gadget/trace_signal_test.go
+++ b/integration/local-gadget/trace_signal_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	signalTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/types"
+)
+
+func TestTraceSignal(t *testing.T) {
+	t.Parallel()
+	ns := GenerateTestNamespaceName("test-trace-signal")
+
+	traceSignalCmd := &Command{
+		Name:         "TraceSignal",
+		Cmd:          fmt.Sprintf("local-gadget trace signal -o json --runtimes=%s", *containerRuntime),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntry := &signalTypes.Event{
+				Event:  BuildBaseEvent(ns),
+				Comm:   "sh",
+				Signal: "SIGTERM",
+			}
+
+			normalize := func(e *signalTypes.Event) {
+				// TODO: Handle it once we support getting K8s container name for docker
+				// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/737
+				if *containerRuntime == ContainerRuntimeDocker {
+					e.Container = "test-pod"
+				}
+
+				e.Pid = 0
+				e.TargetPid = 0
+				e.Retval = 0
+				e.MountNsID = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+		},
+	}
+
+	// TODO: traceSignalCmd should moved up the list once we can trace new cri-o containers.
+	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		BusyboxPodRepeatCommand(ns, "sleep 3 & kill $!"),
+		WaitUntilTestPodReadyCommand(ns),
+		traceSignalCmd,
+		DeleteTestNamespaceCommand(ns),
+	}
+
+	RunCommands(commands, t)
+}

--- a/integration/local-gadget/trace_tcp_test.go
+++ b/integration/local-gadget/trace_tcp_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	tcpTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/types"
+)
+
+func TestTraceTCP(t *testing.T) {
+	t.Parallel()
+	ns := GenerateTestNamespaceName("test-trace-tcp")
+
+	traceTCPCmd := &Command{
+		Name:         "TraceTCP",
+		Cmd:          fmt.Sprintf("local-gadget trace tcp -o json --runtimes=%s", *containerRuntime),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntries := []*tcpTypes.Event{
+				{
+					Event:     BuildBaseEvent(ns),
+					Comm:      "wget",
+					IPVersion: 4,
+					Daddr:     "1.1.1.1",
+					Dport:     80,
+					Operation: "connect",
+				},
+				{
+					Event:     BuildBaseEvent(ns),
+					Comm:      "wget",
+					IPVersion: 4,
+					Daddr:     "1.1.1.1",
+					Dport:     80,
+					Operation: "close",
+				},
+				{
+					Event:     BuildBaseEvent(ns),
+					Comm:      "wget",
+					IPVersion: 4,
+					Daddr:     "1.1.1.1",
+					Dport:     443,
+					Operation: "connect",
+				},
+			}
+
+			normalize := func(e *tcpTypes.Event) {
+				// TODO: Handle it once we support getting K8s container name for docker
+				// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/737
+				if *containerRuntime == ContainerRuntimeDocker {
+					e.Container = "test-pod"
+				}
+
+				e.Pid = 0
+				e.Saddr = ""
+				e.Sport = 0
+				e.MountNsID = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+		},
+	}
+
+	// TODO: traceTCPCmd should moved up the list once we can trace new cri-o containers.
+	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		BusyboxPodRepeatCommand(ns, "wget -q -O /dev/null -T 3 http://1.1.1.1"),
+		WaitUntilTestPodReadyCommand(ns),
+		traceTCPCmd,
+		DeleteTestNamespaceCommand(ns),
+	}
+
+	RunCommands(commands, t)
+}


### PR DESCRIPTION
# Add integration tests for exec/signal/tcp trace gadgets

These three gadgets were missing for tests.

## TODO

- [x] Rebase once https://github.com/inspektor-gadget/inspektor-gadget/pull/1053 is merged.