### PR TITLE
CI: Do not truncate failure logs

### DIFF
--- a/.github/actions/prepare-and-publish-test-reports/action.yml
+++ b/.github/actions/prepare-and-publish-test-reports/action.yml
@@ -5,9 +5,6 @@ inputs:
   test-log-file:
     description: "Test log file to be used to generate reports"
     required: true
-  truncate-lines:
-    description: "Number of failed test log lines to truncate to"
-    default: "50"
 
 runs:
   using: "composite"
@@ -24,5 +21,5 @@ runs:
     - name: Publish test reports as markdown
       shell: bash
       run: |
-        testjson2md -in ./test-report.json -out ./test-report.md -truncate-lines ${{ inputs.truncate-lines }}
+        testjson2md -in ./test-report.json -out ./test-report.md
         cat test-report.md >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -70,5 +70,4 @@ runs:
       uses: ./.github/actions/prepare-and-publish-test-reports
       with:
         test-log-file: integration.log
-        truncate-lines: 200
 

--- a/tools/testjson2md/go.mod
+++ b/tools/testjson2md/go.mod
@@ -2,4 +2,4 @@ module github.com/inspektor-gadget/inspektor-gadget/tools/testjson2md
 
 go 1.18
 
-require github.com/medyagh/gopogh v0.13.0 // indirect
+require github.com/medyagh/gopogh v0.13.0


### PR DESCRIPTION
It is better to skip some logs then to truncate all of them. In this PR we skip the logs if job summary can't handle but by default we will retain all the logs. 

- [sample report](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/3929358173/attempts/1#summary-10671123474). (skipped test `TestTraceFsslower`)

Should help with the [cases](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3912844172/attempts/1#summary-10634393081) like here.