### PR TITLE
gadgets/top: Use the column library

### DIFF
--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -95,7 +95,7 @@ func newBlockIOCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.GetColumnNames(), types.SortByDefault)
+	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	return cmd
 }

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -16,60 +16,16 @@ package top
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/block-io/types"
 )
 
-type BlockIOParser struct {
-	commonutils.BaseParser[types.Stats]
-
-	flags *CommonTopFlags
-}
-
 func newBlockIOCmd() *cobra.Command {
-	commonTopFlags := &CommonTopFlags{
-		CommonFlags: utils.CommonFlags{
-			OutputConfig: commonutils.OutputConfig{
-				// The columns that will be used in case the user does not specify
-				// which specific columns they want to print.
-				CustomColumns: []string{
-					"node",
-					"namespace",
-					"pod",
-					"container",
-					"pid",
-					"comm",
-					"r/w",
-					"major",
-					"minor",
-					"bytes",
-					"time",
-					"ios",
-				},
-			},
-		},
-	}
-
-	columnsWidth := map[string]int{
-		"node":      -16,
-		"namespace": -16,
-		"pod":       -30,
-		"container": -16,
-		"pid":       -7,
-		"comm":      -16,
-		"r/w":       -3,
-		"major":     -6,
-		"minor":     -6,
-		"bytes":     -7,
-		"time":      -8,
-		"ios":       -8,
-	}
+	var commonTopFlags CommonTopFlags
 
 	cols := types.GetColumns()
 
@@ -77,14 +33,14 @@ func newBlockIOCmd() *cobra.Command {
 		Use:   fmt.Sprintf("block-io [interval=%d]", top.IntervalDefault),
 		Short: "Periodically report block device I/O activity",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			parser := &BlockIOParser{
-				BaseParser: commonutils.NewBaseWidthParser[types.Stats](columnsWidth, &commonTopFlags.OutputConfig),
-				flags:      commonTopFlags,
+			parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonTopFlags.OutputConfig, types.GetColumns())
+			if err != nil {
+				return commonutils.WrapInErrParserCreate(err)
 			}
 
 			gadget := &TopGadget[types.Stats]{
 				name:           "biotop",
-				commonTopFlags: commonTopFlags,
+				commonTopFlags: &commonTopFlags,
 				parser:         parser,
 				nodeStats:      make(map[string][]*types.Stats),
 				colMap:         cols.GetColumnMap(),
@@ -95,50 +51,7 @@ func newBlockIOCmd() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
+	addCommonTopFlags(cmd, &commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	return cmd
-}
-
-func (p *BlockIOParser) TransformIntoColumns(stats *types.Stats) string {
-	return p.Transform(stats, func(stats *types.Stats) string {
-		var sb strings.Builder
-
-		for _, col := range p.OutputConfig.CustomColumns {
-			switch col {
-			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
-			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Namespace))
-			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Pod))
-			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Container))
-			case "pid":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
-			case "comm":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Comm))
-			case "r/w":
-				rw := 'R'
-				if stats.Write {
-					rw = 'W'
-				}
-
-				sb.WriteString(fmt.Sprintf("%*c", p.ColumnsWidth[col], rw))
-			case "major":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Major))
-			case "minor":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Minor))
-			case "bytes":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Bytes))
-			case "time":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.MicroSecs))
-			case "ios":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Operations))
-			}
-			sb.WriteRune(' ')
-		}
-
-		return sb.String()
-	})
 }

--- a/cmd/kubectl-gadget/top/block-io.go
+++ b/cmd/kubectl-gadget/top/block-io.go
@@ -100,7 +100,7 @@ func newBlockIOCmd() *cobra.Command {
 	return cmd
 }
 
-func (p *BlockIOParser) TransformStats(stats *types.Stats) string {
+func (p *BlockIOParser) TransformIntoColumns(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -115,7 +115,7 @@ func newEbpfCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.GetColumnNames(), types.SortByDefault)
+	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	return cmd
 }

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -16,15 +16,11 @@ package top
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/types"
 
-	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
 
