### PR TITLE
CI: use job summaries for test reports

### DIFF
--- a/.github/actions/prepare-and-publish-test-reports/action.yml
+++ b/.github/actions/prepare-and-publish-test-reports/action.yml
@@ -1,0 +1,28 @@
+name: "Prepare and publish test reports"
+description: "Given go test results as plain text, prepare and publish test reports"
+
+inputs:
+  test-log-file:
+    description: "Test log file to be used to generate reports"
+    required: true
+  truncate-lines:
+    description: "Number of failed test log lines to truncate to"
+    default: "50"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install testjson2md
+      shell: bash
+      run: |
+        cd tools/testjson2md
+        go install
+    - name: Prepare test report as json
+      shell: bash
+      run: |
+        go tool test2json -t < ./${{ inputs.test-log-file }} > ./test-report.json
+    - name: Publish test reports as markdown
+      shell: bash
+      run: |
+        testjson2md -in ./test-report.json -out ./test-report.md -truncate-lines ${{ inputs.truncate-lines }}
+        cat test-report.md >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -56,10 +56,19 @@ runs:
 
         # https://mywiki.wooledge.org/SignalTrap#When_is_the_signal_handled.3F
         echo "IntegrationTestsJob: Start"
+        set -o pipefail
         make \
           KUBERNETES_DISTRIBUTION=${{ inputs.kubernetes_distribution }} \
           KUBERNETES_ARCHITECTURE=${{ inputs.kubernetes_architecture }} \
           CONTAINER_REPO=${{ inputs.container_repo }} \
           IMAGE_TAG=${{ inputs.image_tag }} \
-          -o kubectl-gadget integration-tests & wait $!
+          -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
+    - name: Prepare and publish test reports
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/prepare-and-publish-test-reports
+      with:
+        test-log-file: integration.log
+        truncate-lines: 200
+

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -553,7 +553,14 @@ jobs:
           sudo swapoff -a
       - name: Run integration for container runtime ${{ matrix.runtime }}
         run: |
-          make -C integration/local-gadget/k8s CONTAINER_RUNTIME=${{ matrix.runtime }} -o build setup test
+          set -o pipefail
+          make -C integration/local-gadget/k8s CONTAINER_RUNTIME=${{ matrix.runtime }} -o build setup test |& tee integration.log
+      - name: Prepare and publish test report for container runtime ${{ matrix.runtime }}
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/prepare-and-publish-test-reports
+        with:
+          test-log-file: integration.log
 
   test-integration-non-k8s-local-gadget:
     name: Integration tests for local gadget with non-Kubernetes Containers
@@ -582,7 +589,14 @@ jobs:
           mv local-gadget local-gadget-linux-amd64
       - name: Run integration for container runtime ${{ matrix.runtime }}
         run: |
-          make -C integration/local-gadget/non-k8s -o build test-${{ matrix.runtime }}
+          set -o pipefail
+          make -C integration/local-gadget/non-k8s -o build test-${{ matrix.runtime }} |& tee integration.log
+      - name: Prepare and publish test report for container runtime ${{ matrix.runtime }}
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/prepare-and-publish-test-reports
+        with:
+          test-log-file: integration.log
 
   test-integration-aks:
     name: Integration tests on AKS

--- a/Makefile
+++ b/Makefile
@@ -169,11 +169,12 @@ local-gadget-tests:
 	rm -f ./local-gadget-manager.test
 
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
-# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -v -no-deploy-ig -no-deploy-spo" make integration-tests
+# INTEGRATION_TESTS_PARAMS="-run TestExecsnoop -no-deploy-ig -no-deploy-spo" make integration-tests
 .PHONY: integration-tests
 integration-tests: kubectl-gadget
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \
 		go test ./integration/inspektor-gadget/... \
+			-v \
 			-integration \
 			-timeout 30m \
 			-k8s-distro $(KUBERNETES_DISTRIBUTION) \

--- a/tools/testjson2md/go.mod
+++ b/tools/testjson2md/go.mod
@@ -1,0 +1,5 @@
+module github.com/inspektor-gadget/inspektor-gadget/tools/testjson2md
+
+go 1.18
+
+require github.com/medyagh/gopogh v0.13.0 // indirect

--- a/tools/testjson2md/go.sum
+++ b/tools/testjson2md/go.sum
@@ -1,0 +1,2 @@
+github.com/medyagh/gopogh v0.13.0 h1:yWsvRn59QX6GwglFCVt7rqA0RcQ+QB4LvStjczNOlGU=
+github.com/medyagh/gopogh v0.13.0/go.mod h1:sjX6uwxxd9ecbjDM5oPfaXVo6myMbeQb/oN45vOGCj8=

