### PR TITLE
cmd/snapshot: Remove unnecessary pointer to slice

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -70,8 +70,8 @@ func (p *ProcessParser) GetOutputConfig() *commonutils.OutputConfig {
 	return p.outputConfig
 }
 
-func (p *ProcessParser) SortEvents(allProcesses *[]*types.Event) {
-	columnssort.SortEntries(types.GetColumns().GetColumnMap(), *allProcesses,
+func (p *ProcessParser) SortEvents(allProcesses []*types.Event) {
+	columnssort.SortEntries(types.GetColumns().GetColumnMap(), allProcesses,
 		[]string{"node", "namespace", "pod", "container", "comm", "pid", "tid", "ppid"})
 }
 

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -40,7 +40,7 @@ type SnapshotEvent interface {
 // implement.
 type SnapshotParser[Event any] interface {
 	// SortEvents sorts a slice of events based on a predefined prioritization.
-	SortEvents(*[]*Event)
+	SortEvents([]*Event)
 
 	// TransformIntoTable is called to transform headers and events into a table.
 	TransformIntoTable([]*Event) string
@@ -56,7 +56,7 @@ type SnapshotGadgetPrinter[Event SnapshotEvent] struct {
 }
 
 func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []*Event) error {
-	g.Parser.SortEvents(&allEvents)
+	g.Parser.SortEvents(allEvents)
 
 	outputConfig := g.Parser.GetOutputConfig()
 	switch outputConfig.OutputMode {

--- a/cmd/common/snapshot/socket.go
+++ b/cmd/common/snapshot/socket.go
@@ -65,8 +65,8 @@ func (s *SocketParser) GetOutputConfig() *commonutils.OutputConfig {
 	return s.outputConfig
 }
 
-func (s *SocketParser) SortEvents(allSockets *[]*types.Event) {
-	columnssort.SortEntries(types.GetColumns().GetColumnMap(), *allSockets,
+func (s *SocketParser) SortEvents(allSockets []*types.Event) {
+	columnssort.SortEntries(types.GetColumns().GetColumnMap(), allSockets,
 		[]string{"node", "namespace", "pod", "proto", "status", "localAddr", "remoteAddr", "localPort", "remotePort", "inode"})
 }
 


### PR DESCRIPTION
# cmd/snapshot: Remove unnecessary pointer to slice

This was needed since the filtering logic for the thread ids in `snapshot process` was on the client side and the slice had to get modified.

With https://github.com/inspektor-gadget/inspektor-gadget/pull/1223 this changes and we can remove the pointer to the slice making the code more readable and maintainable
