### PR TITLE
introduce new gadget: tcpdump

### DIFF
--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -24,7 +24,7 @@ RUN set -ex; \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
 	apt-get install -y golang-1.18 libelf-dev:${TARGETARCH} \
-		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
+		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} libpcap-dev:${TARGETARCH} && \
 	ln -s /usr/lib/go-1.18/bin/go /bin/go && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		apt-get install -y gcc-aarch64-linux-gnu; \
@@ -76,7 +76,7 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio && \
+		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio libpcap-dev && \
 		rmdir /usr/src && ln -sf /host/usr/src /usr/src && \
 		rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 

--- a/Dockerfiles/local-gadget.Dockerfile
+++ b/Dockerfiles/local-gadget.Dockerfile
@@ -29,6 +29,7 @@ RUN \
 		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig ; \
 	fi ; \
 	go build \
+		-tags localgadget \
 		-ldflags "-X main.version=${VERSION} -extldflags '-static'" \
 		-o local-gadget-${GOOS}-${GOARCH} \
 		github.com/inspektor-gadget/inspektor-gadget/cmd/local-gadget

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -29,6 +29,7 @@ const (
 	OutputModeColumns       = "columns"
 	OutputModeJSON          = "json"
 	OutputModeCustomColumns = "custom-columns"
+	OutputModeCustom        = "custom"
 )
 
 var SupportedOutputModes = []string{OutputModeColumns, OutputModeJSON, OutputModeCustomColumns}