@@ -35,43 +31,7 @@ type EbpfParser struct {
 }
 
 func newEbpfCmd() *cobra.Command {
-	commonTopFlags := &CommonTopFlags{
-		CommonFlags: utils.CommonFlags{
-			OutputConfig: commonutils.OutputConfig{
-				// The columns that will be used in case the user does not specify
-				// which specific columns they want to print.
-				CustomColumns: []string{
-					"node",
-					"progid",
-					"type",
-					"name",
-					"pid",
-					"comm",
-					"runtime",
-					"runcount",
-					"mapmemory",
-					"mapcount",
-				},
-			},
-		},
-	}
-
-	columnsWidth := map[string]int{
-		"node":          -16,
-		"progid":        -8,
-		"type":          -16,
-		"name":          -16,
-		"pid":           -7,
-		"comm":          -20,
-		"runtime":       12,
-		"runcount":      10,
-		"totalruntime":  12,
-		"totalruncount": 13,
-		"cumulruntime":  12,
-		"cumulruncount": 13,
-		"mapmemory":     14,
-		"mapcount":      8,
-	}
+	var commonTopFlags CommonTopFlags
 
 	cols := types.GetColumns()
 
@@ -79,14 +39,14 @@ func newEbpfCmd() *cobra.Command {
 		Use:   fmt.Sprintf("ebpf [interval=%d]", top.IntervalDefault),
 		Short: "Periodically report ebpf runtime stats",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			parser := &EbpfParser{
-				BaseParser: commonutils.NewBaseWidthParser[types.Stats](columnsWidth, &commonTopFlags.OutputConfig),
-				flags:      commonTopFlags,
+			parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonTopFlags.OutputConfig, types.GetColumns())
+			if err != nil {
+				return commonutils.WrapInErrParserCreate(err)
 			}
 
 			gadget := &TopGadget[types.Stats]{
 				name:           "ebpftop",
-				commonTopFlags: commonTopFlags,
+				commonTopFlags: &commonTopFlags,
 				parser:         parser,
 				nodeStats:      make(map[string][]*types.Stats),
 				colMap:         cols.GetColumnMap(),
@@ -115,57 +75,7 @@ func newEbpfCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
+	addCommonTopFlags(cmd, &commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	return cmd
-}
-
-func (p *EbpfParser) TransformIntoColumns(stats *types.Stats) string {
-	return p.Transform(stats, func(stats *types.Stats) string {
-		var sb strings.Builder
-
-		for _, col := range p.OutputConfig.CustomColumns {
-			switch col {
-			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
-			case "progid":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.ProgramID))
-			case "type":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Type))
-			case "name":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Name))
-			case "pid":
-				pid := ""
-				if len(stats.Pids) > 0 {
-					pid = fmt.Sprintf("%d", stats.Pids[0].Pid)
-				}
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], pid))
-			case "comm":
-				comm := ""
-				if len(stats.Pids) > 0 {
-					comm = stats.Pids[0].Comm
-				}
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], comm))
-			case "runtime":
-				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.CurrentRuntime)))
-			case "runcount":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.CurrentRunCount))
-			case "totalruntime":
-				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.TotalRuntime)))
-			case "totalruncount":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.TotalRunCount))
-			case "cumulruntime":
-				sb.WriteString(fmt.Sprintf("%*v", p.ColumnsWidth[col], time.Duration(stats.CumulativeRuntime)))
-			case "cumulruncount":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.CumulativeRunCount))
-			case "mapmemory":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], units.BytesSize(float64(stats.MapMemory))))
-			case "mapcount":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.MapCount))
-			}
-			sb.WriteRune(' ')
-		}
-
-		return sb.String()
-	})
 }

--- a/cmd/kubectl-gadget/top/ebpf.go
+++ b/cmd/kubectl-gadget/top/ebpf.go
@@ -120,7 +120,7 @@ func newEbpfCmd() *cobra.Command {
 	return cmd
 }
 
-func (p *EbpfParser) TransformStats(stats *types.Stats) string {
+func (p *EbpfParser) TransformIntoColumns(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -17,78 +17,32 @@ package top
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/types"
 )
 
-type FileParser struct {
-	commonutils.BaseParser[types.Stats]
-
-	flags *CommonTopFlags
-}
-
 func newFileCmd() *cobra.Command {
-	commonTopFlags := &CommonTopFlags{
-		CommonFlags: utils.CommonFlags{
-			OutputConfig: commonutils.OutputConfig{
-				// The columns that will be used in case the user does not specify
-				// which specific columns they want to print.
-				CustomColumns: []string{
-					"node",
-					"namespace",
-					"pod",
-					"container",
-					"pid",
-					"comm",
-					"reads",
-					"writes",
-					"r_kb",
-					"w_kb",
-					"t",
-					"file",
-				},
-			},
-		},
-	}
+	var commonTopFlags CommonTopFlags
 
 	var allFiles bool
-
-	columnsWidth := map[string]int{
-		"node":      -16,
-		"namespace": -16,
-		"pod":       -30,
-		"container": -16,
-		"pid":       -7,
-		"tid":       -7,
-		"comm":      -16,
-		"reads":     -6,
-		"writes":    -6,
-		"r_kb":      -7,
-		"w_kb":      -7,
-		"t":         -1,
-		"file":      -30,
-	}
-
 	cols := types.GetColumns()
 
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("file [interval=%d]", top.IntervalDefault),
 		Short: "Periodically report read/write activity by file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			parser := &FileParser{
-				BaseParser: commonutils.NewBaseWidthParser[types.Stats](columnsWidth, &commonTopFlags.OutputConfig),
-				flags:      commonTopFlags,
+			parser, err := commonutils.NewGadgetParserWithK8sInfo(&commonTopFlags.OutputConfig, types.GetColumns())
+			if err != nil {
+				return commonutils.WrapInErrParserCreate(err)
 			}
 
 			gadget := &TopGadget[types.Stats]{
 				name:           "filetop",
-				commonTopFlags: commonTopFlags,
+				commonTopFlags: &commonTopFlags,
 				params: map[string]string{
 					types.AllFilesParam: strconv.FormatBool(allFiles),
 				},
@@ -103,49 +57,9 @@ func newFileCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
+	addCommonTopFlags(cmd, &commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	cmd.Flags().BoolVarP(&allFiles, "all-files", "a", types.AllFilesDefault, "Include non-regular file types (sockets, FIFOs, etc)")
 
 	return cmd
-}
-
-func (p *FileParser) TransformIntoColumns(stats *types.Stats) string {
-	return p.Transform(stats, func(stats *types.Stats) string {
-		var sb strings.Builder
-
-		for _, col := range p.OutputConfig.CustomColumns {
-			switch col {
-			case "node":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Node))
-			case "namespace":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Namespace))
-			case "pod":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Pod))
-			case "container":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Container))
-			case "pid":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Pid))
-			case "tid":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Tid))
-			case "comm":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Comm))
-			case "reads":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Reads))
-			case "writes":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.Writes))
-			case "r_kb":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.ReadBytes/1024))
-			case "w_kb":
-				sb.WriteString(fmt.Sprintf("%*d", p.ColumnsWidth[col], stats.WriteBytes/1024))
-			case "t":
-				sb.WriteString(fmt.Sprintf("%*c", p.ColumnsWidth[col], stats.FileType))
-			case "file":
-				sb.WriteString(fmt.Sprintf("%*s", p.ColumnsWidth[col], stats.Filename))
-			}
-			sb.WriteRune(' ')
-		}
-
-		return sb.String()
-	})
 }

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -110,7 +110,7 @@ func newFileCmd() *cobra.Command {
 	return cmd
 }
 
