### PR TITLE
local-gadget: Run docker tests in non-interactive mode

### DIFF
--- a/integration/local-gadget/non-k8s/snapshot_process_test.go
+++ b/integration/local-gadget/non-k8s/snapshot_process_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	snapshotprocessTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestSnapshotProcess(t *testing.T) {
+	t.Parallel()
+	cn := "test-snapshot-process"
+
+	snapshotProcessCmd := &Command{
+		Name: "SnapshotProcess",
+		Cmd:  fmt.Sprintf("./local-gadget snapshot process -o json --runtimes=docker -c %s", cn),
+		ExpectedOutputFn: func(output string) error {
+			expectedEntry := &snapshotprocessTypes.Event{
+				Event: eventtypes.Event{
+					Type: eventtypes.NORMAL,
+					CommonData: eventtypes.CommonData{
+						Namespace: "default",
+						Pod:       cn,
+						Container: cn,
+					},
+				},
+				Command: "nc",
+			}
+
+			normalize := func(e *snapshotprocessTypes.Event) {
+				e.Pid = 0
+				e.Tid = 0
+				e.ParentPid = 0
+				e.MountNsID = 0
+			}
+
+			return ExpectEntriesInArrayToMatch(output, normalize, expectedEntry)
+		},
+	}
+
+	testSteps := []TestStep{
+		&DockerContainer{
+			Name:         cn,
+			Cmd:          "nc -l -p 9090",
+			StartAndStop: true,
+		},
+		snapshotProcessCmd,
+	}
+
+	RunTestSteps(testSteps, t)
+}

--- a/integration/local-gadget/non-k8s/top_ebpf_test.go
+++ b/integration/local-gadget/non-k8s/top_ebpf_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	topebpfTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/types"
+)
+
+func TestTopEbpf(t *testing.T) {
+	t.Parallel()
+
+	topebpfCmd := &Command{
+		Name:         "TopEbpf",
+		Cmd:          "./local-gadget top ebpf -o json -m 100 --runtimes=docker",
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntry := &topebpfTypes.Stats{
+				Type: ebpf.Tracing.String(),
+				Name: "ig_top_ebpf_it",
+			}
+
+			normalize := func(e *topebpfTypes.Stats) {
+				e.ProgramID = 0
+				e.Pids = nil
+				e.CurrentRuntime = 0
+				e.CurrentRunCount = 0
+				e.CumulativeRuntime = 0
+				e.CumulativeRunCount = 0
+				e.TotalRuntime = 0
+				e.TotalRunCount = 0
+				e.MapMemory = 0
+				e.MapCount = 0
+			}
+
+			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		},
+	}
+
+	commands := []*Command{
+		topebpfCmd,
+	}
+
+	RunTestSteps(commands, t)
+}

--- a/integration/local-gadget/non-k8s/trace_dns_test.go
+++ b/integration/local-gadget/non-k8s/trace_dns_test.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	dnsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestTraceDns(t *testing.T) {
+	t.Parallel()
+	cn := "test-trace-dns"
+
+	traceDNSCmd := &Command{
+		Name:         "TraceDns",
+		Cmd:          fmt.Sprintf("./local-gadget trace dns -o json --runtimes=docker -c %s", cn),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			expectedEntries := []*dnsTypes.Event{
+				{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+						CommonData: eventtypes.CommonData{
+							Namespace: "default",
+							Pod:       cn,
+							Container: cn,
+						},
+					},
+					Qr:         dnsTypes.DNSPktTypeQuery,
+					Nameserver: "8.8.4.4",
+					PktType:    "OUTGOING",
+					DNSName:    "inspektor-gadget.io.",
+					QType:      "A",
+				},
+				{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+						CommonData: eventtypes.CommonData{
+							Namespace: "default",
+							Pod:       cn,
+							Container: cn,
+						},
+					},
+					Qr:         dnsTypes.DNSPktTypeResponse,
+					Nameserver: "8.8.4.4",
+					PktType:    "HOST",
+					DNSName:    "inspektor-gadget.io.",
+					QType:      "A",
+					Rcode:      "NoError",
+				},
+				{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+						CommonData: eventtypes.CommonData{
+							Namespace: "default",
+							Pod:       cn,
+							Container: cn,
+						},
+					},
+					Qr:         dnsTypes.DNSPktTypeQuery,
+					Nameserver: "8.8.4.4",
+					PktType:    "OUTGOING",
+					DNSName:    "inspektor-gadget.io.",
+					QType:      "AAAA",
+				},
+				{
+					Event: eventtypes.Event{
+						Type: eventtypes.NORMAL,
+						CommonData: eventtypes.CommonData{
+							Namespace: "default",
+							Pod:       cn,
+							Container: cn,
+						},
+					},
+					Qr:         dnsTypes.DNSPktTypeResponse,
+					Nameserver: "8.8.4.4",
+					PktType:    "HOST",
+					DNSName:    "inspektor-gadget.io.",
+					QType:      "AAAA",
+					Rcode:      "NoError",
+				},
+			}
+
+			normalize := func(e *dnsTypes.Event) {
+				e.ID = ""
+				e.Timestamp = 0
+			}
+
+			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+		},
+	}
+
+	testSteps := []TestStep{
+		traceDNSCmd,
+		&DockerContainer{
+			Name: cn,
+			Cmd: "nslookup -type=a inspektor-gadget.io. 8.8.4.4 ; " +
+				"nslookup -type=aaaa inspektor-gadget.io. 8.8.4.4",
+		},
+	}
+
+	RunTestSteps(testSteps, t)
+}

