### PR TITLE
ci: Do not cancel in progress jobs on main.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -6,7 +6,9 @@ env:
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: true
+  # We do not want to cancel job in progress on main to be sure to catch new
+  # regression as soon as they are introduced.
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 on:
   pull_request:
   push:


### PR DESCRIPTION
Hi.


In this PR, I made `cancel-in-progress` to be set only when branch is different than main.
Indeed, we want to catch regression as soon as they are introduced, so we do not want to cancel in progress CI jobs on main branch.


Best regards.