### PR TITLE
ci: Use install-debian-packages before running the linter.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -54,6 +54,8 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
     - name: Lint
       uses: golangci/golangci-lint-action@v3.3.1
       with:


### PR DESCRIPTION
golangci-lint will sort of compile our code by using typecheck golang analyzer [1, 2].
Without installing libseccomp-dev, the following error is thrown: gadget-container/gadgettracermanager/controller.go:35:2: "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets" imported but not used (typecheck)
        "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
This error message is wrong but another message is generated (but not printed): (dlv) bt
 0  0x0000000000dece51 in github.com/golangci/golangci-lint/pkg/golinters/goanalysis.buildIssuesFromIllTypedError
    at /tmp/golangci-lint/pkg/golinters/goanalysis/errors.go:41
 1  0x0000000000df8d05 in github.com/golangci/golangci-lint/pkg/golinters/goanalysis.runAnalyzers
    at /tmp/golangci-lint/pkg/golinters/goanalysis/runners.go:76
 2  0x0000000000dee52d in github.com/golangci/golangci-lint/pkg/golinters/goanalysis.MetaLinter.Run
    at /tmp/golangci-lint/pkg/golinters/goanalysis/metalinter.go:31
(dlv) p ill.Pkg.Errors
[]golang.org/x/tools/go/packages.Error len: 2, cap: 2, [
	{
		Pos: "/mnt/gadget-container/gadgettracermanager/controller.go:34:19",
		Msg: "could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (/mnt/pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (/mnt/pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (/mnt/pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))",
		Kind: TypeError (3),},
	{
		Pos: "/mnt/gadget-container/gadgettracermanager/controller.go:35:2",
		Msg: "\"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets\" imported but not used",
		Kind: TypeError (3),},
]

Regarding why this problem occurs now (1st December 2022) and not at the time of the merge of fixed commit (25th November 22), this is because the package was still in the cache and today the cache expired [3].

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
Fixes: c4e35287390b ("ci/lint: Don't cache in go setup")

[1] https://github.com/golangci/golangci-lint/blob/f9d815115c5ab85c454b0c5029712dd805dfda53/pkg/golinters/typecheck.go#L9 [2] https://pkg.go.dev/golang.org/x/tools/go/analysis [3] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy