### PR TITLE
integration: Use /bin/sleep rather than sleep.

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -640,7 +640,7 @@ func TestExecsnoop(t *testing.T) {
 
 	t.Parallel()
 
-	cmd := "while true; do date ; sleep 0.1; done"
+	cmd := "while true; do date ; /bin/sleep 0.1; done"
 	shArgs := []string{"/bin/sh", "-c", cmd}
 	dateArgs := []string{"/bin/date"}
 	sleepArgs := []string{"/bin/sleep", "0.1"}

--- a/integration/local-gadget/k8s/trace_exec_test.go
+++ b/integration/local-gadget/k8s/trace_exec_test.go
@@ -26,7 +26,7 @@ func TestTraceExec(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-exec")
 
-	cmd := "while true; do date ; sleep 0.1; done"
+	cmd := "while true; do date ; /bin/sleep 0.1; done"
 	shArgs := []string{"/bin/sh", "-c", cmd}
 	dateArgs := []string{"/bin/date"}
 	sleepArgs := []string{"/bin/sleep", "0.1"}


### PR DESCRIPTION
```
Busybox commit 58598eb70935 ("ash: optional sleep builtin") compiles by default sleep as a builtin [1].
This commit is part of release 1.36.0 which was released 3 days ago [2].

As a consequence, TestExecsnoop which awaits an events with command sleep was failing.
This commit forces using /bin/sleep rather than the builtin so our integration test passes.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1] https://git.busybox.net/busybox/commit/?id=58598eb7093561d914a6254697e137b815f1fdfc [2] https://git.busybox.net/busybox/commit/?id=70f77e4617e06077231b8b63c3fb3406d7f8865d
```