### PR TITLE
Remove deprecated ioutil.ReadFile

### DIFF
--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -157,7 +156,7 @@ func runeBPFCollector(config *Config, enricher gadgets.DataEnricherByMntNs) ([]*
 func getTidEvent(config *Config, enricher gadgets.DataEnricherByMntNs, pid, tid int) (*processcollectortypes.Event, error) {
 	var val uint32
 
-	commBytes, _ := ioutil.ReadFile(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/comm", tid)))
+	commBytes, _ := os.ReadFile(filepath.Join(hostRoot, fmt.Sprintf("/proc/%d/comm", tid)))
 	comm := strings.TrimRight(string(commBytes), "\n")
 	mntnsid, err := containerutils.GetMntNs(tid)
 	if err != nil {


### PR DESCRIPTION
Symptoms: 'make lint' gives the following:

> pkg/gadgets/snapshot/process/tracer/tracer.go:21:2: SA1019: "io/ioutil"
> has been deprecated since Go 1.16: As of Go 1.16, the same functionality
> is now provided by package io or package os, and those implementations
> should be preferred in new code. See the specific function documentation
> for details. (staticcheck)
> 	"io/ioutil"
> 	^

It seems to have been fixed by #1225 but it came back.