### PR TITLE
gadgets: Fix networking gadgets on old kernels

### DIFF
--- a/pkg/gadgets/internal/networktracer/tracer.go
+++ b/pkg/gadgets/internal/networktracer/tracer.go
@@ -119,6 +119,8 @@ func NewTracer[Event any](
 	baseEvent func(ev types.Event) *Event,
 	parseEvent func([]byte) (*Event, error),
 ) *Tracer[Event] {
+	gadgets.FixBpfKtimeGetBootNs(spec.Programs)
+
 	return &Tracer[Event]{
 		spec:            spec,
 		attachments:     make(map[uint64]*attachment),


### PR DESCRIPTION
There is a missing call to FixBpfKtimeGetBootNs() in networking gadgets to enable them to work in old kernels.

Fixes: ffb7d9910f2d ("gadgets: get timestamp from userspace on Linux <5.7")
Fixes: 7982f833d3ba ("trace sni gadget: add timestamps")

---
[Integration tests on AKS (Ubuntu, amd64)](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3906312046/jobs/6674433125#logs) were failing because that uses an old kernel. 