### PR TITLE
ci: Compute checksums and publish file containing them as release asset.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -816,6 +816,13 @@ jobs:
         for i in *-gadget-*-*-tar-gz/*-gadget-*-*.tar.gz; do
           mv $i $(dirname $i)/$(basename $i .tar.gz)-${{ github.ref_name }}.tar.gz
         done
+    - name: Compute checksums for all artifacts
+      shell: bash
+      run: |
+        for i in *-gadget-*-*-tar-gz/*-gadget-*-*.tar.gz inspektor-gadget-${{ github.ref_name }}.yaml; do
+          hash=$(sha256sum $i | cut -d' ' -f1)
+          echo "${hash}  $(basename $i)" >> inspektor-gadget-${{ github.ref_name }}_checksums.txt
+        done
     - name: Upload Gadget Release *.tar.gz
       uses: csexton/release-asset-action@v2
       with:
@@ -826,6 +833,12 @@ jobs:
       uses: csexton/release-asset-action@v2
       with:
         file: inspektor-gadget-${{ github.ref_name }}.yaml
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        release-url: ${{ steps.create_release.outputs.upload_url }}
+    - name: Upload checksums file
+      uses: csexton/release-asset-action@v2
+      with:
+        file: inspektor-gadget-${{ github.ref_name }}_checksums.txt
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}
     - name: Update new version in krew-index


### PR DESCRIPTION
Hi.


While playing with `cosign` to test how we can use this tools to sign our release assets, I wrote this commit to compute checksums for our release assets.
The result can be found [here](https://github.com/eiffel-fl/inspektor-gadget/releases/tag/vtest3) and the corresponding pipeline is this [one](https://github.com/eiffel-fl/inspektor-gadget/actions/runs/3948084444).
Note that, with this commit, only the `_checksums.txt` file will be published as asset and no signature or certificate files.


Best regards.