### PR TITLE
ci: Fix cleanup process for integration-tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -40,7 +40,7 @@ runs:
             # Forward the SIGINT directly to test process but wait for current
             # active jobs since we can only wait for current shell child process.
             echo "IntegrationTestsJob: Notifying the integration tests process about the cancellation"
-            kill -2 $(pidof integration.test) > /dev/null
+            kill -2 $(pidof inspektor-gadget.test) > /dev/null
             echo "IntegrationTestsJob: Waiting for the integration tests process to finish"
             wait $(jobs -p)
             echo "IntegrationTestsJob: We are done with the clean-up. Let the job exit"


### PR DESCRIPTION
We moved the inspektor-gadget integration tests to a new directory resulting in the test process named differently i.e inspektor-gadget.test rather than integration.test. This PR uses the correct process name in the cleanup. 

### Testing Done
A [workflow run](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3338706275/jobs/5527308288) with cancellation. 