### PR TITLE
integration-tests: Only Skip deployment for SPO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ local-gadget-tests:
 	rm -f ./local-gadget-manager.test
 
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
-# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v" make integration-tests
+# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v -no-deploy-ig -no-deploy-spo" make integration-tests
 .PHONY: integration-tests
 integration-tests: kubectl-gadget
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \


### PR DESCRIPTION
With PR #1110 we introduced changes to skip installation of IG/SPO in case they are already installed on the cluster. This commit reverts the changes related to IG and re-introduces '-no-deploy-spo/-no-deploy-ig' flags.

