### PR TITLE
CI: Workaround for buildkit error while pushing to registry

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -207,6 +207,10 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
+      # FIXME: remove this when https://github.com/docker/build-push-action/issues/761 is fixed
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
     - name: Cache Docker layers
       uses: actions/cache@v3.2.3
       with:


### PR DESCRIPTION
The latest version for buildkit v0.11.0 breaks the image push to registry. Use the previous stable version till upstream bug is fixed. Related upstream issues are: 

- https://github.com/docker/build-push-action/issues/761
- https://github.com/containerd/containerd/issues/7972
- https://github.com/moby/buildkit/issues/3347

The workaround has been recommended [here](https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381) and I tested ([v0.10.6](https://github.com/mqasimsarfraz/actions/actions/runs/3947633886) vs [v0.11.0](https://github.com/mqasimsarfraz/actions/actions/runs/3940073459)) it as well. Also, on [fork](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/3949535040/jobs/6760870559#step:4:151).

We can also wait till the situation is clear and re-trigger in case of failures since only `main` is effected.  

Related #1267