### PR TITLE
cmd: Remove OutputModeColumns

### DIFF
--- a/cmd/common/profile/cpu.go
+++ b/cmd/common/profile/cpu.go
@@ -108,8 +108,6 @@ func (p *CPUParser) TransformReport(report *cpuTypes.Report) string {
 		}
 
 		return string(b)
-	case utils.OutputModeColumns:
-		fallthrough
 	case utils.OutputModeCustomColumns:
 		otherCols := p.TransformIntoColumns(report)
 		if p.CPUFlags.ProfileUserOnly {

--- a/cmd/common/snapshot/snapshot.go
+++ b/cmd/common/snapshot/snapshot.go
@@ -68,8 +68,6 @@ func (g *SnapshotGadgetPrinter[Event]) PrintEvents(allEvents []*Event) error {
 
 		fmt.Printf("%s\n", b)
 		return nil
-	case commonutils.OutputModeColumns:
-		fallthrough
 	case commonutils.OutputModeCustomColumns:
 		allEventsTrimmed := []*Event{}
 		for _, e := range allEvents {

--- a/cmd/common/top/top.go
+++ b/cmd/common/top/top.go
@@ -96,8 +96,6 @@ func (g *TopGadget[Stats]) PrintStats(stats []*Stats) {
 		}
 		fmt.Println(string(b))
 
-	case commonutils.OutputModeColumns:
-		fallthrough
 	case commonutils.OutputModeCustomColumns:
 		for _, stat := range stats {
 			fmt.Println(g.Parser.TransformIntoColumns(stat))

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -26,12 +26,11 @@ import (
 )
 
 const (
-	OutputModeColumns       = "columns"
 	OutputModeJSON          = "json"
 	OutputModeCustomColumns = "custom-columns"
 )
 
-var SupportedOutputModes = []string{OutputModeColumns, OutputModeJSON, OutputModeCustomColumns}
+var SupportedOutputModes = []string{OutputModeJSON, OutputModeCustomColumns}
 
 // OutputConfig contains the flags that describes how to print the gadget's output
 type OutputConfig struct {
@@ -50,7 +49,7 @@ func AddOutputFlags(command *cobra.Command, outputConfig *OutputConfig) {
 		&outputConfig.OutputMode,
 		"output",
 		"o",
-		OutputModeColumns,
+		"",
 		fmt.Sprintf("Output format (%s).", strings.Join(SupportedOutputModes, ", ")),
 	)
 
@@ -68,8 +67,9 @@ func (config *OutputConfig) ParseOutputConfig() error {
 	}
 
 	switch {
-	case config.OutputMode == OutputModeColumns:
-		fallthrough
+	case len(config.OutputMode) == 0:
+		config.OutputMode = OutputModeCustomColumns
+		return nil
 	case config.OutputMode == OutputModeJSON:
 		return nil
 	case strings.HasPrefix(config.OutputMode, OutputModeCustomColumns):

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -108,8 +108,6 @@ func (p *BaseParser[E]) Transform(element *E, toColumns func(*E) string) string 
 		}
 
 		return string(b)
-	case OutputModeColumns:
-		fallthrough
 	case OutputModeCustomColumns:
 		return toColumns(element)
 	}

--- a/cmd/kubectl-gadget/audit/seccomp.go
+++ b/cmd/kubectl-gadget/audit/seccomp.go
@@ -76,8 +76,6 @@ func newSeccompCmd() *cobra.Command {
 				}
 
 				return string(b)
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				return parser.TransformIntoColumns(&e)
 			}

--- a/cmd/kubectl-gadget/trace/trace.go
+++ b/cmd/kubectl-gadget/trace/trace.go
@@ -75,8 +75,6 @@ func (g *TraceGadget[Event]) Run() error {
 			}
 
 			return string(b)
-		case commonutils.OutputModeColumns:
-			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			return g.parser.TransformIntoColumns(&e)
 		}

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -197,8 +197,6 @@ func runTraceloopList(cmd *cobra.Command, args []string) error {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoColumns(&info))
 			}
@@ -256,8 +254,6 @@ func runTraceloopShow(cmd *cobra.Command, args []string) error {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoColumns(&event))
 			}

--- a/cmd/local-gadget/audit/seccomp.go
+++ b/cmd/local-gadget/audit/seccomp.go
@@ -71,8 +71,6 @@ func newSeccompCmd() *cobra.Command {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoColumns(&event))
 			}

--- a/cmd/local-gadget/containers/containers.go
+++ b/cmd/local-gadget/containers/containers.go
@@ -128,8 +128,6 @@ func printContainers(parser *commonutils.GadgetParser[containercollection.Contai
 		}
 
 		fmt.Printf("%s\n", b)
-	case commonutils.OutputModeColumns:
-		fallthrough
 	case commonutils.OutputModeCustomColumns:
 		fmt.Println(parser.TransformIntoTable(containers))
 	}
@@ -145,8 +143,6 @@ func printPubSubEvent(parser *commonutils.GadgetParser[containercollection.PubSu
 			return commonutils.WrapInErrMarshalOutput(err)
 		}
 		fmt.Printf("%s\n", b)
-	case commonutils.OutputModeColumns:
-		fallthrough
 	case commonutils.OutputModeCustomColumns:
 		fmt.Println(parser.TransformIntoColumns(event))
 	}

--- a/cmd/local-gadget/trace/dns.go
+++ b/cmd/local-gadget/trace/dns.go
@@ -82,8 +82,6 @@ func newDNSCmd() *cobra.Command {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoColumns(&event))
 			}

--- a/cmd/local-gadget/trace/sni.go
+++ b/cmd/local-gadget/trace/sni.go
@@ -82,8 +82,6 @@ func newSNICmd() *cobra.Command {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeColumns:
-				fallthrough
 			case commonutils.OutputModeCustomColumns:
 				fmt.Println(parser.TransformIntoColumns(&event))
 			}

--- a/cmd/local-gadget/trace/trace.go
+++ b/cmd/local-gadget/trace/trace.go
@@ -84,8 +84,6 @@ func (g *TraceGadget[Event]) Run() error {
 			}
 
 			fmt.Println(string(b))
-		case commonutils.OutputModeColumns:
-			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			fmt.Println(g.parser.TransformIntoColumns(&event))
 		}


### PR DESCRIPTION
# Remove OutputModeColumns

This PR removes `OutputModeColumns` from the `SupportedOutputModes`.

As the default value of `--output` there is an empty string now. Internally it will get parsed as `OutputModeCustomColumns` with no `CustomColums` selected.
Achieving this combination is manually not possible, which means that `--output OutputModeCustomColums=` is not possible. This behavior is the same before this PR

Is this the way we should implement this or do we want a now option like `OutputModeDefault` (Which internally maps to `OutputModeCustomColumns` with no `CustomColums` again, etc...) or else?

resolves #908 