### PR TITLE
pkg/columns: fix handling of fields with alternative type definitions

### DIFF
--- a/pkg/columns/columns_test.go
+++ b/pkg/columns/columns_test.go
@@ -30,7 +30,7 @@ func TestColumnMap(t *testing.T) {
 		t.Errorf("Expected stringfield in column map")
 	}
 	if _, ok := columnMap["intfield"]; !ok {
-		t.Errorf("Expected stringfield in column map")
+		t.Errorf("Expected intfield in column map")
 	}
 }
 
@@ -43,6 +43,28 @@ func TestEmptyStruct(t *testing.T) {
 	columnMap := cols.GetColumnMap()
 	if len(columnMap) != 0 {
 		t.Errorf("Expected empty column map")
+	}
+}
+
+func TestFieldsWithTypeDefinition(t *testing.T) {
+	type StringAlias string
+	type IntAlias int
+	type testStruct struct {
+		StringField StringAlias `column:"stringField"`
+		IntField    IntAlias    `column:"intField"`
+	}
+
+	testVar := &testStruct{
+		StringField: "abc",
+		IntField:    123,
+	}
+
+	cols := expectColumnsSuccess[testStruct](t)
+	if expectColumn(t, cols, "stringField").Get(testVar).Interface() != testVar.StringField {
+		t.Errorf("expected stringField to contain %q", testVar.StringField)
+	}
+	if expectColumn(t, cols, "intField").Get(testVar).Interface() != testVar.IntField {
+		t.Errorf("expected intField to contain %q", testVar.IntField)
 	}
 }
 

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -52,7 +52,7 @@ func (tf *TextColumnsFormatter[T]) setFormatter(column *Column[T]) {
 		}
 	case reflect.String:
 		column.formatter = func(v interface{}) string {
-			return tf.buildFixedString(v.(string), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
+			return tf.buildFixedString(reflect.ValueOf(v).String(), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
 		}
 	default:
 		column.formatter = func(v interface{}) string {

--- a/pkg/columns/formatter/textcolumns/scaler.go
+++ b/pkg/columns/formatter/textcolumns/scaler.go
@@ -267,7 +267,7 @@ func (tf *TextColumnsFormatter[T]) AdjustWidthsToContent(entries []*T, considerH
 				reflect.Float64:
 				flen = len([]rune(strconv.FormatFloat(field.Float(), 'f', column.col.Precision, 64)))
 			case reflect.String:
-				flen = len([]rune(field.Interface().(string)))
+				flen = len([]rune(field.String()))
 			default:
 				flen = len([]rune(fmt.Sprintf("%v", field.Interface())))
 			}

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -204,3 +204,25 @@ func TestWidthRestrictions(t *testing.T) {
 		}
 	})
 }
+
+func TestWithTypeDefinition(t *testing.T) {
+	type StringAlias string
+	type testStruct struct {
+		Name StringAlias `column:"name,width:5,minWidth:2,maxWidth:10"`
+	}
+	entries := []*testStruct{
+		{"123456789012"},
+		{"234567890123"},
+	}
+	cols, err := columns.NewColumns[testStruct]()
+	if err != nil {
+		t.Fatalf("error initializing")
+	}
+	formatter := NewFormatter(cols.GetColumnMap(), WithAutoScale(false))
+	formatter.AdjustWidthsToContent(entries, false, 0, false)
+	for _, entry := range entries {
+		if formatter.FormatEntry(entry) != string(entry.Name) {
+			t.Errorf("expected %q, got %q", entry.Name, formatter.FormatEntry(entry))
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an issue with alternative string types in `pkg/columns/formatter/textcolumns` (seen in #1071)  and adds tests for it. The issue could only happen for strings as they have been cast directly to string instead of using the `.String()` function of the reflect package.

The issue also exists in `pkg/columns/filter` but should be fixed once #1081 is merged.