### PR TITLE
cmd/local-gadget: Add global flag `--timeout`

### DIFF
--- a/cmd/local-gadget/audit/seccomp.go
+++ b/cmd/local-gadget/audit/seccomp.go
@@ -18,8 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -100,10 +98,7 @@ func newSeccompCmd() *cobra.Command {
 		}
 		defer tracer.Close()
 
-		stop := make(chan os.Signal, 1)
-		signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
-		<-stop
-
+		utils.WaitForEnd(&commonFlags)
 		return nil
 	}
 

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -18,8 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -100,10 +98,7 @@ func NewListContainersCmd() *cobra.Command {
 				}
 			}
 
-			stop := make(chan os.Signal, 1)
-			signal.Notify(stop, syscall.SIGINT)
-			<-stop
-
+			utils.WaitForEnd(&commonFlags)
 			return nil
 		},
 	}

--- a/cmd/local-gadget/snapshot/process.go
+++ b/cmd/local-gadget/snapshot/process.go
@@ -62,6 +62,7 @@ func newProcessCmd() *cobra.Command {
 	cmd := commonsnapshot.NewProcessCmd(runCmd, &flags)
 
 	utils.AddCommonFlags(cmd, &commonFlags)
+	utils.HideFlagTimeout(cmd)
 
 	return cmd
 }

--- a/cmd/local-gadget/snapshot/socket.go
+++ b/cmd/local-gadget/snapshot/socket.go
@@ -94,6 +94,7 @@ func newSocketCmd() *cobra.Command {
 	cmd := commonsnapshot.NewSocketCmd(runCmd, &flags)
 
 	utils.AddCommonFlags(cmd, &commonFlags)
+	utils.HideFlagTimeout(cmd)
 
 	return cmd
 }

--- a/cmd/local-gadget/top/top.go
+++ b/cmd/local-gadget/top/top.go
@@ -16,11 +16,8 @@ package top
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/cilium/ebpf"
 	"github.com/spf13/cobra"
@@ -100,10 +97,7 @@ func (g *TopGadget[Stats]) Run(args []string) error {
 	}
 	defer gadgetTracer.Stop()
 
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
-	<-stop
-
+	utils.WaitForEnd(g.commonFlags)
 	return nil
 }
 

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -18,8 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/cilium/ebpf"
 	"github.com/spf13/cobra"
@@ -95,10 +93,7 @@ func (g *TraceGadget[Event]) Run() error {
 	}
 	defer gadgetTracer.Stop()
 
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
-	<-stop
-
+	utils.WaitForEnd(g.commonFlags)
 	return nil
 }
 

--- a/cmd/local-gadget/utils/flags.go
+++ b/cmd/local-gadget/utils/flags.go
@@ -43,6 +43,9 @@ type CommonFlags struct {
 	// RuntimeConfigs contains the list of the container runtimes to be used
 	// with their specific socket path.
 	RuntimeConfigs []*containerutils.RuntimeConfig
+
+	// Number of seconds that the gadget will run for
+	Timeout int
 }
 
 func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
@@ -110,4 +113,15 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		fmt.Sprintf("Container runtimes to be used separated by comma. Supported values are: %s",
 			strings.Join(containerutils.AvailableRuntimes, ", ")),
 	)
+
+	command.PersistentFlags().IntVar(
+		&commonFlags.Timeout,
+		"timeout",
+		0,
+		"Number of seconds that the gadget will run for",
+	)
+}
+
+func HideFlagTimeout(command *cobra.Command) {
+	command.PersistentFlags().MarkHidden("timeout")
 }

--- a/cmd/local-gadget/utils/utils.go
+++ b/cmd/local-gadget/utils/utils.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// WaitForEnd waits until the user-set timeout happened or SIGINT or SIGTERM
+// is sent to us
+func WaitForEnd(f *CommonFlags) {
+	timeoutChannel := make(<-chan time.Time)
+	if f.Timeout != 0 {
+		timeoutChannel = time.After(time.Duration(f.Timeout) * time.Second)
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case <-timeoutChannel:
+	case <-stop:
+	}
+}


### PR DESCRIPTION
# cmd/local-gadget: Add global flag `--timeout`

This PR adds a new flag called `--timeout` to `local-gadget`.

A helper function was introduced which waits for `SIGTERM` or `SIGINT` or an elapsed timeout in order to reduce code duplication. Of course there are special cases like for `advise seccomp-profile`

### Questions/Comments/...

1. Naming things is still not easy for me :smile: Suggestions welcome, be it for the function name or filename
1. Since now every gadget in `local-gadget` has the `--timeout` flag available, it has needed to "hide" it in some gadgets like `snapshot`. Is this a good way to solve that?
1. Should i create another following PR which unifies this `--timeout` flag, since now `kubectl-gadget` and `local-gadget` has it? There is currently a Flagset which is shared called `OutputConfig`. `--timeout` would not fit in there -> Rename the Flagset? Create a new one? WDYT?
1. Rewrite some of the `local-gadget` tests to use `--timeout` instead of setting `startAndStop` to true? Not all since we want to test both paths