### PR TITLE
Remove extra output mode validation

### DIFF
--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -98,8 +98,6 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []Event) error {
 		}
 
 		w.Flush()
-	default:
-		return commonutils.WrapInErrOutputModeNotSupported(outputConfig.OutputMode)
 	}
 
 	return nil

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -91,8 +91,7 @@ func (config *OutputConfig) ParseOutputConfig() error {
 		config.OutputMode = OutputModeCustomColumns
 		return nil
 	default:
-		return WrapInErrInvalidArg("--output / -o",
-			fmt.Errorf("%q is not a valid output format", config.OutputMode))
+		return WrapInErrOutputModeNotSupported(config.OutputMode)
 	}
 }
 

--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -106,13 +106,7 @@ func newCPUCmd() *cobra.Command {
 }
 
 func (p *CPUParser) DisplayResultsCallback(traceOutputMode string, results []string) error {
-	// Print header
-	switch p.OutputConfig.OutputMode {
-	case commonutils.OutputModeJSON:
-		// Nothing to print
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
+	if p.OutputConfig.OutputMode != commonutils.OutputModeJSON {
 		fmt.Println(p.BuildColumnsHeader())
 	}
 

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -48,13 +48,7 @@ func (g *TraceGadget[Event]) Run() error {
 		Parameters:       g.params,
 	}
 
-	// Print header
-	switch g.commonFlags.OutputMode {
-	case commonutils.OutputModeJSON:
-		// Nothing to print
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
+	if g.commonFlags.OutputMode != commonutils.OutputModeJSON {
 		fmt.Println(g.parser.BuildColumnsHeader())
 	}
 
@@ -85,10 +79,9 @@ func (g *TraceGadget[Event]) Run() error {
 			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			return g.parser.TransformIntoColumns(&e)
-		default:
-			fmt.Fprint(os.Stderr, commonutils.WrapInErrOutputModeNotSupported(g.commonFlags.OutputMode))
-			return ""
 		}
+
+		return ""
 	}
 
 	if err := utils.RunTraceAndPrintStream(config, transformEvent); err != nil {

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -174,7 +174,6 @@ func runTraceloopList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Print header
 	if params.OutputMode != commonutils.OutputModeJSON {
 		fmt.Println(parser.BuildColumnsHeader())
 	}
@@ -228,16 +227,8 @@ func runTraceloopShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Print header
-	switch params.OutputMode {
-	case commonutils.OutputModeJSON:
-		// Nothing to print
-	case commonutils.OutputModeColumns:
-		fallthrough
-	case commonutils.OutputModeCustomColumns:
+	if params.OutputMode != commonutils.OutputModeJSON {
 		fmt.Println(parser.BuildColumnsHeader())
-	default:
-		return commonutils.WrapInErrOutputModeNotSupported(params.OutputMode)
 	}
 
 	var traceID string

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -62,8 +62,6 @@ func NewListContainersCmd() *cobra.Command {
 				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoTable(containers))
-			default:
-				return commonutils.WrapInErrOutputModeNotSupported(commonFlags.OutputMode)
 			}
 
 			return nil

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -88,8 +88,6 @@ func (g *TraceGadget[Event]) Run() error {
 			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			fmt.Println(g.parser.TransformIntoColumns(&event))
-		default:
-			fmt.Fprint(os.Stderr, commonutils.WrapInErrOutputModeNotSupported(g.commonFlags.OutputMode))
 		}
 	}
 

--- a/cmd/local-gadget/traceloop.go
+++ b/cmd/local-gadget/traceloop.go
@@ -91,7 +91,6 @@ func newTraceloopCmd() *cobra.Command {
 			// Just to avoid mixing Ctrl^C and data.
 			fmt.Println()
 
-			// Print header
 			if commonFlags.OutputMode != commonutils.OutputModeJSON {
 				fmt.Println(parser.BuildColumnsHeader())
 			}


### PR DESCRIPTION
The output mode is validated in ParseOutputConfig() when building the common flags. Let's remove some extra validations around as they're not needed.

