### PR TITLE
integrationtest/TestFiletop: Validate json output

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 	ebpftopTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/types"
+	filetopTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/types"
 	tcptopTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/tcp/types"
 	bindTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/bind/types"
 	capabilitiesTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
@@ -611,10 +612,30 @@ func TestFiletop(t *testing.T) {
 	t.Parallel()
 
 	filetopCmd := &Command{
-		Name:           "StartFiletopGadget",
-		Cmd:            fmt.Sprintf("$KUBECTL_GADGET top file -n %s", ns),
-		ExpectedRegexp: fmt.Sprintf(`%s\s+test-pod\s+test-pod\s+\d+\s+\S*\s+0\s+\d+\s+0\s+\d+\s+R\s+date`, ns),
-		StartAndStop:   true,
+		Name:         "StartFiletopGadget",
+		Cmd:          fmt.Sprintf("$KUBECTL_GADGET top file -n %s -o json", ns),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntry := &filetopTypes.Stats{
+				CommonData: BuildCommonData(ns),
+				Reads:      0,
+				ReadBytes:  0,
+				Filename:   "date.txt",
+				FileType:   byte('R'), // Regular file
+				Comm:       "sh",
+			}
+
+			normalize := func(e *filetopTypes.Stats) {
+				e.Node = ""
+				e.Writes = 0
+				e.WriteBytes = 0
+				e.Pid = 0
+				e.Tid = 0
+				e.MountNsID = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+		},
 	}
 
 	commands := []*Command{

--- a/pkg/gadgets/top/file/types/types.go
+++ b/pkg/gadgets/top/file/types/types.go
@@ -90,7 +90,7 @@ type Stats struct {
 	MountNsID  uint64 `json:"mountnsid,omitempty"`
 	Filename   string `json:"filename,omitempty"`
 	Comm       string `json:"comm,omitempty"`
-	FileType   byte   `json:"fileType,omitempty"`
+	FileType   byte   `json:"fileType,omitempty"` // R = Regular File, S = Socket, O = Other
 }
 
 func SortStats(stats []Stats, sortBy SortBy) {


### PR DESCRIPTION
### integrationtest/TestFiletop: Validate json output

Uses the json output in order to validate as much information as possible from the `top file` gadget

### Question/Comment
General comment/question about the `FileType` member variable of the `Stats struct` in `top/types.go`.
Should the type of `FileType` be a char/enum, since in the eBPF program only `R`,  `S` or `O` will get assigned.
And where can we put this documentation. Is it right when it is in the same line for such a small comment?