### PR TITLE
use gRPC via port-forwarding instead of exec to retrieve events from traces

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile.dockerignore
+++ b/Dockerfiles/gadget-core.Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 !go.mod
 !go.sum
 !gadget-container
+!internal
 !pkg
 !tools
 !Makefile*

--- a/Dockerfiles/gadget-default.Dockerfile.dockerignore
+++ b/Dockerfiles/gadget-default.Dockerfile.dockerignore
@@ -1,6 +1,7 @@
 *
 !go.mod
 !go.sum
+!internal
 !gadget-container
 !pkg
 !tools

--- a/Dockerfiles/kubectl-gadget.Dockerfile.dockerignore
+++ b/Dockerfiles/kubectl-gadget.Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 !go.mod
 !go.sum
 !cmd
+!internal
 !pkg
 !tools
 !Makefile

--- a/Dockerfiles/local-gadget.Dockerfile.dockerignore
+++ b/Dockerfiles/local-gadget.Dockerfile.dockerignore
@@ -3,6 +3,7 @@
 !go.sum
 !cmd
 !gadget-container
+!internal
 !pkg
 !tools
 !Makefile*

--- a/cmd/kubectl-gadget/utils/auth.go
+++ b/cmd/kubectl-gadget/utils/auth.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os/user"
+
+	"k8s.io/client-go/kubernetes"
+
+	certhelpers "github.com/inspektor-gadget/inspektor-gadget/internal/cert-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/internal/certs"
+)
+
+// getTLSConfig returns a tls.Config for use with a gRPC client; node is the name of the node you connect to and
+// will be verified against the certificate
+func getTLSConfig(node string, clientset *kubernetes.Clientset) (*tls.Config, error) {
+	name := "gadget-user"
+
+	// Use local username if possible for certificate
+	if currentUser, err := user.Current(); err == nil {
+		name = currentUser.Username
+	}
+
+	cert, key, ca, err := certs.GenerateClientCertificate(context.Background(), name, clientset)
+	if err != nil {
+		return nil, fmt.Errorf("loading certificates: %w", err)
+	}
+	crt, err := tls.X509KeyPair(certhelpers.CertPEM(cert), certhelpers.PrivateKeyPEM(key))
+	if err != nil {
+		return nil, fmt.Errorf("loading x509 keypair: %w", err)
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(ca)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{crt},
+		RootCAs:      certPool,
+		ServerName:   node,
+	}
+	return tlsConfig, nil
+}

--- a/cmd/kubectl-gadget/utils/exec.go
+++ b/cmd/kubectl-gadget/utils/exec.go
@@ -17,17 +17,27 @@ package utils
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport/spdy"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	pb "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager/api"
 )
 
 func ExecPodSimple(client *kubernetes.Clientset, node string, podCmd string) string {
@@ -99,4 +109,114 @@ func ExecPod(client *kubernetes.Clientset, node string, podCmd string, cmdStdout
 		Tty:    true,
 	})
 	return err
