### PR TITLE
cmd/deploy: Add node-selector flag

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -37,8 +37,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	k8sversion "k8s.io/apimachinery/pkg/util/version"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -46,6 +48,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
@@ -75,6 +78,7 @@ var (
 	debug               bool
 	wait                bool
 	runtimesConfig      commonutils.RuntimesSocketPathConfig
+	nodeSelector        string
 )
 
 func init() {
@@ -131,6 +135,11 @@ func init() {
 		"debug", "d",
 		false,
 		"show extra debug information")
+	deployCmd.PersistentFlags().StringVarP(
+		&nodeSelector,
+		"node-selector", "",
+		"",
+		"node labels selector for the Inspektor Gadget DaemonSet")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -233,6 +242,81 @@ func createOrUpdateResource(client dynamic.Interface, mapper meta.RESTMapper, ob
 	return obj, nil
 }
 
+// Based on https://github.com/kubernetes/kubernetes/issues/98256#issue-790804261
+func operatorAsNodeSelectorOperator(sop selection.Operator) (v1.NodeSelectorOperator, error) {
+	switch sop {
+	case selection.DoesNotExist:
+		return v1.NodeSelectorOpDoesNotExist, nil
+	case selection.Equals, selection.DoubleEquals, selection.In:
+		return v1.NodeSelectorOpIn, nil
+	case selection.NotEquals, selection.NotIn:
+		return v1.NodeSelectorOpNotIn, nil
+	case selection.Exists:
+		return v1.NodeSelectorOpExists, nil
+	case selection.GreaterThan:
+		return v1.NodeSelectorOpGt, nil
+	case selection.LessThan:
+		return v1.NodeSelectorOpLt, nil
+	default:
+		return v1.NodeSelectorOpIn, fmt.Errorf("%q is not a valid node selector operator", sop)
+	}
+}
+
+func selectorAsNodeSelector(s string) (*v1.NodeSelector, error) {
+	selector, err := labels.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("parsing labels: %w", err)
+	}
+
+	nreqs := []v1.NodeSelectorRequirement{}
+	reqs, _ := selector.Requirements()
+	for _, req := range reqs {
+		operator, err := operatorAsNodeSelectorOperator(req.Operator())
+		if err != nil {
+			return nil, err
+		}
+		nreq := v1.NodeSelectorRequirement{
+			Key:      req.Key(),
+			Operator: operator,
+			Values:   req.Values().List(),
+		}
+		nreqs = append(nreqs, nreq)
+	}
+	nodeSelector := &v1.NodeSelector{
+		NodeSelectorTerms: []v1.NodeSelectorTerm{
+			{
+				MatchExpressions: nreqs,
+			},
+		},
+	}
+	return nodeSelector, nil
+}
+
+// createAffinity returns the affinity to be used for the DaemonSet.
+func createAffinity(client *kubernetes.Clientset) (*v1.Affinity, error) {
+	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		return nil, fmt.Errorf("no nodes found for labels: %q", nodeSelector)
+	}
+
+	nodeSelector, err := selectorAsNodeSelector(nodeSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	affinity := &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: nodeSelector,
+		},
+	}
+
+	return affinity, nil
+}
+
 func runDeploy(cmd *cobra.Command, args []string) error {
 	if hookMode != "auto" &&
 		hookMode != "crio" &&
@@ -330,6 +414,14 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				case utils.GadgetEnvironmentDockerSocketpath:
 					gadgetContainer.Env[i].Value = runtimesConfig.Docker
 				}
+			}
+
+			if nodeSelector != "" {
+				affinity, err := createAffinity(k8sClient)
+				if err != nil {
+					return fmt.Errorf("creating affinity: %w", err)
+				}
+				daemonSet.Spec.Template.Spec.Affinity = affinity
 			}
 
 			// Get gadget daemon set (if any) to check if it was modified

--- a/docs/install.md
+++ b/docs/install.md
@@ -87,6 +87,23 @@ If you wish to install an alternative gadget image, you could use the following 
 $ kubectl gadget deploy --image=ghcr.io/myfork/inspektor-gadget:tag
 ```
 
+### Deploy to specific nodes
+
+The `--node-selector` flag accepts a [label
+selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
+that defines the nodes where Inspektor Gadget will be deloyed to:
+
+```bash
+# Deploy only to the minikube-m02 node
+$ kubectl gadget deploy --node-selector kubernetes.io/hostname=minikube-m02
+
+# Deploy to all nodes but minikube
+$ kubectl gadget deploy --node-selector kubernetes.io/hostname!=minikube
+
+# Deploy to minikube and minikube-m03 nodes only
+$ kubectl gadget deploy --node-selector 'kubernetes.io/hostname in (minikube, minikube-m03)'
+```
+
 ### Hook Mode
 
 Inspektor Gadget needs to detect when containers are started and stopped.


### PR DESCRIPTION
    Currently Inspektor Gadget is deployed to all nodes in the cluster. In
    some conditions we don't want to deploy it to all nodes, for instance
    when there're some nodes that are not compatible with it.
    
    This commit introduces a new "--node-selector" flag to the kubectl
    gadget deploy command. This allows the user to set the nodes to
    deploy / no deploy based on labels.


--- 

While checking old issues in the repo I found https://github.com/inspektor-gadget/inspektor-gadget/issues/168 and https://github.com/inspektor-gadget/inspektor-gadget/issues/125. IMO it's a valid use case to allow users to select the nodes that they want to deploy Inspektor Gadget to. 

## How to test it:

```bash
# Create a minikube cluster with 3 nodes:
$  minikube start --nodes=3

# deploy Inspektor Gadget in different ways using the node-selector flag and check the nodes where it was deployed too
$ ./kubectl-gadget deploy --node-selector kubernetes.io/hostname=minikube-m02

$ kubectl -n gadget get pods -o wide 
NAME           READY   STATUS    RESTARTS   AGE   IP             NODE           NOMINATED NODE   READINESS GATES
gadget-6zkhx   1/1     Running   0          5s    192.168.58.4   minikube-m03   <none>           <none>
gadget-g5vkb   1/1     Running   0          5s    192.168.58.2   minikube       <none>           <none

# undeploy 

$ ./kubectl-gadget deploy --node-selector kubernetes.io/hostname=minikube-m03

$ kubectl -n gadget get pods -o wide 
NAME           READY   STATUS    RESTARTS   AGE   IP             NODE           NOMINATED NODE   READINESS GATES
gadget-tgplg   1/1     Running   0          13s   192.168.58.4   minikube-m03   <none>           <none>

$ ./kubectl-gadget deploy --node-selector 'kubernetes.io/hostname in (minikube, minikube-m03)'

$ kubectl get pods -n gadget -o wide 
NAME           READY   STATUS    RESTARTS   AGE   IP             NODE           NOMINATED NODE   READINESS GATES
gadget-fp9lb   1/1     Running   0          22s   192.168.58.4   minikube-m03   <none>           <none>
gadget-zlvfb   1/1     Running   0          22s   192.168.58.2   minikube       <none>           <none>

# try many different combinations...


# if the labels don't match any node, an error is printed
$ ./kubectl-gadget deploy --node-selector kubernetes.io/hostname=non-existing-node
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Error: creating affinity: no nodes found for labels: "kubernetes.io/hostname=non-existing-node"
```
