### PR TITLE
local-gadget: fix tracing new crio containers

### DIFF
--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -92,6 +92,7 @@ Flags:
       --crio-socketpath string         CRI-O CRI Unix socket path (default "/run/crio/crio.sock")
       --docker-socketpath string       Docker Engine API Unix socket path (default "/run/docker.sock")
   -r, --runtimes string                Container runtimes to be used separated by comma. Supported values are: docker, containerd, cri-o (default "docker,containerd,cri-o")
+  -w, --watch                          After listing the containers, watch for new containers
   ...
 ```
 

--- a/integration/command.go
+++ b/integration/command.go
@@ -624,3 +624,11 @@ func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 func WaitUntilTestPodReadyCommand(namespace string) *Command {
 	return WaitUntilPodReadyCommand(namespace, "test-pod")
 }
+
+// SleepForSecondsCommand returns a Command which sleeps for given seconds
+func SleepForSecondsCommand(seconds int) *Command {
+	return &Command{
+		Name: "SleepForSeconds",
+		Cmd:  fmt.Sprintf("sleep %d", seconds),
+	}
+}

--- a/integration/local-gadget/list_containers_test.go
+++ b/integration/local-gadget/list_containers_test.go
@@ -15,9 +15,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
@@ -60,19 +58,7 @@ func TestListContainers(t *testing.T) {
 				c.PodUID = ""
 			}
 
-			var containers []*containercollection.Container
-			if err := json.Unmarshal([]byte(output), &containers); err != nil {
-				return err
-			}
-
-			for _, gotContainer := range containers {
-				normalize(gotContainer)
-				if reflect.DeepEqual(gotContainer, expectedContainer) {
-					return nil
-				}
-			}
-
-			return fmt.Errorf("output doesn't contain the expected container: %+v", expectedContainer)
+			return ExpectEntriesInArrayToMatch(output, normalize, expectedContainer)
 		},
 	}
 
@@ -143,23 +129,7 @@ spec:
 				c.PodUID = ""
 			}
 
-			var containers []*containercollection.Container
-			if err := json.Unmarshal([]byte(output), &containers); err != nil {
-				return err
-			}
-
-			if len(containers) == 0 {
-				return fmt.Errorf("expect at least one container in output")
-			}
-
-			for _, gotContainer := range containers {
-				normalize(gotContainer)
-				if !reflect.DeepEqual(gotContainer, expectedContainer) {
-					return fmt.Errorf("expect at least one container to match, expected=%+v, got=%+v", expectedContainer, gotContainer)
-				}
-			}
-
-			return nil
+			return ExpectAllToMatch(output, normalize, expectedContainer)
 		},
 	}
 

--- a/integration/local-gadget/list_containers_test.go
+++ b/integration/local-gadget/list_containers_test.go
@@ -73,43 +73,24 @@ func TestListContainers(t *testing.T) {
 	RunCommands(commands, t)
 }
 
-func TestListSingleContainer(t *testing.T) {
+func TestFilterByContainerName(t *testing.T) {
 	t.Parallel()
-	prefix := "test-list-single"
-	po := fmt.Sprintf("%s-pod", prefix)
-	cn := fmt.Sprintf("%s-container", prefix)
-	ns := GenerateTestNamespaceName(fmt.Sprintf("%s-namespace", prefix))
+	cn := "test-filtered-container"
+	ns := GenerateTestNamespaceName(cn)
 
 	// TODO: Handle it once we support getting K8s container name for docker
 	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/737
 	if *containerRuntime == ContainerRuntimeDocker {
-		t.Skip("Skip TestListSingleContainer on docker since we don't propagate the Kubernetes pod container name")
+		t.Skip("Skip TestFilterByContainerName on docker since we don't propagate the Kubernetes pod container name")
 	}
 
-	TestPodYaml := fmt.Sprintf(`
-apiVersion: v1
-kind: Pod
-metadata:
-  namespace: %s
-  name: %s
-spec:
-  restartPolicy: Never
-  terminationGracePeriodSeconds: 0
-  containers:
-  - name: %s
-    image: busybox
-    command: ["/bin/sh", "-c"]
-    args:
-    - "sleep inf"
-`, ns, po, cn)
-
 	listContainersCmd := &Command{
-		Name: "RunListSingleContainer",
+		Name: "RunFilterByContainerName",
 		Cmd:  fmt.Sprintf("local-gadget list-containers -o json --runtimes=%s --containername=%s", *containerRuntime, cn),
 		ExpectedOutputFn: func(output string) error {
 			expectedContainer := &containercollection.Container{
 				Name:      cn,
-				Podname:   po,
+				Podname:   cn,
 				Runtime:   *containerRuntime,
 				Namespace: ns,
 			}
@@ -129,23 +110,69 @@ spec:
 				c.PodUID = ""
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedContainer)
+			return ExpectAllInArrayToMatch(output, normalize, expectedContainer)
 		},
 	}
 
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
-		{
-			Name:           "RunTestListSinglePod",
-			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", TestPodYaml),
-			ExpectedRegexp: fmt.Sprintf("pod/%s created", po),
-		},
-		{
-			Name:           "WaitForTestListSinglePod",
-			Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", ns, po),
-			ExpectedString: fmt.Sprintf("pod/%s condition met\n", po),
-		},
+		PodCommand(cn, "busybox", ns, `["sleep", "inf"]`, ""),
+		WaitUntilPodReadyCommand(ns, cn),
 		listContainersCmd,
+		DeleteTestNamespaceCommand(ns),
+	}
+
+	RunCommands(commands, t)
+}
+
+func TestWatchContainers(t *testing.T) {
+	t.Parallel()
+	cn := "test-watched-container"
+	ns := GenerateTestNamespaceName(cn)
+
+	// TODO: Handle it once we support getting K8s container name for docker
+	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/737
+	if *containerRuntime == ContainerRuntimeDocker {
+		t.Skip("Skip TestWatchContainers on docker since we don't propagate the Kubernetes pod container name")
+	}
+
+	watchContainersCmd := &Command{
+		Name:         "RunWatchContainers",
+		Cmd:          fmt.Sprintf("local-gadget list-containers -o json --runtimes=%s --containername=%s --watch", *containerRuntime, cn),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedContainer := &containercollection.Container{
+				Name:      cn,
+				Podname:   cn,
+				Runtime:   *containerRuntime,
+				Namespace: ns,
+			}
+
+			normalize := func(c *containercollection.Container) {
+				c.ID = ""
+				c.Pid = 0
+				c.OciConfig = nil
+				c.Bundle = ""
+				c.Mntns = 0
+				c.Netns = 0
+				c.CgroupPath = ""
+				c.CgroupID = 0
+				c.CgroupV1 = ""
+				c.CgroupV2 = ""
+				c.Labels = nil
+				c.PodUID = ""
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedContainer)
+		},
+	}
+
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		watchContainersCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
+		PodCommand(cn, "busybox", ns, `["sleep", "inf"]`, ""),
+		WaitUntilPodReadyCommand(ns, cn),
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_bind_test.go
+++ b/integration/local-gadget/trace_bind_test.go
@@ -57,13 +57,11 @@ func TestTraceBind(t *testing.T) {
 		},
 	}
 
-	// TODO: traceBindCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceBindCmd,
 		BusyboxPodRepeatCommand(ns, "nc -l -p 9090 -w 1"),
 		WaitUntilTestPodReadyCommand(ns),
-		traceBindCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_bind_test.go
+++ b/integration/local-gadget/trace_bind_test.go
@@ -60,6 +60,7 @@ func TestTraceBind(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceBindCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, "nc -l -p 9090 -w 1"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_capabilities_test.go
+++ b/integration/local-gadget/trace_capabilities_test.go
@@ -58,13 +58,11 @@ func TestTraceCapabilities(t *testing.T) {
 		},
 	}
 
-	// TODO: capabilitiesCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		capabilitiesCmd,
 		BusyboxPodRepeatCommand(ns, "nice -n -20 echo"),
 		WaitUntilTestPodReadyCommand(ns),
-		capabilitiesCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_capabilities_test.go
+++ b/integration/local-gadget/trace_capabilities_test.go
@@ -61,6 +61,7 @@ func TestTraceCapabilities(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		capabilitiesCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, "nice -n -20 echo"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_exec_test.go
+++ b/integration/local-gadget/trace_exec_test.go
@@ -26,8 +26,8 @@ func TestTraceExec(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-exec")
 
-	cmd := "date"
-	// shArgs := []string{"/bin/sh", "-c", cmd}
+	cmd := "while true; do date ; sleep 0.1; done"
+	shArgs := []string{"/bin/sh", "-c", cmd}
 	dateArgs := []string{"/bin/date"}
 	sleepArgs := []string{"/bin/sleep", "0.1"}
 
@@ -37,13 +37,11 @@ func TestTraceExec(t *testing.T) {
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntries := []*execTypes.Event{
-				// TODO: Enable this test once we can trace new cri-o containers.
-				// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
-				// {
-				// 	Event: BuildBaseEvent(ns),
-				// 	Comm:  "sh",
-				// 	Args:  shArgs,
-				// },
+				{
+					Event: BuildBaseEvent(ns),
+					Comm:  "sh",
+					Args:  shArgs,
+				},
 				{
 					Event: BuildBaseEvent(ns),
 					Comm:  "date",
@@ -74,13 +72,11 @@ func TestTraceExec(t *testing.T) {
 		},
 	}
 
-	// TODO: traceExecCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
-		BusyboxPodRepeatCommand(ns, cmd),
-		WaitUntilTestPodReadyCommand(ns),
 		traceExecCmd,
+		BusyboxPodCommand(ns, cmd),
+		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_exec_test.go
+++ b/integration/local-gadget/trace_exec_test.go
@@ -75,6 +75,7 @@ func TestTraceExec(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceExecCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodCommand(ns, cmd),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_fsslower_test.go
+++ b/integration/local-gadget/trace_fsslower_test.go
@@ -62,6 +62,7 @@ func TestTraceFsslower(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceFsslowerCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodCommand(ns, "echo 'this is foo' > foo && while true; do cat foo && sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_fsslower_test.go
+++ b/integration/local-gadget/trace_fsslower_test.go
@@ -59,13 +59,11 @@ func TestTraceFsslower(t *testing.T) {
 		},
 	}
 
-	// TODO: traceFsslowerCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceFsslowerCmd,
 		BusyboxPodCommand(ns, "echo 'this is foo' > foo && while true; do cat foo && sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
-		traceFsslowerCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_mount_test.go
+++ b/integration/local-gadget/trace_mount_test.go
@@ -61,13 +61,11 @@ func TestTraceMount(t *testing.T) {
 		},
 	}
 
-	// TODO: traceMountCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceMountCmd,
 		BusyboxPodRepeatCommand(ns, "mount /mnt /mnt"),
 		WaitUntilTestPodReadyCommand(ns),
-		traceMountCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_mount_test.go
+++ b/integration/local-gadget/trace_mount_test.go
@@ -64,6 +64,7 @@ func TestTraceMount(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceMountCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, "mount /mnt /mnt"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_oomkill_test.go
+++ b/integration/local-gadget/trace_oomkill_test.go
@@ -78,6 +78,7 @@ spec:
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceOOMKillCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),

--- a/integration/local-gadget/trace_oomkill_test.go
+++ b/integration/local-gadget/trace_oomkill_test.go
@@ -75,17 +75,15 @@ spec:
     - while true; do tail /dev/zero; done
 `, ns)
 
