### PR TITLE
pkg/gadgets: Remove Cgo for advise seccomp-profile.

### DIFF
--- a/pkg/gadgets/advise/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/advise/seccomp/tracer/tracer.go
@@ -25,8 +25,12 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET -cc clang seccomp ./bpf/seccomp.c -- -I./bpf/ -I../../../../${TARGET}
 
-// #include "bpf/seccomp-common.h"
-import "C"
+// This must match content of bpf/seccomp-common.h.
+const (
+	syscallsCount              = 500
+	syscallsMapValueFooterSize = 1
+	syscallsMapValueSize       = syscallsCount + syscallsMapValueFooterSize
+)
 
 const (
 	BPFProgName = "ig_seccomp_e"
@@ -60,7 +64,7 @@ func NewTracer() (*Tracer, error) {
 		seccompMap: coll.Maps[BPFMapName],
 	}
 
-	t.seccompMap.Update(uint64(0), [C.SYSCALLS_MAP_VALUE_SIZE]byte{}, ebpf.UpdateAny)
+	t.seccompMap.Update(uint64(0), [syscallsMapValueSize]byte{}, ebpf.UpdateAny)
 
 	tracepointProg, ok := coll.Programs[BPFProgName]
 	if !ok {
@@ -82,20 +86,20 @@ func (t *Tracer) Peek(mntns uint64) []byte {
 	b, err := t.seccompMap.LookupBytes(mntns)
 	if err != nil {
 		log.Errorf("Error while looking up the seccomp map: %s", err)
-		return make([]byte, C.SYSCALLS_COUNT)
+		return make([]byte, syscallsCount)
 	}
 	// LookupBytes does not return an error when the entry is not found, so
 	// we need to test b==nil too
 	if b == nil {
 		// The container just hasn't done any syscall
 		log.Errorf("No syscall found with mntns %d", mntns)
-		return make([]byte, C.SYSCALLS_COUNT)
+		return make([]byte, syscallsCount)
 	}
-	if len(b) < C.SYSCALLS_COUNT {
+	if len(b) < syscallsCount {
 		log.Errorf("Error while looking up the seccomp map: wrong length: %d", len(b))
-		return make([]byte, C.SYSCALLS_COUNT)
+		return make([]byte, syscallsCount)
 	}
-	return b[:C.SYSCALLS_COUNT]
+	return b[:syscallsCount]
 }
 
 func (t *Tracer) Delete(mntns uint64) {


### PR DESCRIPTION
Hi.


In this PR, I removed the usage of `Cgo` for `advise seccomp-profile`.


Best regards.