### PR TITLE
integration/inspektor-gadget: Clean up log files after NetworkPolicy test

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -912,6 +912,11 @@ spec:
 		},
 		DeleteTestNamespaceCommand(nsClient),
 		DeleteTestNamespaceCommand(nsServer),
+		{
+			Name:    "CleanupLogFiles",
+			Cmd:     "rm -f networktrace-client.log networktrace-server.log",
+			Cleanup: true,
+		},
 	}
 
 	RunCommands(commands, t)


### PR DESCRIPTION
# Clean up log files after NetworkPolicy test

Avoid leaving log files after running the IG integration tests.
