### PR TITLE
cmd/common: Clean up special event management

### DIFF
--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -90,7 +90,7 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 		for _, e := range allEvents {
 			baseEvent := e.GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
+				commonutils.ManageSpecialEvent(&baseEvent, outputConfig.Verbose)
 				continue
 			}
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -90,7 +90,7 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 		for _, e := range allEvents {
 			baseEvent := e.GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
+				commonutils.HandleSpecialEvent(baseEvent, outputConfig.Verbose)
 				continue
 			}
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -35,7 +35,7 @@ type SnapshotEvent interface {
 	// x is of type parameter type even if all types in the type parameter's
 	// type set have a field f. We may remove this restriction in Go 1.19. See
 	// https://tip.golang.org/doc/go1.18#generics.
-	GetBaseEvent() eventtypes.Event
+	GetBaseEvent() *eventtypes.Event
 }
 
 // SnapshotParser defines the interface that every snapshot-gadget parser has to
@@ -90,7 +90,7 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 		for _, e := range allEvents {
 			baseEvent := e.GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(&baseEvent, outputConfig.Verbose)
+				commonutils.ManageSpecialEvent(baseEvent, outputConfig.Verbose)
 				continue
 			}
 

--- a/cmd/common/trace/trace.go
+++ b/cmd/common/trace/trace.go
@@ -27,7 +27,7 @@ type TraceEvent interface {
 	// of type parameter type even if all types in the type parameter's type set
 	// have a field f. We may remove this restriction in Go 1.19. See
 	// https://tip.golang.org/doc/go1.18#generics.
-	GetBaseEvent() eventtypes.Event
+	GetBaseEvent() *eventtypes.Event
 }
 
 // TraceParser defines the interface that every trace-gadget parser has to

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -21,7 +21,7 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-func ManageSpecialEvent(e eventtypes.Event, verbose bool) {
+func ManageSpecialEvent(e *eventtypes.Event, verbose bool) {
 	switch e.Type {
 	case eventtypes.READY:
 		// TODO

--- a/cmd/common/utils/events.go
+++ b/cmd/common/utils/events.go
@@ -21,7 +21,10 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-func ManageSpecialEvent(e *eventtypes.Event, verbose bool) {
+// HandleSpecialEvent prints the special events. Notice it does not receive the
+// OutputMode so it will always print the special events messages without any
+// specific format to standard error.
+func HandleSpecialEvent(e *eventtypes.Event, verbose bool) {
 	switch e.Type {
 	case eventtypes.READY:
 		// TODO

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -63,7 +63,7 @@ func newSeccompCmd() *cobra.Command {
 
 			baseEvent := e.Event
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(&baseEvent, commonFlags.Verbose)
+				commonutils.HandleSpecialEvent(&baseEvent, commonFlags.Verbose)
 				return ""
 			}
 

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -63,7 +63,7 @@ func newSeccompCmd() *cobra.Command {
 
 			baseEvent := e.Event
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, commonFlags.Verbose)
+				commonutils.ManageSpecialEvent(&baseEvent, commonFlags.Verbose)
 				return ""
 			}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -62,7 +62,7 @@ func (g *TraceGadget[Event]) Run() error {
 
 		baseEvent := e.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -62,7 +62,7 @@ func (g *TraceGadget[Event]) Run() error {
 
 		baseEvent := e.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -62,7 +62,7 @@ func (g *TraceGadget[Event]) Run() error {
 
 		baseEvent := e.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+			commonutils.HandleSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return ""
 		}
 

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -243,7 +243,7 @@ func runTraceloopShow(cmd *cobra.Command, args []string) error {
 		for _, event := range events {
 			baseEvent := event.GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, params.Verbose)
+				commonutils.HandleSpecialEvent(baseEvent, params.Verbose)
 				return ""
 			}
 

--- a/cmd/local-gadget/audit/seccomp.go
+++ b/cmd/local-gadget/audit/seccomp.go
@@ -58,7 +58,7 @@ func newSeccompCmd() *cobra.Command {
 		eventCallback := func(event seccompauditTypes.Event) {
 			baseEvent := event.Event
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, commonFlags.Verbose)
+				commonutils.HandleSpecialEvent(&baseEvent, commonFlags.Verbose)
 				return
 			}
 

--- a/cmd/local-gadget/trace/dns.go
+++ b/cmd/local-gadget/trace/dns.go
@@ -62,7 +62,7 @@ func newDNSCmd() *cobra.Command {
 		eventCallback := func(container *containercollection.Container, event dnsTypes.Event) {
 			baseEvent := event.GetBaseEvent()
 			if baseEvent.Type != eventtypes.NORMAL {
-				commonutils.ManageSpecialEvent(baseEvent, commonFlags.Verbose)
+				commonutils.HandleSpecialEvent(baseEvent, commonFlags.Verbose)
 				return
 			}
 

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -71,7 +71,7 @@ func (g *TraceGadget[Event]) Run() error {
 	eventCallback := func(event Event) {
 		baseEvent := event.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return
 		}
 

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -71,7 +71,7 @@ func (g *TraceGadget[Event]) Run() error {
 	eventCallback := func(event Event) {
 		baseEvent := event.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+			commonutils.ManageSpecialEvent(&baseEvent, g.commonFlags.Verbose)
 			return
 		}
 

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -71,7 +71,7 @@ func (g *TraceGadget[Event]) Run() error {
 	eventCallback := func(event Event) {
 		baseEvent := event.GetBaseEvent()
 		if baseEvent.Type != eventtypes.NORMAL {
-			commonutils.ManageSpecialEvent(baseEvent, g.commonFlags.Verbose)
+			commonutils.HandleSpecialEvent(baseEvent, g.commonFlags.Verbose)
 			return
 		}
 

--- a/pkg/gadgets/snapshot/process/types/process-collector.go
+++ b/pkg/gadgets/snapshot/process/types/process-collector.go
@@ -25,7 +25,3 @@ type Event struct {
 	Command   string `json:"comm"`
 	MountNsID uint64 `json:"mntns"`
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -55,7 +55,3 @@ func ParseProtocol(protocol string) (Proto, error) {
 
 	return INVALID, fmt.Errorf("%q is not a valid protocol value", protocol)
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/bind/types/types.go
+++ b/pkg/gadgets/trace/bind/types/types.go
@@ -41,7 +41,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -64,7 +64,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/dns/types/dns.go
+++ b/pkg/gadgets/trace/dns/types/dns.go
@@ -51,7 +51,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -48,7 +48,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/fsslower/types/types.go
+++ b/pkg/gadgets/trace/fsslower/types/types.go
@@ -45,7 +45,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/mount/types/types.go
+++ b/pkg/gadgets/trace/mount/types/types.go
@@ -75,7 +75,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -85,7 +85,3 @@ func GetColumns() *columns.Columns[Event] {
 
 	return cols
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/oomkill/types/types.go
+++ b/pkg/gadgets/trace/oomkill/types/types.go
@@ -39,7 +39,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -41,7 +41,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/signal/types/types.go
+++ b/pkg/gadgets/trace/signal/types/types.go
@@ -41,7 +41,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/sni/types/snisnoop.go
+++ b/pkg/gadgets/trace/sni/types/snisnoop.go
@@ -39,7 +39,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/tcp/types/types.go
+++ b/pkg/gadgets/trace/tcp/types/types.go
@@ -59,7 +59,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -41,7 +41,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/gadgets/traceloop/types/types.go
+++ b/pkg/gadgets/traceloop/types/types.go
@@ -100,7 +100,3 @@ func Base(ev eventtypes.Event) Event {
 		Event: ev,
 	}
 }
-
-func (e Event) GetBaseEvent() eventtypes.Event {
-	return e.Event
-}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,6 +99,12 @@ type Event struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetBaseEvent is needed to implement commonutils.BaseElement and
+// snapshot.SnapshotEvent interfaces.
+func (e Event) GetBaseEvent() *Event {
+	return &e
+}
+
 func Err(msg string) Event {
 	return Event{
 		CommonData: CommonData{


### PR DESCRIPTION
# cmd/common: Clean up special event management

- There is no need to make a copy of the Event to print special events, instead, use pointers.
- Move `GetBaseEvent` into the embedded struct so that it doesn't need to be implemented by every gadget.
- Rename ManageSpecialEvent to HandleSpecialEvent as in this case, "Handle" is more accurate than "Manage".