### PR TITLE
ci: Add integration tests for Mariner 2

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -521,7 +521,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os-sku: [Ubuntu]
+        os-sku: [Ubuntu, Mariner]
         arch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v3
@@ -553,6 +553,12 @@ jobs:
           # 'p' means the node size corresponds to arm64 hardware.
           node_size='Standard_D2ps_v5'
         fi
+
+        # Enable the aks-preview extension to use Mariner as --os-sku.
+        # This should lead to AKS being deployed on top of Mariner 2.0.
+        # We do not upgrade az because there is a problem doing so in the
+        # GitHub Action.
+        az extension add --name aks-preview
 
         # Let's keep thing in the US to avoid data crossing the Atlantic as
         # GitHub data centers are in the US:

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -52,6 +52,7 @@ import (
 )
 
 const (
+	K8sDistroAKSMariner = "aks-Mariner"
 	K8sDistroAKSUbuntu  = "aks-Ubuntu"
 	K8sDistroARO        = "aro"
 	K8sDistroMinikubeGH = "minikube-github"
@@ -60,7 +61,7 @@ const (
 const securityProfileOperatorNamespace = "security-profiles-operator"
 
 var (
-	supportedK8sDistros = []string{K8sDistroAKSUbuntu, K8sDistroARO, K8sDistroMinikubeGH}
+	supportedK8sDistros = []string{K8sDistroAKSMariner, K8sDistroAKSUbuntu, K8sDistroARO, K8sDistroMinikubeGH}
 	cleaningUp          = uint32(0)
 )
 
@@ -643,7 +644,7 @@ func TestExecsnoop(t *testing.T) {
 	sleepArgs := []string{"/bin/sleep", "0.1"}
 	// on arm64, trace exec uses kprobe and it cannot trace the arguments:
 	// 243759db6b19 ("pkg/gadgets: Use kprobe for execsnoop on arm64.")
-	if *k8sDistro == K8sDistroAKSUbuntu && *k8sArch == "arm64" {
+	if *k8sArch == "arm64" {
 		shArgs = nil
 		dateArgs = nil
 		sleepArgs = nil


### PR DESCRIPTION
Hi.


In this PR, I added integration tests for Mariner 2.
The pipeline [passed successfully](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3640277087).


Best regards.