### PR TITLE
pkg/gadgets: Use Event timestamp to compute latency in DNS gadget.

### DIFF
--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -65,9 +65,9 @@ func NewTracer() (*Tracer, error) {
 		// Filter by packet type (OUTGOING for queries and HOST for responses) to exclude cases where
 		// the packet is forwarded between containers in the host netns.
 		if bpfEvent.Qr == 0 && bpfEvent.PktType == unix.PACKET_OUTGOING {
-			latencyCalc.storeDNSQueryTimestamp(netns, bpfEvent.Id, bpfEvent.Timestamp)
+			latencyCalc.storeDNSQueryTimestamp(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
 		} else if bpfEvent.Qr == 1 && bpfEvent.PktType == unix.PACKET_HOST {
-			event.Latency = latencyCalc.calculateDNSResponseLatency(netns, bpfEvent.Id, bpfEvent.Timestamp)
+			event.Latency = latencyCalc.calculateDNSResponseLatency(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
 		}
 
 		return event, nil


### PR DESCRIPTION
Hi.


In this PR, I used the `Event.timestamp` rather than eBPF even one to compute DNS latency.
As a consequence, we can now get the latency on older kernels:

```
# Output before on older kernels:
{"node":"aks-nodepool1-36057238-vmss000000","namespace":"demo","pod":"mypod","timestamp":1674472952503856300,"type":"normal","id":"49d6","qr":"Q","nameserver":"8.8.4.4","pktType":"OUTGOING","qtype":"A","name":"inspektor-gadget.io."}
{"node":"aks-nodepool1-36057238-vmss000000","namespace":"demo","pod":"mypod","timestamp":1674472952523841639,"type":"normal","id":"49d6","qr":"R","nameserver":"8.8.4.4","pktType":"HOST","qtype":"A","name":"inspektor-gadget.io.","rcode":"NoError"}
# Output now on older kernels:
{"node":"aks-nodepool1-36057238-vmss000000","namespace":"demo","pod":"mypod","timestamp":1674473235926363771,"type":"normal","id":"1ed5","qr":"Q","nameserver":"8.8.4.4","pktType":"OUTGOING","qtype":"A","name":"inspektor-gadget.io."}
{"node":"aks-nodepool1-36057238-vmss000000","namespace":"demo","pod":"mypod","timestamp":1674473236028490471,"type":"normal","id":"1ed5","qr":"R","nameserver":"8.8.4.4","pktType":"HOST","qtype":"A","name":"inspektor-gadget.io.","rcode":"NoError","latency":102126700}
```


Best regards and thank you in advance.