--- a/integration/local-gadget/non-k8s/trace_network_test.go
+++ b/integration/local-gadget/non-k8s/trace_network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 
 func TestTraceNetwork(t *testing.T) {
 	t.Parallel()
-	cn := "test-trace-dns"
+	cn := "test-trace-network"
 
 	traceNetworkCmd := &Command{
 		Name:         "TraceNetwork",

--- a/pkg/local-gadget-manager/local-gadget-manager_test.go
+++ b/pkg/local-gadget-manager/local-gadget-manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Inspektor Gadget authors
+// Copyright 2021-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,23 +16,16 @@ package localgadgetmanager
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
-	top "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
-	ebpftoptypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/types"
-	dnstypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 var rootTest = flag.Bool("root-test", false, "enable tests requiring root")
@@ -51,6 +44,19 @@ func TestBasic(t *testing.T) {
 	if !*rootTest {
 		t.Skip("skipping test requiring root.")
 	}
+
+	localGadgetManager, err := NewManager(nil)
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+	localGadgetManager.Close()
+}
+
+func TestListGadgets(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+
 	localGadgetManager, err := NewManager(nil)
 	if err != nil {
 		t.Fatalf("Failed to start local gadget manager: %s", err)
@@ -63,14 +69,42 @@ func TestBasic(t *testing.T) {
 	}
 }
 
-func stacks() string {
-	buf := make([]byte, 1024)
-	for {
-		n := runtime.Stack(buf, true)
-		if n < len(buf) {
-			return string(buf[:n])
-		}
-		buf = make([]byte, 2*len(buf))
+func TestContainersMap(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager(nil)
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+	defer localGadgetManager.Close()
+
+	if m := localGadgetManager.ContainersMap(); m == nil {
+		t.Fatal("container map is nil")
+	}
+}
+
+func TestMountNsMap(t *testing.T) {
+	if !*rootTest {
+		t.Skip("skipping test requiring root.")
+	}
+	localGadgetManager, err := NewManager(nil)
+	if err != nil {
+		t.Fatalf("Failed to start local gadget manager: %s", err)
+	}
+	defer localGadgetManager.Close()
+
+	m, err := localGadgetManager.CreateMountNsMap(containercollection.ContainerSelector{})
+	if err != nil {
+		t.Fatalf("Failed to create mount namespace map: %s", err)
+	}
+	if m == nil {
+		t.Fatalf("mount namespace map is nil: %s", err)
+	}
+
+	err = localGadgetManager.RemoveMountNsMap()
+	if err != nil {
+		t.Fatalf("Failed to remove mount namespace map: %s", err)
 	}
 }
 
@@ -130,259 +164,4 @@ func TestClose(t *testing.T) {
 	}
 
 	checkFdList(t, initialFdList, checkFdListAttempts, checkFdListInterval)
-}
-
-func TestEbpftop(t *testing.T) {
-	if !*rootTest {
-		t.Skip("skipping test requiring root.")
-	}
-	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
-	if err != nil {
-		t.Fatalf("Failed to start local gadget manager: %s", err)
-	}
-	defer localGadgetManager.Close()
-
-	containerName := "test-local-gadget-dns001"
-	err = localGadgetManager.AddTraceResource("ebpftop", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream)
-	if err != nil {
-		t.Fatalf("Failed to create tracer: %s", err)
-	}
-	err = localGadgetManager.ExecTraceResourceOperation("my-tracer", gadgetv1alpha1.OperationStart)
-	if err != nil {
-		t.Fatalf("Failed to start the tracer: %s", err)
-	}
-
-	stop := make(chan struct{})
-
-	ch, err := localGadgetManager.StreamTraceResourceOutput("my-tracer", stop)
-	if err != nil {
-		t.Fatalf("Failed to get stream: %s", err)
-	}
-
-	timeout := time.NewTimer(time.Second * 10)
-
-	ctr := 0
-
-	found := false
-
-ebpfeventloop:
-	for {
-		select {
-		case <-timeout.C:
-			t.Fatalf("Timeout while waiting for stream events")
-			break ebpfeventloop
-		case result := <-ch:
-			event := top.Event[ebpftoptypes.Stats]{}
-			if err := json.Unmarshal([]byte(result), &event); err != nil {
-				t.Fatalf("failed to unmarshal json: %s", err)
-			}
-
-			for _, s := range event.Stats {
-				if s.Type == "Tracing" && s.Name == "ig_top_ebpf_it" {
-					found = true
-					break ebpfeventloop
-				}
-			}
-
-			if ctr > 5 {
-				break ebpfeventloop
-			}
-			ctr++
-		}
-	}
-
-	close(stop)
-
-	err = localGadgetManager.DeleteTraceResource("my-tracer")
-	if err != nil {
-		t.Fatalf("Failed to delete tracer: %s", err)
-	}
-
-	s := stacks()
-	keyword := "ebpftop"
-	if strings.Contains(s, keyword) {
-		t.Fatalf("Error: stack contains %q:\n%s", keyword, s)
-	}
-
-	if !found {
-		t.Fatalf("Expected ebpf program not found in ebpftop")
-	}
-}
-
-func TestDNS(t *testing.T) {
-	if !*rootTest {
-		t.Skip("skipping test requiring root.")
-	}
-	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
-	if err != nil {
-		t.Fatalf("Failed to start local gadget manager: %s", err)
-	}
-	defer localGadgetManager.Close()
-
-	initialFdList := currentFdList(t)
-
-	containerName := "test-local-gadget-dns001"
-	err = localGadgetManager.AddTraceResource("dns", "my-tracer", containerName, gadgetv1alpha1.TraceOutputModeStream)
-	if err != nil {
-		t.Fatalf("Failed to create tracer: %s", err)
-	}
-	err = localGadgetManager.ExecTraceResourceOperation("my-tracer", gadgetv1alpha1.OperationStart)
-	if err != nil {
-		t.Fatalf("Failed to start the tracer: %s", err)
-	}
-
-	// select a nameserver that is not symmetrical with endianness
-	nameserver := "8.8.4.4"
-
-	testutils.RunDockerContainer(context.Background(), t,
-		"dig @"+nameserver+" magic-1-2-3-4.nip.io",
-		testutils.WithName(containerName),
-		testutils.WithImage("docker.io/tutum/dnsutils"),
-	)
-
-	stop := make(chan struct{})
-
-	ch, err := localGadgetManager.StreamTraceResourceOutput("my-tracer", stop)
-	if err != nil {
-		t.Fatalf("Failed to get stream: %s", err)
-	}
-
-	var event dnstypes.Event
-	var expectedEvent dnstypes.Event
-	var result string
-
-	// check that attached message is sent
-	result = <-ch
-	event = dnstypes.Event{}
-	if err := json.Unmarshal([]byte(result), &event); err != nil {
-		t.Fatalf("failed to unmarshal json: %s", err)
-	}
-
-	expectedEvent = dnstypes.Event{
-		Event: eventtypes.Event{
-			Type: eventtypes.DEBUG,
-			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
-			},
-			Message: "tracer attached",
-		},
-	}
-
-	if event != expectedEvent {
-		t.Fatalf("Received: %v, Expected: %v", event, expectedEvent)
-	}
-
-	// check dns request is traced
-	result = <-ch
-	event = dnstypes.Event{}
-	if err := json.Unmarshal([]byte(result), &event); err != nil {
-		t.Fatalf("failed to unmarshal json: %s", err)
-	}
-
-	expectedEvent = dnstypes.Event{
-		Event: eventtypes.Event{
-			Type: eventtypes.NORMAL,
-			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
-			},
-		},
-		ID:         "0000",
-		Qr:         dnstypes.DNSPktTypeQuery,
-		Nameserver: nameserver,
-		DNSName:    "magic-1-2-3-4.nip.io.",
-		PktType:    "OUTGOING",
-		QType:      "A",
-	}
-
-	// normalize
-	event.Timestamp = 0
-	id := event.ID
-	event.ID = "0000"
-
-	if event != expectedEvent {
-		t.Fatalf("Received: %v, Expected: %v", event, expectedEvent)
-	}
-
-	// check dns response is traced
-	result = <-ch
-	event = dnstypes.Event{}
-	if err := json.Unmarshal([]byte(result), &event); err != nil {
-		t.Fatalf("failed to unmarshal json: %s", err)
-	}
-
-	expectedEvent.PktType = "HOST"
-	expectedEvent.Qr = dnstypes.DNSPktTypeResponse
-	expectedEvent.Rcode = "NoError"
-
-	if event.ID != id {
-		t.Fatalf("Response ID: %v, Expected: %v", event.ID, id)
-	}
-	event.Timestamp = 0
-	event.ID = "0000"
-
-	if event != expectedEvent {
-		t.Fatalf("Received: %v, Expected: %v", event, expectedEvent)
-	}
-
-	// check that detached message is sent
-	result = <-ch
-	event = dnstypes.Event{}
-	if err := json.Unmarshal([]byte(result), &event); err != nil {
-		t.Fatalf("failed to unmarshal json: %s", err)
-	}
-
-	expectedEvent = dnstypes.Event{
-		Event: eventtypes.Event{
-			Type: eventtypes.DEBUG,
-			CommonData: eventtypes.CommonData{
-				Node:      "local",
-				Namespace: "default",
-				Pod:       "test-local-gadget-dns001",
-			},
-			Message: "tracer detached",
-		},
-	}
-
-	if event != expectedEvent {
-		t.Fatalf("Received: %v, Expected: %v", event, expectedEvent)
-	}
-
-	close(stop)
-
-	err = localGadgetManager.DeleteTraceResource("my-tracer")
-	if err != nil {
-		t.Fatalf("Failed to delete tracer: %s", err)
-	}
-
-	s := stacks()
-	keyword := "pkg/gadgets/trace/dns/"
-	if strings.Contains(s, keyword) {
-		t.Fatalf("Error: stack contains %q:\n%s", keyword, s)
-	}
-
-	checkFdList(t, initialFdList, checkFdListAttempts, checkFdListInterval)
-}
-
-func TestCollector(t *testing.T) {
-	if !*rootTest {
-		t.Skip("skipping test requiring root.")
-	}
-	localGadgetManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
-	if err != nil {
-		t.Fatalf("Failed to start local gadget manager: %s", err)
-	}
-	defer localGadgetManager.Close()
-
-	err = localGadgetManager.AddTraceResource("socket-collector", "my-tracer1", "my-container", gadgetv1alpha1.TraceOutputModeStatus)
-	if err != nil {
-		t.Fatalf("Failed to create tracer: %s", err)
-	}
-	err = localGadgetManager.ExecTraceResourceOperation("my-tracer1", gadgetv1alpha1.OperationCollect)
-	if err != nil {
-		t.Fatalf("Failed to run the tracer: %s", err)
-	}
 }


### PR DESCRIPTION
# Run docker tests in non-interactive mode

This is the first step to removing the local-gadget interactive mode (Trace CR).