### PR TITLE
ci: Update download-artifact from v2 to v3

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Get kubectl-gadget-linux-amd64.tar.gz from artifact.
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: kubectl-gadget-linux-amd64-tar-gz
         path: /home/runner/work/inspektor-gadget/inspektor-gadget/


### PR DESCRIPTION
# ci: Update download-artifact from v2 to v3

Resolves the last warnings/messages from a successful CI run. See https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3547192062

Only breaking change in the Changelog is the following:
`With the update to Node 16, all scripts will now be run with Node 16 rather than Node 12.`