### PR TITLE
pkg/gadgettracermanager: Add OCI enricher to IG

### DIFF
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -256,6 +256,7 @@ func NewServer(conf *Conf) (*GadgetTracerManager, error) {
 		containercollection.WithNodeName(conf.NodeName),
 	}
 	if !conf.TestOnly {
+		opts = append(opts, containercollection.WithOCIConfigEnrichment())
 		opts = append(opts, containercollection.WithCgroupEnrichment())
 		opts = append(opts, containercollection.WithLinuxNamespaceEnrichment())
 		opts = append(opts, containercollection.WithKubernetesEnrichment(g.nodeName, nil))


### PR DESCRIPTION
Add the OCI enrichment to `inspektor-gadget`. The root cause of why `KubernetesEnrichment`/`RuncFanotify` weren't working for cri-o containers was fixed [by ensuring a unique key is used for every cri-o container](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/runcfanotify/runcfanotify.go#L461). So this is just an improvement to use OCI annotations for metadata once available. 

Fixes #1142 

### Testing done
Build IG with following patch to ensure `KubernetesEnrichment` isn't used:

```
diff --git a/pkg/gadgettracermanager/gadgettracermanager.go b/pkg/gadgettracermanager/gadgettracermanager.go
index 4f46975a..9f11a435 100644
--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -259,7 +259,7 @@ func NewServer(conf *Conf) (*GadgetTracerManager, error) {
 		opts = append(opts, containercollection.WithOCIConfigEnrichment())
 		opts = append(opts, containercollection.WithCgroupEnrichment())
 		opts = append(opts, containercollection.WithLinuxNamespaceEnrichment())
-		opts = append(opts, containercollection.WithKubernetesEnrichment(g.nodeName, nil))
+		//opts = append(opts, containercollection.WithKubernetesEnrichment(g.nodeName, nil))
 	}
 
 	podInformerUsed := false

```

Seems like `cri-o` with `minikube image load` doesn't work well so I pushed changes to the [fork](https://github.com/mqasimsarfraz/inspektor-gadget/commit/33ebb54fc774410f197cea51b9c758b1fa0c4cb2) for testing.  

Traces e.g tracing open syscalls should still work as expected:

```
minikube start --container-runtime cri-o --driver kvm2
./kubectl-gadget deploy --fallback-podinformer=false --hook-mode fanotify --image ghcr.io/mqasimsarfraz/inspektor-gadget:latest
./kubectl-gadget trace open
kubectl run --restart=Never -ti --image=busybox mypod -- sh -c 'while /bin/true ; do whoami ; sleep 3 ; done'
```