### PR TITLE
Unit and Integrationtests for `profile` gadgets

### DIFF
--- a/cmd/kubectl-gadget/profile/block-io_test.go
+++ b/cmd/kubectl-gadget/profile/block-io_test.go
@@ -1,8 +1,28 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package profile
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
 )
 
 type stsTestCase struct {
@@ -133,6 +153,66 @@ func TestStarsToString(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.ToString(), func(t *testing.T) {
 			validateStarsToString(testCase, t)
+		})
+	}
+}
+
+func validateReportToString(report types.Report, t *testing.T) {
+	result := reportToString(report)
+
+	if len(report.Data) == 0 {
+		assert.Equal(t, result, "")
+		return
+	}
+
+	lines := regexp.MustCompile("\r?\n").Split(result, -1)
+
+	assert.Equal(t, len(lines), len(report.Data)+2)
+	regexHeader := regexp.MustCompile(fmt.Sprintf(`\s*%s\s+:\s+count\s+distribution`, report.ValType))
+	assert.Assert(t, regexHeader.MatchString(lines[0]))
+	assert.Equal(t, lines[len(lines)-1], "")
+
+	regexData := regexp.MustCompile(`\s*(\d+)\s->\s(\d+)\s+:\s(\d+)\s+\|\**\s*\|`)
+
+	for i, data := range report.Data {
+		// The first line contains the header, therefore +1 to start at the data lines
+		line := lines[i+1]
+		parts := regexData.FindStringSubmatch(line)
+
+		assert.Equal(t, len(parts), 4)
+		assert.Equal(t, parts[0], line)
+		assert.Equal(t, parts[1], strconv.FormatUint(data.IntervalStart, 10))
+		assert.Equal(t, parts[2], strconv.FormatUint(data.IntervalEnd, 10))
+		assert.Equal(t, parts[3], strconv.FormatUint(data.Count, 10))
+	}
+}
+
+func TestReportToString(t *testing.T) {
+	testCases := []types.Report{
+		{
+			ValType: "TwoRows",
+			Data: []types.Data{
+				{Count: 4, IntervalStart: 0, IntervalEnd: 4},
+				{Count: 2, IntervalStart: 5, IntervalEnd: 10},
+			},
+		},
+		{
+			ValType: "ManyRows",
+			Data: []types.Data{
+				{Count: 4, IntervalStart: 0, IntervalEnd: 4},
+				{Count: 2, IntervalStart: 5, IntervalEnd: 10},
+				{Count: 41, IntervalStart: 11, IntervalEnd: 11},
+				{Count: 25, IntervalStart: 12, IntervalEnd: 100},
+				{Count: 78, IntervalStart: 101, IntervalEnd: 105},
+				{Count: 35, IntervalStart: 106, IntervalEnd: 109},
+				{Count: 7, IntervalStart: 110, IntervalEnd: 100000},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.ValType, func(t *testing.T) {
+			validateReportToString(testCase, t)
 		})
 	}
 }

--- a/cmd/kubectl-gadget/profile/block-io_test.go
+++ b/cmd/kubectl-gadget/profile/block-io_test.go
@@ -1,0 +1,138 @@
+package profile
+
+import (
+	"fmt"
+	"testing"
+)
+
+type stsTestCase struct {
+	val      uint64
+	valMax   uint64
+	width    uint64
+	expected string
+}
+
+func (testcase stsTestCase) ToString() string {
+	return fmt.Sprintf("(%v/%v), width %v", testcase.val, testcase.valMax, testcase.width)
+}
+
+func validateStarsToString(testCase stsTestCase, t *testing.T) {
+	str := starsToString(testCase.val, testCase.valMax, testCase.width)
+	if str != testCase.expected {
+		t.Fail()
+	}
+}
+
+func TestStarsToString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []stsTestCase{
+		/* Behaviour on values on the boundary of a new "*" */
+		{
+			val:      0,
+			valMax:   64,
+			width:    4,
+			expected: "    ",
+		},
+		{
+			val:      1,
+			valMax:   64,
+			width:    4,
+			expected: "    ",
+		},
+		{
+			val:      15,
+			valMax:   64,
+			width:    4,
+			expected: "    ",
+		},
+		{
+			val:      16,
+			valMax:   64,
+			width:    4,
+			expected: "*   ",
+		},
+		{
+			val:      31,
+			valMax:   64,
+			width:    4,
+			expected: "*   ",
+		},
+		{
+			val:      32,
+			valMax:   64,
+			width:    4,
+			expected: "**  ",
+		},
+		{
+			val:      63,
+			valMax:   64,
+			width:    4,
+			expected: "*** ",
+		},
+		{
+			val:      64,
+			valMax:   64,
+			width:    4,
+			expected: "****",
+		},
+		/* When val > valMax */
+		{
+			val:      100,
+			valMax:   2,
+			width:    4,
+			expected: "****+",
+		},
+		/* width is not divisor of valMax */
+		{
+			val:      38,
+			valMax:   64,
+			width:    5,
+			expected: "**   ",
+		},
+		{
+			val:      39,
+			valMax:   64,
+			width:    5,
+			expected: "***  ",
+		},
+		/* width 1 */
+		{
+			val:      63,
+			valMax:   64,
+			width:    1,
+			expected: " ",
+		},
+		{
+			val:      64,
+			valMax:   64,
+			width:    1,
+			expected: "*",
+		},
+		/* width 0 */
+		{
+			val:      0,
+			valMax:   64,
+			width:    0,
+			expected: "",
+		},
+		{
+			val:      64,
+			valMax:   64,
+			width:    0,
+			expected: "",
+		},
+		{
+			val:      65,
+			valMax:   64,
+			width:    0,
+			expected: "+",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.ToString(), func(t *testing.T) {
+			validateStarsToString(testCase, t)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/kr/pretty v0.3.0
 	github.com/moby/moby v20.10.18+incompatible
+	gotest.tools/v3 v3.0.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1668,7 +1668,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	bioprofileTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
 	cpuprofileTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/types"
 	processCollectorTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
 	socketCollectorTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
@@ -370,9 +371,20 @@ func TestBiolatency(t *testing.T) {
 
 	commands := []*Command{
 		{
-			Name:           "RunBiolatencyGadget",
-			Cmd:            "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15",
-			ExpectedRegexp: `usecs\s+:\s+count\s+distribution`,
+			Name: "RunBiolatencyGadget",
+			Cmd:  "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15 -o json",
+			ExpectedOutputFn: func(output string) error {
+				expectedEntry := &bioprofileTypes.Report{
+					ValType: "usecs",
+				}
+
+				normalize := func(e *bioprofileTypes.Report) {
+					e.Data = nil
+					e.Time = ""
+				}
+
+				return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			},
 		},
 	}
 


### PR DESCRIPTION
### Unit and Integrationtests for `profile` gadgets

Uses the json output in order to validate as much information as possible from the `profile` gadgets. Additionally two unittest for the `profile block-io` gadget helper functions were written.

### New `import` added in `block-io_test.go`: `"gotest.tools/v3/assert"`

For testing i like something like `assert.Equal` or `assert.Assert` to avoid having to write `if ... {t.Fail(...)}` 