-func (p *FileParser) TransformStats(stats *types.Stats) string {
+func (p *FileParser) TransformIntoColumns(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/file.go
+++ b/cmd/kubectl-gadget/top/file.go
@@ -103,7 +103,7 @@ func newFileCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.GetColumnNames(), types.SortByDefault)
+	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	cmd.Flags().BoolVarP(&allFiles, "all-files", "a", types.AllFilesDefault, "Include non-regular file types (sockets, FIFOs, etc)")
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -130,7 +130,7 @@ func newTCPCmd() *cobra.Command {
 	return cmd
 }
 
-func (p *TCPParser) TransformStats(stats *types.Stats) string {
+func (p *TCPParser) TransformIntoColumns(stats *types.Stats) string {
 	return p.Transform(stats, func(stats *types.Stats) string {
 		var sb strings.Builder
 

--- a/cmd/kubectl-gadget/top/tcp.go
+++ b/cmd/kubectl-gadget/top/tcp.go
@@ -110,7 +110,7 @@ func newTCPCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 	}
 
-	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.GetColumnNames(), types.SortByDefault)
+	addCommonTopFlags(cmd, commonTopFlags, &commonTopFlags.CommonFlags, cols.ColumnMap, types.SortByDefault)
 
 	cmd.PersistentFlags().UintVarP(
 		&filteredPid,

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -70,7 +70,7 @@ func addCommonTopFlags[Stats any](
 		&commonTopFlags.SortBy, "sort",
 		"",
 		strings.Join(sortBySliceDefault, ","),
-		fmt.Sprintf("Sort columns. Join multiple columns with ','. Prefix with '-' to sort descending for that column. Available columns: (%s)", strings.Join(validCols, ", ")))
+		fmt.Sprintf("Sort by columns. Join multiple columns with ','. Prefix a column with '-' to sort in descending order. Available columns: (%s)", strings.Join(validCols, ", ")))
 	utils.AddCommonFlags(command, commonFlags)
 }
 
@@ -217,6 +217,20 @@ func (g *TopGadget[Stats]) PrintStats() {
 		if idx == g.commonTopFlags.MaxRows {
 			break
 		}
-		fmt.Println(g.parser.TransformIntoColumns(stat))
+
+		switch g.commonTopFlags.OutputConfig.OutputMode {
+		case commonutils.OutputModeJSON:
+			b, err := json.Marshal(stat)
+			if err != nil {
+				fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
+				continue
+			}
+
+			fmt.Println(string(b))
+		case commonutils.OutputModeColumns:
+			fallthrough
+		case commonutils.OutputModeCustomColumns:
+			fmt.Println(g.parser.TransformIntoColumns(stat))
+		}
 	}
 }

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -74,7 +74,7 @@ type TopParser[Stats any] interface {
 	// BuildColumnsHeader returns a header to be used when the user requests to
 	// present the output in columns.
 	BuildColumnsHeader() string
-	TransformStats(*Stats) string
+	TransformIntoColumns(*Stats) string
 }
 
 // TopGadget represents a gadget belonging to the top category.
@@ -211,6 +211,6 @@ func (g *TopGadget[Stats]) PrintStats() {
 		if idx == g.commonTopFlags.MaxRows {
 			break
 		}
-		fmt.Println(g.parser.TransformStats(stat))
+		fmt.Println(g.parser.TransformIntoColumns(stat))
 	}
 }

--- a/cmd/kubectl-gadget/top/top.go
+++ b/cmd/kubectl-gadget/top/top.go
@@ -30,6 +30,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 )
 
@@ -56,15 +57,20 @@ func NewTopCmd() *cobra.Command {
 	return cmd
 }
 
