### PR TITLE
tools: Fix git status regular expression.

### DIFF
--- a/tools/image-tag
+++ b/tools/image-tag
@@ -12,13 +12,12 @@ if [ -n "$IMAGE_TAG" ]; then
   exit 0
 fi
 
-WORKING_SUFFIX=$(if git status --porcelain | grep -qE '^(?:[^?][^ ]|[^ ][^?])\s'; then echo "-WIP"; else echo ""; fi)
 BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
 if [ "$1" = "branch" ] ; then
   if [ "$BRANCH_PREFIX" = "main" ] ; then
     BRANCH_PREFIX="latest"
   fi
-  echo "${BRANCH_PREFIX//\//-}$WORKING_SUFFIX"
+  echo "${BRANCH_PREFIX//\//-}"
 else
-  echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)$WORKING_SUFFIX"
+  echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)"
 fi


### PR DESCRIPTION
In tools/image-tag, the output of git status --porcelain is analyzed to determine if we should append "-WIP" to the image tag. Sadly, grep 3.8 prints a warning message when running this regular expression [1, 2].

This commit simplifies and fixes the existing regex. Indeed, the previous regex was wrong as it tries to use non capturing group ('?:' operator), which are not available in grep with the extended regex engine. As a consequence, the colon was treated as a character but this character is never printed by git status --porcelain.
Then, the left part of the or operator (i.e. ?:[^?][^ ]) was always wrong and only the right one could be right ([^ ][^?]).
So, this commit simplifies the regex by only applying the previous right part on git status --porcelain output.

[1] https://git.savannah.gnu.org/cgit/grep.git/commit/?h=v3.8&id=154661743525 [2] https://github.com/inspektor-gadget/inspektor-gadget/issues/1192#issue-1487457701