### PR TITLE
timestamp column: set maximum width

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -28,7 +28,7 @@ var node string
 
 func init() {
 	// Register column templates
-	columns.MustRegisterTemplate("timestamp", "width:35,hide")
+	columns.MustRegisterTemplate("timestamp", "width:35,maxWidth:35,hide")
 	columns.MustRegisterTemplate("node", "width:30,ellipsis:middle")
 	columns.MustRegisterTemplate("namespace", "width:30")
 	columns.MustRegisterTemplate("pod", "width:30,ellipsis:middle")


### PR DESCRIPTION
This is not using the 'fixed' keyword so that the width can be reduced if necessary.

Example of output:
```
$ ./kubectl-gadget trace open -A -o custom-columns=timestamp,comm,path
TIMESTAMP                           COMM             PATH
2023-01-12T16:31:47.311311188+01:00 kube-apiserver   /var/lib/minikube/certs/apiserver-kubelet-client.crt
2023-01-12T16:31:47.311342955+01:00 kube-apiserver   /var/lib/minikube/certs/apiserver-kubelet-client.key
```

With this patch, there is more space for the path.
