### PR TITLE
pkg/exec: Lint correctly arm64_loadlinks.go.

### DIFF
--- a/pkg/gadgets/trace/exec/tracer/arm64_loadlinks.go
+++ b/pkg/gadgets/trace/exec/tracer/arm64_loadlinks.go
@@ -1,4 +1,4 @@
-//go:build (linux && arm64)
+//go:build linux && arm64
 // +build linux,arm64
 
 // Copyright 2019-2022 The Inspektor Gadget authors


### PR DESCRIPTION
Hi.


In this PR, I run manually `gofumpt` to format `arm64_loadlinks.go`, thus making [`go report`](https://goreportcard.com/report/github.com/inspektor-gadget/inspektor-gadget) happy.


Best regards.