### PR TITLE
ociannotations: Move annotation handling to separate package

### DIFF
--- a/pkg/container-utils/oci-annotations/resolver_containerd.go
+++ b/pkg/container-utils/oci-annotations/resolver_containerd.go
@@ -12,28 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package containercollection
+package ociannotations
 
 const (
-	// container types used by the runtimes
-	containerTypeSandbox   = "sandbox"
-	containerTypeContainer = "container"
-
-	// cri-o container annotations to get container information
-	// https://github.com/containers/podman/blob/main/pkg/annotations/annotations.go
-	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/labels.go
-	crioContainerManagerAnnotation = "io.container.manager"
-	crioPodNameAnnotation          = "io.kubernetes.pod.name"
-	crioPodNamespaceAnnotation     = "io.kubernetes.pod.namespace"
-	crioPodUIDAnnotation           = "io.kubernetes.pod.uid"
-	crioContainerNameAnnotation    = "io.kubernetes.container.name"
-	crioContainerTypeAnnotation    = "io.kubernetes.cri-o.ContainerType"
-
 	// containerd container annotations to get container information
 	// https://github.com/containerd/containerd/blob/main/pkg/cri/annotations/annotations.go
+	//
+	// Pod UID annotation added in:
+	// * containerd v1.7.0 via https://github.com/containerd/containerd/pull/7697
+	// * containerd v1.6.11 via https://github.com/containerd/containerd/pull/7735
 	containerdPodNameAnnotation       = "io.kubernetes.cri.sandbox-name"
 	containerdPodNamespaceAnnotation  = "io.kubernetes.cri.sandbox-namespace"
 	containerdPodUIDAnnotation        = "io.kubernetes.cri.sandbox-uid"
 	containerdContainerNameAnnotation = "io.kubernetes.cri.container-name"
 	containerdContainerTypeAnnotation = "io.kubernetes.cri.container-type"
 )
+
+type containerdResolver struct{}
+
+func (containerdResolver) ContainerName(annotations map[string]string) string {
+	return annotations[containerdContainerNameAnnotation]
+}
+
+func (containerdResolver) ContainerType(annotations map[string]string) string {
+	return annotations[containerdContainerTypeAnnotation]
+}
+
+func (containerdResolver) PodName(annotations map[string]string) string {
+	return annotations[containerdPodNameAnnotation]
+}
+
+func (containerdResolver) PodUID(annotations map[string]string) string {
+	return annotations[containerdPodUIDAnnotation]
+}
+
+func (containerdResolver) PodNamespace(annotations map[string]string) string {
+	return annotations[containerdPodNamespaceAnnotation]
+}
+
+func (containerdResolver) Runtime() string {
+	return "containerd"
+}

--- a/pkg/container-utils/oci-annotations/resolver_containerd_test.go
+++ b/pkg/container-utils/oci-annotations/resolver_containerd_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ociannotations
+
+import "testing"
+
+func Test_containerdResolver(t *testing.T) {
+	annotations := map[string]string{
+		containerdPodNameAnnotation:       "test-pod-name",
+		containerdPodNamespaceAnnotation:  "test-pod-namespace",
+		containerdPodUIDAnnotation:        "test-pod-uid",
+		containerdContainerNameAnnotation: "test-container-name",
+		containerdContainerTypeAnnotation: "test-container-type",
+	}
+
+	resolver := containerdResolver{}
+	assert := func(got string, want string) {
+		if got != want {
+			t.Fatalf("Assertion failed got=%s, want=%s", got, want)
+		}
+	}
+
+	t.Logf("Test resolving annotations for %s", resolver.Runtime())
+	assert(resolver.PodName(annotations), "test-pod-name")
+	assert(resolver.PodNamespace(annotations), "test-pod-namespace")
+	assert(resolver.PodUID(annotations), "test-pod-uid")
+	assert(resolver.ContainerName(annotations), "test-container-name")
+	assert(resolver.ContainerType(annotations), "test-container-type")
+}

--- a/pkg/container-utils/oci-annotations/resolver_crio.go
+++ b/pkg/container-utils/oci-annotations/resolver_crio.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ociannotations
+
+const (
+	// cri-o container annotations to get container information
+	// https://github.com/containers/podman/blob/main/pkg/annotations/annotations.go
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/labels.go
+	crioContainerManagerAnnotation = "io.container.manager"
+	crioPodNameAnnotation          = "io.kubernetes.pod.name"
+	crioPodNamespaceAnnotation     = "io.kubernetes.pod.namespace"
+	crioPodUIDAnnotation           = "io.kubernetes.pod.uid"
+	crioContainerNameAnnotation    = "io.kubernetes.container.name"
+	crioContainerTypeAnnotation    = "io.kubernetes.cri-o.ContainerType"
+)
+
+type crioResolver struct{}
+
+func (crioResolver) ContainerName(annotations map[string]string) string {
+	return annotations[crioContainerNameAnnotation]
+}
+
+func (crioResolver) ContainerType(annotations map[string]string) string {
+	return annotations[crioContainerTypeAnnotation]
+}
+
+func (crioResolver) PodName(annotations map[string]string) string {
+	return annotations[crioPodNameAnnotation]
+}
+
+func (crioResolver) PodUID(annotations map[string]string) string {
+	return annotations[crioPodUIDAnnotation]
+}
+
+func (crioResolver) PodNamespace(annotations map[string]string) string {
+	return annotations[crioPodNamespaceAnnotation]
+}
+
+func (crioResolver) Runtime() string {
+	return "cri-o"
+}