--- a/cmd/kubectl-gadget/trace/tcpdump.go
+++ b/cmd/kubectl-gadget/trace/tcpdump.go
@@ -1,0 +1,399 @@
+// Copyright 2019-2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commontrace "github.com/inspektor-gadget/inspektor-gadget/cmd/common/trace"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpdump/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type Decoder string
+
+type nameEvent struct {
+	IP   net.IP
+	Name string
+}
+
+type TCPDumpParser struct {
+	commonutils.BaseParser[types.Event]
+	pcapngWriter   *pcapgo.NgWriter
+	writer         io.Writer
+	decoder        Decoder
+	snapLen        int
+	filter         string
+	interfaces     map[string]int
+	interfacesLock sync.RWMutex
+	events         chan *types.Event // channel for incoming packets
+	nameEvents     chan *nameEvent   // channel for dns resolution information
+}
+
+const (
+	DecoderWireshark = "wireshark"
+	DecoderTCPDump   = "tcpdump"
+	DecoderExternal  = "external"
+	DecoderInternal  = "internal"
+	DecoderFile      = "file"
+)
+
+var decoderCmd *exec.Cmd
+
+// populate DNS entries
+func (p *TCPDumpParser) populateDNS(ctx context.Context) ([]byte, error) {
+	client, err := k8sutil.NewClientsetFromConfigFlags(utils.KubernetesConfigFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		list, _ := client.CoreV1().Pods("").Watch(ctx, metav1.ListOptions{})
+		for info := range list.ResultChan() {
+			pod := info.Object.(*corev1.Pod)
+			for _, ip := range pod.Status.PodIPs {
+				if parsedIP := net.ParseIP(ip.IP); parsedIP != nil {
+					p.nameEvents <- &nameEvent{
+						IP:   parsedIP,
+						Name: fmt.Sprintf("%s.%s.pod", strings.Replace(ip.IP, ".", "-", -1), pod.Namespace),
+					}
+				}
+			}
+		}
+	}()
+	go func() {
+		list, _ := client.CoreV1().Services("").Watch(ctx, metav1.ListOptions{})
+		for info := range list.ResultChan() {
+			svc := info.Object.(*corev1.Service)
+			for _, ip := range svc.Spec.ClusterIPs {
+				if parsedIP := net.ParseIP(ip); parsedIP != nil {
+					p.nameEvents <- &nameEvent{
+						IP:   parsedIP,
+						Name: fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
+					}
+				}
+			}
+			for _, ip := range svc.Spec.ExternalIPs {
+				if parsedIP := net.ParseIP(ip); parsedIP != nil {
+					p.nameEvents <- &nameEvent{
+						IP:   parsedIP,
+						Name: fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
+					}
+				}
+			}
+			if svc.Spec.LoadBalancerIP != "" {
+				if parsedIP := net.ParseIP(svc.Spec.LoadBalancerIP); parsedIP != nil {
+					p.nameEvents <- &nameEvent{
+						IP:   parsedIP,
+						Name: fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
+					}
+				}
+			}
+		}
+	}()
+	return nil, nil
+}
+
+func getDNSBlock(ip net.IP, name string) []byte {
+	// TODO: add support for IPv6
+	ipv4 := ip.To4()
+	if ipv4 == nil || len(ipv4) != net.IPv4len {
+		return nil
+	}
+
+	nsblock := bytes.NewBuffer(nil)
+
+	header := make([]byte, 8)
+	binary.LittleEndian.PutUint32(header[0:], 0x00000004) // Block type
+	nsblock.Write(header)
+
+	plen := 4 + 4 + len([]byte(name)) + 1 // header + ip + name + \0 terminator
+	if plen%4 != 0 {
+		// pad to 32bit
+		plen += 4 - plen%4
+	}
+	record := make([]byte, plen)
+
+	binary.LittleEndian.PutUint16(record[0:2], 0x0001)                        // ipv4
+	binary.LittleEndian.PutUint16(record[2:4], uint16(4+len([]byte(name))+1)) // length of name + \0 terminator
+
+	copy(record[4:8], ipv4[0:4])
+	copy(record[8:], []byte(name))
+	nsblock.Write(record)
+
+	footer := make([]byte, 4)
+	nsblock.Write(footer) // nrb_record_end + length
+
+	nsblock.Write(footer) // Block size
+
+	out := nsblock.Bytes()
+	binary.LittleEndian.PutUint32(out[4:], uint32(len(out)))
+	binary.LittleEndian.PutUint32(out[len(out)-4:], uint32(len(out)))
+	return out
+}
+
+func newTCPDumpCmd() *cobra.Command {
+	commonFlags := &utils.CommonFlags{
+		OutputConfig: commonutils.OutputConfig{
+			OutputMode:    commonutils.OutputModeCustom,
+			CustomColumns: []string{},
+		},
+	}
+
+	var decoderParam string
+	var decoderArgsParam string
+	var decoderBinaryParam string
+	var snapLen int
+	var filenameParam string
+	var disableDNSPopulation bool
+
+	cmd := &cobra.Command{
+		Use:   "tcpdump",
+		Short: "Trace packets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			decoderArgs := []string{}
+			var decoder Decoder
+			var decoderBinary string
+			var ngw *pcapgo.NgWriter
+
+			// Writer, used for external output (pcapng)
+			var out io.Writer
+
+			switch Decoder(decoderParam) {
+			case DecoderWireshark:
+				decoder = DecoderExternal
+				decoderArgs = []string{"-k", "-i", "-"}
+				decoderBinary = "wireshark"
+			case DecoderTCPDump:
+				decoder = DecoderExternal
+				decoderArgs = []string{"-r", "-"}
+				decoderBinary = "tcpdump"
+			case DecoderInternal:
+				decoder = DecoderInternal
+			case DecoderFile:
+				decoder = DecoderFile
+			default:
+				return errors.New("unknown decoder")
+			}
+
+			if decoder == DecoderFile {
+				if filenameParam == "" {
+					return fmt.Errorf("no filename specified")
+				}
+				f, err := os.Create(filenameParam)
+				if err != nil {
+					return fmt.Errorf("creating file: %w", err)
+				}
+				out = f
+			}
+
+			if decoder == DecoderExternal {
+				r, w, err := os.Pipe()
+				if err != nil {
+					return fmt.Errorf("could not create pipe: %w", err)
+				}
+
+				if decoderArgsParam != "" {
+					decoderArgs = append(decoderArgs, strings.Split(decoderArgsParam, " ")...)
+				}
+				if decoderBinaryParam != "" {
+					decoderBinary = decoderBinaryParam
+				}
+
+				// xwr := &wr{File: os.Stdout}
+
+				decoderCmd = exec.Command(decoderBinary, decoderArgs...)
+				decoderCmd.Stdout = os.Stdout
+				decoderCmd.Stderr = os.Stderr
+				decoderCmd.Stdin = r
+				err = decoderCmd.Start()
+				if err != nil {
+					return fmt.Errorf("could not start tcpdump: %w", err)
+				}
+
+				out = w
+			}
+
+			if out != nil {
+				var err error
+				dummyInterface := pcapgo.DefaultNgInterface
+				dummyInterface.LinkType = layers.LinkTypeEthernet
+				dummyInterface.SnapLength = uint32(snapLen)
+				ngw, err = pcapgo.NewNgWriterInterface(out, dummyInterface, pcapgo.NgWriterOptions{SectionInfo: pcapgo.NgSectionInfo{
+					Hardware:    runtime.GOARCH,
+					OS:          runtime.GOOS,
+					Application: "InspektorGadget",
+					Comment:     "using gopacket",
+				}})
+				if err != nil {
+					return fmt.Errorf("instantiating NgWriter: %w", err)
+				}
+				ngw.Flush()
+			}
+
+			filter := strings.Join(args, " ")
+
+			tcpdumpGadget := &TraceGadget[types.Event]{
+				name:        "tcpdump",
+				commonFlags: commonFlags,
+				parser:      NewTCPDump(&commonFlags.OutputConfig, filter, snapLen, decoder, ngw, out),
+				params: map[string]string{
+					types.FilterStringParam: filter,
+					types.SnapLenParam:      strconv.Itoa(snapLen),
+				},
+			}
+
+			return tcpdumpGadget.Run()
+		},
+	}
+
+	utils.AddCommonFlags(cmd, commonFlags)
+	cmd.Flags().StringVar(&decoderParam, "decoder", "internal", "name of the decoder to use (either tcpdump, wireshark, internal or file)")
+	cmd.Flags().StringVar(&decoderArgsParam, "decoder-args", "", "arguments to forward to decoder")
+	cmd.Flags().StringVar(&decoderBinaryParam, "decoder-binary", "", "path to decoder binary (defaults to 'wireshark' or 'tcpdump' depending on decoder)")
+	cmd.Flags().StringVar(&filenameParam, "out-file", "", "output file name")
+	cmd.Flags().BoolVar(&disableDNSPopulation, "disable-dns", false, "disable DNS population from kubernetes")
+	cmd.Flags().IntVar(&snapLen, "snaplen", 68, "number of bytes to capture per packet")
+	return cmd
+}
+
+func NewTCPDump(outputConfig *commonutils.OutputConfig, filter string, snapLen int, decoder Decoder, pcapngWriter *pcapgo.NgWriter, writer io.Writer) commontrace.TraceParser[types.Event] {
+	columnsWidth := map[string]int{}
+	outputConfig.OutputMode = commonutils.OutputModeCustom
+	p := &TCPDumpParser{
+		BaseParser:   commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
+		filter:       filter,
+		snapLen:      snapLen,
+		decoder:      decoder,
+		pcapngWriter: pcapngWriter,
+		writer:       writer,
+		interfaces:   make(map[string]int),
+		events:       make(chan *types.Event, 1024),
+		nameEvents:   make(chan *nameEvent, 32),
+	}
+
+	if p.decoder != DecoderInternal {
+		go p.populateDNS(context.TODO())
+	}
+	go p.run()
+	return p
+}
+
+func (p *TCPDumpParser) getPodInterface(event *types.Event) int {
+	p.interfacesLock.RLock()
+	if id, ok := p.interfaces[event.Container]; ok {
+		p.interfacesLock.RUnlock()
+		return id
+	}
+	p.interfacesLock.RUnlock()
+	// Define new interface
+	p.interfacesLock.Lock()
+	id, err := p.pcapngWriter.AddInterface(pcapgo.NgInterface{
+		Name:        event.Container,
+		Comment:     "",
+		Description: fmt.Sprintf("Node: %s, Namespace: %s, Pod: %s", event.Node, event.Namespace, event.Pod),
+		Filter:      p.filter,
+		OS:          "",
+		LinkType:    layers.LinkTypeEthernet,
+		SnapLength:  uint32(p.snapLen),
+		Statistics:  pcapgo.NgInterfaceStatistics{},
+	})
+	if err != nil {
+		panic(fmt.Errorf("registering interface: %w", err))
+	}
+	p.interfaces[event.Container] = id
+	p.interfacesLock.Unlock()
+	return id
+}
+
+type wr struct {
+	*os.File
+}
+
+func (wr *wr) Write(data []byte) (int, error) {
+	defer wr.File.Sync()
+	log.Printf("--\n--\n")
+	return wr.File.Write(data)
+}
+
+// since pcapngWriter.WritePacket isn't thread safe, we need to serialize incoming events
+func (p *TCPDumpParser) run() {
+	for {
+		select {
+		case event := <-p.events:
+			if event.Event.Type != eventtypes.NORMAL {
+				log.Printf("ERROR: %s", event.Message)
+				continue
+			}
+			if p.decoder == DecoderInternal {
+				packet := gopacket.NewPacket(event.Payload, layers.LayerTypeEthernet, gopacket.NoCopy)
+				fmt.Println(packet.String())
+			} else {
+				id := p.getPodInterface(event)
+				err := p.pcapngWriter.WritePacket(gopacket.CaptureInfo{
+					Timestamp:      time.Unix(0, event.Time),
+					CaptureLength:  len(event.Payload),
+					Length:         int(event.OLen),
+					InterfaceIndex: id,
+				}, event.Payload)
+				if err != nil {
+					log.Printf("error: %v", err)
+				}
+
+				if p.decoder != DecoderFile {
+					// If we're streaming to an application, let's flush here
+					p.pcapngWriter.Flush()
+				}
+			}
+		case nameEvent := <-p.nameEvents:
+			if dnsBlock := getDNSBlock(nameEvent.IP, nameEvent.Name); dnsBlock != nil {
+				p.writer.Write(dnsBlock)
+			} else {
+				log.Printf("got invalid IP: %s", nameEvent.IP)
+			}
+		}
+	}
+}
+
+func (p *TCPDumpParser) TransformIntoColumns(event *types.Event) string {
+	// This is a hack for now - we use "custom" output mode and have this method called to
+	// forward packets to tcpdump / decode ourselves
+	p.events <- event
+	return ""
+}

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -85,6 +85,9 @@ func (g *TraceGadget[Event]) Run() error {
 			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			return g.parser.TransformIntoColumns(&e)
+		case commonutils.OutputModeCustom:
+			g.parser.TransformIntoColumns(&e) // Forward to this method, but don't do anything else
+			return ""
 		default:
 			fmt.Fprint(os.Stderr, commonutils.WrapInErrOutputModeNotSupported(g.commonFlags.OutputMode))
 			return ""
@@ -114,6 +117,7 @@ func NewTraceCmd() *cobra.Command {
 	traceCmd.AddCommand(newSNICmd())
 	traceCmd.AddCommand(newTCPCmd())
 	traceCmd.AddCommand(newTcpconnectCmd())
+	traceCmd.AddCommand(newTCPDumpCmd())
 
 	return traceCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -43,9 +43,12 @@ require (
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/cloudflare/cbpfc v0.0.0-20221017140110-11acb56438a2
 	github.com/google/go-cmp v0.5.8
+	github.com/google/gopacket v1.1.19
 	github.com/kr/pretty v0.3.0
 	github.com/moby/moby v20.10.18+incompatible
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )
 
 require (
@@ -134,7 +137,6 @@ require (
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,9 +186,12 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.9.0/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/cbpfc v0.0.0-20221017140110-11acb56438a2 h1:tR13nc9+yx04rglzDJGQLoz3bTsh0os9tXpis6qwSVk=
+github.com/cloudflare/cbpfc v0.0.0-20221017140110-11acb56438a2/go.mod h1:KV9WSdjdUOxRC4RdsvoV1W5JTdMe7IjMgSUwcBrs860=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -395,6 +398,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNy
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
+github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -563,6 +567,8 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -1270,6 +1276,7 @@ golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1398,6 +1405,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210921065528-437939a70204/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/pkg/gadget-collection/gadget-collection.go
+++ b/pkg/gadget-collection/gadget-collection.go
@@ -39,6 +39,7 @@ import (
 	snisnoop "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace/sni"
 	tcptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace/tcp"
 	tcpconnect "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace/tcpconnect"
+	tcpdump "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/trace/tcpdump"
 	traceloop "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop"
 )
 
@@ -65,6 +66,7 @@ func TraceFactories() map[string]gadgets.TraceFactory {
 		"snisnoop":          snisnoop.NewFactory(),
 		"socket-collector":  socketcollector.NewFactory(),
 		"tcpconnect":        tcpconnect.NewFactory(),
+		"tcpdump":           tcpdump.NewFactory(),
 		"tcptop":            tcptop.NewFactory(),
 		"tcptracer":         tcptracer.NewFactory(),
 		"traceloop":         traceloop.NewFactory(),

--- a/pkg/gadget-collection/gadgets/trace/tcpdump/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/tcpdump/gadget.go
@@ -1,0 +1,281 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcpdump
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
+	tcpdumptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpdump/tracer"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpdump/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type Trace struct {
+	helpers gadgets.GadgetHelpers
+	client  client.Client
+
+	started bool
+
+	tracer *tcpdumptracer.Tracer
+
+	netnsHost uint64
+}
+
+type TraceFactory struct {
+	gadgets.BaseFactory
+
+	netnsHost uint64
+}
+
+func NewFactory() gadgets.TraceFactory {
+	netnsHost, _ := containerutils.GetNetNs(os.Getpid())
+	return &TraceFactory{
+		BaseFactory: gadgets.BaseFactory{DeleteTrace: deleteTrace},
+		netnsHost:   netnsHost,
+	}
+}
+
+func (f *TraceFactory) Description() string {
+	return `The tcpdump gadget retrieves packets from pods`
+}
+
+func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
+	return map[gadgetv1alpha1.TraceOutputMode]struct{}{
+		gadgetv1alpha1.TraceOutputModeStream: {},
+	}
+}
+
+func deleteTrace(name string, t interface{}) {
+	trace := t.(*Trace)
+	if trace.started {
+		trace.helpers.Unsubscribe(genPubSubKey(name))
+		trace.tracer.Close()
+		trace.tracer = nil
+	}
+}
+
+func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
+	n := func() interface{} {
+		return &Trace{
+			client:    f.Client,
+			helpers:   f.Helpers,
+			netnsHost: f.netnsHost,
+		}
+	}
+
+	return map[gadgetv1alpha1.Operation]gadgets.TraceOperation{
+		gadgetv1alpha1.OperationStart: {
+			Doc: "Start tcpdump",
+			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
+				f.LookupOrCreate(name, n).(*Trace).Start(trace)
+			},
+		},
+		gadgetv1alpha1.OperationStop: {
+			Doc: "Stop tcpdump",
+			Operation: func(name string, trace *gadgetv1alpha1.Trace) {
+				f.LookupOrCreate(name, n).(*Trace).Stop(trace)
+			},
+		},
+	}
+}
+
+type pubSubKey string
+
+func genPubSubKey(name string) pubSubKey {
+	return pubSubKey(fmt.Sprintf("gadget/tcpdump/%s", name))
+}
+
+func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
+	if t.started {
+		trace.Status.State = gadgetv1alpha1.TraceStateStarted
+		return
+	}
+
+	config := &tcpdumptracer.Config{
+		SnapLen:      68, // default value for tcpdump (https://wiki.wireshark.org/SnapLen.md)
+		FilterString: trace.Spec.Parameters[types.FilterStringParam],
+	}
+
+	if snapLen, err := strconv.Atoi(trace.Spec.Parameters[types.SnapLenParam]); err == nil {
+		config.SnapLen = snapLen
+	}
+
+	var err error
+	t.tracer, err = tcpdumptracer.NewTracer(config)
+	if err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to start tcpdump tracer: %s", err)
+		return
+	}
+
+	printMessage := func(key string, t eventtypes.EventType, message string) string {
+		event := &types.Event{
+			Event: eventtypes.Event{
+				Type: t,
+				CommonData: eventtypes.CommonData{
+					Node: trace.Spec.Node,
+				},
+				Message: message,
+			},
+		}
+
+		// fillEvent(event, key)
+
+		b, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Sprintf("error marshalling results: %s", err)
+		}
+		return string(b)
+	}
+	/*
+		fillEvent := func(event *types.Event, key string) {
+			event.Node = trace.Spec.Node
+			keyParts := strings.SplitN(key, "/", 2)
+			if len(keyParts) == 2 {
+				event.Namespace = keyParts[0]
+				event.Pod = keyParts[1]
+			} else if key != "host" {
+				event.Type = eventtypes.ERR
+				event.Message = fmt.Sprintf("unknown key %s", key)
+			}
+		}
+		printEvent := func(key string, event *types.Event) string {
+			// event := &types.Event{
+			// 	Event: eventtypes.Event{
+			// 		Type: eventtypes.NORMAL,
+			// 		CommonData: eventtypes.CommonData{
+			// 			Node: trace.Spec.Node,
+			// 		},
+			// 	},
+			// 	Payload: payload,
+			// }
+			fillEvent(event, key)
+
+			b, err := json.Marshal(event)
+			if err != nil {
+				return fmt.Sprintf("error marshalling results: %s", err)
+			}
+			return string(b)
+		}
+	*/
+
+	traceName := gadgets.TraceName(trace.ObjectMeta.Namespace, trace.ObjectMeta.Name)
+
+	newPacketCallback := func(key string, container *containercollection.Container) func(event *types.Event) {
+		return func(event *types.Event) {
+			event.Namespace = container.Namespace
+			event.Container = container.Name
+			event.Pod = container.Podname
+			d, _ := json.Marshal(event)
+			t.helpers.PublishEvent(
+				traceName,
+				string(d),
+			)
+		}
+	}
+
+	genKey := func(container *containercollection.Container) string {
+		if container.Netns == t.netnsHost {
+			return "host"
+		}
+		return container.Namespace + "/" + container.Podname
+	}
+
+	attachContainerFunc := func(container *containercollection.Container) error {
+		log.Warnf("Attaching to pid %d", container.Pid)
+
+		key := genKey(container)
+
+		err = t.tracer.Attach(key, container.Pid, newPacketCallback(key, container))
+		if err != nil {
+			t.helpers.PublishEvent(
+				traceName,
+				printMessage(key, eventtypes.ERR, fmt.Sprintf("failed to attach tracer: %s", err)),
+			)
+			return err
+		}
+		t.helpers.PublishEvent(
+			traceName,
+			printMessage(key, eventtypes.DEBUG, "tracer attached"),
+		)
+		return nil
+	}
+
+	detachContainerFunc := func(container *containercollection.Container) {
+		key := genKey(container)
+
+		err := t.tracer.Detach(key)
+		if err != nil {
+			t.helpers.PublishEvent(
+				traceName,
+				printMessage(key, eventtypes.ERR, fmt.Sprintf("failed to detach tracer: %s", err)),
+			)
+			return
+		}
+		t.helpers.PublishEvent(
+			traceName,
+			printMessage(key, eventtypes.DEBUG, "tracer detached"),
+		)
+	}
+
+	containerEventCallback := func(event containercollection.PubSubEvent) {
+		switch event.Type {
+		case containercollection.EventTypeAddContainer:
+			attachContainerFunc(event.Container)
+		case containercollection.EventTypeRemoveContainer:
+			detachContainerFunc(event.Container)
+		}
+	}
+
+	existingContainers := t.helpers.Subscribe(
+		genPubSubKey(trace.ObjectMeta.Namespace+"/"+trace.ObjectMeta.Name),
+		*gadgets.ContainerSelectorFromContainerFilter(trace.Spec.Filter),
+		containerEventCallback,
+	)
+
+	for _, c := range existingContainers {
+		err := attachContainerFunc(c)
+		if err != nil {
+			log.Warnf("Warning: couldn't attach BPF program: %s", err)
+			break
+		}
+	}
+	t.started = true
+
+	trace.Status.State = gadgetv1alpha1.TraceStateStarted
+}
+
+func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
+	if !t.started {
+		trace.Status.OperationError = "Not started"
+		return
+	}
+
+	t.helpers.Unsubscribe(genPubSubKey(trace.ObjectMeta.Namespace + "/" + trace.ObjectMeta.Name))
+	t.tracer.Close()
+	t.tracer = nil
+	t.started = false
+
+	trace.Status.State = gadgetv1alpha1.TraceStateStopped
+}

