### PR TITLE
Revert "integration: Remove skipping snapshot socket test on AKS."

### DIFF
--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -28,6 +28,10 @@ func TestSnapshotSocket(t *testing.T) {
 		t.Skip("Skip running snapshot socket gadget on ARO: iterators are not supported on kernel 4.18.0-305.19.1.el8_4.x86_64")
 	}
 
+	if *k8sDistro == K8sDistroAKSUbuntu && *k8sArch == "amd64" {
+		t.Skip("Skip running snapshot socket gadget on AKS Ubuntu amd64: iterators are not supported on kernel 5.4.0-1089-azure")
+	}
+
 	ns := GenerateTestNamespaceName("test-socket-collector")
 
 	t.Parallel()


### PR DESCRIPTION
For some unknown reason the tested cluster is using Ubuntu 18.04:

https://pipelines.actions.githubusercontent.com/serviceHosts/4d4f4f2a-5591-4838-91d9-a0bf1152d97d/_apis/pipelines/1/runs/6673/signedlogcontent/50?urlExpires=2023-01-11T20%3A58%3A34.2655967Z&urlSigningMethod=HMACV1&urlSignature=NopV9FZ%2Bl0XBAJ%2Bg5%2Fdf0UBhkIcVQ1ilIoAwAJ07b7k%3D

```
2023-01-11T20:51:08.8431329Z         + kubectl get pods -n gadget -o name
2023-01-11T20:51:08.8431903Z         + kubectl logs -n gadget pod/gadget-6bk87
2023-01-11T20:51:08.8432382Z         OS detected: Ubuntu 18.04.6 LTS
2023-01-11T20:51:08.8432903Z         Kernel detected: 5.4.0-1098-azure
2023-01-11T20:51:08.8433357Z         bcc detected: 0.24.0-1
```

This reverts commit 2741fa08929435f4d50682da8bb32c7ce5d673f8.
