### PR TITLE
tests/tcp: Only test against a cluser local IP

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -571,12 +571,18 @@ func DeleteRemainingNamespacesCommand() *Command {
 	}
 }
 
+// WaitUntilPodReadyCommand returns a Command which waits until pod with the specified name in
+// the given as parameter namespace is ready.
+func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
+	return &Command{
+		Name:           "WaitForTestPod",
+		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", namespace, podname),
+		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
+	}
+}
+
 // WaitUntilTestPodReadyCommand returns a Command which waits until test-pod in
 // the given as parameter namespace is ready.
 func WaitUntilTestPodReadyCommand(namespace string) *Command {
-	return &Command{
-		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s test-pod", namespace),
-		ExpectedString: "pod/test-pod condition met\n",
-	}
+	return WaitUntilPodReadyCommand(namespace, "test-pod")
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"reflect"
 	"strings"
 
@@ -151,4 +152,15 @@ func BuildBaseEvent(namespace string) eventtypes.Event {
 		Type:       eventtypes.NORMAL,
 		CommonData: BuildCommonData(namespace),
 	}
+}
+
+func GetTestPodIP(ns string, podname string) string {
+	cmd := exec.Command("kubectl", "-n", ns, "get", "pod", podname, "-o", "jsonpath='{.status.podIP}'")
+	r, err := cmd.Output()
+	if err != nil {
+		return fmt.Sprintf("failed to get Pod IP: %s", err)
+	}
+
+	ip := string(r)
+	return ip[1 : len(ip)-1]
 }

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -1319,6 +1319,8 @@ func TestTcpconnect(t *testing.T) {
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			saddr := GetTestPodIP(ns, "test-pod")
+
 			expectedEntries := []*tcpconnectTypes.Event{
 				{
 					Event:     BuildBaseEvent(ns),
@@ -1326,6 +1328,7 @@ func TestTcpconnect(t *testing.T) {
 					IPVersion: 4,
 					Daddr:     "1.1.1.1",
 					Dport:     80,
+					Saddr:     saddr,
 				},
 				{
 					Event:     BuildBaseEvent(ns),
@@ -1333,13 +1336,13 @@ func TestTcpconnect(t *testing.T) {
 					IPVersion: 4,
 					Daddr:     "1.1.1.1",
 					Dport:     443,
+					Saddr:     saddr,
 				},
 			}
 
 			normalize := func(e *tcpconnectTypes.Event) {
 				e.Node = ""
 				e.Pid = 0
-				e.Saddr = ""
 				e.MountNsID = 0
 			}
 
@@ -1368,6 +1371,8 @@ func TestTcptracer(t *testing.T) {
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcp -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			saddr := GetTestPodIP(ns, "test-pod")
+
 			expectedEntries := []*tcpTypes.Event{
 				{
 					Event:     BuildBaseEvent(ns),
@@ -1376,6 +1381,7 @@ func TestTcptracer(t *testing.T) {
 					Daddr:     "1.1.1.1",
 					Dport:     80,
 					Operation: "connect",
+					Saddr:     saddr,
 				},
 				{
 					Event:     BuildBaseEvent(ns),
@@ -1384,6 +1390,7 @@ func TestTcptracer(t *testing.T) {
 					Daddr:     "1.1.1.1",
 					Dport:     80,
 					Operation: "close",
+					Saddr:     saddr,
 				},
 				{
 					Event:     BuildBaseEvent(ns),
@@ -1392,13 +1399,13 @@ func TestTcptracer(t *testing.T) {
 					Daddr:     "1.1.1.1",
 					Dport:     443,
 					Operation: "connect",
+					Saddr:     saddr,
 				},
 			}
 
 			normalize := func(e *tcpTypes.Event) {
 				e.Node = ""
 				e.Pid = 0
-				e.Saddr = ""
 				e.Sport = 0
 				e.MountNsID = 0
 			}
@@ -1428,17 +1435,19 @@ func TestTcptop(t *testing.T) {
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			saddr := GetTestPodIP(ns, "test-pod")
+
 			expectedEntry := &tcptopTypes.Stats{
 				CommonData: BuildCommonData(ns),
 				Daddr:      "1.1.1.1",
 				Comm:       "wget",
 				Dport:      80,
 				Family:     syscall.AF_INET,
+				Saddr:      saddr,
 			}
 
 			normalize := func(e *tcptopTypes.Stats) {
 				e.Node = ""
-				e.Saddr = ""
 				e.MountNsID = 0
 				e.Pid = 0
 				e.Sport = 0


### PR DESCRIPTION
Many TCP Tests sometimes fail.
These flaky tests are not productive for the team, since we should rely on their results.

Outside services are not always up or can change their behavior. Furthermore we should not check for both ports `80` and `443` when we only specificed one.

This PR creates a new `nginx` pod and tries to connect to its port `80`


See:
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3378520742/jobs/5610001881#step:7:499
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3378520742/jobs/5610002721#step:8:603