### PR TITLE
cmd/top: Output JSON Arrays instead of single JSON objects

### DIFF
--- a/cmd/common/top/top.go
+++ b/cmd/common/top/top.go
@@ -81,23 +81,25 @@ func (g *TopGadget[Stats]) PrintHeader() {
 func (g *TopGadget[Stats]) PrintStats(stats []*Stats) {
 	top.SortStats(stats, g.CommonTopFlags.ParsedSortBy, &g.ColMap)
 
-	for idx, stat := range stats {
-		if idx == g.CommonTopFlags.MaxRows {
-			break
+	sliceEnd := g.CommonTopFlags.MaxRows
+	if sliceEnd > len(stats) {
+		sliceEnd = len(stats)
+	}
+
+	stats = stats[:sliceEnd]
+
+	switch g.OutputConfig.OutputMode {
+	case commonutils.OutputModeJSON:
+		b, err := json.Marshal(stats)
+		if err != nil {
+			fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
 		}
+		fmt.Println(string(b))
 
-		switch g.OutputConfig.OutputMode {
-		case commonutils.OutputModeJSON:
-			b, err := json.Marshal(stat)
-			if err != nil {
-				fmt.Fprint(os.Stderr, fmt.Sprint(commonutils.WrapInErrMarshalOutput(err)))
-				continue
-			}
-
-			fmt.Println(string(b))
-		case commonutils.OutputModeColumns:
-			fallthrough
-		case commonutils.OutputModeCustomColumns:
+	case commonutils.OutputModeColumns:
+		fallthrough
+	case commonutils.OutputModeCustomColumns:
+		for _, stat := range stats {
 			fmt.Println(g.Parser.TransformIntoColumns(stat))
 		}
 	}

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -448,7 +448,7 @@ func TestBiotop(t *testing.T) {
 				e.Bytes = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 
@@ -623,7 +623,7 @@ func TestEbpftop(t *testing.T) {
 				e.MapCount = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 
@@ -727,7 +727,7 @@ func TestFiletop(t *testing.T) {
 				e.MountNsID = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 
@@ -1468,7 +1468,7 @@ func TestTcptop(t *testing.T) {
 				e.Received = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/local-gadget/k8s/top_block_io_test.go
+++ b/integration/local-gadget/k8s/top_block_io_test.go
@@ -52,7 +52,7 @@ func TestTopBlockIO(t *testing.T) {
 				e.Operations = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/local-gadget/k8s/top_ebpf_test.go
+++ b/integration/local-gadget/k8s/top_ebpf_test.go
@@ -55,7 +55,7 @@ func TestTopEbpf(t *testing.T) {
 				e.MapCount = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/local-gadget/k8s/top_file_test.go
+++ b/integration/local-gadget/k8s/top_file_test.go
@@ -54,7 +54,7 @@ func TestTopFile(t *testing.T) {
 				e.WriteBytes = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/local-gadget/k8s/top_tcp_test.go
+++ b/integration/local-gadget/k8s/top_tcp_test.go
@@ -63,7 +63,7 @@ func TestTopTCP(t *testing.T) {
 				e.Received = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
 		},
 	}
 


### PR DESCRIPTION
# cmd/top: Output JSON Arrays instead of single JSON objects

Rationale see https://github.com/inspektor-gadget/inspektor-gadget/issues/1157

Output for example:
```bash
$ ./kubectl-gadget top file -o json
[]
[{"node":"minikube","namespace":"default","pod":"nginx","container":"nginx","pid":582310,"tid":582310,"comm":"touch","reads":1,"rbytes":832,"mountnsid":4026533425,"fileType":82,"filename":"libc-2.31.so"}]
[]
[]
[]
[]
[{"node":"minikube","namespace":"default","pod":"nginx","container":"nginx","pid":582618,"tid":582618,"comm":"cat","reads":2,"rbytes":262144,"mountnsid":4026533425,"fileType":82,"filename":"docker-entrypoint.sh"},{"node":"minikube","namespace":"default","pod":"nginx","container":"nginx","pid":582618,"tid":582618,"comm":"cat","reads":1,"rbytes":832,"mountnsid":4026533425,"fileType":82,"filename":"libc-2.31.so"}]
[]
```