### PR TITLE
ci: Invalidate install-debian-packages cache when files are changed.

### DIFF
--- a/.github/actions/install-debian-packages/action.yml
+++ b/.github/actions/install-debian-packages/action.yml
@@ -14,8 +14,9 @@ runs:
       id: cache-debs
       with:
         path: "~/cache-debs"
-        # Update cache key if you add or update a package.
-        key: v4
+        # Any changes to this file or main workflow file will invalidate the
+        # cache.
+        key: ${{ hashFiles('.github/actions/install-debian-packages/action.yml', '.github/workflows/inspektor-gadget.yml') }}
     - name: Install debian packages
       shell: bash
       run: |


### PR DESCRIPTION
Before this commit, each time you changed the installed packages, you needed to manually update the cache key.
With this commit, the cache key is now crafted as the hash of the install-debian-packages action file and the main workflow file. So, any modifications to these two files will invalidate the cache