### PR TITLE
snapshot/process: Fix false sorting name for column "comm", "pid" and "tid"

### DIFF
--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -82,7 +82,7 @@ func (p *ProcessParser) SortEvents(allProcesses *[]*types.Event) {
 	}
 
 	columnssort.SortEntries(types.GetColumns().GetColumnMap(), *allProcesses,
-		[]string{"node", "namespace", "pod", "container", "comm", "pid", "tid"})
+		[]string{"node", "namespace", "pod", "container", "comm", "pid", "tid", "ppid"})
 }
 
 func NewProcessCmd(runCmd func(*cobra.Command, []string) error, flags *ProcessFlags) *cobra.Command {

--- a/cmd/common/snapshot/process.go
+++ b/cmd/common/snapshot/process.go
@@ -82,7 +82,7 @@ func (p *ProcessParser) SortEvents(allProcesses *[]*types.Event) {
 	}
 
 	columnssort.SortEntries(types.GetColumns().GetColumnMap(), *allProcesses,
-		[]string{"node", "namespace", "pod", "container", "cmd", "tgid", "pid"})
+		[]string{"node", "namespace", "pod", "container", "comm", "pid", "tid"})
 }
 
 func NewProcessCmd(runCmd func(*cobra.Command, []string) error, flags *ProcessFlags) *cobra.Command {


### PR DESCRIPTION
# snapshot/process: Fix false sorting name for column "comm", "pid" and "tid"

The columnname for the Command column is `comm` and not `cmd`. Same for `pid` and `tid`