### PR TITLE
gadgets/snapshot/process: Rename columns to match user space

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -63,7 +63,7 @@ func (p *ProcessParser) SortEvents(allProcesses *[]*types.Event) {
 	if !p.flags.showThreads {
 		allProcessesTrimmed := []*types.Event{}
 		for _, i := range *allProcesses {
-			if i.Tgid == i.Pid {
+			if i.Tid == i.Pid {
 				allProcessesTrimmed = append(allProcessesTrimmed, i)
 			}
 		}

--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -35,6 +35,11 @@ type ProcessParser struct {
 }
 
 func newProcessParser(outputConfig *commonutils.OutputConfig, flags *ProcessFlags, cols *columns.Columns[types.Event], options ...commonutils.Option) (SnapshotParser[types.Event], error) {
+	if flags.showThreads {
+		col, _ := cols.GetColumn("tid")
+		col.Visible = true
+	}
+
 	gadgetParser, err := commonutils.NewGadgetParser(outputConfig, cols, options...)
 	if err != nil {
 		return nil, commonutils.WrapInErrParserCreate(err)

--- a/docs/local-gadget.md
+++ b/docs/local-gadget.md
@@ -190,7 +190,7 @@ And, show the all threads using the `-t` flag:
 
 ```bash
 $ sudo local-gadget snapshot process --containername gadget -t
-CONTAINER    COMM               TGID     PID
+CONTAINER    COMM               PID      TID
 gadget       gadgettracerman    39645    39645
 gadget       gadgettracerman    39645    39668
 gadget       gadgettracerman    39645    39669

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -1137,8 +1137,8 @@ func TestProcessCollector(t *testing.T) {
 
 				normalize := func(e *processCollectorTypes.Event) {
 					e.Node = ""
-					e.Tgid = 0
 					e.Pid = 0
+					e.Tid = 0
 					e.MountNsID = 0
 				}
 

--- a/integration/local-gadget/snapshot_process_test.go
+++ b/integration/local-gadget/snapshot_process_test.go
@@ -40,8 +40,8 @@ func TestSnapshotProcess(t *testing.T) {
 			normalize := func(e *types.Event) {
 				e.Node = ""
 				e.Container = ""
-				e.Tgid = 0
 				e.Pid = 0
+				e.Tid = 0
 				e.MountNsID = 0
 			}
 

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -101,8 +101,8 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]*process
 			Event: eventtypes.Event{
 				Type: eventtypes.NORMAL,
 			},
-			Tgid:      tgid,
-			Pid:       pid,
+			Pid:       tgid,
+			Tid:       pid,
 			Command:   command,
 			MountNsID: mntnsid,
 		}

--- a/pkg/gadgets/snapshot/process/types/process-collector.go
+++ b/pkg/gadgets/snapshot/process/types/process-collector.go
@@ -23,8 +23,8 @@ type Event struct {
 	eventtypes.Event
 
 	Command   string `json:"comm" column:"comm,template:comm"`
-	Tgid      int    `json:"tgid" column:"tgid,template:pid,hide"`
 	Pid       int    `json:"pid" column:"pid,template:pid"`
+	Tid       int    `json:"tid" column:"tid,template:pid,hide"`
 	MountNsID uint64 `json:"mntns" column:"mntns,template:ns"`
 }
 


### PR DESCRIPTION
    The naming around process / thread / task in kernel and user space
    is different and it's very confusing. In the kernel, each thread has an
    ID, called PID, and also has a TGID (Task Group ID) that is the PID of
    the first thread in the group. From user space we have PID
    (Process Identifier), that matches TGID on the kernel, and TID
    (Thread ID), that matches PID on the kernel.
    
    In summary[0]:
    
    User  | Kernel
    ------+-------
    PID   | TGID
    TID   | PID
    
    Then, TGID is a kernel concept and we shouldn't show this to the user,
    hence this commit uses PID and TID on the snapshot process gadget.