--- a/tools/testjson2md/testjson2md.go
+++ b/tools/testjson2md/testjson2md.go
@@ -1,0 +1,152 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/medyagh/gopogh/pkg/models"
+	"github.com/medyagh/gopogh/pkg/parser"
+	"github.com/medyagh/gopogh/pkg/report"
+)
+
+var ErrInvalidContent = fmt.Errorf("invalid content")
+
+var (
+	inPath        = flag.String("in", "", "path to JSON file produced by go tool test2json")
+	outPath       = flag.String("out", "", "path to output file")
+	truncateLines = flag.Int("truncate-lines", 50, "number of failed test log lines to truncate to")
+)
+
+func main() {
+	flag.Parse()
+
+	if *inPath == "" {
+		log.Fatal("must provide path to JSON input file")
+	}
+
+	if *outPath == "" {
+		log.Fatal("must provide path to output file")
+	}
+
+	events, err := parser.ParseJSON(*inPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	groups := parser.ProcessEvents(events)
+	content, err := report.Generate(models.ReportDetail{}, groups)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	markdown, err := markdownForContent(content)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = os.WriteFile(*outPath, markdown, 0644); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func markdownForContent(content report.DisplayContent) ([]byte, error) {
+	// validation
+	if _, ok := content.Results["pass"]; !ok {
+		return nil, fmt.Errorf("checking passed tests: %w", ErrInvalidContent)
+	}
+	if _, ok := content.Results["skip"]; !ok {
+		return nil, fmt.Errorf("checking skip tests: %w", ErrInvalidContent)
+	}
+	if _, ok := content.Results["fail"]; !ok {
+		return nil, fmt.Errorf("checking failed tests: %w", ErrInvalidContent)
+	}
+
+	// set report status
+	reportStatus := ":green_circle:"
+	if len(content.Results["fail"]) > 0 {
+		reportStatus = ":red_circle:"
+	}
+
+	// summary
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "### Test Report %s\n", reportStatus)
+	fmt.Fprintf(&buf, "#### Summary\n")
+	fmt.Fprintf(&buf, "| Total Tests | Passed :heavy_check_mark: | Failed :x: | Skipped :arrow_right_hook: |\n")
+	fmt.Fprintf(&buf, "| ----- | ---- | ---- | ---- |\n")
+	fmt.Fprintf(&buf, "| %d | %d | %d | %d |\n", content.TotalTests,
+		len(content.Results["pass"]), len(content.Results["fail"]), len(content.Results["skip"]))
+
+	// failed tests
+	if len(content.Results["fail"]) > 0 {
+		fmt.Fprintf(&buf, "#### Failed Tests\n")
+		for _, test := range content.Results["fail"] {
+			fmt.Fprintf(&buf, "<details><summary>%s</summary>\n\n", test.TestName)
+			fmt.Fprintf(&buf, "```code\n")
+			fmt.Fprintf(&buf, "%s", testEventToString(lastN(test.Events, *truncateLines)))
+			fmt.Fprintf(&buf, "```\n")
+			fmt.Fprintf(&buf, "</details>\n")
+		}
+		fmt.Fprintf(&buf, "\n")
+	}
+
+	// test durations
+	fmt.Fprintf(&buf, "#### Test Durations :stopwatch:\n")
+	appendDuration(content, &buf, "Passed", "pass")
+	appendDuration(content, &buf, "Failed", "fail")
+	appendDuration(content, &buf, "Skipped", "skip")
+
+	return buf.Bytes(), nil
+}
+
+func appendDuration(content report.DisplayContent, buf *bytes.Buffer, title, status string) {
+	if len(content.Results[status]) == 0 {
+		return
+	}
+	fmt.Fprintf(buf, "<details><summary>%s</summary>\n\n", title)
+	fmt.Fprintf(buf, "| Duration | Test | Run Order |\n")
+	fmt.Fprintf(buf, "| -------- | ---- | --------- |\n")
+	for _, test := range sortTestGroups(content.Results[status]) {
+		fmt.Fprintf(buf, "| %s | %s | %d |\n", time.Duration(test.Duration*float64(time.Second)), test.TestName, test.TestOrder)
+	}
+	fmt.Fprintf(buf, "</details>\n")
+}
+
+func sortTestGroups(groups []models.TestGroup) []models.TestGroup {
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Duration > groups[j].Duration
+	})
+	return groups
+}
+
+func testEventToString(events []models.TestEvent) string {
+	var buf bytes.Buffer
+	for _, event := range events {
+		fmt.Fprintf(&buf, "%s", event.Output)
+	}
+	return buf.String()
+}
+
+func lastN[T any](s []T, n int) []T {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}


### PR DESCRIPTION
Initial attempt to improve readability for test results. As a first step we are using [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) to publish test report containing details about tests and [failure logs](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/3856171191/attempts/1#summary-10484646582) (truncated) to ease identifying the failing test. You can find sample report [failed](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3856411053/attempts/1#summary-10485328919)/[passed](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3873387049/attempts/1#summary-10523660691) here.

Relates #688

## Future work
We can use `gopogh` (will need a dedicated storage for `html` reports) or something similar latter on. Job summaries allows having run detail in one place rather than spamming PR so we can continue to keep them and can update this [action](https://github.com/inspektor-gadget/inspektor-gadget/tree/qasim/test-reporting/.github/actions/prepare-and-publish-test-reports) to handle html reports easily. 