### PR TITLE
[Fix ARO CI] Increase the buffersize of `bufio.Scanner`

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -78,6 +78,9 @@ func parseMultipleJSONArrayOutput[T any](output string, normalize func(*T)) ([]*
 		}
 		allEntries = append(allEntries, entries...)
 	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("parsing multiple JSON arrays: %w", err)
+	}
 
 	return allEntries, nil
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -70,7 +70,10 @@ func parseJSONArrayOutput[T any](output string, normalize func(*T)) ([]*T, error
 
 func parseMultipleJSONArrayOutput[T any](output string, normalize func(*T)) ([]*T, error) {
 	allEntries := make([]*T, 0)
+
 	sc := bufio.NewScanner(strings.NewReader(output))
+	// On ARO we saw arrays with charcounts of > 100,000. Lets just set 1 MB as the limit
+	sc.Buffer(make([]byte, 1024), 1024*1024)
 	for sc.Scan() {
 		entries, err := parseJSONArrayOutput(sc.Text(), normalize)
 		if err != nil {


### PR DESCRIPTION
# Increase the buffersize of `bufio.Scanner`

The output of the ARO test was too large for the default buffer of `bufio.Scanner`. Sometimes there was more than 100k characters in a line. Optimistically i set the size to `1 MB`.

Additionally an error will now be logged when the scanner encounters any issue. This was the problem why we didn't see any problems in the logs.
Huge thanks to @mqasimsarfraz for finding this :fire: :rocket: