### PR TITLE
treewide: Replace pcomm by comm.

### DIFF
--- a/cmd/kubectl-gadget/utils/post-process_test.go
+++ b/cmd/kubectl-gadget/utils/post-process_test.go
@@ -39,11 +39,11 @@ func TestPostProcessFirstLineOutStream(t *testing.T) {
 		SkipFirstLine: true,
 	})
 
-	postProcess.OutStreams[0].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
-	postProcess.OutStreams[1].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[0].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[1].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
 
 	expected := `
-PCOMM  PID    PPID   RET ARGS
+COMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -83,11 +83,11 @@ func TestPostProcessMultipleLines(t *testing.T) {
 		SkipFirstLine: true,
 	})
 
-	postProcess.OutStreams[0].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[0].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
 
 	postProcess.OutStreams[0].Write([]byte("wget   "))
 	expected = `
-PCOMM  PID    PPID   RET ARGS
+COMM  PID    PPID   RET ARGS
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)
@@ -96,7 +96,7 @@ PCOMM  PID    PPID   RET ARGS
 	postProcess.OutStreams[0].Write([]byte("200000 200000   0 /usr/bin/wget\n"))
 
 	expected = `
-PCOMM  PID    PPID   RET ARGS
+COMM  PID    PPID   RET ARGS
 wget   200000 200000   0 /usr/bin/wget
 `
 	if "\n"+string(mock.output) != expected {
@@ -113,11 +113,11 @@ func TestMultipleNodes(t *testing.T) {
 		SkipFirstLine: true,
 	})
 
-	postProcess.OutStreams[0].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[0].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
 	postProcess.OutStreams[0].Write([]byte("curl   100000 100000   0 /usr/bin/curl\n"))
 