-func addCommonTopFlags(
+func addCommonTopFlags[Stats any](
 	command *cobra.Command,
 	commonTopFlags *CommonTopFlags,
 	commonFlags *utils.CommonFlags,
-	sortBySlice []string,
+	colMap columns.ColumnMap[Stats],
 	sortBySliceDefault []string,
 ) {
 	command.Flags().IntVarP(&commonTopFlags.MaxRows, "max-rows", "r", top.MaxRowsDefault, "Maximum rows to print")
-	command.Flags().StringVarP(&commonTopFlags.SortBy, "sort", "", strings.Join(sortBySliceDefault, ","), fmt.Sprintf("Sort by column. Join multiple columsn with ','. Prefix with '-' to sort descending for that column. Columns: (%s)", strings.Join(sortBySlice, ", ")))
+	validCols, _ := sort.FilterSortableColumns(colMap, colMap.GetColumnNames())
+	command.Flags().StringVarP(
+		&commonTopFlags.SortBy, "sort",
+		"",
+		strings.Join(sortBySliceDefault, ","),
+		fmt.Sprintf("Sort columns. Join multiple columns with ','. Prefix with '-' to sort descending for that column. Available columns: (%s)", strings.Join(validCols, ", ")))
 	utils.AddCommonFlags(command, commonFlags)
 }
 
@@ -103,7 +109,7 @@ func (g *TopGadget[Stats]) Run(args []string) error {
 	}
 
 	sortByColumns := strings.Split(g.commonTopFlags.SortBy, ",")
-	_, invalidCols := g.colMap.VerifyColumnNames(sortByColumns)
+	_, invalidCols := sort.FilterSortableColumns(g.colMap, sortByColumns)
 
 	if len(invalidCols) > 0 {
 		return commonutils.WrapInErrInvalidArg("--sort", fmt.Errorf("invalid columns to sort by: %q", strings.Join(invalidCols, ",")))

--- a/docs/gadgets/ebpftop.md
+++ b/docs/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,progid,pids,name,type,currentRuntime,currentRunCount,cumulRuntime,cumulRunCount,totalRuntime,totalRunCount,mapMemory,mapCount). (default -currentRuntime,-currentRunCount)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,progid,type,name,pid,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/gadgets/filetop.md
+++ b/docs/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,reads,writes,rbytes,wbytes,pid,tid,mountnsid,filename,comm,fileType). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,pid,tid,comm,reads,writes,rbytes,wbytes,mountnsid,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - pid: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/docs/guides/top/tcp.md
+++ b/docs/guides/top/tcp.md
@@ -19,8 +19,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget top tcp
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             IPv LADDR
-    RADDR                                               RX_KB   TX_KB
+NODE            NAMESPACE       POD             CONTAINER       PID     COMM    IP REMOTE                LOCAL                 SENT    RECV
 ```
 
 Indeed, it is waiting for TCP connection to occur.
@@ -33,10 +32,9 @@ $ kubectl exec -ti test-pod -- wget kinvolk.io
 On *the first terminal*, you should see:
 
 ```
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             IPv LADDR
-    RADDR                                               RX_KB   TX_KB
-minikube         default          test-pod         test-pod         49447   wget             4   10.244.2.2:45426
-    188.114.97.3:443                                    10      0
+NODE            NAMESPACE       POD             CONTAINER       PID     COMM    IP REMOTE                LOCAL                 SENT    RECV
+minikube        default         test-pod        test-pod        134110  wget    4  188.114.96.3:443      172.17.0.2:38190      0       2
+minikube        default         test-pod        test-pod        134110  wget    4  188.114.96.3:80       172.17.0.2:33286      0       1
 ```
 
 This line corresponds to the TCP connection initiated by `wget`.
@@ -55,11 +53,10 @@ PID     COMM
 The following command is the same as default printing:
 
 ```bash
