### PR TITLE
gadgets/trace/network: Fix for old kernels

### DIFF
--- a/pkg/gadgets/trace/network/tracer/tracer.go
+++ b/pkg/gadgets/trace/network/tracer/tracer.go
@@ -123,6 +123,8 @@ func (t *Tracer) Attach(pid uint32) (err error) {
 		return fmt.Errorf("failed to load asset: %w", err)
 	}
 
+	gadgets.FixBpfKtimeGetBootNs(spec.Programs)
+
 	consts := map[string]interface{}{
 		"container_netns": netns,
 	}


### PR DESCRIPTION
Same as 21437a26ec7c ("gadgets: Fix networking gadgets on old kernels") but for the trace network gadget.

Fixes: ffb7d9910f2d ("gadgets: get timestamp from userspace on Linux <5.7")
Fixes: 7982f833d3ba ("trace sni gadget: add timestamps")

