### PR TITLE
gadgets/snapshot: Use columns library

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -30,7 +30,8 @@ type ProcessFlags struct {
 type ProcessParser struct {
 	commonutils.GadgetParser[types.Event]
 
-	flags *ProcessFlags
+	flags        *ProcessFlags
+	outputConfig *commonutils.OutputConfig
 }
 
 func newProcessParser(outputConfig *commonutils.OutputConfig, flags *ProcessFlags, cols *columns.Columns[types.Event], options ...commonutils.Option) (SnapshotParser[types.Event], error) {
@@ -42,6 +43,7 @@ func newProcessParser(outputConfig *commonutils.OutputConfig, flags *ProcessFlag
 	return &ProcessParser{
 		flags:        flags,
 		GadgetParser: *gadgetParser,
+		outputConfig: outputConfig,
 	}, nil
 }
 
@@ -53,14 +55,8 @@ func NewProcessParserWithRuntimeInfo(outputConfig *commonutils.OutputConfig, fla
 	return newProcessParser(outputConfig, flags, types.GetColumns(), commonutils.WithMetadataTag(commonutils.ContainerRuntimeTag))
 }
 
-func (p *ProcessParser) TransformToColumns(e *types.Event) string {
-	return p.GadgetParser.TransformIntoColumns(e)
-}
-
 func (p *ProcessParser) GetOutputConfig() *commonutils.OutputConfig {
-	return &commonutils.OutputConfig{
-		OutputMode: commonutils.OutputModeColumns,
-	}
+	return p.outputConfig
 }
 
 func (p *ProcessParser) SortEvents(allProcesses *[]*types.Event) {

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -40,7 +40,7 @@ type SnapshotEvent interface {
 // implement.
 type SnapshotParser[Event any] interface {
 	// SortEvents sorts a slice of events based on a predefined prioritization.
-	SortEvents(*[]Event)
+	SortEvents(*[]*Event)
 
 	// TransformToColumns is called to transform an event to columns.
 	TransformToColumns(*Event) string
@@ -60,7 +60,7 @@ type SnapshotGadgetPrinter[Event SnapshotEvent] struct {
 	Parser SnapshotParser[Event]
 }
 
-func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
+func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []*Event) error {
 	g.Parser.SortEvents(&allEvents)
 
 	outputConfig := g.Parser.GetOutputConfig()
@@ -79,13 +79,13 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 		fmt.Println(g.Parser.BuildColumnsHeader())
 
 		for _, e := range allEvents {
-			baseEvent := e.GetBaseEvent()
+			baseEvent := (*e).GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
 				commonutils.HandleSpecialEvent(baseEvent, outputConfig.Verbose)
 				continue
 			}
 
-			fmt.Println(g.Parser.TransformToColumns(&e))
+			fmt.Println(g.Parser.TransformToColumns(e))
 		}
 	}
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -42,13 +42,8 @@ type SnapshotParser[Event any] interface {
 	// SortEvents sorts a slice of events based on a predefined prioritization.
 	SortEvents(*[]*Event)
 
-	// TransformToColumns is called to transform an event to columns.
-	TransformToColumns(*Event) string
-
-	// BuildColumnsHeader returns a header with the requested custom columns
-	// that exist in the predefined columns list. The columns are separated by
-	// tabs.
-	BuildColumnsHeader() string
+	// TransformIntoTable is called to transform headers and events into a table.
+	TransformIntoTable([]*Event) string
 
 	// GetOutputConfig returns the output configuration.
 	GetOutputConfig() *commonutils.OutputConfig
@@ -76,17 +71,18 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []*Event) error {
 	case commonutils.OutputModeColumns:
 		fallthrough
 	case commonutils.OutputModeCustomColumns:
-		fmt.Println(g.Parser.BuildColumnsHeader())
-
+		allEventsTrimmed := []*Event{}
 		for _, e := range allEvents {
 			baseEvent := (*e).GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
 				commonutils.HandleSpecialEvent(baseEvent, outputConfig.Verbose)
 				continue
 			}
-
-			fmt.Println(g.Parser.TransformToColumns(e))
+			allEventsTrimmed = append(allEventsTrimmed, e)
 		}
+		allEvents = allEventsTrimmed
+
+		fmt.Println(g.Parser.TransformIntoTable(allEvents))
 	}
 
 	return nil

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -17,8 +17,6 @@ package snapshot
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -78,14 +76,7 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 	case commonutils.OutputModeColumns:
 		fallthrough
 	case commonutils.OutputModeCustomColumns:
-		// In the snapshot gadgets it's possible to use a tabwriter because
-		// we have the full list of events to print available, hence the
-		// tablewriter is able to determine the columns width. In other
-		// gadgets we don't know the size of all columns "a priori", hence
-		// we have to do a best effort printing fixed-width columns.
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-
-		fmt.Fprintln(w, g.Parser.BuildColumnsHeader())
+		fmt.Println(g.Parser.BuildColumnsHeader())
 
 		for _, e := range allEvents {
 			baseEvent := e.GetBaseEvent()
@@ -94,10 +85,8 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 				continue
 			}
 
-			fmt.Fprintln(w, g.Parser.TransformToColumns(&e))
+			fmt.Println(g.Parser.TransformToColumns(&e))
 		}
-
-		w.Flush()
 	}
 
 	return nil

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -16,13 +16,14 @@ package snapshot
 
 import (
 	"fmt"
-	"sort"
 	"strings"
+
+	"github.com/spf13/cobra"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	columnssort "github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
-	"github.com/spf13/cobra"
 )
 
 type SocketFlags struct {
@@ -68,32 +69,9 @@ func (p *SocketParser) GetOutputConfig() *commonutils.OutputConfig {
 	}
 }
 