-$ kubectl gadget top tcp -o custom-columns=node,namespace,pod,container,pid,comm,family,saddr,daddr,sent,received
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             IPv LADDR
-    RADDR                                               RX_KB   TX_KB
-minikube         default          test-pod         test-pod         49447   wget             4   10.244.2.2:45426
-    188.114.97.3:443                                    10      0
+$ kubectl gadget top tcp -o custom-columns=node,namespace,pod,container,pid,comm,family,saddr,daddr,sent,recv
+NODE            NAMESPACE       POD             CONTAINER       PID     COMM    IP REMOTE                LOCAL                 SENT    RECV
+minikube        default         test-pod        test-pod        134752  wget    4  188.114.96.3:443      172.17.0.2:37563      0       2
+minikube        default         test-pod        test-pod        134752  wget    4  188.114.96.3:80       172.17.0.2:34258      0       1
 ```
 
 ## Use JSON output

--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -308,3 +308,13 @@ func (ci *Column[T]) IsEmbedded() bool {
 	}
 	return true
 }
+
+// IsVirtual returns true, if the column has direct reference to a field
+func (ci *Column[T]) IsVirtual() bool {
+	return ci.fieldIndex == virtualIndex
+}
+
+// HasCustomExtractor returns true, if the column has a user defined extractor set
+func (ci *Column[T]) HasCustomExtractor() bool {
+	return ci.Extractor != nil
+}

--- a/pkg/columns/sort/doc.go
+++ b/pkg/columns/sort/doc.go
@@ -23,5 +23,15 @@ for example sorts the array by the time column in descending order and afterward
 
 The "-" prefix means the sorter should use descending order. Sorting by multiple fields will be done from the last field
 to the first in a stable way - so the first column always gets the highest priority.
+
+Three special cases exist:
+ 1. Non-existent columns will be silently ignored.
+ 2. When a virtual column is selected as a column to sort by, that column will be silently ignored.
+ 3. A column with a custom extractor is allowed to sort by.
+    But the sorting function uses the underlying value instead of the result of the extractor function
+
+One can use sort.CanSortBy(columnMap, []string{"node", "-time"}) to check if any column will be silently ignored. For more
+information the function sort.FilterSortableColumns(columnMap, []string{"node", "-time"}) can be used, which returns two lists.
+One with all valid filterable columns and another one with the invalid columns
 */
 package sort

--- a/pkg/columns/sort/sort_test.go
+++ b/pkg/columns/sort/sort_test.go
@@ -15,52 +15,82 @@
 package sort
 
 import (
+	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 )
 
+type testEmbedded struct {
+	EmbeddedInt int `column:"embeddedInt"`
+}
+type testData struct {
+	testEmbedded
+	Int       int     `column:"int"`
+	Uint      uint    `column:"uint"`
+	String    string  `column:"string"`
+	Float32   float32 `column:"float32"`
+	Float64   float64 `column:"float64"`
+	Bool      bool    `column:"bool"`
+	Group     string  `column:"group"`
+	Extractor int     `column:"extractor"`
+}
+
+func getTestCol(t *testing.T) *columns.Columns[testData] {
+	cols, err := columns.NewColumns[testData]()
+	if err != nil {
+		t.Errorf("failed to initialize: %v", err)
+	}
+	cols.MustSetExtractor("extractor", func(t *testData) string {
+		return fmt.Sprint(t.Extractor)
+	})
+	cols.MustAddColumn(columns.Column[testData]{
+		Name: "virtual_column",
+		Extractor: func(*testData) string {
+			return ""
+		},
+	})
+
+	return cols
+}
+
 func TestSorter(t *testing.T) {
-	type testEmbedded struct {
-		EmbeddedInt int `column:"embeddedInt"`
-	}
-	type testData struct {
-		testEmbedded
-		Int     int     `column:"int"`
-		Uint    uint    `column:"uint"`
-		String  string  `column:"string"`
-		Float32 float32 `column:"float32"`
-		Float64 float64 `column:"float64"`
-		Bool    bool    `column:"bool"`
-		Group   string  `column:"group"`
-	}
 	testEntries := []*testData{
 		nil,
-		{Int: 1, Uint: 2, String: "c", Float32: 3, Float64: 4, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 7}},
+		{Int: 1, Uint: 2, String: "c", Float32: 3, Float64: 4, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 7}, Extractor: 1},
 		nil,
-		{Int: 2, Uint: 3, String: "d", Float32: 4, Float64: 5, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 6}},
+		{Int: 2, Uint: 3, String: "d", Float32: 4, Float64: 5, Group: "b", testEmbedded: testEmbedded{EmbeddedInt: 6}, Extractor: 2},
 		nil,
-		{Int: 3, Uint: 4, String: "e", Float32: 5, Float64: 1, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 5}},
+		{Int: 3, Uint: 4, String: "e", Float32: 5, Float64: 1, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 5}, Extractor: 3},
 		nil,
-		{Int: 4, Uint: 5, String: "a", Float32: 1, Float64: 2, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 4}},
+		{Int: 4, Uint: 5, String: "a", Float32: 1, Float64: 2, Group: "a", testEmbedded: testEmbedded{EmbeddedInt: 4}, Extractor: 4},
 		nil,
-		{Int: 5, Uint: 1, String: "b", Float32: 2, Float64: 3, Group: "c", testEmbedded: testEmbedded{EmbeddedInt: 3}},
+		{Int: 5, Uint: 1, String: "b", Float32: 2, Float64: 3, Group: "c", testEmbedded: testEmbedded{EmbeddedInt: 3}, Extractor: 5},
 		nil,
 	}
 
 	// Using shuffle should cover all sorting paths
 	rand.Seed(0)
 
-	cols, err := columns.NewColumns[testData]()
-	if err != nil {
-		t.Errorf("failed to initialize: %v", err)
-	}
-
-	cmap := cols.GetColumnMap()
+	cmap := getTestCol(t).GetColumnMap()
 
 	shuffle := func() {
 		rand.Shuffle(len(testEntries), func(i, j int) { testEntries[i], testEntries[j] = testEntries[j], testEntries[i] })
+	}
+
+	if !CanSortBy(cmap, []string{"uint"}) {
+		t.Errorf("expected sort to be able to sort by \"uint\" (struct field without custom extractor)")
+	}
+	if !CanSortBy(cmap, []string{"extractor"}) {
+		t.Errorf("expected sort to be able to sort by \"extractor\" (struct field with custom extractor)")
+	}
+	if CanSortBy(cmap, []string{"virtual_column"}) {
+		t.Errorf("expected sort to not be able to sort by \"virtual_column\" (virtual column)")
+	}
+	if CanSortBy(cmap, []string{"non_existent_column"}) {
+		t.Errorf("expected sort to not be able to sort by \"non_existent_column\" (column doesn't exist)")
 	}
 
 	shuffle()
@@ -124,6 +154,12 @@ func TestSorter(t *testing.T) {
 	}
 
 	shuffle()
+	SortEntries(cmap, testEntries, []string{"-extractor"})
+	if testEntries[0].Extractor != 5 {
+		t.Errorf("expected value to be 5")
+	}
+
+	shuffle()
 	SortEntries(cmap, testEntries, []string{"string"})
 	if testEntries[0].String != "a" {
 		t.Errorf("expected value to be a")
@@ -149,4 +185,47 @@ func TestSorter(t *testing.T) {
 
 	// Sort nil array - should result in noop
 	SortEntries(cmap, nil, []string{""})
+}
+
+func TestCanSortBy(t *testing.T) {
+	cmap := getTestCol(t).GetColumnMap()
+
+	if !CanSortBy(cmap, []string{"uint"}) {
+		t.Errorf("expected sort to be able to sort by \"uint\" (struct field without custom extractor)")
+	}
+	if !CanSortBy(cmap, []string{"extractor"}) {
+		t.Errorf("expected sort to be able to sort by \"extractor\" (struct field with custom extractor)")
+	}
+	if CanSortBy(cmap, []string{"virtual_column"}) {
+		t.Errorf("expected sort to not be able to sort by \"virtual_column\" (virtual column)")
+	}
+	if CanSortBy(cmap, []string{"non_existent_column"}) {
+		t.Errorf("expected sort to not be able to sort by \"non_existent_column\" (column doesn't exist)")
+	}
+}
+
+func TestFilterSortableColumns(t *testing.T) {
+	cmap := getTestCol(t).GetColumnMap()
+
+	valid, invalid := FilterSortableColumns(cmap, []string{"uint"})
+	if !reflect.DeepEqual(valid, []string{"uint"}) || len(invalid) != 0 {
+		t.Errorf("expected FilterSortableColumns to return \"uint\" in the valid array (struct field without custom extractor)")
+	}
+	valid, invalid = FilterSortableColumns(cmap, []string{"extractor"})
+	if !reflect.DeepEqual(valid, []string{"extractor"}) || len(invalid) != 0 {
+		t.Errorf("expected FilterSortableColumns to return \"extractor\" in the valid array (struct field with custom extractor)")
+	}
+	valid, invalid = FilterSortableColumns(cmap, []string{"virtual_column"})
+	if len(valid) != 0 || !reflect.DeepEqual(invalid, []string{"virtual_column"}) {
+		t.Errorf("expected FilterSortableColumns to return \"virtual_column\" in the invalid array (virtual column)")
+	}
+	valid, invalid = FilterSortableColumns(cmap, []string{"non_existent_column"})
+	if len(valid) != 0 || !reflect.DeepEqual(invalid, []string{"non_existent_column"}) {
+		t.Errorf("expected FilterSortableColumns to return \"non_existent_column\" in the invalid array (column doesn't exist)")
+	}
+
+	valid, _ = FilterSortableColumns(cmap, []string{"uint", "extractor"})
+	if len(valid) != 2 || !reflect.DeepEqual(valid, []string{"uint", "extractor"}) {
+		t.Errorf("expected FilterSortableColumns to not change the ordering")
+	}
 }

--- a/pkg/gadget-collection/gadgets/top/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/block-io/gadget.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	biotoptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/block-io/tracer"
@@ -49,6 +50,7 @@ func NewFactory() gadgets.TraceFactory {
 
 func (f *TraceFactory) Description() string {
 	cols := types.GetColumns()
+	validCols, _ := sort.FilterSortableColumns(cols.ColumnMap, cols.GetColumnNames())
 
 	t := `biotop shows command generating block I/O, with container details.
 
