### PR TITLE
dns/sni: Reduce duplicated code in network tracers

### DIFF
--- a/examples/gadgets/basic/trace/dns/dns.go
+++ b/examples/gadgets/basic/trace/dns/dns.go
@@ -26,8 +26,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
 )
 
-const key = "host"
-
 func main() {
 	// In some kernel versions it's needed to bump the rlimits to
 	// use run BPF programs.
@@ -58,11 +56,11 @@ func main() {
 	// The tracer has to be attached. The DNS packets will be traced on
 	// the network namespace of pid.
 	pid := uint32(os.Getpid())
-	if err := tracer.Attach(key, pid, eventCallback); err != nil {
+	if err := tracer.Attach(pid, eventCallback); err != nil {
 		fmt.Printf("error attaching tracer: %s\n", err)
 		return
 	}
-	defer tracer.Detach(key)
+	defer tracer.Detach(pid)
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)

--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -16,14 +16,12 @@ package dns
 
 import (
 	"fmt"
-	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection/networktracer"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	dnsTracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/tracer"
 	dnsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
@@ -38,21 +36,15 @@ type Trace struct {
 
 	tracer *dnsTracer.Tracer
 	conn   *networktracer.ConnectionToContainerCollection
-
-	netnsHost uint64
 }
 
 type TraceFactory struct {
 	gadgets.BaseFactory
-
-	netnsHost uint64
 }
 
 func NewFactory() gadgets.TraceFactory {
-	netnsHost, _ := containerutils.GetNetNs(os.Getpid())
 	return &TraceFactory{
 		BaseFactory: gadgets.BaseFactory{DeleteTrace: deleteTrace},
-		netnsHost:   netnsHost,
 	}
 }
 
@@ -80,9 +72,8 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			client:    f.Client,
-			helpers:   f.Helpers,
-			netnsHost: f.netnsHost,
+			client:  f.Client,
+			helpers: f.Helpers,
 		}
 	}
 

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -16,14 +16,12 @@ package snisnoop
 
 import (
 	"fmt"
-	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection/networktracer"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	sniTracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/tracer"
 	sniTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/types"
@@ -38,21 +36,15 @@ type Trace struct {
 
 	tracer *sniTracer.Tracer
 	conn   *networktracer.ConnectionToContainerCollection
-
-	netnsHost uint64
 }
 
 type TraceFactory struct {
 	gadgets.BaseFactory
-
-	netnsHost uint64
 }
 
 func NewFactory() gadgets.TraceFactory {
-	netnsHost, _ := containerutils.GetNetNs(os.Getpid())
 	return &TraceFactory{
 		BaseFactory: gadgets.BaseFactory{DeleteTrace: deleteTrace},
-		netnsHost:   netnsHost,
 	}
 }
 
@@ -80,9 +72,8 @@ func deleteTrace(name string, t interface{}) {
 func (f *TraceFactory) Operations() map[gadgetv1alpha1.Operation]gadgets.TraceOperation {
 	n := func() interface{} {
 		return &Trace{
-			client:    f.Client,
-			helpers:   f.Helpers,
-			netnsHost: f.netnsHost,
+			client:  f.Client,
+			helpers: f.Helpers,
 		}
 	}
 

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/link"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 

--- a/pkg/gadgets/internal/networktracer/tracer.go
+++ b/pkg/gadgets/internal/networktracer/tracer.go
@@ -1,0 +1,215 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networktracer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"golang.org/x/sys/unix"
+
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/rawsock"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type attachment struct {
+	collection *ebpf.Collection
+	perfRd     *perf.Reader
+
+	sockFd int
+
+	// users keeps track of the users' pid that have called Attach(). This can
+	// happen for two reasons:
+	// 1. several containers in a pod (sharing the netns)
+	// 2. pods with networkHost=true
+	// In both cases, we want to attach the BPF program only once.
+	users map[uint32]struct{}
+}
+
+func newAttachment(
+	pid uint32,
+	spec *ebpf.CollectionSpec,
+	bpfProgName string,
+	bpfPerfMapName string,
+	bpfSocketAttach int,
+) (_ *attachment, err error) {
+	a := &attachment{
+		sockFd: -1,
+		users:  map[uint32]struct{}{pid: {}},
+	}
+	defer func() {
+		if err != nil {
+			if a.perfRd != nil {
+				a.perfRd.Close()
+			}
+			if a.sockFd != -1 {
+				unix.Close(a.sockFd)
+			}
+			if a.collection != nil {
+				a.collection.Close()
+			}
+		}
+	}()
+
+	a.collection, err = ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
+	}
+
+	a.perfRd, err = perf.NewReader(a.collection.Maps[bpfPerfMapName], gadgets.PerfBufferPages*os.Getpagesize())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get a perf reader: %w", err)
+	}
+
+	prog, ok := a.collection.Programs[bpfProgName]
+	if !ok {
+		return nil, fmt.Errorf("failed to find BPF program %q", bpfProgName)
+	}
+
+	a.sockFd, err = rawsock.OpenRawSock(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open raw socket: %w", err)
+	}
+
+	if err := syscall.SetsockoptInt(a.sockFd, syscall.SOL_SOCKET, bpfSocketAttach, prog.FD()); err != nil {
+		return nil, fmt.Errorf("failed to attach BPF program: %w", err)
+	}
+
+	return a, nil
+}
+
+type Tracer[Event any] struct {
+	spec *ebpf.CollectionSpec
+
+	// key: network namespace inode number
+	// value: Tracelet
+	attachments map[uint64]*attachment
+
+	bpfProgName     string
+	bpfPerfMapName  string
+	bpfSocketAttach int
+
+	baseEvent  func(ev types.Event) Event
+	parseEvent func([]byte) (*Event, error)
+}
+
+func NewTracer[Event any](
+	spec *ebpf.CollectionSpec,
+	bpfProgName string,
+	bpfPerfMapName string,
+	bpfSocketAttach int,
+	baseEvent func(ev types.Event) Event,
+	parseEvent func([]byte) (*Event, error),
+) *Tracer[Event] {
+	return &Tracer[Event]{
+		spec:            spec,
+		attachments:     make(map[uint64]*attachment),
+		bpfProgName:     bpfProgName,
+		bpfPerfMapName:  bpfPerfMapName,
+		bpfSocketAttach: bpfSocketAttach,
+		baseEvent:       baseEvent,
+		parseEvent:      parseEvent,
+	}
+}
+
+func (t *Tracer[Event]) Attach(pid uint32, eventCallback func(Event)) error {
+	netns, err := containerutils.GetNetNs(int(pid))
+	if err != nil {
+		return fmt.Errorf("getting network namespace of pid %d: %w", pid, err)
+	}
+	if a, ok := t.attachments[netns]; ok {
+		a.users[pid] = struct{}{}
+		return nil
+	}
+
+	a, err := newAttachment(pid, t.spec, t.bpfProgName, t.bpfPerfMapName, t.bpfSocketAttach)
+	if err != nil {
+		return fmt.Errorf("creating network tracer attachment for pid %d: %w", pid, err)
+	}
+	t.attachments[netns] = a
+
+	go t.listen(netns, a.perfRd, t.baseEvent, t.parseEvent, eventCallback)
+
+	return nil
+}
+
+func (t *Tracer[Event]) listen(
+	netns uint64,
+	rd *perf.Reader,
+	baseEvent func(ev types.Event) Event,
+	parseEvent func([]byte) (*Event, error),
+	eventCallback func(Event),
+) {
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, perf.ErrClosed) {
+				return
+			}
+
+			msg := fmt.Sprintf("Error reading perf ring buffer (%d): %s", netns, err)
+			eventCallback(baseEvent(types.Err(msg)))
+			return
+		}
+
+		if record.LostSamples != 0 {
+			msg := fmt.Sprintf("lost %d samples (%d)", record.LostSamples, netns)
+			eventCallback(baseEvent(types.Warn(msg)))
+			continue
+		}
+
+		event, err := parseEvent(record.RawSample)
+		if err != nil {
+			eventCallback(baseEvent(types.Err(err.Error())))
+			continue
+		}
+		if event == nil {
+			continue
+		}
+		eventCallback(*event)
+	}
+}
+
+func (t *Tracer[Event]) releaseAttachment(netns uint64, a *attachment) {
+	a.perfRd.Close()
+	unix.Close(a.sockFd)
+	a.collection.Close()
+	delete(t.attachments, netns)
+}
+
+func (t *Tracer[Event]) Detach(pid uint32) error {
+	for netns, a := range t.attachments {
+		if _, ok := a.users[pid]; ok {
+			delete(a.users, pid)
+			if len(a.users) == 0 {
+				t.releaseAttachment(netns, a)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("pid %d is not attached", pid)
+}
+
+func (t *Tracer[Event]) Close() {
+	for key, l := range t.attachments {
+		t.releaseAttachment(key, l)
+	}
+}

--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Inspektor Gadget authors
+// Copyright 2019-2022 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,17 +17,12 @@ package tracer
 import (
 	"errors"
 	"fmt"
-	"os"
 	"syscall"
 	"unsafe"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/perf"
-	"golang.org/x/sys/unix"
-
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/networktracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/rawsock"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -35,28 +30,12 @@ import (
 
 const (
 	BPFProgName     = "ig_trace_dns"
-	BPFMapName      = "events"
+	BPFPerfMapName  = "events"
 	BPFSocketAttach = 50
 )
 
-type link struct {
-	collection *ebpf.Collection
-	perfRd     *perf.Reader
-
-	sockFd int
-
-	// users count how many users called Attach(). This can happen for two reasons:
-	// 1. several containers in a pod (sharing the netns)
-	// 2. pods with networkHost=true
-	users int
-}
-
 type Tracer struct {
-	spec *ebpf.CollectionSpec
-
-	// key: namespace/podname
-	// value: Tracelet
-	attachments map[string]*link
+	*networktracer.Tracer[types.Event]
 }
 
 func NewTracer() (*Tracer, error) {
@@ -65,71 +44,16 @@ func NewTracer() (*Tracer, error) {
 		return nil, fmt.Errorf("failed to load asset: %w", err)
 	}
 
-	t := &Tracer{
-		spec:        spec,
-		attachments: make(map[string]*link),
-	}
-
-	return t, nil
-}
-
-func (t *Tracer) Attach(
-	key string,
-	pid uint32,
-	eventCallback func(types.Event),
-) (err error) {
-	if l, ok := t.attachments[key]; ok {
-		l.users++
-		return nil
-	}
-
-	l := &link{
-		sockFd: -1,
-		users:  1,
-	}
-	defer func() {
-		if err != nil {
-			if l.perfRd != nil {
-				l.perfRd.Close()
-			}
-			if l.sockFd != -1 {
-				unix.Close(l.sockFd)
-			}
-			if l.collection != nil {
-				l.collection.Close()
-			}
-		}
-	}()
-
-	l.collection, err = ebpf.NewCollection(t.spec)
-	if err != nil {
-		return fmt.Errorf("failed to create BPF collection: %w", err)
-	}
-
-	l.perfRd, err = perf.NewReader(l.collection.Maps[BPFMapName], gadgets.PerfBufferPages*os.Getpagesize())
-	if err != nil {
-		return fmt.Errorf("failed to get a perf reader: %w", err)
-	}
-
-	prog, ok := l.collection.Programs[BPFProgName]
-	if !ok {
-		return fmt.Errorf("failed to find BPF program %q", BPFProgName)
-	}
-
-	l.sockFd, err = rawsock.OpenRawSock(pid)
-	if err != nil {
-		return fmt.Errorf("failed to open raw socket: %w", err)
-	}
-
-	if err := syscall.SetsockoptInt(l.sockFd, syscall.SOL_SOCKET, BPFSocketAttach, prog.FD()); err != nil {
-		return fmt.Errorf("failed to attach BPF program: %w", err)
-	}
-
-	t.attachments[key] = l
-
-	go t.listen(key, l.perfRd, eventCallback)
-
-	return nil
+	return &Tracer{
+		Tracer: networktracer.NewTracer(
+			spec,
+			BPFProgName,
+			BPFPerfMapName,
+			BPFSocketAttach,
+			types.Base,
+			parseDNSEvent,
+		),
+	}, nil
 }
 
 // pkt_type definitions:
@@ -308,61 +232,4 @@ func parseDNSEvent(rawSample []byte) (*types.Event, error) {
 	}
 
 	return &event, nil
-}
-
-func (t *Tracer) listen(
-	key string,
-	rd *perf.Reader,
-	eventCallback func(types.Event),
-) {
-	for {
-		record, err := rd.Read()
-		if err != nil {
-			if errors.Is(err, perf.ErrClosed) {
-				return
-			}
-
-			msg := fmt.Sprintf("Error reading perf ring buffer (%s): %s", key, err)
-			eventCallback(types.Base(eventtypes.Err(msg)))
-			return
-		}
-
-		if record.LostSamples != 0 {
-			msg := fmt.Sprintf("lost %d samples (%s)", record.LostSamples, key)
-			eventCallback(types.Base(eventtypes.Warn(msg)))
-			continue
-		}
-
-		event, err := parseDNSEvent(record.RawSample)
-		if err != nil {
-			eventCallback(types.Base(eventtypes.Err(err.Error())))
-			continue
-		}
-		eventCallback(*event)
-	}
-}
-
-func (t *Tracer) releaseLink(key string, l *link) {
-	l.perfRd.Close()
-	unix.Close(l.sockFd)
-	l.collection.Close()
-	delete(t.attachments, key)
-}
-
-func (t *Tracer) Detach(key string) error {
-	if l, ok := t.attachments[key]; ok {
-		l.users--
-		if l.users == 0 {
-			t.releaseLink(key, l)
-		}
-		return nil
-	} else {
-		return fmt.Errorf("key not attached: %q", key)
-	}
-}
-
-func (t *Tracer) Close() {
-	for key, l := range t.attachments {
-		t.releaseLink(key, l)
-	}
 }

--- a/pkg/gadgets/trace/sni/tracer/tracer.go
+++ b/pkg/gadgets/trace/sni/tracer/tracer.go
@@ -15,18 +15,11 @@
 package tracer
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"syscall"
-
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/perf"
-	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/networktracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/rawsock"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -34,29 +27,13 @@ import (
 
 const (
 	BPFProgName         = "ig_trace_sni"
-	BPFMapName          = "events"
+	BPFPerfMapName      = "events"
 	BPFSocketAttach     = 50
 	TLSMaxServerNameLen = len(snisnoopEventT{}.Name)
 )
 
-type link struct {
-	collection *ebpf.Collection
-	perfRd     *perf.Reader
-
-	sockFd int
-
-	// users count how many users called Attach(). This can happen for two reasons:
-	// 1. several containers in a pod (sharing the netns)
-	// 2. pods with networkHost=true
-	users int
-}
-
 type Tracer struct {
-	spec *ebpf.CollectionSpec
-
-	// key: namespace/podname
-	// value: Tracelet
-	attachments map[string]*link
+	*networktracer.Tracer[types.Event]
 }
 
 func NewTracer() (*Tracer, error) {
@@ -65,134 +42,34 @@ func NewTracer() (*Tracer, error) {
 		return nil, fmt.Errorf("failed to load asset: %w", err)
 	}
 
-	t := &Tracer{
-		spec:        spec,
-		attachments: make(map[string]*link),
-	}
-
-	return t, nil
+	return &Tracer{
+		Tracer: networktracer.NewTracer(
+			spec,
+			BPFProgName,
+			BPFPerfMapName,
+			BPFSocketAttach,
+			types.Base,
+			parseSNIEvent,
+		),
+	}, nil
 }
 
-func (t *Tracer) Attach(
-	key string,
-	pid uint32,
-	eventCallback func(types.Event),
-) (err error) {
-	if l, ok := t.attachments[key]; ok {
-		l.users++
-		return nil
+func parseSNIEvent(sample []byte) (*types.Event, error) {
+	if len(sample) > TLSMaxServerNameLen {
+		sample = sample[:TLSMaxServerNameLen]
 	}
 
-	l := &link{
-		users:  1,
-		sockFd: -1,
-	}
-	defer func() {
-		if err != nil {
-			if l.perfRd != nil {
-				l.perfRd.Close()
-			}
-			if l.sockFd != -1 {
-				unix.Close(l.sockFd)
-			}
-			if l.collection != nil {
-				l.collection.Close()
-			}
-		}
-	}()
-
-	l.collection, err = ebpf.NewCollection(t.spec)
-	if err != nil {
-		return fmt.Errorf("failed to create BPF collection: %w", err)
+	name := gadgets.FromCString(sample)
+	if len(name) == 0 {
+		return nil, nil
 	}
 
-	l.perfRd, err = perf.NewReader(l.collection.Maps[BPFMapName], gadgets.PerfBufferPages*os.Getpagesize())
-	if err != nil {
-		return fmt.Errorf("failed to get a perf reader: %w", err)
+	event := types.Event{
+		Event: eventtypes.Event{
+			Type: eventtypes.NORMAL,
+		},
+		Name: name,
 	}
 
-	prog, ok := l.collection.Programs[BPFProgName]
-	if !ok {
-		return fmt.Errorf("failed to find BPF program %q", BPFProgName)
-	}
-
-	l.sockFd, err = rawsock.OpenRawSock(pid)
-	if err != nil {
-		return fmt.Errorf("failed to open raw socket: %w", err)
-	}
-
-	if err := syscall.SetsockoptInt(l.sockFd, syscall.SOL_SOCKET, BPFSocketAttach, prog.FD()); err != nil {
-		return fmt.Errorf("failed to attach BPF program: %w", err)
-	}
-
-	t.attachments[key] = l
-
-	go t.listen(key, l.perfRd, eventCallback)
-
-	return nil
-}
-
-func (t *Tracer) listen(
-	key string,
-	rd *perf.Reader,
-	eventCallback func(types.Event),
-) {
-	for {
-		record, err := rd.Read()
-		if err != nil {
-			if errors.Is(err, perf.ErrClosed) {
-				return
-			}
-			msg := fmt.Sprintf("Error reading perf ring buffer (%s): %s", key, err)
-			eventCallback(types.Base(eventtypes.Err(msg)))
-			return
-		}
-
-		if record.LostSamples != 0 {
-			msg := fmt.Sprintf("lost %d samples (%s)", record.LostSamples, key)
-			eventCallback(types.Base(eventtypes.Warn(msg)))
-			continue
-		}
-
-		sample := record.RawSample
-		if len(sample) > TLSMaxServerNameLen {
-			sample = sample[:TLSMaxServerNameLen]
-		}
-
-		name := gadgets.FromCString(sample)
-		if len(name) > 0 {
-			event := types.Event{
-				Event: eventtypes.Event{
-					Type: eventtypes.NORMAL,
-				},
-				Name: name,
-			}
-			eventCallback(event)
-		}
-	}
-}
-
-func (t *Tracer) releaseLink(key string, l *link) {
-	l.perfRd.Close()
-	unix.Close(l.sockFd)
-	l.collection.Close()
-	delete(t.attachments, key)
-}
-
-func (t *Tracer) Detach(key string) error {
-	if l, ok := t.attachments[key]; ok {
-		l.users--
-		if l.users == 0 {
-			t.releaseLink(key, l)
-		}
-		return nil
-	} else {
-		return fmt.Errorf("key not attached: %q", key)
-	}
-}
-
-func (t *Tracer) Close() {
-	for key, l := range t.attachments {
-		t.releaseLink(key, l)
-	}
+	return &event, nil
 }


### PR DESCRIPTION
# Reduce duplicated code in network tracers

This PR also moves the attachment key's management internally into the tracer itself to avoid callers generating a key that was always the network namespace (it can be computed internally from the PID).