+}
+
+// ReceiveStream uses a tunnel (port forwarding) through the API server to fetch a trace stream
+func ReceiveStream(
+	client *kubernetes.Clientset,
+	node string,
+	traceID string,
+	callback func(line string, node string),
+	transform func(line string) string,
+	writer io.Writer,
+) error {
+	listOptions := metav1.ListOptions{
+		LabelSelector: "k8s-app=gadget",
+		FieldSelector: "spec.nodeName=" + node + ",status.phase=Running",
+	}
+	pods, err := client.CoreV1().Pods("gadget").List(context.TODO(), listOptions)
+	if err != nil {
+		return commonutils.WrapInErrListPods(err)
+	}
+	if len(pods.Items) == 0 {
+		return commonutils.ErrGadgetPodNotFound
+	}
+	if len(pods.Items) != 1 {
+		return commonutils.ErrMultipleGadgetPodFound
+	}
+	podName := pods.Items[0].Name
+
+	restConfig, err := kubeRestConfig()
+	if err != nil {
+		return err
+	}
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return fmt.Errorf("creating roundtripper: %w", err)
+	}
+
+	targetURL, err := url.Parse(restConfig.Host)
+	if err != nil {
+		return fmt.Errorf("parsing restConfig.Host: %w", err)
+	}
+
+	targetURL.Path = path.Join(
+		"api", "v1",
+		"namespaces", "gadget",
+		"pods", podName,
+		"portforward",
+	)
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, targetURL)
+	readyChan := make(chan struct{})
+	stopChan := make(chan struct{})
+
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", 0, 7080)}, stopChan, readyChan, nil, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("creating port forwarder: %w", err)
+	}
+
+	go fw.ForwardPorts()
+	defer close(stopChan)
+
+	// Wait for ready signal
+	<-readyChan
+
+	ports, err := fw.GetPorts()
+	if err != nil {
+		return err
+	}
+
+	if len(ports) != 1 {
+		return errors.New("unexpected result from GetPorts()")
+	}
+
+	tlsConfig, err := getTLSConfig(node, client)
+	if err != nil {
+		return fmt.Errorf("generating certificate: %w", err)
+	}
+	cr := credentials.NewTLS(tlsConfig)
+
+	conn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", ports[0].Local), grpc.WithTransportCredentials(cr))
+	if err != nil {
+		return fmt.Errorf("connecting to grpc: %w", err)
+	}
+	defer conn.Close()
+
+	svc := pb.NewGadgetTracerManagerClient(conn)
+
+	rsc, err := svc.ReceiveStream(context.Background(), &pb.TracerID{Id: traceID})
+	if err != nil {
+		return err
+	}
+	for {
+		data, err := rsc.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("receiving gRPC data: %w", err)
+		}
+		if callback != nil {
+			callback(data.Line, node)
+		} else {
+			if transform != nil {
+				data.Line = transform(data.Line)
+			}
+			if data.Line != "" {
+				fmt.Fprintf(writer, "%s\n", data.Line)
+			}
+		}
+	}
 }

--- a/gadget-container/gadgettracermanager/auth.go
+++ b/gadget-container/gadgettracermanager/auth.go
@@ -1,0 +1,86 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"k8s.io/client-go/kubernetes"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+
+	certhelpers "github.com/inspektor-gadget/inspektor-gadget/internal/cert-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/internal/certs"
+)
+
+func streamInterceptor() func(srv interface{}, serverStream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv interface{}, serverStream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		p, ok := peer.FromContext(serverStream.Context())
+		if !ok {
+			return status.Errorf(codes.Unauthenticated, "invalid certificate")
+		}
+		tlsInfo := p.AuthInfo.(credentials.TLSInfo)
+		subject := tlsInfo.State.VerifiedChains[0][0].Subject
+		log.Infof("stream request from %s", subject)
+		return handler(srv, serverStream)
+	}
+}
+
+func unaryInterceptor() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		p, ok := peer.FromContext(ctx)
+		if !ok {
+			return nil, status.Errorf(codes.Unauthenticated, "invalid certificate")
+		}
+		tlsInfo := p.AuthInfo.(credentials.TLSInfo)
+		subject := tlsInfo.State.VerifiedChains[0][0].Subject
+		log.Infof("request from %s", subject)
+		return handler(ctx, req)
+	}
+}
+
+// getTLSConfig returns a tls.Config for use with a gRPC endpoint; this also enables
+// client verification by checking client certificates against our CA
+func getTLSConfig(node string) (*tls.Config, error) {
+	cfg := controllerruntime.GetConfigOrDie()
+	clientset := kubernetes.NewForConfigOrDie(cfg)
+
+	cert, key, ca, err := certs.GenerateServerCertificate(context.Background(), node, clientset)
+	if err != nil {
+		return nil, fmt.Errorf("loading certificates: %w", err)
+	}
+	crt, err := tls.X509KeyPair(certhelpers.CertPEM(cert), certhelpers.PrivateKeyPEM(key))
+	if err != nil {
+		return nil, fmt.Errorf("loading x509 keypair: %w", err)
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(ca)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{crt},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+	}
+	return tlsConfig, nil
+}