@@ -58,7 +60,7 @@ The following parameters are supported:
  - %s: The field to sort the results by (%s). (default %s)`
 	return fmt.Sprintf(t, top.IntervalParam, top.IntervalDefault,
 		top.MaxRowsParam, top.MaxRowsDefault,
-		top.SortByParam, strings.Join(cols.GetColumnNames(), ","), strings.Join(types.SortByDefault, ","))
+		top.SortByParam, strings.Join(validCols, ","), strings.Join(types.SortByDefault, ","))
 }
 
 func (f *TraceFactory) OutputModesSupported() map[gadgetv1alpha1.TraceOutputMode]struct{} {
@@ -132,7 +134,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params[top.SortByParam]; ok {
 			sortByColumns := strings.Split(val, ",")
 
-			_, invalidCols := types.GetColumns().VerifyColumnNames(sortByColumns)
+			_, invalidCols := sort.FilterSortableColumns(types.GetColumns().ColumnMap, sortByColumns)
 			if len(invalidCols) > 0 {
 				trace.Status.OperationError = fmt.Sprintf("%q are not valid for %q", strings.Join(invalidCols, ","), top.SortByParam)
 				return

--- a/pkg/gadget-collection/gadgets/top/file/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/file/gadget.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	filetoptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/tracer"
@@ -49,6 +50,7 @@ func NewFactory() gadgets.TraceFactory {
 
 func (f *TraceFactory) Description() string {
 	cols := types.GetColumns()
+	validCols, _ := sort.FilterSortableColumns(cols.ColumnMap, cols.GetColumnNames())
 
 	t := `filetop shows reads and writes by file, with container details.
 