--- a/pkg/container-utils/oci-annotations/resolver_crio_test.go
+++ b/pkg/container-utils/oci-annotations/resolver_crio_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ociannotations
+
+import "testing"
+
+func Test_crioResolver(t *testing.T) {
+	annotations := map[string]string{
+		crioPodNameAnnotation:       "test-pod-name",
+		crioPodNamespaceAnnotation:  "test-pod-namespace",
+		crioPodUIDAnnotation:        "test-pod-uid",
+		crioContainerNameAnnotation: "test-container-name",
+		crioContainerTypeAnnotation: "test-container-type",
+	}
+
+	resolver := crioResolver{}
+	assert := func(got string, want string) {
+		if got != want {
+			t.Fatalf("Assertion failed got=%s, want=%s", got, want)
+		}
+	}
+
+	t.Logf("Test resolving annotations for %s", resolver.Runtime())
+	assert(resolver.PodName(annotations), "test-pod-name")
+	assert(resolver.PodNamespace(annotations), "test-pod-namespace")
+	assert(resolver.PodUID(annotations), "test-pod-uid")
+	assert(resolver.ContainerName(annotations), "test-container-name")
+	assert(resolver.ContainerType(annotations), "test-container-type")
+}

--- a/pkg/container-utils/oci-annotations/types.go
+++ b/pkg/container-utils/oci-annotations/types.go
@@ -1,0 +1,60 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ociannotations
+
+import "errors"
+
+// ErrUnsupportedContainerRuntime is used for unsupported container runtime
+var ErrUnsupportedContainerRuntime = errors.New("unsupported container runtime")
+
+// Resolver is used to resolve attributes for a container
+// by using container runtime annotations
+type Resolver interface {
+	// ContainerName returns the name of the container in a pod
+	ContainerName(annotations map[string]string) string
+	// ContainerType returns the type of the container i.e "container" or "sandbox"
+	ContainerType(annotations map[string]string) string
+	// PodName returns the name of the pod to which the container belongs
+	PodName(annotations map[string]string) string
+	// PodUID returns the uid of pod to which the container belongs
+	PodUID(annotations map[string]string) string
+	// PodNamespace returns the namespace of the pod to which container belongs
+	PodNamespace(annotations map[string]string) string
+	// Runtime returns runtime in which the container is running
+	Runtime() string
+}
+
+// NewResolver creates a Resolver for a given container runtime
+func NewResolver(runtime string) (Resolver, error) {
+	switch runtime {
+	case "cri-o":
+		return crioResolver{}, nil
+	case "containerd":
+		return containerdResolver{}, nil
+	}
+	return nil, ErrUnsupportedContainerRuntime
+}
+
+// NewResolverFromAnnotations creates a Resolver by detecting runtime from annotations
+func NewResolverFromAnnotations(annotations map[string]string) (Resolver, error) {
+	if cm := annotations[crioContainerManagerAnnotation]; cm != "" {
+		return crioResolver{}, nil
+	}
+	if _, isContainerd := annotations[containerdContainerTypeAnnotation]; isContainerd {
+		return containerdResolver{}, nil
+	}
+
+	return nil, ErrUnsupportedContainerRuntime
+}

--- a/pkg/container-utils/oci-annotations/types_test.go
+++ b/pkg/container-utils/oci-annotations/types_test.go
@@ -1,0 +1,100 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ociannotations
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewResolver(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "get cri-o resolver",
+			runtime: "cri-o",
+			want:    "cri-o",
+			wantErr: false,
+		},
+		{
+			name:    "get containerd resolver",
+			runtime: "containerd",
+			want:    "containerd",
+			wantErr: false,
+		},
+		{
+			name:    "unsupported resolver",
+			runtime: "unsupported",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewResolver(tt.runtime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewResolver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got.Runtime(), tt.want) {
+				t.Errorf("NewResolverFromAnnotations().Runtime() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewResolverFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "get cri-o resolver",
+			annotations: map[string]string{crioContainerManagerAnnotation: "cri-o"},
+			want:        "cri-o",
+			wantErr:     false,
+		},
+		{
+			name:        "get containerd resolver",
+			annotations: map[string]string{containerdContainerTypeAnnotation: "test-container-type"},
+			want:        "containerd",
+			wantErr:     false,
+		},
+		{
+			name:        "unsupported resolver",
+			annotations: map[string]string{},
+			want:        "",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewResolverFromAnnotations(tt.annotations)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewResolverFromAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got.Runtime(), tt.want) {
+				t.Errorf("NewResolverFromAnnotations().Runtime() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move annotation handling to separate package to simplify OCIConfig enricher. 

Fixes #1145