--- a/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_libpcap.go
+++ b/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_libpcap.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !localgadget
+
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"golang.org/x/net/bpf"
+)
+
+// Partly copied from https://github.com/cloudflare/xdpcap/blob/12307bddefb8a850f940cbbf46836760c1444138/internal/tcpdump.go
+
+func TcpdumpExprToBPF(filterExpr string, linkType layers.LinkType, snapLen int) ([]bpf.RawInstruction, error) {
+	// We treat any != 0 filter return code as a match
+	insns, err := pcap.CompileBPFFilter(linkType, snapLen, filterExpr)
+	if err != nil {
+		return nil, fmt.Errorf("compiling expression to BPF: %w", err)
+	}
+	return bpf.Assemble(pcapInsnToX(insns))
+}
+
+func pcapInsnToX(insns []pcap.BPFInstruction) []bpf.Instruction {
+	xInsns := make([]bpf.Instruction, len(insns))
+
+	for i, insn := range insns {
+		xInsns[i] = bpf.RawInstruction{
+			Op: insn.Code,
+			Jt: insn.Jt,
+			Jf: insn.Jf,
+			K:  insn.K,
+		}.Disassemble()
+	}
+
+	return xInsns
+}

--- a/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_tcpdump.go
+++ b/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_tcpdump.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build localgadget
+
+package compiler
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/google/gopacket/layers"
+	"golang.org/x/net/bpf"
+)
+
+func TcpdumpExprToBPF(filterExpr string, linkType layers.LinkType, snapLen int) ([]bpf.RawInstruction, error) {
+	if linkType != layers.LinkTypeEthernet {
+		return nil, errors.New("unsupported linkType")
+	}
+
+	// We'll use an installed tcpdump to compile the filter
+	cmd := exec.Command("tcpdump", "-ddd", "-s", strconv.Itoa(snapLen), filterExpr)
+
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("compiling filter using tcpdump binary: %w", err)
+	}
+
+	// Read lines
+	lines := strings.Split(strings.Replace(b.String(), "\r", "", -1), "\n")
+	if len(lines) < 1 {
+		return nil, fmt.Errorf("unexpected output from tcpdump")
+	}
+	count, err := strconv.Atoi(lines[0])
+	if err != nil {
+		return nil, fmt.Errorf("expected first line from tcpdump to be count of instructions")
+	}
+
+	xInsns := make([]bpf.Instruction, 0, count)
+	for _, line := range lines[1:] {
+		parts := strings.Split(line, " ")
+		if len(parts) != 4 {
+			continue // skip empty lines
+		}
+		op, err := strconv.ParseInt(parts[0], 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid op %q in instruction: %q", parts[0], line)
+		}
+		jt, err := strconv.ParseInt(parts[0], 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jt %q in instruction: %q", parts[1], line)
+		}
+		jf, err := strconv.ParseInt(parts[0], 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jf %q in instruction: %q", parts[2], line)
+		}
+		k, err := strconv.ParseInt(parts[0], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid k %q in instruction: %q", parts[3], line)
+		}
+		xInsns = append(xInsns, bpf.RawInstruction{
+			Op: uint16(op),
+			Jt: uint8(jt),
+			Jf: uint8(jf),
+			K:  uint32(k),
+		}.Disassemble())
+	}
+
+	if len(xInsns) != count {
+		return nil, fmt.Errorf("instruction count does not match number of instructions given: count: %d, instructions found: %d", count, len(xInsns))
+	}
+
+	return bpf.Assemble(xInsns)
+}

