### PR TITLE
gadgets/profile: Fix bad stop logic

### DIFF
--- a/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/block-io/gadget.go
@@ -19,13 +19,11 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/profile"
-
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/tracer"
 	standardtracer "github.com/inspektor-gadget/inspektor-gadget/pkg/standardgadgets/profile/block-io"
-
-	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 )
 
 type Trace struct {
@@ -115,7 +113,6 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 
 	trace.Status.Output = ""
 	trace.Status.State = gadgetv1alpha1.TraceStateStarted
-	return
 }
 
 func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
@@ -124,16 +121,17 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
+	defer func() {
+		t.started = false
+		t.tracer = nil
+	}()
+
 	output, err := t.tracer.Stop()
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return
 	}
 
-	t.tracer = nil
-	t.started = false
-
 	trace.Status.Output = output
 	trace.Status.State = gadgetv1alpha1.TraceStateCompleted
-	return
 }

--- a/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
@@ -19,14 +19,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/profile"
-
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/tracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/types"
 	standardtracer "github.com/inspektor-gadget/inspektor-gadget/pkg/standardgadgets/profile/cpu"
-
-	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 )
 
 type Trace struct {
@@ -134,14 +132,16 @@ func (t *Trace) Stop(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
+	defer func() {
+		t.started = false
+		t.tracer = nil
+	}()
+
 	output, err := t.tracer.Stop()
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return
 	}
-
-	t.tracer = nil
-	t.started = false
 
 	trace.Status.Output = output
 	trace.Status.State = gadgetv1alpha1.TraceStateCompleted


### PR DESCRIPTION
If there is an error calling tracer.Stop(), t.started will continue to be always true, and further calls to Stop() will fail, hence the tracer will enter a non recoverable state. This commit sets t.started to false on Stop() whether there is an error or not. After this, the error could be recovered by calling Start() again.

## How to test 

The original issue was described in  https://github.com/inspektor-gadget/inspektor-gadget/issues/305, at that time there was not a CO-RE implementation of the profile block-io gadget, anyway, it's not only related to the standard tracer and can also be emulated with the CO-RE one. In order to simulate an error, we can apply the following:

```diff
diff --git pkg/gadgets/profile/block-io/tracer/tracer.go pkg/gadgets/profile/block-io/tracer/tracer.go
index 3fcd2df9..b889391c 100644
--- pkg/gadgets/profile/block-io/tracer/tracer.go
+++ pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -19,6 +19,7 @@ package tracer

 import (
        "encoding/json"
+       "errors"
        "fmt"
        "unsafe"

@@ -87,6 +88,8 @@ func getReport(histMap *ebpf.Map) (types.Report, error) {
        return report, nil
 }

+var i int
+
 func (t *Tracer) Stop() (string, error) {
        t.blockRqCompleteLink = gadgets.CloseLink(t.blockRqCompleteLink)
        t.blockRqInsertLink = gadgets.CloseLink(t.blockRqInsertLink)
@@ -94,6 +97,12 @@ func (t *Tracer) Stop() (string, error) {

        defer t.objs.Close()

+       // fake an error the first time this function is executed
+       if i == 0 {
+               i++
+               return "", errors.New("fake error")
+       }
+
        if t.objs.Hists == nil {
                return "", nil
        }
```

### Test without this fix 

```bash
# Create the trace (be sure the node matches your environment)
$ kubectl apply -f pkg/resources/samples/trace-biolatency.yaml
trace.gadget.kinvolk.io/biolatency created

# start the tracer
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=start
trace.gadget.kinvolk.io/biolatency annotated

# wait a bit (1 second is enough) before stopping 
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=stop
trace.gadget.kinvolk.io/biolatency annotated

# print the status of the trace 
$ kubectl -n gadget get trace -o=jsonpath='{.items[0].status}' | jq
{
  "operationError": "fake error",
  "state": "Started"
}

# try to start and stop again 
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=start
trace.gadget.kinvolk.io/biolatency annotated

# wait a bit here 
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=stop
trace.gadget.kinvolk.io/biolatency annotated

# a different error is shown but it doesn't work anyway
$ kubectl -n gadget get trace -o=jsonpath='{.items[0].status}' | jq
{
  "operationError": "error getting next key: next key: bad file descriptor",
  "state": "Started"
}
```


### Test with this fix 

```bash
# Create trace 
$ kubectl apply -f pkg/resources/samples/trace-biolatency.yaml
trace.gadget.kinvolk.io/biolatency created

# start and stop as above 
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=start
trace.gadget.kinvolk.io/biolatency annotated
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=stop
trace.gadget.kinvolk.io/biolatency annotated

# simulated error happened here
$ kubectl -n gadget get trace -o=jsonpath='{.items[0].status}' | jq
{
  "operationError": "fake error",
  "state": "Started"
}

# start and stop again 
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=start
trace.gadget.kinvolk.io/biolatency annotated
$ kubectl -n gadget annotate trace biolatency gadget.kinvolk.io/operation=stop
trace.gadget.kinvolk.io/biolatency annotated

# this time it works
$ kubectl -n gadget get trace -o=jsonpath='{.items[0].status}' | jq
{
  "output": "{\"valType\":\"usecs\",\"data\":[{\"count\":0,\"intervalStart\":1,\"intervalEnd\":1},{\"count\":0,\"intervalStart\":2,\"intervalEnd\":3},{\"count\":0,\"intervalStart\":4,\"intervalEnd\":7},{\"count\":0,\"intervalStart\":8,\"intervalEnd\":15},{\"count\":1,\"intervalStart\":16,\"intervalEnd\":31},{\"count\":13,\"intervalStart\":32,\"intervalEnd\":63},{\"count\":61,\"intervalStart\":64,\"intervalEnd\":127}]}",
  "state": "Completed"
}
```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/305