-	// TODO: traceOOMKillCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceOOMKillCmd,
 		{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),
 			ExpectedRegexp: "pod/test-pod created",
 		},
 		WaitUntilTestPodReadyCommand(ns),
-		traceOOMKillCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_open_test.go
+++ b/integration/local-gadget/trace_open_test.go
@@ -56,13 +56,11 @@ func TestTraceOpen(t *testing.T) {
 		},
 	}
 
-	// TODO: traceOpenCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceOpenCmd,
 		BusyboxPodRepeatCommand(ns, "cat /dev/null"),
 		WaitUntilTestPodReadyCommand(ns),
-		traceOpenCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_open_test.go
+++ b/integration/local-gadget/trace_open_test.go
@@ -59,6 +59,7 @@ func TestTraceOpen(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceOpenCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, "cat /dev/null"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_signal_test.go
+++ b/integration/local-gadget/trace_signal_test.go
@@ -57,6 +57,7 @@ func TestTraceSignal(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceSignalCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, "sleep 3 & kill $!"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_signal_test.go
+++ b/integration/local-gadget/trace_signal_test.go
@@ -54,13 +54,11 @@ func TestTraceSignal(t *testing.T) {
 		},
 	}
 
-	// TODO: traceSignalCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
+		traceSignalCmd,
 		BusyboxPodRepeatCommand(ns, "sleep 3 & kill $!"),
 		WaitUntilTestPodReadyCommand(ns),
-		traceSignalCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_tcp_test.go
+++ b/integration/local-gadget/trace_tcp_test.go
@@ -70,6 +70,7 @@ func TestTraceTCP(t *testing.T) {
 
 	commands := []*Command{
 		traceTCPCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_tcp_test.go
+++ b/integration/local-gadget/trace_tcp_test.go
@@ -34,6 +34,7 @@ func TestTraceTCP(t *testing.T) {
 
 	RunCommands(commandsPreTest, t)
 	NginxIP := GetTestPodIP(ns, "nginx-pod")
+
 	traceTCPCmd := &Command{
 		Name:         "TraceTCP",
 		Cmd:          fmt.Sprintf("local-gadget trace tcp -o json --runtimes=%s", *containerRuntime),
@@ -67,12 +68,10 @@ func TestTraceTCP(t *testing.T) {
 		},
 	}
 
-	// TODO: traceTCPCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
+		traceTCPCmd,
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
 		WaitUntilTestPodReadyCommand(ns),
-		traceTCPCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/integration/local-gadget/trace_tcpconnect_test.go
+++ b/integration/local-gadget/trace_tcpconnect_test.go
@@ -68,6 +68,7 @@ func TestTraceTcpconnect(t *testing.T) {
 
 	commands := []*Command{
 		tcpconnectCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),

--- a/integration/local-gadget/trace_tcpconnect_test.go
+++ b/integration/local-gadget/trace_tcpconnect_test.go
@@ -66,12 +66,10 @@ func TestTraceTcpconnect(t *testing.T) {
 		},
 	}
 
-	// TODO: tcpconnectCmd should moved up the list once we can trace new cri-o containers.
-	// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1018
 	commands := []*Command{
+		tcpconnectCmd,
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
 		WaitUntilTestPodReadyCommand(ns),
-		tcpconnectCmd,
 		DeleteTestNamespaceCommand(ns),
 	}
 

--- a/pkg/container-collection/annotations.go
+++ b/pkg/container-collection/annotations.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containercollection
+
+const (
+	// container types used by the runtimes
+	containerTypeSandbox   = "sandbox"
+	containerTypeContainer = "container"
+
+	// cri-o container annotations to get container information
+	// https://github.com/containers/podman/blob/main/pkg/annotations/annotations.go
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/labels.go
+	crioContainerManagerAnnotation = "io.container.manager"
+	crioPodNameAnnotation          = "io.kubernetes.pod.name"
+	crioPodNamespaceAnnotation     = "io.kubernetes.pod.namespace"
+	crioPodUIDAnnotation           = "io.kubernetes.pod.uid"
+	crioContainerNameAnnotation    = "io.kubernetes.container.name"
+	crioContainerTypeAnnotation    = "io.kubernetes.cri-o.ContainerType"
+
+	// containerd container annotations to get container information
+	// https://github.com/containerd/containerd/blob/main/pkg/cri/annotations/annotations.go
+	containerdPodNameAnnotation       = "io.kubernetes.cri.sandbox-name"
+	containerdPodNamespaceAnnotation  = "io.kubernetes.cri.sandbox-namespace"
+	containerdPodUIDAnnotation        = "io.kubernetes.cri.sandbox-uid"
+	containerdContainerNameAnnotation = "io.kubernetes.cri.container-name"
+	containerdContainerTypeAnnotation = "io.kubernetes.cri.container-type"
+)

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -162,3 +162,7 @@ func ownerReferenceEnrichment(
 func GetColumns() *columns.Columns[Container] {
 	return columns.MustCreateColumns[Container]()
 }
+
+func (c *Container) IsEnriched() bool {
+	return c.Name != "" && c.Podname != "" && c.Namespace != "" && c.PodUID != "" && c.Runtime != ""
+}

--- a/pkg/local-gadget-manager/local-gadget-manager.go
+++ b/pkg/local-gadget-manager/local-gadget-manager.go
@@ -348,6 +348,7 @@ func NewManager(runtimes []*containerutils.RuntimeConfig) (*LocalGadgetManager, 
 
 	err = l.ContainerCollection.Initialize(
 		containercollection.WithPubSub(containerEventFuncs...),
+		containercollection.WithOCIConfigEnrichment(),
 		containercollection.WithCgroupEnrichment(),
 		containercollection.WithLinuxNamespaceEnrichment(),
 		containercollection.WithMultipleContainerRuntimesEnrichment(runtimes),

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -102,6 +102,7 @@ var runcPaths = []string{
 	"/usr/bin/runc",
 	"/usr/sbin/runc",
 	"/usr/local/sbin/runc",
+	"/usr/lib/cri-o-runc/sbin/runc",
 	"/run/torcx/unpack/docker/bin/runc",
 }
 
@@ -421,7 +422,9 @@ func (n *RuncNotifier) watchPidFileIterate(pidFileDirNotify *fanotify.NotifyFD, 
 		return false, err
 	}
 
-	containerID := filepath.Base(filepath.Clean(bundleDir))
+	// cri-o appends userdata to bundleDir,
+	// so we trim it here to get the correct containerID
+	containerID := filepath.Base(filepath.Clean(strings.TrimSuffix(bundleDir, "userdata")))
 
 	err = n.AddWatchContainerTermination(containerID, containerPID)
 	if err != nil {


### PR DESCRIPTION
`runcfanotify` doesn't work for `cri-o` containers. The idea here is to adopt it to support tracing `cri-o` containers. 

Fixes #1018
Related #1028

### Idea
During `runc` notification container creation is blocked on `pidfile` so enriching the container using the container runtime won't work because we hit `Runtime enricher (cri-o): failed to get container: container "2899fb3ce898a2ed1d4426b0cb6df81ee72cd630ce0fb9e10eb53f04d5eb4e9b" not found`. In order to avoid this we are using annotations fetched via `OCIConfig` to enrich containers. 

### Usage
```
$ docker exec -it minikube-cri-o bash
$ local-gadget list-containers --watch 
# Create a container in another terminal e.g kubectl run test-pod --image busybox:latest sleep inf
...
cri-o      a0ddd82147f5536d38c449f39edff4151ae0aa39b9653045449302915c85… test-pod
...
```
JSON mode should also work here. Before this PR this will only works for `docker/containerd` but now it should work for `cri-o` as well.

### Future work
Consider using annotations for other runtimes or other information like `cgroups` etc. Having said that, `containerd` has some annotations but `docker` has none. 