### PR TITLE
ci: Fix release job part in charge of creating release YAML.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -702,10 +702,10 @@ jobs:
     - name: Build release YAML
       run: |
         export IMAGE_TAG=${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
-        export IMAGE="${{ env.REGISTRY }}/${{ env.RELEASE_CONTAINER_REPO }}:${IMAGE_TAG}"
+        export IMAGE="${{ env.REGISTRY }}/${{ env.CONTAINER_REPO }}:${IMAGE_TAG}"
 
         # Use echo of cat to avoid printing a new line between files.
-        echo "$(cat pkg/resources/manifests/deploy.yaml) $(cat pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml) > inspektor-gadget.yaml
+        echo "$(cat pkg/resources/manifests/deploy.yaml) $(cat pkg/resources/crd/bases/gadget.kinvolk.io_traces.yaml)" > inspektor-gadget-${GITHUB_REF_NAME}.yaml
 
         perl -pi -e 's@(image:) ".+\"@$1 "$ENV{IMAGE}"@; s@"latest"@"$ENV{IMAGE_TAG}"@;' inspektor-gadget-${GITHUB_REF_NAME}.yaml
     - name: Create Release


### PR DESCRIPTION
There were several problems with this subjob:
1. It used RELEASE_CONTAINER_REPO which is no more used since a long time.
2. The echo command had an opening quote but not a closing one.
3. The echo command outputted to inspektor-gadget.yaml without taking into account the release version.

Fixes: 22cbf6d05c2f ("ci: Add inspektor-gadget.yaml as release artifact.")