### PR TITLE
integraton-tests: Fail if no entries provided to expectAllToMatch

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -505,6 +505,13 @@ jobs:
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  test"
           sudo apt-get update
           sudo apt-get install docker-ce
+      # For containerd, swap limit isn't propogated to memory controller of pod cgroup with
+      # memory.memsw.limit_in_bytes set to a large value, resulting in OOM not triggered.
+      # Disable swap to make things simpler for us
+      - name: Disable swap for ${{ matrix.runtime }}
+        if: matrix.runtime == 'containerd'
+        run: |
+          sudo swapoff -a
       - name: Run integration for container runtime ${{ matrix.runtime }}
         run: |
           make -C integration/local-gadget CONTAINER_RUNTIME=${{ matrix.runtime }} -o build setup test

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -68,6 +68,9 @@ func parseJSONArrayOutput[T any](output string, normalize func(*T)) ([]*T, error
 }
 
 func expectAllToMatch[T any](entries []*T, expectedEntry *T) error {
+	if len(entries) == 0 {
+		return fmt.Errorf("no output entries to match")
+	}
 	for _, entry := range entries {
 		if !reflect.DeepEqual(expectedEntry, entry) {
 			return fmt.Errorf("unexpected output entry:\n%s",


### PR DESCRIPTION
It seems like if no entries are passed to `expectAllToMatch` the test still goes and passes. We should explicitly fail if no entries are given. 