### PR TITLE
profile/cpu: Add suffix "stack" to kernel/user parameter name

### DIFF
--- a/cmd/kubectl-gadget/profile/cpu.go
+++ b/cmd/kubectl-gadget/profile/cpu.go
@@ -87,14 +87,14 @@ func newCPUCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVarP(
 		&cpuFlags.profileUserOnly,
-		"user",
+		"user-stack",
 		"U",
 		false,
 		"Show stacks from user space only (no kernel space stacks)",
 	)
 	cmd.PersistentFlags().BoolVarP(
 		&cpuFlags.profileKernelOnly,
-		"kernel",
+		"kernel-stack",
 		"K",
 		false,
 		"Show stacks from kernel space only (no user space stacks)",


### PR DESCRIPTION
# profile/cpu: Add suffix "stack" to kernel/user parameter name

A kubernetes parameter already uses the `--user` parameter.
The following screenshot (yellow highlight by me) shows that `-U`/`--user` is missing for `profile cpu` which would only show the userspace stack.
![image](https://user-images.githubusercontent.com/113581185/204520781-74a7ccaf-2973-412c-a802-f22c47fa3f04.png)

# Changed behavior on latests version of `cobra`
While getting a minimal testcode i discovered that the behavior changed. On our version the global flag (the kubernetes one) has precedence.
With the newest version `1.6.1` the local parameter (the userspace stack one) will be shown and shadows the global flag

Should i open an Issue/PR with a potential fix on the cobra github?