-func (s *SocketParser) SortEvents(allSockets *[]types.Event) {
-	sort.Slice(*allSockets, func(i, j int) bool {
-		si, sj := (*allSockets)[i], (*allSockets)[j]
-		switch {
-		case si.Node != sj.Node:
-			return si.Node < sj.Node
-		case si.Namespace != sj.Namespace:
-			return si.Namespace < sj.Namespace
-		case si.Pod != sj.Pod:
-			return si.Pod < sj.Pod
-		case si.Protocol != sj.Protocol:
-			return si.Protocol < sj.Protocol
-		case si.Status != sj.Status:
-			return si.Status < sj.Status
-		case si.LocalAddress != sj.LocalAddress:
-			return si.LocalAddress < sj.LocalAddress
-		case si.RemoteAddress != sj.RemoteAddress:
-			return si.RemoteAddress < sj.RemoteAddress
-		case si.LocalPort != sj.LocalPort:
-			return si.LocalPort < sj.LocalPort
-		case si.RemotePort != sj.RemotePort:
-			return si.RemotePort < sj.RemotePort
-		default:
-			return si.InodeNumber < sj.InodeNumber
-		}
-	})
+func (s *SocketParser) SortEvents(allSockets *[]*types.Event) {
+	columnssort.SortEntries(types.GetColumns().GetColumnMap(), *allSockets,
+		[]string{"node", "namespace", "pod", "proto", "status", "localAddr", "remoteAddr", "localPort", "remotePort", "inode"})
 }
 
 func NewSocketCmd(runCmd func(*cobra.Command, []string) error, flags *SocketFlags) *cobra.Command {

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -35,6 +35,7 @@ type SocketFlags struct {
 
 type SocketParser struct {
 	commonutils.GadgetParser[types.Event]
+	outputConfig *commonutils.OutputConfig
 }
 
 func newSocketParser(outputConfig *commonutils.OutputConfig, flags *SocketFlags, cols *columns.Columns[types.Event], options ...commonutils.Option) (SnapshotParser[types.Event], error) {
@@ -48,6 +49,7 @@ func newSocketParser(outputConfig *commonutils.OutputConfig, flags *SocketFlags,
 
 	return &SocketParser{
 		GadgetParser: *gadgetParser,
+		outputConfig: outputConfig,
 	}, nil
 }
 
@@ -59,14 +61,8 @@ func NewSocketParserWithRuntimeInfo(outputConfig *commonutils.OutputConfig, flag
 	return newSocketParser(outputConfig, flags, types.GetColumns(), commonutils.WithMetadataTag(commonutils.ContainerRuntimeTag))
 }
 
-func (p *SocketParser) TransformToColumns(e *types.Event) string {
-	return p.GadgetParser.TransformIntoColumns(e)
-}
-
-func (p *SocketParser) GetOutputConfig() *commonutils.OutputConfig {
-	return &commonutils.OutputConfig{
-		OutputMode: commonutils.OutputModeColumns,
-	}
+func (s *SocketParser) GetOutputConfig() *commonutils.OutputConfig {
+	return s.outputConfig
 }
 
 func (s *SocketParser) SortEvents(allSockets *[]*types.Event) {

--- a/cmd/kubectl-gadget/snapshot/process.go
+++ b/cmd/kubectl-gadget/snapshot/process.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	commonsnapshot "github.com/inspektor-gadget/inspektor-gadget/cmd/common/snapshot"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
 )
@@ -27,11 +28,16 @@ func newProcessCmd() *cobra.Command {
 	var flags commonsnapshot.ProcessFlags
 
 	runCmd := func(cmd *cobra.Command, args []string) error {
+		parser, err := commonsnapshot.NewProcessParserWithK8sInfo(&commonFlags.OutputConfig, &flags)
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
+		}
+
 		processGadget := &SnapshotGadget[types.Event]{
 			name:        "process-collector",
 			commonFlags: &commonFlags,
 			SnapshotGadgetPrinter: commonsnapshot.SnapshotGadgetPrinter[types.Event]{
-				Parser: commonsnapshot.NewProcessParserWithK8sInfo(&commonFlags.OutputConfig, &flags),
+				Parser: parser,
 			},
 		}
 

--- a/cmd/kubectl-gadget/snapshot/snapshot.go
+++ b/cmd/kubectl-gadget/snapshot/snapshot.go
@@ -50,14 +50,14 @@ func (g *SnapshotGadget[Event]) Run() error {
 	// generates a list of results per node. It merges, sorts and print all of them
 	// in the requested mode.
 	callback := func(traceOutputMode string, results []string) error {
-		allEvents := []Event{}
+		allEvents := []*Event{}
 
 		for _, r := range results {
 			if len(r) == 0 {
 				continue
 			}
 
-			var events []Event
+			var events []*Event
 			if err := json.Unmarshal([]byte(r), &events); err != nil {
 				return commonutils.WrapInErrUnmarshalOutput(err, r)
 			}

--- a/cmd/kubectl-gadget/snapshot/socket.go
+++ b/cmd/kubectl-gadget/snapshot/socket.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	commonsnapshot "github.com/inspektor-gadget/inspektor-gadget/cmd/common/snapshot"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
 )
@@ -27,11 +28,16 @@ func newSocketCmd() *cobra.Command {
 	var flags commonsnapshot.SocketFlags
 
 	runCmd := func(cmd *cobra.Command, args []string) error {
+		parser, err := commonsnapshot.NewSocketParserWithK8sInfo(&commonFlags.OutputConfig, &flags)
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
+		}
+
 		socketGadget := &SnapshotGadget[types.Event]{
 			name:        "socket-collector",
 			commonFlags: &commonFlags,
 			SnapshotGadgetPrinter: commonsnapshot.SnapshotGadgetPrinter[types.Event]{
-				Parser: commonsnapshot.NewSocketParserWithK8sInfo(&commonFlags.OutputConfig, &flags),
+				Parser: parser,
 			},
 			params: map[string]string{
 				"protocol": flags.Protocol,

--- a/cmd/local-gadget/snapshot/process.go
+++ b/cmd/local-gadget/snapshot/process.go
@@ -31,9 +31,14 @@ func newProcessCmd() *cobra.Command {
 	var flags commonsnapshot.ProcessFlags
 
 	runCmd := func(*cobra.Command, []string) error {
+		parser, err := commonsnapshot.NewProcessParserWithRuntimeInfo(&commonFlags.OutputConfig, &flags)
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
+		}
+
 		processGadget := &SnapshotGadget[processTypes.Event]{
 			SnapshotGadgetPrinter: commonsnapshot.SnapshotGadgetPrinter[processTypes.Event]{
-				Parser: commonsnapshot.NewProcessParserWithRuntimeInfo(&commonFlags.OutputConfig, &flags),
+				Parser: parser,
 			},
 			commonFlags: &commonFlags,
 			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]processTypes.Event, error) {

--- a/cmd/local-gadget/snapshot/process.go
+++ b/cmd/local-gadget/snapshot/process.go
@@ -41,7 +41,7 @@ func newProcessCmd() *cobra.Command {
 				Parser: parser,
 			},
 			commonFlags: &commonFlags,
-			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]processTypes.Event, error) {
+			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]*processTypes.Event, error) {
 				// Create mount namespace map to filter by containers
 				mountnsmap, err := localGadgetManager.CreateMountNsMap(*containerSelector)
 				if err != nil {

--- a/cmd/local-gadget/snapshot/snapshot.go
+++ b/cmd/local-gadget/snapshot/snapshot.go
@@ -29,7 +29,7 @@ type SnapshotGadget[Event commonsnapshot.SnapshotEvent] struct {
 	commonsnapshot.SnapshotGadgetPrinter[Event]
 
 	commonFlags *utils.CommonFlags
-	runTracer   func(*localgadgetmanager.LocalGadgetManager, *containercollection.ContainerSelector) ([]Event, error)
+	runTracer   func(*localgadgetmanager.LocalGadgetManager, *containercollection.ContainerSelector) ([]*Event, error)
 }
 
 // Run runs a SnapshotGadget and prints the output after parsing it using the

--- a/cmd/local-gadget/snapshot/socket.go
+++ b/cmd/local-gadget/snapshot/socket.go
@@ -43,8 +43,8 @@ func newSocketCmd() *cobra.Command {
 				Parser: parser,
 			},
 			commonFlags: &commonFlags,
-			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]socketTypes.Event, error) {
-				allSockets := []socketTypes.Event{}
+			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]*socketTypes.Event, error) {
+				allSockets := []*socketTypes.Event{}
 
 				// Given that the tracer works per network namespace, we only
 				// need to run it once per namespace.

--- a/cmd/local-gadget/snapshot/socket.go
+++ b/cmd/local-gadget/snapshot/socket.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	commonsnapshot "github.com/inspektor-gadget/inspektor-gadget/cmd/common/snapshot"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/local-gadget/utils"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/tracer"
@@ -32,9 +33,14 @@ func newSocketCmd() *cobra.Command {
 	var flags commonsnapshot.SocketFlags
 
 	runCmd := func(*cobra.Command, []string) error {
+		parser, err := commonsnapshot.NewSocketParserWithRuntimeInfo(&commonFlags.OutputConfig, &flags)
+		if err != nil {
+			return commonutils.WrapInErrParserCreate(err)
+		}
+
 		socketGadget := &SnapshotGadget[socketTypes.Event]{
 			SnapshotGadgetPrinter: commonsnapshot.SnapshotGadgetPrinter[socketTypes.Event]{
-				Parser: commonsnapshot.NewSocketParserWithRuntimeInfo(&commonFlags.OutputConfig, &flags),
+				Parser: parser,
 			},
 			commonFlags: &commonFlags,
 			runTracer: func(localGadgetManager *localgadgetmanager.LocalGadgetManager, containerSelector *containercollection.ContainerSelector) ([]socketTypes.Event, error) {

--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -81,7 +81,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	allSockets := []socketcollectortypes.Event{}
+	allSockets := []*socketcollectortypes.Event{}
 
 	// Given that the socket-collector tracer works per network namespace and
 	// all the containers inside a namespace/pod share the network namespace,

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -34,7 +34,7 @@ const (
 	BPFIterName = "ig_snap_proc"
 )
 
-func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processcollectortypes.Event, error) {
+func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]*processcollectortypes.Event, error) {
 	var err error
 	var spec *ebpf.CollectionSpec
 
@@ -80,7 +80,7 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processc
 	}
 	defer file.Close()
 
-	var events []processcollectortypes.Event
+	var events []*processcollectortypes.Event
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -116,7 +116,7 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]processc
 			enricher.Enrich(&event.CommonData, event.MountNsID)
 		}
 
-		events = append(events, event)
+		events = append(events, &event)
 	}
 
 	return events, nil

--- a/pkg/gadgets/snapshot/process/types/process-collector.go
+++ b/pkg/gadgets/snapshot/process/types/process-collector.go
@@ -15,13 +15,19 @@
 package types
 
 import (
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type Event struct {
 	eventtypes.Event
-	Tgid      int    `json:"tgid"`
-	Pid       int    `json:"pid"`
-	Command   string `json:"comm"`
-	MountNsID uint64 `json:"mntns"`
+
+	Command   string `json:"comm" column:"comm,template:comm"`
+	Tgid      int    `json:"tgid" column:"tgid,template:pid,hide"`
+	Pid       int    `json:"pid" column:"pid,template:pid"`
+	MountNsID uint64 `json:"mntns" column:"mntns,template:ns"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	return columns.MustCreateColumns[Event]()
 }

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -104,7 +104,7 @@ func getUDPIter() (*link.Iter, error) {
 	return it, nil
 }
 
-func RunCollector(pid uint32, podname, namespace, node string, proto socketcollectortypes.Proto) ([]socketcollectortypes.Event, error) {
+func RunCollector(pid uint32, podname, namespace, node string, proto socketcollectortypes.Proto) ([]*socketcollectortypes.Event, error) {
 	var err error
 	var it *link.Iter
 	iters := []*link.Iter{}
@@ -131,7 +131,7 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 		iters = append(iters, it)
 	}
 
-	sockets := []socketcollectortypes.Event{}
+	sockets := []*socketcollectortypes.Event{}
 	err = netnsenter.NetnsEnter(int(pid), func() error {
 		for _, it := range iters {
 			reader, err := it.Open()
@@ -161,7 +161,7 @@ func RunCollector(pid uint32, podname, namespace, node string, proto socketcolle
 					return err
 				}
 
-				sockets = append(sockets, socketcollectortypes.Event{
+				sockets = append(sockets, &socketcollectortypes.Event{
 					Event: eventtypes.Event{
 						Type: eventtypes.NORMAL,
 						CommonData: eventtypes.CommonData{

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -46,7 +46,7 @@ type Event struct {
 	RemoteAddress string `json:"remoteAddress" column:"remoteAddr,template:ipaddr,hide"`
 	RemotePort    uint16 `json:"remotePort" column:"remotePort,template:ipport,hide"`
 	Status        string `json:"status" column:"status,order:1002,maxWidth:12"`
-	InodeNumber   uint64 `json:"inodeNumber" column:"inode,hide"`
+	InodeNumber   uint64 `json:"inodeNumber" column:"inode,order:1003,hide"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -39,13 +40,44 @@ var ProtocolsMap = map[string]Proto{
 type Event struct {
 	eventtypes.Event
 
-	Protocol      string `json:"protocol"`
-	LocalAddress  string `json:"localAddress"`
-	LocalPort     uint16 `json:"localPort"`
-	RemoteAddress string `json:"remoteAddress"`
-	RemotePort    uint16 `json:"remotePort"`
-	Status        string `json:"status"`
-	InodeNumber   uint64 `json:"inodeNumber"`
+	Protocol      string `json:"protocol" column:"protocol,maxWidth:8"`
+	LocalAddress  string `json:"localAddress" column:"localAddr,template:ipaddr,hide"`
+	LocalPort     uint16 `json:"localPort" column:"localPort,template:ipport,hide"`
+	RemoteAddress string `json:"remoteAddress" column:"remoteAddr,template:ipaddr,hide"`
+	RemotePort    uint16 `json:"remotePort" column:"remotePort,template:ipport,hide"`
+	Status        string `json:"status" column:"status,order:1002,maxWidth:12"`
+	InodeNumber   uint64 `json:"inodeNumber" column:"inode,hide"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	cols := columns.MustCreateColumns[Event]()
+
+	col, _ := cols.GetColumn("container")
+	col.Visible = false
+
+	cols.MustAddColumn(columns.Column[Event]{
+		Name:     "local",
+		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
+		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
+		Visible:  true,
+		Order:    1000,
+		Extractor: func(e *Event) string {
+			return fmt.Sprintf("%s:%d", e.LocalAddress, e.LocalPort)
+		},
+	})
+
+	cols.MustAddColumn(columns.Column[Event]{
+		Name:     "remote",
+		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
+		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
+		Visible:  true,
+		Order:    1001,
+		Extractor: func(e *Event) string {
+			return fmt.Sprintf("%s:%d", e.RemoteAddress, e.RemotePort)
+		},
+	})
+
+	return cols
 }
 
 func ParseProtocol(protocol string) (Proto, error) {


### PR DESCRIPTION
# gadgets/snapshot: Use columns library

With this PR both `snapshot` gadgets are using the `columns` library.
Specifically it is using the `TransformIntoTable` function which finds the perfect width, since we already have all events. (Like not using extra width on a wide column which currently only has very small entries)
Example:
```
NODE     NAMESPACE POD                                  CONTAINER           COMM PID
minikube default   kubernetes-bootcamp-75c5d958ff-rntpk kubernetes-bootcamp sh   648715
minikube default   kubernetes-bootcamp-75c5d958ff-rntpk kubernetes-bootcamp node 648781
minikube default   kubernetes-bootcamp-75c5d958ff-rntpk kubernetes-bootcamp bash 650668
```

Additionally the sorting was also modified to use the `columssort` instead of doing it ourselves in the different gadgets

