### PR TITLE
integration: Ensure local-gadget is ready before running test

### DIFF
--- a/integration/local-gadget/non-k8s/trace_dns_test.go
+++ b/integration/local-gadget/non-k8s/trace_dns_test.go
@@ -108,6 +108,7 @@ func TestTraceDns(t *testing.T) {
 
 	testSteps := []TestStep{
 		traceDNSCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		&DockerContainer{
 			Name: cn,
 			Cmd: "nslookup -type=a inspektor-gadget.io. 8.8.4.4 ; " +

--- a/integration/local-gadget/non-k8s/trace_network_test.go
+++ b/integration/local-gadget/non-k8s/trace_network_test.go
@@ -73,6 +73,7 @@ func TestTraceNetwork(t *testing.T) {
 
 	testSteps := []TestStep{
 		traceNetworkCmd,
+		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
 		&DockerContainer{
 			Name:    cn,
 			Cmd:     "nginx && curl 127.0.0.1",


### PR DESCRIPTION
We have seen [scenario](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3949717373/attempts/1#summary-10727271605) in CI here `local-gadget` isn't ready when test events are generated resulting in missing initial events. Add a sleep to ensure local-gadget is ready before we generate test events.