@@ -59,7 +61,7 @@ The following parameters are supported:
  - %s: Show all files. (default %v, i.e. show regular files only)`
 	return fmt.Sprintf(t, top.IntervalParam, top.IntervalDefault,
 		top.MaxRowsParam, top.MaxRowsDefault,
-		top.SortByParam, strings.Join(cols.GetColumnNames(), ","), strings.Join(types.SortByDefault, ","),
+		top.SortByParam, strings.Join(validCols, ","), strings.Join(types.SortByDefault, ","),
 		types.AllFilesParam, types.AllFilesDefault)
 }
 
@@ -135,7 +137,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params[top.SortByParam]; ok {
 			sortByColumns := strings.Split(val, ",")
 
-			_, invalidCols := types.GetColumns().VerifyColumnNames(sortByColumns)
+			_, invalidCols := sort.FilterSortableColumns(types.GetColumns().ColumnMap, sortByColumns)
 			if len(invalidCols) > 0 {
 				trace.Status.OperationError = fmt.Sprintf("%q are not valid for %q", strings.Join(invalidCols, ","), top.SortByParam)
 				return

--- a/pkg/gadget-collection/gadgets/top/tcp/gadget.go
+++ b/pkg/gadget-collection/gadgets/top/tcp/gadget.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	tcptoptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/tcp/tracer"
@@ -49,6 +50,7 @@ func NewFactory() gadgets.TraceFactory {
 
 func (f *TraceFactory) Description() string {
 	cols := types.GetColumns()
+	validCols, _ := sort.FilterSortableColumns(cols.ColumnMap, cols.GetColumnNames())
 
 	t := `tcptop shows command generating TCP connections, with container details.
 