--- a/internal/cert-helpers/cert-helpers.go
+++ b/internal/cert-helpers/cert-helpers.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certhelpers
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const (
+	Year = time.Hour * 24 * 365
+)
+
+func PrivateKeyPEM(key []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key})
+}
+
+func CertPEM(key []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: key})
+}
+
+func X509CertificateFromDER(der []byte) (*x509.Certificate, error) {
+	return x509.ParseCertificate(der)
+}
+
+// GenerateCA generates a new certificate authority for inspektor gadget. This is used to create server
+// and client certificates to communicate via gRPC
+func GenerateCA() ([]byte, []byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating keypair: %w", err)
+	}
+
+	now := time.Now()
+
+	tpl := &x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(0),
+		Subject: pkix.Name{
+			CommonName: "inspektor-gadget-ca",
+		},
+		DNSNames:              []string{"inspektor-gadget-ca"},
+		NotBefore:             now.UTC(),
+		NotAfter:              now.Add(Year * 10).UTC(), // 10 years
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tpl, tpl, privateKey.Public(), privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("self-signing cert: %w", err)
+	}
+
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("self-signing cert: %w", err)
+	}
+
+	return certDER, privateKeyDER, nil
+}
+
+// GenerateCertificate generates a new private key and a certificate signed by the given CA
+func GenerateCertificate(name string, usage x509.ExtKeyUsage, validFor time.Duration, caCertDER, caPrivateKeyDER []byte) ([]byte, []byte, error) {
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading CA certificate: %w", err)
+	}
+
+	caPrivateKey, err := x509.ParsePKCS8PrivateKey(caPrivateKeyDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing CA private key: %w", err)
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating keypair: %w", err)
+	}
+
+	now := time.Now()
+
+	tpl := &x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(0),
+		Subject: pkix.Name{
+			CommonName: name,
+		},
+		DNSNames:    []string{name},
+		NotBefore:   now.UTC(),
+		NotAfter:    now.Add(validFor).UTC(),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{usage},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tpl, caCert, privateKey.Public(), caPrivateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("signing cert: %w", err)
+	}
+
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("self-signing cert: %w", err)
+	}
+
+	return certDER, privateKeyDER, nil
+}

