### PR TITLE
Remove cgo where possible from gadgets

### DIFF
--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -16,6 +16,7 @@ package gadgets
 
 import (
 	"encoding/binary"
+	"net/netip"
 	"unsafe"
 
 	"github.com/cilium/ebpf/link"
@@ -64,4 +65,15 @@ func Htons(hs uint16) uint16 {
 	var ns [2]byte
 	binary.BigEndian.PutUint16(ns[:], hs)
 	return *(*uint16)(unsafe.Pointer(&ns[0]))
+}
+
+func IPStringFromBytes(ipBytes [16]byte, ipType int) string {
+	switch ipType {
+	case 4:
+		return netip.AddrFrom4(*(*[4]byte)(ipBytes[0:4])).String()
+	case 6:
+		return netip.AddrFrom16(ipBytes).String()
+	default:
+		return ""
+	}
 }

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -41,3 +41,12 @@ func CloseLink(l link.Link) link.Link {
 type DataEnricher interface {
 	Enrich(event *types.CommonData, mountnsid uint64)
 }
+
+func FromCString(in []byte) string {
+	for i := 0; i < len(in); i++ {
+		if in[i] == 0 {
+			return string(in[:i])
+		}
+	}
+	return string(in)
+}

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -15,6 +15,9 @@
 package gadgets
 
 import (
+	"encoding/binary"
+	"unsafe"
+
 	"github.com/cilium/ebpf/link"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -49,4 +52,16 @@ func FromCString(in []byte) string {
 		}
 	}
 	return string(in)
+}
+
+func Htonl(hl uint32) uint32 {
+	var nl [4]byte
+	binary.BigEndian.PutUint32(nl[:], hl)
+	return *(*uint32)(unsafe.Pointer(&nl[0]))
+}
+
+func Htons(hs uint16) uint16 {
+	var ns [2]byte
+	binary.BigEndian.PutUint16(ns[:], hs)
+	return *(*uint16)(unsafe.Pointer(&ns[0]))
 }

--- a/pkg/gadgettracermanager/common/common.go
+++ b/pkg/gadgettracermanager/common/common.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Inspektor Gadget authors
+// Copyright 2019-2022 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gadgettracermanager
-
-// #include "common.h"
-import "C"
+package common
 
 const (
-	MaxContainersPerNode = C.MAX_CONTAINERS_PER_NODE
+	MaxContainersPerNode = 1024
+	NameMaxLength        = 256
 )
+
+type Container struct {
+	ContainerID [NameMaxLength]byte
+	Namespace   [NameMaxLength]byte
+	Pod         [NameMaxLength]byte
+	Container   [NameMaxLength]byte
+}

--- a/pkg/gadgettracermanager/common/common.h
+++ b/pkg/gadgettracermanager/common/common.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (GPL-2.0 WITH Linux-syscall-note) OR Apache-2.0 */
+
+#ifndef GADGET_TRACER_MANAGER_COMMON_H
+#define GADGET_TRACER_MANAGER_COMMON_H
+
+#define MAX_CONTAINERS_PER_NODE 1024
+
+#define NAME_MAX_LENGTH 256
+
+struct container {
+	__u8 container_id[NAME_MAX_LENGTH];
+	__u8 namespace[NAME_MAX_LENGTH];
+	__u8 pod[NAME_MAX_LENGTH];
+	__u8 container[NAME_MAX_LENGTH];
+};
+
+#endif

--- a/pkg/gadgettracermanager/containers-map/tracer.go
+++ b/pkg/gadgettracermanager/containers-map/tracer.go
@@ -24,24 +24,20 @@ import (
 	"golang.org/x/sys/unix"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager/common"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang containersmap ./bpf/containers-map.c -- -I./bpf/ -I../../ -I../../${TARGET}
 
-// #include "../common.h"
-import "C"
-
 const (
 	BPFMapName        = "containers"
-	NameMaxLength     = C.NAME_MAX_LENGTH
+	NameMaxLength     = common.NameMaxLength
 	NameMaxCharacters = NameMaxLength - 1
 )
 
-type Container = C.struct_container
-
-func copyToC(dest *[NameMaxLength]C.char, source string) {
+func copyToC(dest *[NameMaxLength]byte, source string) {
 	for i := 0; i < len(source) && i < NameMaxCharacters; i++ {
-		dest[i] = C.char(source[i])
+		dest[i] = source[i]
 	}
 }
 
@@ -109,12 +105,12 @@ func (cm *ContainersMap) addContainerInMap(c *containercollection.Container) {
 	}
 	mntnsC := uint64(c.Mntns)
 
-	val := Container{}
+	val := common.Container{}
 
-	copyToC(&val.container_id, c.ID)
-	copyToC(&val.namespace, c.Namespace)
-	copyToC(&val.pod, c.Podname)
-	copyToC(&val.container, c.Name)
+	copyToC(&val.ContainerID, c.ID)
+	copyToC(&val.Namespace, c.Namespace)
+	copyToC(&val.Pod, c.Podname)
+	copyToC(&val.Container, c.Name)
 
 	cm.containersMap.Put(mntnsC, val)
 }

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -35,8 +35,6 @@ import (
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-import "C"
-
 type GadgetTracerManager struct {
 	pb.UnimplementedGadgetTracerManagerServer
 	containercollection.ContainerCollection
@@ -311,9 +309,9 @@ type Conf struct {
 
 // Close releases any resource that could be in use by the tracer manager, like
 // ebpf maps.
-func (m *GadgetTracerManager) Close() {
-	if m.containersMap != nil {
-		m.containersMap.Close()
+func (g *GadgetTracerManager) Close() {
+	if g.containersMap != nil {
+		g.containersMap.Close()
 	}
-	m.ContainerCollection.Close()
+	g.ContainerCollection.Close()
 }


### PR DESCRIPTION
As we want to enable third parties to use our gadgets directly in their own environments / tools, we should make it as easy as possible. Sometimes, a significant hurdle in building tools written in Go is the requirement of CGO - hence we should try to remove as many dependencies on that as possible. Also, switching from Go to C code at runtime always comes with increased costs in terms of CPU usage, so that is another reason to avoid mixed code.

This is the first PR laying the groundwork for all our gadgets. The updated gadgets themselves will follow in separate PRs by gadget category.

* #1093

Fixes #872 