### PR TITLE
trace/network: Remove OutputModeColumns

### DIFF
--- a/cmd/local-gadget/trace/network.go
+++ b/cmd/local-gadget/trace/network.go
@@ -155,8 +155,6 @@ func printEvents(
 			}
 
 			fmt.Println(string(b))
-		case commonutils.OutputModeColumns:
-			fallthrough
 		case commonutils.OutputModeCustomColumns:
 			fmt.Println(parser.TransformIntoColumns(event))
 		}


### PR DESCRIPTION
# trace/network: Remove OutputModeColumns

https://github.com/inspektor-gadget/inspektor-gadget/pull/1255 was not rebased on top of main
