### PR TITLE
ci: Update libseccomp version and remove other packages.

### DIFF
--- a/.github/actions/install-debian-packages/action.yml
+++ b/.github/actions/install-debian-packages/action.yml
@@ -2,12 +2,9 @@ name: "Install debian packages"
 description: "Install debian packages needed by inspektor-gadget"
 
 inputs:
-  libbpf-version:
-    description: "Version of the libbpf to install."
-    default: "1:0.5.0-1~ubuntu20.04.1"
   libseccomp-version:
     description: "Version of the libseccomp to install."
-    default: "2.5.1-1ubuntu1~20.04.2"
+    default: "2.5.3-2ubuntu2"
 
 runs:
   using: "composite"
@@ -18,19 +15,17 @@ runs:
       with:
         path: "~/cache-debs"
         # Update cache key if you add or update a package.
-        key: v3
+        key: v4
     - name: Install debian packages
       shell: bash
       run: |
         if [[ "${{steps.cache-debs.outputs.cache-hit}}" == 'true' ]]; then
           sudo cp --verbose --force --recursive ~/cache-debs/* /
         else
-          sudo apt install -y software-properties-common llvm
-          sudo add-apt-repository -y ppa:tuxinvader/kernel-build-tools
           sudo apt-get update
-          sudo apt install -y libbpf-dev="${{inputs.libbpf-version}}" libseccomp-dev="${{inputs.libseccomp-version}}"
+          sudo apt-get install -y libseccomp-dev="${{inputs.libseccomp-version}}"
           mkdir -p ~/cache-debs
-          sudo dpkg -L libbpf-dev libseccomp-dev llvm | \
+          sudo dpkg -L libseccomp-dev | \
               while IFS= read -r f; do \
                   if test -f $f; then echo $f; fi; \
               done | xargs cp --parents --target-directory ~/cache-debs/


### PR DESCRIPTION
Hi.


In this PR, I updated the version of `libseccomp` to match for Ubuntu 22.04 and I also removed unused packages.
The whole pipeline was [tested and validated](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3523840635).


Best regards.