### PR TITLE
trace/sni: Use columns library

### DIFF
--- a/cmd/common/trace/sni.go
+++ b/cmd/common/trace/sni.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewSNICmd(runCmd func(*cobra.Command, []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   "sni",
+		Short: "Trace Server Name Indication (SNI) from TLS requests",
+		RunE:  runCmd,
+	}
+}

--- a/cmd/kubectl-gadget/trace/sni.go
+++ b/cmd/kubectl-gadget/trace/sni.go
@@ -15,87 +15,34 @@
 package trace
 
 import (
-	"fmt"
-	"strings"
-
 	commontrace "github.com/inspektor-gadget/inspektor-gadget/cmd/common/trace"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/types"
+	sniTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/types"
 
 	"github.com/spf13/cobra"
 )
 
-type SNIParser struct {
-	commonutils.BaseParser[types.Event]
-}
-
 func newSNICmd() *cobra.Command {
-	commonFlags := &utils.CommonFlags{
-		OutputConfig: commonutils.OutputConfig{
-			// The columns that will be used in case the user does not specify
-			// which specific columns they want to print.
-			CustomColumns: []string{
-				"node",
-				"namespace",
-				"pod",
-				"name",
-			},
-		},
-	}
+	var commonFlags utils.CommonFlags
 
-	cmd := &cobra.Command{
-		Use:   "sni",
-		Short: "Trace Server Name Indication (SNI) from TLS requests",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			sniGadget := &TraceGadget[types.Event]{
-				name:        "snisnoop",
-				commonFlags: commonFlags,
-				parser:      NewSNIParser(&commonFlags.OutputConfig),
-			}
-
-			return sniGadget.Run()
-		},
-	}
-
-	utils.AddCommonFlags(cmd, commonFlags)
-
-	return cmd
-}
-
-func NewSNIParser(outputConfig *commonutils.OutputConfig) commontrace.TraceParser[types.Event] {
-	columnsWidth := map[string]int{
-		"node":      -16,
-		"namespace": -16,
-		"pod":       -30,
-		"name":      -24,
-	}
-
-	return &SNIParser{
-		BaseParser: commonutils.NewBaseWidthParser[types.Event](columnsWidth, outputConfig),
-	}
-}
-
-func (p *SNIParser) TransformIntoColumns(event *types.Event) string {
-	var sb strings.Builder
-
-	for _, col := range p.OutputConfig.CustomColumns {
-		switch col {
-		case "node":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Node))
-		case "namespace":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Namespace))
-		case "pod":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Pod))
-		case "name":
-			sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], event.Name))
-		default:
-			continue
+	runCmd := func(cmd *cobra.Command, args []string) error {
+		parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonFlags.OutputConfig, sniTypes.GetColumns())
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
 		}
 
-		// Needed when field is larger than the predefined columnsWidth.
-		sb.WriteRune(' ')
+		sniGadget := &TraceGadget[sniTypes.Event]{
+			name:        "snisnoop",
+			commonFlags: &commonFlags,
+			parser:      parser,
+		}
+
+		return sniGadget.Run()
 	}
 
-	return sb.String()
+	cmd := commontrace.NewSNICmd(runCmd)
+	utils.AddCommonFlags(cmd, &commonFlags)
+
+	return cmd
 }

--- a/pkg/gadgets/trace/sni/types/snisnoop.go
+++ b/pkg/gadgets/trace/sni/types/snisnoop.go
@@ -15,13 +15,23 @@
 package types
 
 import (
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type Event struct {
 	eventtypes.Event
 
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" column:"name,width:30"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	cols := columns.MustCreateColumns[Event]()
+
+	col, _ := cols.GetColumn("container")
+	col.Visible = false
+
+	return cols
 }
 
 func Base(ev eventtypes.Event) Event {


### PR DESCRIPTION
Use columns library for `sni` gadget.

Task #1003 Related #893 