-	postProcess.OutStreams[1].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
-	postProcess.OutStreams[2].Write([]byte("PCOMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[1].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
+	postProcess.OutStreams[2].Write([]byte("COMM  PID    PPID   RET ARGS\n"))
 
 	postProcess.OutStreams[2].Write([]byte("mkdir  "))
 
@@ -128,7 +128,7 @@ func TestMultipleNodes(t *testing.T) {
 	postProcess.OutStreams[2].Write([]byte("0 /usr/bin/mkdir /tmp/install.sh.10\n"))
 
 	expected := `
-PCOMM  PID    PPID   RET ARGS
+COMM  PID    PPID   RET ARGS
 curl   100000 100000   0 /usr/bin/curl
 wget   200000 200000   0 /usr/bin/wget
 mkdir  199679 199678   0 /usr/bin/mkdir /tmp/install.sh.10
@@ -148,27 +148,27 @@ func TestSkipFirstLineFalse(t *testing.T) {
 		SkipFirstLine: false,
 	})
 
-	postProcess.OutStreams[0].Write([]byte(`{"pcomm": "cat", "pid": 11}` + "\n"))
-	postProcess.OutStreams[0].Write([]byte(`{"pcomm": "ping", "pid": 22}` + "\n"))
+	postProcess.OutStreams[0].Write([]byte(`{"comm": "cat", "pid": 11}` + "\n"))
+	postProcess.OutStreams[0].Write([]byte(`{"comm": "ping", "pid": 22}` + "\n"))
 
-	postProcess.OutStreams[0].Write([]byte(`{"pcomm": "curl", "pid": 33}` + "\n"))
-	postProcess.OutStreams[0].Write([]byte(`{"pcomm": "nc", "pid": 44}` + "\n"))
+	postProcess.OutStreams[0].Write([]byte(`{"comm": "curl", "pid": 33}` + "\n"))
+	postProcess.OutStreams[0].Write([]byte(`{"comm": "nc", "pid": 44}` + "\n"))
 
 	// this prints json in different lines
-	postProcess.OutStreams[2].Write([]byte(`{"pcomm": "rm"`))
+	postProcess.OutStreams[2].Write([]byte(`{"comm": "rm"`))
 
-	postProcess.OutStreams[1].Write([]byte(`{"pcomm": "sleep", "pid": 55}` + "\n"))
+	postProcess.OutStreams[1].Write([]byte(`{"comm": "sleep", "pid": 55}` + "\n"))
 
 	postProcess.OutStreams[2].Write([]byte(` , "pid": 77}` + "\n"))
 
 	// first line is not skipped and incompleted ones are assembled together
 	expected := `
-{"pcomm": "cat", "pid": 11}
-{"pcomm": "ping", "pid": 22}
-{"pcomm": "curl", "pid": 33}
-{"pcomm": "nc", "pid": 44}
-{"pcomm": "sleep", "pid": 55}
-{"pcomm": "rm" , "pid": 77}
+{"comm": "cat", "pid": 11}
+{"comm": "ping", "pid": 22}
+{"comm": "curl", "pid": 33}
+{"comm": "nc", "pid": 44}
+{"comm": "sleep", "pid": 55}
+{"comm": "rm" , "pid": 77}
 `
 	if "\n"+string(mock.output) != expected {
 		t.Fatalf("%v != %v", string(mock.output), expected)

--- a/docs/guides/trace/exec.md
+++ b/docs/guides/trace/exec.md
@@ -30,26 +30,26 @@ ip-10-0-30-247 where myapp1-pod-2gs5r and myapp2-pod-mqfxv are running:
 
 ```bash
 $ kubectl gadget trace exec --selector role=demo --node ip-10-0-30-247
-NODE                NAMESPACE        POD              CONTAINER       PID     PPID    PCOMM            RET ARGS
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728770  728166  date               0 /bin/date
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728771  728166  cat                0 /bin/cat /proc/version
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728772  728166  sleep              0 /bin/sleep 1
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728802  728166  true               0 /bin/true
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728803  728166  date               0 /bin/date
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728804  728166  cat                0 /bin/cat /proc/version
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728805  728166  sleep              0 /bin/sleep 1
-ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728832  728052  true               0 /bin/true
-ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728833  728052  date               0 /bin/date
-ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728834  728052  echo               0 /bin/echo sleep-10
-ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728835  728052  sleep              0 /bin/sleep 10
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728836  728166  true               0 /bin/true
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728837  728166  date               0 /bin/date
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728838  728166  cat                0 /bin/cat /proc/version
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728839  728166  sleep              0 /bin/sleep 1
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728880  728166  true               0 /bin/true
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728881  728166  date               0 /bin/date
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728882  728166  cat                0 /bin/cat /proc/version
-ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728883  728166  sleep              0 /bin/sleep 1
+NODE                NAMESPACE        POD              CONTAINER       PID     PPID    COMM            RET ARGS
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728770  728166  date              0 /bin/date
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728771  728166  cat               0 /bin/cat /proc/version
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728772  728166  sleep             0 /bin/sleep 1
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728802  728166  true              0 /bin/true
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728803  728166  date              0 /bin/date
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728804  728166  cat               0 /bin/cat /proc/version
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728805  728166  sleep             0 /bin/sleep 1
+ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728832  728052  true              0 /bin/true
+ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728833  728052  date              0 /bin/date
+ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728834  728052  echo              0 /bin/echo sleep-10
+ip-10-0-30-247      default          myapp2-pod-mqfxv myapp2-pod      728835  728052  sleep             0 /bin/sleep 10
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728836  728166  true              0 /bin/true
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728837  728166  date              0 /bin/date
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728838  728166  cat               0 /bin/cat /proc/version
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728839  728166  sleep             0 /bin/sleep 1
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728880  728166  true              0 /bin/true
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728881  728166  date              0 /bin/date
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728882  728166  cat               0 /bin/cat /proc/version
+ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728883  728166  sleep             0 /bin/sleep 1
 ^C
 Terminating...
 ```

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -231,21 +231,21 @@ This is the output when executing this gadget on a Kubernetes node:
 
 ```bash
 $ sudo local-gadget trace exec
-CONTAINER        PID     PPID    PCOMM            RET  ARGS
-calico-node      416789  416777  calico-node      0    /bin/calico-node -felix-live -bird-live
-calico-node      416804  416789  sv               0    /usr/local/bin/sv status /etc/service/enabled/confd
-calico-node      416805  416789  sv               0    /usr/local/bin/sv status /etc/service/enabled/bird
-gadget           416816  416806  gadgettracerman  0    /bin/gadgettracermanager -liveness
-gadget           416842  416823  gadgettracerman  0    /bin/gadgettracermanager -liveness
-calico-node      416887  416876  calico-node      0    /bin/calico-node -felix-ready -bird-ready
+CONTAINER        PID     PPID    COMM            RET  ARGS
+calico-node      416789  416777  calico-node     0    /bin/calico-node -felix-live -bird-live
+calico-node      416804  416789  sv              0    /usr/local/bin/sv status /etc/service/enabled/confd
+calico-node      416805  416789  sv              0    /usr/local/bin/sv status /etc/service/enabled/bird
+gadget           416816  416806  gadgettracerman 0    /bin/gadgettracermanager -liveness
+gadget           416842  416823  gadgettracerman 0    /bin/gadgettracermanager -liveness
+calico-node      416887  416876  calico-node     0    /bin/calico-node -felix-ready -bird-ready
 ```
 
 Remember that we can use the `-o custom-columns` flag to show only the columns
 we are interested in:
 
 ```bash
-$ sudo local-gadget trace exec -o custom-columns=container,pid,pcomm
-CONTAINER        PID     PCOMM
+$ sudo local-gadget trace exec -o custom-columns=container,pid,comm
+CONTAINER        PID     COMM
 calico-node      421023  ipset
 calico-node      421039  calico-node
 calico-node      421056  sv

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -26,7 +26,7 @@ type Event struct {
 
 	Pid       uint32   `json:"pid,omitempty" column:"pid,template:pid"`
 	Ppid      uint32   `json:"ppid,omitempty" column:"ppid,template:pid"`
-	Comm      string   `json:"pcomm,omitempty" column:"comm,template:comm"`
+	Comm      string   `json:"comm,omitempty" column:"comm,template:comm"`
 	Retval    int      `json:"ret,omitempty" column:"ret,width:3,fixed"`
 	Args      []string `json:"args,omitempty" column:"args,width:40"`
 	UID       uint32   `json:"uid,omitempty" column:"uid,minWidth:10,hide"`

--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -25,7 +25,7 @@ type Event struct {
 	MountNsID uint64 `json:"mountnsid,omitempty" column:"mntns,width:12,hide"`
 	Pid       uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
 	UID       uint32 `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
-	Comm      string `json:"pcomm,omitempty" column:"comm,maxWidth:16"`
+	Comm      string `json:"comm,omitempty" column:"comm,maxWidth:16"`
 	Fd        int    `json:"fd,omitempty" column:"fd,minWidth:2,width:3"`
 	Ret       int    `json:"ret,omitempty" column:"ret,width:3,fixed,hide"`
 	Err       int    `json:"err,omitempty" column:"err,width:3,fixed"`


### PR DESCRIPTION
Hi.


In this PR, I replaced all occurrences of `pcomm`/`PCOMM` by `comm`/`COMM`.
This fixes #1038.


Best regards.