### PR TITLE
Revert "tools: Use fork of btfhub until upstream is fixed"

### DIFF
--- a/tools/getbtfhub.sh
+++ b/tools/getbtfhub.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-git clone --depth 1 https://github.com/inspektor-gadget/btfhub /tmp/btfhub -b mauricio/update-bpftool
+git clone --depth 1 https://github.com/aquasecurity/btfhub /tmp/btfhub
 git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ /tmp/btfhub-archive/


### PR DESCRIPTION
This reverts commit 9694d16360bcd4391f57e4c8f6af2c9da863efa1.

The necessary patch was merged upstream:
https://github.com/aquasecurity/btfhub/pull/52#event-8192729854

See https://github.com/aquasecurity/btfhub/issues/51
