### PR TITLE
integration-tests: Improve deployment workflow for IG/SPO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ local-gadget-tests:
 	rm -f ./local-gadget-manager.test
 
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
-# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v -no-deploy-ig -no-deploy-spo" make integration-tests
+# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v" make integration-tests
 .PHONY: integration-tests
 integration-tests: kubectl-gadget
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -164,3 +164,8 @@ func GetTestPodIP(ns string, podname string) string {
 	ip := string(r)
 	return ip[1 : len(ip)-1]
 }
+
+func CheckNamespace(ns string) bool {
+	cmd := exec.Command("kubectl", "get", "ns", ns)
+	return cmd.Run() == nil
+}

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -67,9 +67,6 @@ var (
 	// image such as ghcr.io/inspektor-gadget/inspektor-gadget:latest
 	image = flag.String("image", "", "gadget container image")
 
-	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")
-	doNotDeploySPO = flag.Bool("no-deploy-spo", false, "don't deploy the Security Profiles Operator (SPO)")
-
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
 	k8sArch   = flag.String("k8s-arch", "amd64", "allows to skip tests that are not supported on a given CPU architecture")
 )
@@ -137,7 +134,8 @@ func testMain(m *testing.M) int {
 	initCommands := []*Command{}
 	cleanupCommands := []*Command{DeleteRemainingNamespacesCommand()}
 
-	if !*doNotDeployIG {
+	deployIG := !CheckNamespace("gadget")
+	if deployIG {
 		imagePullPolicy := "Always"
 		if *k8sDistro == K8sDistroMinikubeGH {
 			imagePullPolicy = "Never"
@@ -148,7 +146,8 @@ func testMain(m *testing.M) int {
 		cleanupCommands = append(cleanupCommands, CleanupInspektorGadget)
 	}
 
-	if !*doNotDeploySPO {
+	deploySPO := !CheckNamespace("security-profiles-operator")
+	if deploySPO {
 		limitReplicas := false
 		patchWebhookConfig := false
 		bestEffortResourceMgmt := false


### PR DESCRIPTION
If we have a cluster with pre-installed IG/SPO we end up removing them if '-no-deploy-ig/-no-deploy-spo' isn't specified. Here we add some logic to detect if these components are already installed and skip deployment/cleanup. This can also be helpful to skip SPO installation against ARO cluster without extra config. 

Fixes #976 