### PR TITLE
Remove `io/ioutil` from `snapshot process` tracer

### DIFF
--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -171,7 +170,7 @@ func getPidEvents(config *Config, enricher gadgets.DataEnricher, pid int) ([]*pr
 		}
 		tid := int(tid64)
 
-		commBytes, _ := ioutil.ReadFile(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/comm", tid)))
+		commBytes, _ := os.ReadFile(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/comm", tid)))
 		comm := strings.TrimRight(string(commBytes), "\n")
 		mntnsid, err := containerutils.GetMntNs(tid)
 		if err != nil {


### PR DESCRIPTION
Hi.


This PR removes `io/ioutil` as this package is deprecated.


Best regards.