--- a/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_tcpdump_test.go
+++ b/pkg/gadgets/trace/tcpdump/tracer/compiler/compiler_tcpdump_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build localgadget
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/google/gopacket/layers"
+)
+
+func TestTcpdumpCompiler(t *testing.T) {
+	_, err := TcpdumpExprToBPF("host 127.0.0.1", layers.LinkTypeEthernet, 100)
+	if err != nil {
+		t.Fatalf("compiling program: %v", err)
+	}
+}

--- a/pkg/gadgets/trace/tcpdump/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpdump/tracer/tracer.go
@@ -1,0 +1,193 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/google/gopacket/afpacket"
+	"github.com/google/gopacket/layers"
+	"github.com/vishvananda/netns"
+	"golang.org/x/net/bpf"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpdump/tracer/compiler"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpdump/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type Config struct {
+	FilterString string
+	SnapLen      int
+}
+
+type link struct {
+	tpacket *afpacket.TPacket
+
+	// users count how many users called Attach(). This can happen for two reasons:
+	// 1. several containers in a pod (sharing the netns)
+	// 2. pods with networkHost=true
+	users int
+}
+
+type Tracer struct {
+	config  *Config
+	program []bpf.RawInstruction
+
+	// key: namespace/podname
+	// value: Tracelet
+	attachments map[string]*link
+}
+
+func NewTracer(config *Config) (*Tracer, error) {
+	t := &Tracer{
+		config:      config,
+		attachments: map[string]*link{},
+	}
+
+	var err error
+	t.program, err = compiler.TcpdumpExprToBPF(config.FilterString, layers.LinkTypeEthernet, config.SnapLen)
+	if err != nil {
+		return nil, fmt.Errorf("compile tcpdump expression to bpf: %w", err)
+	}
+
+	return t, nil
+}
+
+func (t *Tracer) releaseLink(key string, l *link) {
+	if t.attachments[key].tpacket != nil {
+		t.attachments[key].tpacket.Close()
+	}
+	delete(t.attachments, key)
+}
+
+func (t *Tracer) Close() {
+	for key, l := range t.attachments {
+		t.releaseLink(key, l)
+	}
+}
+
+func runWithNamespaceFromPid(pid uint32, fn func() error) error {
+	if pid != 0 {
+		// Lock the OS Thread so we don't accidentally switch namespaces
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		// Save the current network namespace
+		origns, _ := netns.Get()
+		defer origns.Close()
+
+		netnsHandle, err := netns.GetFromPid(int(pid))
+		if err != nil {
+			return err
+		}
+		defer netnsHandle.Close()
+		err = netns.Set(netnsHandle)
+		if err != nil {
+			return err
+		}
+
+		// Switch back to the original namespace
+		defer netns.Set(origns)
+	}
+	return fn()
+}
+
+func (t *Tracer) Attach(
+	key string,
+	pid uint32,
+	eventCallback func(*types.Event),
+) (err error) {
+	if l, ok := t.attachments[key]; ok {
+		l.users++
+		return nil
+	}
+
+	l := &link{
+		users: 1,
+	}
+
+	err = runWithNamespaceFromPid(pid, func() error {
+		tpacket, err := afpacket.NewTPacket()
+		if err != nil {
+			return err
+		}
+		l.tpacket = tpacket
+		return nil
+	})
+	defer func() {
+		if err != nil {
+			if l.tpacket != nil {
+				l.tpacket.Close()
+			}
+		}
+	}()
+	if err != nil {
+		return fmt.Errorf("open raw socket: %w", err)
+	}
+
+	err = l.tpacket.SetBPF(t.program)
+	if err != nil {
+		return fmt.Errorf("set bpf filter: %w", err)
+	}
+
+	t.attachments[key] = l
+
+	go t.run(l, eventCallback)
+
+	return nil
+}
+
+func (t *Tracer) Detach(key string) error {
+	if l, ok := t.attachments[key]; ok {
+		l.users--
+		if l.users == 0 {
+			t.releaseLink(key, l)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("key not attached: %q", key)
+	}
+}
+
+func (t *Tracer) run(
+	l *link,
+	eventCallback func(*types.Event),
+) {
+	ctr := uint32(1)
+	for {
+		d, info, err := l.tpacket.ZeroCopyReadPacketData()
+		if err != nil {
+			break
+		}
+		if t.config.SnapLen != 0 && len(d) > t.config.SnapLen {
+			// This can happen for packets received before the filter has been installed, so we need to manually adjust
+			d = d[:t.config.SnapLen]
+			info.CaptureLength = t.config.SnapLen
+		}
+		// eventCallback MUST serialize payload d directly as the next call to ZeroCopyReadPacketData() will invalidate
+		// the buffer.
+		eventCallback(&types.Event{
+			Event: eventtypes.Event{
+				Type: eventtypes.NORMAL,
+			},
+			Time:    info.Timestamp.UnixNano(),
+			Counter: ctr,
+			Payload: d,
+			OLen:    uint32(info.Length),
+		})
+	}
+	return
+}

--- a/pkg/gadgets/trace/tcpdump/types/types.go
+++ b/pkg/gadgets/trace/tcpdump/types/types.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+const (
+	FilterStringParam = "FilterString"
+	SnapLenParam      = "SnapLen"
+)
+
+type Event struct {
+	eventtypes.Event
+
+	OLen    uint32 `json:"len"`
+	Counter uint32 `json:"counter"`
+	Time    int64  `json:"time"`
+	Payload []byte `json:"payload"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	return columns.MustCreateColumns[Event]()
+}
+
+func Base(ev eventtypes.Event) Event {
+	return Event{
+		Event: ev,
+	}
+}
+
+func (e Event) GetBaseEvent() eventtypes.Event {
+	return e.Event
+}


### PR DESCRIPTION
This PR introduces a new gadget that allows distributed packet capturing and inspection. It uses libpcap to compile rules like the ones used in tcpdump (hence the name) into cBPF and filters them using a raw socket with the compiled filter attached.

The received stream will by default be analyzed using gopacket but can optionally be forwarded to a local tcpdump or wireshark instance (it uses the pcap format).

Right now packets are encoded using JSON (like all the other gadgets), but I hope that we get better support for binary content using #1096.

### Additional Features

The gadget uses the pcapng file format and uses two features not yet commonly used:

#### Interface Names

Each container will have its own interface registered in the pcapng file - that makes it easy (especially in Wireshark) to differentiate the traffic. Additionally, as metadata, we add podname and namespace.

#### Name Resolution Blocks

Before starting to stream traffic into the pcapng file (or to tcpdump/WireShark), we generate DNS records for all pods and services and populate the file with them. That way you can easier see what is communicating with what inside the cluster.
Afterwards it will add updates as they come in (new pods, new services etc.)

### Sample output

Using gopacket (default)

![Using gopacket](https://user-images.githubusercontent.com/1550037/199745446-a587a9e2-762d-4c06-957a-4cc1028e96be.png)

Using tcpdump

![Using tcpdump](https://user-images.githubusercontent.com/1550037/199745551-07157bef-25a3-4d47-81d0-2a57cbdadd16.png)

Using tcpdump with additional parameters

![Using tcpdump with parameters](https://user-images.githubusercontent.com/1550037/199745612-708039c7-8a81-49cc-82af-c5bd7a3e49f5.png)

Using WireShark with interface names and name resolution blocks inserted (need to enable name resolution in WireShark for that)

![wireshark](https://user-images.githubusercontent.com/1550037/201638869-24fa2b44-5034-4531-855a-b2c7ee532c5a.png)

### Todo

* [x] add snaplen parameter
* [ ] use binary encoding
* [x] add option to save to pcap file
* [ ] add tests
* [ ] decide whether to have a new category "tools" or just place it into "trace"
* [ ] add more information about dropped packets
* [x] use pcapng as file format and enrich it with interface names and name resolution blocks
* [ ] make it work with local-gadget
* [x] optimize for speed as this is probably a high throughput gadget