### PR TITLE
hooks: Install cri-o hooks in multiple folders

### DIFF
--- a/gadget-container/cleanup.sh
+++ b/gadget-container/cleanup.sh
@@ -22,8 +22,12 @@ for i in ocihookgadget prestart.sh poststop.sh ; do
 done
 
 # CRIO hooks
-rm -f /host/etc/containers/oci/hooks.d/gadget-prestart.json
-rm -f /host/etc/containers/oci/hooks.d/gadget-poststop.json
+for HOOK_PATH in "/host/etc/containers/oci/hooks.d" \
+                 "/host/usr/share/containers/oci/hooks.d/"
+do
+  rm -f $HOOK_PATH/gadget-prestart.json
+  rm -f $HOOK_PATH/gadget-poststop.json
+done
 
 # ld preload support
 if [ -f "/host/etc/ld.so.preload" ] ; then

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -80,16 +80,20 @@ if [ "$HOOK_MODE" = "crio" ] ; then
     cp /opt/hooks/oci/$i /host/opt/hooks/oci/
   done
 
-  echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d"
-  mkdir -p /host/etc/containers/oci/hooks.d
-  cp /opt/hooks/crio/gadget-prestart.json /host/etc/containers/oci/hooks.d/ 2>/dev/null || true
-  cp /opt/hooks/crio/gadget-poststop.json /host/etc/containers/oci/hooks.d/ 2>/dev/null || true
+  for HOOK_PATH in "/host/etc/containers/oci/hooks.d" \
+                   "/host/usr/share/containers/oci/hooks.d/"
+  do
+    echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d"
+    mkdir -p $HOOK_PATH
+    cp /opt/hooks/crio/gadget-prestart.json $HOOK_PATH 2>/dev/null || true
+    cp /opt/hooks/crio/gadget-poststop.json $HOOK_PATH 2>/dev/null || true
 
-  if ! ls /host/etc/containers/oci/hooks.d/gadget-{prestart,poststop}.json > /dev/null 2>&1; then
-    echo "Couldn't install OCI hooks configuration" >&2
-  else
-    echo "Hooks installation done"
-  fi
+    if ! ls $HOOK_PATH/gadget-{prestart,poststop}.json > /dev/null 2>&1; then
+      echo "Couldn't install OCI hooks configuration" >&2
+    else
+      echo "Hooks installation done"
+    fi
+  done
 fi
 
 if [ "$HOOK_MODE" = "nri" ] ; then


### PR DESCRIPTION
We don't have a deterministic way to understand where these hooks should be installed, then try to install in the well-known paths.

Installing multiple times the same hook is not an issue as they are only executed once https://github.com/containers/podman/blob/v3.0.1/pkg/hooks/docs/oci-hooks.5.md#directories

## Ref 

It seems we got this wrong on https://github.com/inspektor-gadget/inspektor-gadget/pull/483. 

## How to test 

### Before this change

```
# Create a cluster with minikube
$ minikube start --container-runtime=cri-o --driver=kvm2

# start a tracer
$ kubectl gadget trace exec 

# run a pod (in another terminal)
$ kubectl run mypod$RANDOM --image=praqma/network-multitool -- sleep 9999

# the tracer terminal won't show any event 
```

### After this change 


```
# Create a cluster with minikube
$ minikube start --container-runtime=cri-o --driver=kvm2

# start a tracer
$ kubectl gadget trace exec 

# run a pod (in another terminal)
$ kubectl run mypod$RANDOM --image=praqma/network-multitool -- sleep 9999

# the tracer terminal will print the first events of the container
```