### PR TITLE
ci: Use a new release action

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -693,7 +693,13 @@ jobs:
         name: Release ${{ github.ref }}
     - name: Get all artifacts.
       uses: actions/download-artifact@v2
-    - name: Upload Gadget Release *-gadget-*-*.tar.gz
+    - name: Rename all artifacts to *-${{ env.GITHUB_REF_NAME }}.tar.gz
+      shell: bash
+      run: |
+        for i in *-gadget-*-*-tar-gz/*-gadget-*-*.tar.gz; do
+          mv $i $(dirname $i)/$(basename $i .tar.gz)-${GITHUB_REF_NAME}.tar.gz
+        done
+    - name: Upload Gadget Release *.tar.gz
       uses: csexton/release-asset-action@v2
       with:
         pattern: "*-gadget-*-*-tar-gz/*-gadget-*-*.tar.gz"


### PR DESCRIPTION
Hi.


This PR supersedes #1068 by using [softprops/action-gh-release](https://github.com/softprops/action-gh-release) instead of [actions/create-release](https://github.com/actions/create-release) which is now archived.
It also appends the tag name to release artifacts.
It was tested and validated in a [fork](https://github.com/eiffel-fl/inspektor-gadget/releases/tag/vtest42).


Best regards.