### PR TITLE
pkg/gadget/trace/capabilities: Sync default audit-only value with CLI

### DIFF
--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	AuditOnlyDefault = false
+	AuditOnlyDefault = true
 	UniqueDefault    = false
 )
 


### PR DESCRIPTION
# cabapilities: Sync default `audit-only` value with CLI

For people using the CLI, the default is true. Let's set the same default for people using the trace CR directly.
