### PR TITLE
Remove Lint errors

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -53,12 +53,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: true
       id: go
-    - name: Install debian packages
-      # ALERT This action must be run after code was checkout otherwise it will
-      # not find this file.
-      uses: ./.github/actions/install-debian-packages
     - name: Lint
       uses: golangci/golangci-lint-action@v3.3.1
       with:


### PR DESCRIPTION
# Remove Lint errors

This PR removes the Lint Errors that we see on the summary page of Workflows and the Lint page itself.
Example see https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3540176371
Even though everything was ok, we see errors.

With this change we do not use the cache of the `setup go` step on the Lint step anymore

Related https://github.com/golangci/golangci-lint-action/issues/23