### PR TITLE
gadgets/snapshot/process: Add support for older kernels

### DIFF
--- a/cmd/local-gadget/snapshot/process.go
+++ b/cmd/local-gadget/snapshot/process.go
@@ -48,8 +48,10 @@ func newProcessCmd() *cobra.Command {
 					return nil, commonutils.WrapInErrManagerCreateMountNsMap(err)
 				}
 				defer localGadgetManager.RemoveMountNsMap()
-
-				return processTracer.RunCollector(&localGadgetManager.ContainerCollection, mountnsmap)
+				config := &processTracer.Config{
+					MountnsMap: mountnsmap,
+				}
+				return processTracer.RunCollector(config, &localGadgetManager.ContainerCollection)
 			},
 		}
 

--- a/examples/gadgets/basic/snapshot/process/process.go
+++ b/examples/gadgets/basic/snapshot/process/process.go
@@ -29,7 +29,7 @@ func main() {
 		return
 	}
 
-	processes, err := tracer.RunCollector(nil, nil)
+	processes, err := tracer.RunCollector(&tracer.Config{}, nil)
 	if err != nil {
 		fmt.Printf("error running collector: %s\n", err)
 		return

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -1110,14 +1110,6 @@ func TestNetworkGraph(t *testing.T) {
 }
 
 func TestProcessCollector(t *testing.T) {
-	if *k8sDistro == K8sDistroARO {
-		t.Skip("Skip running process-collector gadget on ARO: iterators are not supported on kernel 4.18.0-305.19.1.el8_4.x86_64")
-	}
-
-	if *k8sDistro == K8sDistroAKSUbuntu && *k8sArch == "amd64" {
-		t.Skip("Skip running process-collector gadget on AKS Ubuntu amd64: iterators are not supported on kernel 5.4.0-1089-azure")
-	}
-
 	ns := GenerateTestNamespaceName("test-process-collector")
 
 	t.Parallel()

--- a/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/process/gadget.go
@@ -71,7 +71,10 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 		trace.Status.OperationError = fmt.Sprintf("failed to find tracer's mount ns map: %s", err)
 		return
 	}
-	events, err := tracer.RunCollector(t.helpers, mountNsMap)
+	config := &tracer.Config{
+		MountnsMap: mountNsMap,
+	}
+	events, err := tracer.RunCollector(config, t.helpers)
 	if err != nil {
 		trace.Status.OperationError = err.Error()
 		return

--- a/pkg/gadgets/internal/test/helpers.go
+++ b/pkg/gadgets/internal/test/helpers.go
@@ -29,7 +29,7 @@ import (
 
 // CreateMntNsFilterMap creates and fills an eBPF map that can be used
 // to filter by mount namespace in the different tracers.
-func CreateMntNsFilterMap(t *testing.T, mountNsIDs ...uint64) *ebpf.Map {
+func CreateMntNsFilterMap(t testing.TB, mountNsIDs ...uint64) *ebpf.Map {
 	t.Helper()
 
 	const one = uint32(1)
@@ -58,7 +58,7 @@ func CreateMntNsFilterMap(t *testing.T, mountNsIDs ...uint64) *ebpf.Map {
 }
 
 // RequireRoot skips the test if the not running as root
-func RequireRoot(t *testing.T) {
+func RequireRoot(t testing.TB) {
 	t.Helper()
 
 	if unix.Getuid() != 0 {
@@ -66,7 +66,7 @@ func RequireRoot(t *testing.T) {
 	}
 }
 
-func RequireKernelVersion(t *testing.T, expectedVersion *kernel.VersionInfo) {
+func RequireKernelVersion(t testing.TB, expectedVersion *kernel.VersionInfo) {
 	version, err := kernel.GetKernelVersion()
 	if err != nil {
 		t.Fatalf("Failed to get kernel version: %s", err)
@@ -133,7 +133,7 @@ func ExpectOneEvent[Event any, Extra any](getEvent func(info *RunnerInfo, extra 
 		expectedEvent := getEvent(info, extra)
 
 		if len(events) != 1 {
-			t.Fatalf("More than one event found")
+			t.Fatalf("One event expected, found: %d", len(events))
 		}
 
 		if !reflect.DeepEqual(expectedEvent, &events[0]) {

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -16,12 +16,18 @@ package tracer
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	processcollectortypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -33,7 +39,31 @@ type Config struct {
 	MountnsMap *ebpf.Map
 }
 
+var hostRoot string
+
+func init() {
+	hostRoot = os.Getenv("HOST_ROOT")
+}
+
 func RunCollector(config *Config, enricher gadgets.DataEnricher) ([]*processcollectortypes.Event, error) {
+	events, err := runeBPFCollector(config, enricher)
+	if err == nil {
+		return events, nil
+	}
+
+	if !errors.Is(err, ebpf.ErrNotSupported) {
+		return nil, fmt.Errorf("running ebpf iterator: %w", err)
+	}
+
+	events, err = runProcfsCollector(config, enricher)
+	if err != nil {
+		return nil, fmt.Errorf("running procfs collector: %w", err)
+	}
+
+	return events, err
+}
+
+func runeBPFCollector(config *Config, enricher gadgets.DataEnricher) ([]*processcollectortypes.Event, error) {
 	spec, err := loadProcessCollector()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load ebpf program: %w", err)
@@ -116,6 +146,94 @@ func RunCollector(config *Config, enricher gadgets.DataEnricher) ([]*processcoll
 		}
 
 		events = append(events, &event)
+	}
+
+	return events, nil
+}
+
+func getPidEvents(config *Config, enricher gadgets.DataEnricher, pid int) ([]*processcollectortypes.Event, error) {
+	var events []*processcollectortypes.Event
+	var val uint32
+
+	items, err := os.ReadDir(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/task/", pid)))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		if !item.IsDir() {
+			continue
+		}
+
+		tid64, err := strconv.ParseUint(item.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		tid := int(tid64)
+
+		commBytes, _ := ioutil.ReadFile(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/comm", tid)))
+		comm := strings.TrimRight(string(commBytes), "\n")
+		mntnsid, err := containerutils.GetMntNs(tid)
+		if err != nil {
+			continue
+		}
+
+		if config.MountnsMap != nil {
+			// TODO: This would be more efficient to store
+			// these elements in user space to avoid
+			// performing systemcalls to lookup in the eBPF
+			// map
+			err := config.MountnsMap.Lookup(&mntnsid, &val)
+			if err != nil {
+				continue
+			}
+		}
+
+		event := processcollectortypes.Event{
+			Event: eventtypes.Event{
+				Type: eventtypes.NORMAL,
+			},
+			Tid:       tid,
+			Pid:       pid,
+			Command:   comm,
+			MountNsID: mntnsid,
+		}
+
+		if enricher != nil {
+			enricher.Enrich(&event.CommonData, event.MountNsID)
+		}
+
+		events = append(events, &event)
+	}
+
+	return events, nil
+}
+
+func runProcfsCollector(config *Config, enricher gadgets.DataEnricher) ([]*processcollectortypes.Event, error) {
+	items, err := os.ReadDir(filepath.Join(hostRoot, "/proc/"))
+	if err != nil {
+		return nil, err
+	}
+
+	var events []*processcollectortypes.Event
+
+	for _, item := range items {
+		if !item.IsDir() {
+			continue
+		}
+
+		pid64, err := strconv.ParseUint(item.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		pid := int(pid64)
+
+		pidEvents, err := getPidEvents(config, enricher, pid)
+		if err != nil {
+			continue
+		}
+
+		events = append(events, pidEvents...)
 	}
 
 	return events, nil

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -29,7 +29,11 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang processCollector ./bpf/process-collector.bpf.c -- -I../../../../${TARGET} -Werror -O2 -g -c -x c
 
-func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]*processcollectortypes.Event, error) {
+type Config struct {
+	MountnsMap *ebpf.Map
+}
+
+func RunCollector(config *Config, enricher gadgets.DataEnricher) ([]*processcollectortypes.Event, error) {
 	spec, err := loadProcessCollector()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load ebpf program: %w", err)
@@ -38,9 +42,9 @@ func RunCollector(enricher gadgets.DataEnricher, mntnsmap *ebpf.Map) ([]*process
 	mapReplacements := map[string]*ebpf.Map{}
 	filterByMntNs := false
 
-	if mntnsmap != nil {
+	if config.MountnsMap != nil {
 		filterByMntNs = true
-		mapReplacements["mount_ns_filter"] = mntnsmap
+		mapReplacements["mount_ns_filter"] = config.MountnsMap
 	}
 
 	consts := map[string]interface{}{

--- a/pkg/gadgets/snapshot/process/tracer/tracer_test.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/test"
+	processcollectortypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
+)
+
+type collectorFunc func(config *Config, enricher gadgets.DataEnricher) ([]*processcollectortypes.Event, error)
+
+func BenchmarkEBPFTracer(b *testing.B) {
+	benchmarkTracer(b, runeBPFCollector)
+}
+
+func BenchmarkProcfsTracer(b *testing.B) {
+	benchmarkTracer(b, runProcfsCollector)
+}
+
+func benchmarkTracer(b *testing.B, runCollector collectorFunc) {
+	utilstest.RequireRoot(b)
+
+	for n := 0; n < b.N; n++ {
+		_, err := runCollector(&Config{}, nil)
+		if err != nil {
+			b.Fatalf("benchmarking collector: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
    Add a fallback mechanism that works on older kernels too. This reads
    the information about the processes from /proc/, even if this is slower
    than the eBPF-based implementation, it can be useful in cases that
    eBPF-iterators are not available.
    
    The following benchmark shows that the procfs-based implementation is
    ~30% slower than the ebpf-based one:
    
    ```
    $ go test -exec sudo -bench=. -benchtime=100x . -v
    [sudo] password for mvb:
    goos: linux
    goarch: amd64
    pkg: github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/tracer
    cpu: AMD Ryzen 7 3700X 8-Core Processor
    BenchmarkEBPFTracer
    BenchmarkEBPFTracer-16               100          21743119 ns/op
    BenchmarkProcfsTracer
    BenchmarkProcfsTracer-16             100          31169492 ns/op
    PASS
    ok      github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/tracer        8.340s
    ```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/843