--- a/internal/cert-helpers/cert-helpers_test.go
+++ b/internal/cert-helpers/cert-helpers_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certhelpers
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+)
+
+func TestCerts(t *testing.T) {
+	caCert, caPrivateKey, err := GenerateCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCert, serverPrivateKey, err := GenerateCertificate("server", x509.ExtKeyUsageServerAuth, Year, caCert, caPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCert, clientPrivateKey, err := GenerateCertificate("client", x509.ExtKeyUsageClientAuth, Year, caCert, caPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, err := x509.ParseCertificate(caCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := x509.ParseCertificate(serverCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := x509.ParseCertificate(clientCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := server.CheckSignatureFrom(ca); err != nil {
+		t.Errorf("checking server signature: %v", err)
+	}
+	if err := client.CheckSignatureFrom(ca); err != nil {
+		t.Errorf("checking server signature: %v", err)
+	}
+
+	_, err = tls.X509KeyPair(CertPEM(clientCert), PrivateKeyPEM(clientPrivateKey))
+	if err != nil {
+		t.Errorf("loading client key pair: %v", err)
+	}
+	_, err = tls.X509KeyPair(CertPEM(serverCert), PrivateKeyPEM(serverPrivateKey))
+	if err != nil {
+		t.Errorf("loading server key pair: %v", err)
+	}
+}

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certs
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	certhelpers "github.com/inspektor-gadget/inspektor-gadget/internal/cert-helpers"
+)
+
+const (
+	CASecretName    = "ca"
+	GadgetNamespace = "gadget" // TODO: this needs to be moved somewhere else - right now it's in cmd/kubectl-gadget/utils
+)
+
+// loadCA loads the CA cert and private key from a secret
+func loadCA(ctx context.Context, clientset *kubernetes.Clientset) ([]byte, []byte, error) {
+	obj, err := clientset.CoreV1().Secrets(GadgetNamespace).Get(ctx, CASecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get gadget CA secret: %w", err)
+	}
+	return obj.Data["cert"], obj.Data["key"], nil
+}
+
+// GenerateCertificate generates a new server certificate for the node
+func GenerateCertificate(ctx context.Context, node string, keyUsage x509.ExtKeyUsage, duration time.Duration, clientset *kubernetes.Clientset) ([]byte, []byte, *x509.Certificate, error) {
+	caCert, caPrivateKey, err := loadCA(ctx, clientset)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("get CA: %w", err)
+	}
+
+	ca, err := x509.ParseCertificate(caCert)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parse CA: %w", err)
+	}
+
+	cert, privateKey, err := certhelpers.GenerateCertificate(node, keyUsage, duration, caCert, caPrivateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generate server key: %w", err)
+	}
+
+	return cert, privateKey, ca, nil
+}
+
+func GenerateClientCertificate(ctx context.Context, node string, clientset *kubernetes.Clientset) ([]byte, []byte, *x509.Certificate, error) {
+	return GenerateCertificate(ctx, node, x509.ExtKeyUsageClientAuth, time.Hour*24, clientset)
+}
+
+func GenerateServerCertificate(ctx context.Context, node string, clientset *kubernetes.Clientset) ([]byte, []byte, *x509.Certificate, error) {
+	return GenerateCertificate(ctx, node, x509.ExtKeyUsageServerAuth, certhelpers.Year*10, clientset)
+}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -19,6 +19,9 @@ rules:
   resources: ["pods"]
   # update is needed by traceloop gadget.
   verbs: ["update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This PR changes how event streams are retrieved from the gadgettracermanager.

Until now, whenever a stream is requested (e.g. trace/top gadgets), kubectl gadget would connect to the API server and exec a new process (another instance of gadgettracermanager that is only used as a client) on each node that connects to a unix socket where main gadgettracermanager is listening on using gRPC. It would then print out line by line to stdout, which then is received by the kubectl gadget.

```mermaid
 flowchart TD
	 subgraph Old
		 direction TB
	     user[User]
	     kubectl[kubectl gadget]
	     apisrv{k8s API Server}
	     user <-- kubectl gadget trace tcp --> kubectl
	     kubectl <-.-> apisrv
	     apisrv -- "exec gadgettracermgr(traceID=123)" --> gadgettracermgr-client
	     gadgettracermgr-client -- "JSON encoded lines via stdout" --> apisrv
		 subgraph Node
		     direction TB
		     gadgettracermgr-client <-- gRPC --> gadgettracermgr-server
		 end
	end
 ```

After this PR, the API server will still be used, but instead of execing, a port forwarding is established and used for a gRPC connection directly to the gadgettracermanager.

```mermaid
 flowchart TD
	subgraph New
		direction TB
	    user[User]
	    kubectl[kubectl gadget]
	    apisrv{k8s API Server}
	    user <-- kubectl gadget trace tcp --> kubectl
	    kubectl <-. "gRPC getTrace(traceID=123) in Tunnel" .-> apisrv
		apisrv <-. JSON encoded lines via gRPC .-> gadgettracermgr-server
	end
```

Please note that right now we're still using JSON encoding inside the gRPC messages - so gRPC essentially just replaces the transport.

### Advantages

#### Binary compatible interface

While we're not using binary encoded messages right now, we should consider moving at least gadgets with higher throughput to a more lightweight encodings like protocol buffers. Also, if we want to transport whole packets (or parts) to the kubectl gadget side, JSON becomes really inefficient as it uses base64 encoding in that case.

#### Cleaner interfaces

Using gRPC, we don't have to decode messages ourselves like we do right now when splitting the stdin by lines. Defining alternative messages (proper error handling on the transport layer) becomes much easier using dedicated messages.

Also, this is the first step towards a fanning-out mechanism, where we can use the nodes itself to forward trace requests t other nodes (more on that in future PRs).

### Authentication

On deployment, a CA certificate will be generated and saved into a secret. This secret will be read by the gadgettracermanager on start and a new node (server) certificate will be generated. When using kubectl gadget, the client does the same for a client certificate to establish a secure gRPC connection with the server. Fancier mechanisms using cert-manager etc. might be added later on.