### PR TITLE
integration-tests: Patch seccomp profiles to force SPO cleanup

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -160,7 +160,7 @@ func testMain(m *testing.M) int {
 			patchWebhookConfig = true
 		}
 		initCommands = append(initCommands, DeploySPO(limitReplicas, patchWebhookConfig, bestEffortResourceMgmt))
-		cleanupCommands = append(cleanupCommands, CleanupSPO)
+		cleanupCommands = append(cleanupCommands, CleanupSPO...)
 	}
 
 	notifyInitDone := make(chan bool, 1)


### PR DESCRIPTION
We have seen multiple times that SPO is stuck on 'Terminating' state because of dangling finalizers this commit fixes the issue by forcefully removing finalizers allowing SPO cleanup, since we don't really want to test if the cleanup is working fine.

Fixes #1111 

### Testing
- Start an integration test run: 
```
$ INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v" make IMAGE_TAG=latest  integration-tests
```
- During test run delete all SPO pods to reproduce finalizers issue with:

```
$ kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io spo-mutating-webhook-configuration ; kubectl delete deployments.apps -n  security-profiles-operator  security-profiles-operator  security-profiles-operator-webhook; kubectl delete pods -l name=spod -n ssecurity-profiles-operator; kubectl delete ds -n security-profiles-operator spod
```
### Before the fix
The test run should timeout because of dangling finalizers

### After the fix
The test should complete successful with output as:
```
seccompprofile.security-profiles-operator.x-k8s.io/log-enricher-trace patched
seccompprofile.security-profiles-operator.x-k8s.io/nginx-1.19.1 patched
```