### PR TITLE
lint: increase timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ output:
   sort-results: true
 
 run:
-  timeout: 3m
+  timeout: 10m
   build-tags:
   - withebpf
   - docs

--- a/Dockerfiles/linter.Dockerfile
+++ b/Dockerfiles/linter.Dockerfile
@@ -4,4 +4,7 @@ FROM golangci/golangci-lint:${VERSION}
 # library.
 RUN apt-get update \
 	&& apt-get install -y libseccomp-dev
-ENTRYPOINT golangci-lint run --fix
+
+# The timeout specified below is used by 'make lint'. Please keep in sync with
+# the timeout specified in .golangci.yml used by the CI.
+ENTRYPOINT golangci-lint run --fix --timeout=10m0s


### PR DESCRIPTION
The 'Lint' step in GitHub Action sometimes fails with a timeout. The timeout is set to 1 minute by default. This patch increases this to 10 minutes.
