### PR TITLE
lint: update github action to fix deprecation warning

### DIFF
--- a/.github/actions/install-debian-packages/action.yml
+++ b/.github/actions/install-debian-packages/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache debian packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       id: cache-debs
       with:
         path: "~/cache-debs"


### PR DESCRIPTION
Patch initially proposed in https://github.com/inspektor-gadget/inspektor-gadget/pull/1148