@@ -60,7 +62,7 @@ The following parameters are supported:
 - %s: Only get events for this IP version. (either 4 or 6, default to all)`
 	return fmt.Sprintf(t, top.IntervalParam, top.IntervalDefault,
 		top.MaxRowsParam, top.MaxRowsDefault,
-		top.SortByParam, strings.Join(cols.GetColumnNames(), ","), strings.Join(types.SortByDefault, ","),
+		top.SortByParam, strings.Join(validCols, ","), strings.Join(types.SortByDefault, ","),
 		types.PidParam, types.FamilyParam)
 }
 
@@ -137,7 +139,7 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		if val, ok := params[top.SortByParam]; ok {
 			sortByColumns := strings.Split(val, ",")
 
-			_, invalidCols := types.GetColumns().VerifyColumnNames(sortByColumns)
+			_, invalidCols := sort.FilterSortableColumns(types.GetColumns().ColumnMap, sortByColumns)
 			if len(invalidCols) > 0 {
 				trace.Status.OperationError = fmt.Sprintf("%q are not valid for %q", strings.Join(invalidCols, ","), top.SortByParam)
 				return

--- a/pkg/gadgets/top/block-io/types/types.go
+++ b/pkg/gadgets/top/block-io/types/types.go
@@ -28,23 +28,32 @@ const (
 	TIME
 )
 
-var SortByDefault = []string{"-io", "-bytes", "-us"}
+var SortByDefault = []string{"-ops", "-bytes", "-time"}
 
 // Stats represents the operations performed on a single file
 type Stats struct {
 	eventtypes.CommonData
 
-	Write      bool   `json:"write,omitempty" column:"write"`
+	Pid        int32  `json:"pid,omitempty" column:"pid"`
+	Comm       string `json:"comm,omitempty" column:"comm"`
+	Write      bool   `json:"write,omitempty" column:"r/w,maxWidth:3"`
 	Major      int    `json:"major,omitempty" column:"major"`
 	Minor      int    `json:"minor,omitempty" column:"minor"`
 	Bytes      uint64 `json:"bytes,omitempty" column:"bytes"`
-	MicroSecs  uint64 `json:"us,omitempty" column:"us"`
-	Operations uint32 `json:"io,omitempty" column:"io"`
-	MountNsID  uint64 `json:"mountnsid,omitempty" column:"mountnsid"`
-	Pid        int32  `json:"pid,omitempty" column:"pid"`
-	Comm       string `json:"comm,omitempty" column:"comm"`
+	MicroSecs  uint64 `json:"us,omitempty" column:"time"`
+	Operations uint32 `json:"ops,omitempty" column:"ops"`
+	MountNsID  uint64 `json:"mountnsid,omitempty" column:"mountnsid,template:ns,hide"`
 }
 
 func GetColumns() *columns.Columns[Stats] {
-	return columns.MustCreateColumns[Stats]()
+	cols := columns.MustCreateColumns[Stats]()
+
+	cols.MustSetExtractor("r/w", func(stats *Stats) (ret string) {
+		if stats.Write {
+			return "W"
+		}
+		return "R"
+	})
+
+	return cols
 }

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -15,45 +15,74 @@
 package types
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/docker/go-units"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-type SortBy int
-
-const (
-	ALL SortBy = iota
-	RUNTIME
-	RUNCOUNT
-	PROGRAMID
-	TOTALRUNTIME
-	TOTALRUNCOUNT
-	CUMULRUNTIME
-	CUMULRUNCOUNT
-	MAPMEMORY
-	MAPCOUNT
-)
-
-var SortByDefault = []string{"-currentRuntime", "-currentRunCount"}
+var SortByDefault = []string{"-runtime", "-runcount"}
 
 type Stats struct {
 	eventtypes.CommonData
 	ProgramID          uint32     `json:"progid" column:"progid"`
-	Pids               []*PidInfo `json:"pids,omitempty" column:"pids"`
-	Name               string     `json:"name,omitempty" column:"name"`
 	Type               string     `json:"type,omitempty" column:"type"`
-	CurrentRuntime     int64      `json:"currentRuntime,omitempty" column:"currentRuntime"`
-	CurrentRunCount    uint64     `json:"currentRunCount,omitempty" column:"currentRunCount"`
-	CumulativeRuntime  int64      `json:"cumulRuntime,omitempty" column:"cumulRuntime"`
-	CumulativeRunCount uint64     `json:"cumulRunCount,omitempty" column:"cumulRunCount"`
-	TotalRuntime       int64      `json:"totalRuntime,omitempty" column:"totalRuntime"`
-	TotalRunCount      uint64     `json:"totalRunCount,omitempty" column:"totalRunCount"`
-	MapMemory          uint64     `json:"mapMemory,omitempty" column:"mapMemory"`
-	MapCount           uint32     `json:"mapCount,omitempty" column:"mapCount"`
+	Name               string     `json:"name,omitempty" column:"name"`
+	Pids               []*PidInfo `json:"pids,omitempty" column:"pid"`
+	CurrentRuntime     int64      `json:"currentRuntime,omitempty" column:"runtime,order:1001,align:right"`
+	CurrentRunCount    uint64     `json:"currentRunCount,omitempty" column:"runcount,order:1002,width:10"`
+	CumulativeRuntime  int64      `json:"cumulRuntime,omitempty" column:"cumulruntime,order:1003,hide"`
+	CumulativeRunCount uint64     `json:"cumulRunCount,omitempty" column:"cumulruncount,order:1004,hide"`
+	TotalRuntime       int64      `json:"totalRuntime,omitempty" column:"totalruntime,order:1005,align:right,hide"`
+	TotalRunCount      uint64     `json:"totalRunCount,omitempty" column:"totalRunCount,order:1006,align:right,hide"`
+	MapMemory          uint64     `json:"mapMemory,omitempty" column:"mapmemory,order:1007,align:right"`
+	MapCount           uint32     `json:"mapCount,omitempty" column:"mapcount,order:1008"`
 }
 
 func GetColumns() *columns.Columns[Stats] {
-	return columns.MustCreateColumns[Stats]()
+	cols := columns.MustCreateColumns[Stats]()
+
+	col, _ := cols.GetColumn("namespace")
+	col.Visible = false
+	col, _ = cols.GetColumn("pod")
+	col.Visible = false
+	col, _ = cols.GetColumn("container")
+	col.Visible = false
+
+	cols.MustSetExtractor("pid", func(stats *Stats) (ret string) {
+		if len(stats.Pids) > 0 {
+			return fmt.Sprint(stats.Pids[0].Pid)
+		}
+		return ""
+	})
+	cols.MustAddColumn(columns.Column[Stats]{
+		Name:     "comm",
+		MaxWidth: 16,
+		Visible:  true,
+		Order:    1000,
+		Extractor: func(stats *Stats) string {
+			if len(stats.Pids) > 0 {
+				return fmt.Sprint(stats.Pids[0].Comm)
+			}
+			return ""
+		},
+	})
+	cols.MustSetExtractor("runtime", func(stats *Stats) (ret string) {
+		return fmt.Sprint(time.Duration(stats.CurrentRuntime))
+	})
+	cols.MustSetExtractor("totalruntime", func(stats *Stats) (ret string) {
+		return fmt.Sprint(time.Duration(stats.TotalRuntime))
+	})
+	cols.MustSetExtractor("cumulruntime", func(stats *Stats) (ret string) {
+		return fmt.Sprint(time.Duration(stats.CumulativeRuntime))
+	})
+	cols.MustSetExtractor("mapmemory", func(stats *Stats) (ret string) {
+		return fmt.Sprint(units.BytesSize(float64(stats.MapMemory)))
+	})
+
+	return cols
 }
 
 type PidInfo struct {


### PR DESCRIPTION
# gadgets/top: Use the column library

Use the columns library in the `top` gadgets:
- `block-io`
- `ebpf`
- `file`
- `tcp`

The first commit was made so that every commit itself can be compiled and ran without any issues

### Modifications on the `columns` library

1. The columns library now can sort on columns with a custom extractor. But it can't be a virtual column
2. `Template` and `UseTemplate` are now exported to use templates on virtual columns

@flyth are these modifications ok?
