### PR TITLE
pkg/columns: improve performance of sort & filter

### DIFF
--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -51,6 +51,7 @@ type Column[T any] struct {
 	Order        int                   // Order defines the default order in which columns are shown
 	Tags         []string              // Tags can be used to dynamically include or exclude columns
 
+	offset        uintptr
 	fieldIndex    int          // used for the main struct
 	subFieldIndex []int        // used for embedded structs
 	kind          reflect.Kind // cached kind info from reflection
@@ -231,6 +232,10 @@ func (ci *Column[T]) Get(entry *T) reflect.Value {
 		return reflect.ValueOf(ci.Extractor(v.Interface().(*T)))
 	}
 	return ci.getRawField(v)
+}
+
+func (ci *Column[T]) GetOffset() uintptr {
+	return ci.offset
 }
 
 // GetRef returns the reflected value of an already reflected entry for the current column; expects v to be valid or


### PR DESCRIPTION
This PR improves the performance of the sort and filter subpackage of our columns library. The performance increase is mainly achieved by caching the offsets of fields inside structs and accessing them directly via the `unsafe` package. As we've collected all required information on fields anyways, this isn't particularly unsafe.

Another optimization has been done in the filter package by preparing dedicated functions for types instead of switching on them with every call.

### Some benchmarks

```
name                    old time/op    new time/op    delta
FilterNumberGte-10        23.5ns ± 0%     2.8ns ± 1%   -87.94%  (p=0.008 n=5+5)
FilterNumberEq-10         23.0ns ± 0%     2.8ns ± 1%   -87.70%  (p=0.008 n=5+5)
FilterNumberNeq-10        22.8ns ± 1%     2.8ns ± 1%   -87.59%  (p=0.008 n=5+5)
FilterStringEq-10         32.0ns ± 0%     4.4ns ± 1%   -86.26%  (p=0.008 n=5+5)
FilterStringNeq-10        32.1ns ± 0%     4.4ns ± 0%   -86.31%  (p=0.008 n=5+5)
FilterStringRegex-10      35.8ns ± 0%    30.5ns ± 0%   -14.86%  (p=0.008 n=5+5)
FilterStringRegexCI-10    66.3ns ± 0%    60.9ns ± 0%    -8.07%  (p=0.008 n=5+5)
Group1000to100-10          199µs ± 0%     188µs ± 0%    -5.44%  (p=0.016 n=4+5)
Group1000to10-10           138µs ± 1%     139µs ± 1%      ~     (p=0.222 n=5+5)
SortReflection1000-10      371µs ± 0%     143µs ± 0%   -61.53%  (p=0.008 n=5+5)
SortNative1000-10          122µs ± 1%     124µs ± 0%    +1.94%  (p=0.008 n=5+5)
JSON-10                    356ns ± 0%     363ns ± 0%    +1.84%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
FilterNumberGte-10         8.00B ± 0%     0.00B       -100.00%  (p=0.008 n=5+5)
FilterNumberEq-10          8.00B ± 0%     0.00B       -100.00%  (p=0.008 n=5+5)
FilterNumberNeq-10         8.00B ± 0%     0.00B       -100.00%  (p=0.008 n=5+5)
FilterStringEq-10          16.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
FilterStringNeq-10         16.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
FilterStringRegex-10       0.00B          0.00B           ~     (all equal)
FilterStringRegexCI-10     0.00B          0.00B           ~     (all equal)
Group1000to100-10          103kB ± 0%     103kB ± 0%    -0.06%  (p=0.008 n=5+5)
Group1000to10-10          63.7kB ± 0%    63.7kB ± 0%    -0.10%  (p=0.000 n=5+4)
SortReflection1000-10       169B ± 0%      104B ± 0%   -38.46%  (p=0.008 n=5+5)
SortNative1000-10          56.0B ± 0%     56.0B ± 0%      ~     (all equal)
JSON-10                     208B ± 0%      208B ± 0%      ~     (all equal)

name                    old allocs/op  new allocs/op  delta
FilterNumberGte-10          1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
FilterNumberEq-10           1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
FilterNumberNeq-10          1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
FilterStringEq-10           1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
FilterStringNeq-10          1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
FilterStringRegex-10        0.00           0.00           ~     (all equal)
FilterStringRegexCI-10      0.00           0.00           ~     (all equal)
Group1000to100-10            716 ± 0%       717 ± 0%    +0.14%  (p=0.008 n=5+5)
Group1000to10-10             109 ± 0%       110 ± 0%    +0.92%  (p=0.008 n=5+5)
SortReflection1000-10       4.00 ± 0%      5.00 ± 0%   +25.00%  (p=0.008 n=5+5)
SortNative1000-10           2.00 ± 0%      2.00 ± 0%      ~     (all equal)
JSON-10                     1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```