### PR TITLE
integration: Build local-gadget-test in the same container as local-gadget

### DIFF
--- a/Dockerfiles/local-gadget-builder.Dockerfile
+++ b/Dockerfiles/local-gadget-builder.Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.18
+
+RUN \
+	dpkg --add-architecture arm64 && \
+	apt-get update && \
+	apt-get install -y gcc-aarch64-linux-gnu build-essential crossbuild-essential-arm64 && \
+	apt-get install -y libseccomp2       libseccomp-dev && \
+	apt-get install -y libseccomp2:arm64 libseccomp-dev:arm64
+
+ONBUILD COPY go.mod go.sum /cache/
+ONBUILD RUN cd /cache && go mod download
+ONBUILD ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget

--- a/Dockerfiles/local-gadget-tests.Dockerfile
+++ b/Dockerfiles/local-gadget-tests.Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/inspektor-gadget/local-gadget-builder:latest
+
+WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget/integration/local-gadget/k8s
+
+RUN go test -c -o local-gadget-integration.test ./...

--- a/Dockerfiles/local-gadget-tests.Dockerfile.dockerignore
+++ b/Dockerfiles/local-gadget-tests.Dockerfile.dockerignore
@@ -1,0 +1,7 @@
+*
+!go.mod
+!go.sum
+!pkg
+!integration
+!Makefile*
+!*.mk

--- a/Dockerfiles/local-gadget.Dockerfile
+++ b/Dockerfiles/local-gadget.Dockerfile
@@ -1,16 +1,5 @@
-FROM golang:1.18 AS builder
+FROM ghcr.io/inspektor-gadget/local-gadget-builder:latest
 
-RUN \
-	dpkg --add-architecture arm64 && \
-	apt-get update && \
-	apt-get install -y gcc-aarch64-linux-gnu build-essential crossbuild-essential-arm64 && \
-	apt-get install -y libseccomp2       libseccomp-dev && \
-	apt-get install -y libseccomp2:arm64 libseccomp-dev:arm64
-
-COPY go.mod go.sum /cache/
-RUN cd /cache && go mod download
-
-ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget
 WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget
 
 ARG GOOS=linux

--- a/integration/local-gadget/k8s/Makefile
+++ b/integration/local-gadget/k8s/Makefile
@@ -12,6 +12,11 @@ phony_explicit:
 build:
 	make -C $(shell pwd)/../../.. local-gadget
 
+.PHONY: build-tests
+build-tests:
+	docker buildx build -t local-gadget-tests -f ./../../../Dockerfiles/local-gadget-tests.Dockerfile ../../../
+	docker run --rm --entrypoint cat local-gadget-tests local-gadget-integration.test > ./local-gadget-integration.test
+
 # test
 
 TEST_TARGETS = \
@@ -27,14 +32,13 @@ test: test-$(CONTAINER_RUNTIME)
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
 # INTEGRATION_TESTS_PARAMS="-test.run TestListContainers" CONTAINER_RUNTIME=containerd make -C integration/local-gadget/k8s test
 .PHONY: phony_explicit
-test-%: build
+test-%: build build-tests
 	export MINIKUBE_PROFILE=minikube-$* && \
 	echo "Checking minikube with profile $${MINIKUBE_PROFILE} is running ..." && \
 	$(MINIKUBE) status -p $${MINIKUBE_PROFILE} -f {{.APIServer}} >/dev/null || (echo "Error: $${MINIKUBE_PROFILE} not running, exiting ..." && exit 1) && \
 	echo "Preparing minikube with profile $${MINIKUBE_PROFILE} for testing ..." && \
 	$(MINIKUBE) cp ../../../local-gadget-linux-amd64 $${MINIKUBE_PROFILE}:/bin/local-gadget >/dev/null && \
 	$(MINIKUBE) ssh sudo chmod +x /bin/local-gadget && \
-	go test -c -o local-gadget-integration.test ./... && \
 	$(MINIKUBE) cp local-gadget-integration.test $${MINIKUBE_PROFILE}:/bin/local-gadget-integration.test >/dev/null && \
 	$(MINIKUBE) ssh sudo chmod +x /bin/local-gadget-integration.test && \
 	rm local-gadget-integration.test && \


### PR DESCRIPTION
# integration: Build local-gadget-test in the same container as local-gadget

Since i am on `Ubuntu 22.04` i get the following error when i try to run the integration tests for `local-gadget`:
```bash
.....
/home/burak/codes/inspektor-gadget/integration/local-gadget/bin/minikube-v1.27.0 -p ${MINIKUBE_PROFILE} ssh "sudo local-gadget-integration.test -test.v -integration -container-runtime docker ${INTEGRATION_TESTS_PARAMS}"
Checking minikube with profile minikube-docker is running ...
Preparing minikube with profile minikube-docker for testing ...
Running test in minikube with profile minikube-docker ...
local-gadget-integration.test: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by local-gadget-integration.test)
local-gadget-integration.test: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by local-gadget-integration.test)
ssh: Process exited with status 1
make: *** [Makefile:70: test-docker] Error 1
make: Leaving directory '/home/burak/codes/inspektor-gadget/integration/local-gadget'
```

In order to have the same dependencies in `local-gadget` and `local-gadget-integration.test` i have moved the compilation into a similar Docker container.
Negative effect: `go test -c ...` directly on the host is 20 seconds faster on my machine. When there are no changes the waiting time is negligible.

Therefore the question:
Do we want to create 2 different targets? One with compilation on host and one in the Docker container?