### PR TITLE
integration: Upgrade SPO to v0.6.0

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -113,9 +113,9 @@ func DeployInspektorGadget(image, imagePullPolicy string) *Command {
 
 func DeploySPO(limitReplicas, patchWebhookConfig, bestEffortResourceMgmt bool) *Command {
 	cmdStr := fmt.Sprintf(`
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.yaml
 kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
-curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.3/deploy/operator.yaml | \
+curl https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.6.0/deploy/operator.yaml | \
   if [ %v = true ] ; then
     sed 's/replicas: 3/replicas: 1/' | grep -v cpu:
   else
@@ -196,8 +196,8 @@ var CleanupSPO = []*Command{
 		Name: "RemoveSecurityProfilesOperator",
 		Cmd: `
 		kubectl delete seccompprofile --all --all-namespaces
-		kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.4.3/deploy/operator.yaml --ignore-not-found
-		kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml --ignore-not-found
+		kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v0.6.0/deploy/operator.yaml --ignore-not-found
+		kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.yaml --ignore-not-found
 		`,
 		Cleanup: true,
 	},


### PR DESCRIPTION
We have seen errors related to SPO webhook not available in CI, resulting in failing tests. It seems they have made SPO webhook opt-in [upstream](https://github.com/kubernetes-sigs/security-profiles-operator/pull/1207) to avoid such situation. Upgrading so we don't hit such issues in the CI.

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "recording.spo.io": failed to call webhook: Post "[https://webhook-service.security-profiles-operator.svc:443/mutate-v1-pod-recording?timeout=10s](https://webhook-service.security-profiles-operator.svc/mutate-v1-pod-recording?timeout=10s)": context deadline exceeded
```
Also, I tried to check why `webhook` wasn't available and it seems for some reason `webhook` was being restarted maybe because of low resources in runner?

Related upstream change:
- https://github.com/kubernetes-sigs/security-profiles-operator/pull/1207
> The SPO webhooks have been cluster-wide by default. This is great for
functionality as both recording and binding just works, but might be
dangerous - if there is a bug in the webhook or the webhook is not
replying, then all namespaces might be affected.