### PR TITLE
integration/top/file: Sort descending by writes

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -703,7 +703,7 @@ func TestFiletop(t *testing.T) {
 
 	filetopCmd := &Command{
 		Name:         "StartFiletopGadget",
-		Cmd:          fmt.Sprintf("$KUBECTL_GADGET top file -n %s -o json", ns),
+		Cmd:          fmt.Sprintf("$KUBECTL_GADGET top file -n %s --sort \"-writes\" -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntry := &filetopTypes.Stats{


### PR DESCRIPTION
# integration/top/file: Sort descending by writes

Sometimes the CI test is failing. See https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3638611415/jobs/6141462636#step:8:539

## Problem 

Problem is that the default sorting for the `top file` gadget is that it prioritizes `-reads` before `-writes`.
Additionally the `top` gadgets have a default row amount of 20 + interval of 1 second.
`BusyboxPodRepeatCommand` repeats the command every 10th of a second.

Everything can sum up and we can miss our expected event.

## Solution

Sort by `-writes` should almost guarantee that we see our event.