### PR TITLE
gadget-container: Remove unneeded dependencies from container images

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -65,14 +65,14 @@ FROM ${BASE_IMAGE}
 # available on the base image
 RUN set -ex; \
 	if command -v tdnf; then \
-		tdnf install -y libseccomp wget curl util-linux; \
+		tdnf install -y libseccomp wget util-linux; \
 	elif command -v yum; then \
-		yum install -y libseccomp wget curl util-linux; \
+		yum install -y libseccomp wget util-linux; \
 	elif command -v apt-get; then \
 		apt-get update && \
-		apt-get install -y seccomp wget curl util-linux; \
+		apt-get install -y seccomp wget util-linux; \
 	elif command -v apk; then \
-		apk add gcompat libseccomp bash wget curl util-linux; \
+		apk add gcompat libseccomp wget util-linux; \
 	fi && \
 	(rmdir /usr/src || true) && ln -sf /host/usr/src /usr/src && \
 	rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates curl jq wget xz-utils binutils rpm2cpio cpio && \
+		ca-certificates jq wget xz-utils binutils && \
 		rmdir /usr/src && ln -sf /host/usr/src /usr/src && \
 		rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2019-2021 The Inspektor Gadget authors
 #
@@ -21,7 +21,7 @@ if [ ! -r /host/etc/os-release ] ; then
   exit 1
 fi
 
-source /host/etc/os-release
+. /host/etc/os-release
 
 echo -n "OS detected: "
 echo $PRETTY_NAME


### PR DESCRIPTION
Because of 441f909 we can remove some of the packages from the final image. Also, there is change from 'bash' to 'sh' in the entrypoint.

Related #801 

## stats
```
REPOSITORY                                      TAG                                                      IMAGE ID       CREATED          SIZE
ghcr.io/inspektor-gadget/inspektor-gadget       latest-core                                              d7a3e747aab8   47 seconds ago   133MB
ghcr.io/inspektor-gadget/inspektor-gadget       qasim-remove-packages-core                               550aa27a7732   6 hours ago      129MB
ghcr.io/inspektor-gadget/inspektor-gadget       latest                                                   d7127ddb103e   57 seconds ago   743MB
ghcr.io/inspektor-gadget/inspektor-gadget       qasim-remove-packages                                    02c0aae785c1   6 hours ago      692MB

```
