### PR TITLE
ci: Do not push RC to krew.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -735,7 +735,8 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}
     - name: Update new version in krew-index
-      if: github.repository == 'inspektor-gadget/inspektor-gadget'
+      # We only update version in krew-index for effective release.
+      if: github.repository == 'inspektor-gadget/inspektor-gadget' && !endsWith(github.ref_name, 'rc')
       uses: rajatjindal/krew-release-bot@v0.0.43
       with:
         workdir: /home/runner/work/inspektor-gadget/inspektor-gadget


### PR DESCRIPTION
The goal of RC is to test the pipeline before pushing the effective release. As pushing to krew is at the end of the pipeline, the RC would already have tested everything.
This is a good idea to not push RC to krew to avoid noise for krew maintainers as PR containing RC will not be merged automatically.