### PR TITLE
tests: Make GetTestPodIP() return an error too

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -191,15 +192,17 @@ func BuildBaseEvent(namespace string) eventtypes.Event {
 	}
 }
 
-func GetTestPodIP(ns string, podname string) string {
+func GetTestPodIP(ns string, podname string) (string, error) {
 	cmd := exec.Command("kubectl", "-n", ns, "get", "pod", podname, "-o", "jsonpath='{.status.podIP}'")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	r, err := cmd.Output()
 	if err != nil {
-		return fmt.Sprintf("failed to get Pod IP: %s", err)
+		return "", fmt.Errorf("%w: %s", err, stderr.String())
 	}
 
 	ip := string(r)
-	return ip[1 : len(ip)-1]
+	return ip[1 : len(ip)-1], nil
 }
 
 func CheckNamespace(ns string) bool {

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -29,29 +29,18 @@ func TestTopTcp(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
-		CreateTestNamespaceCommand(ns),
-		PodCommand("nginx-pod", "nginx", ns, "", ""),
-		WaitUntilPodReadyCommand(ns, "nginx-pod"),
-	}
-
-	RunTestSteps(commandsPreTest, t)
-	NginxIP := GetTestPodIP(ns, "nginx-pod")
-
 	topTCPCmd := &Command{
 		Name:         "StartTopTcpGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			TestPodIP := GetTestPodIP(ns, "test-pod")
-
 			expectedEntry := &toptcpTypes.Stats{
 				CommonData: BuildCommonData(ns),
-				Comm:       "wget",
+				Comm:       "curl",
 				Dport:      80,
 				Family:     syscall.AF_INET,
-				Saddr:      TestPodIP,
-				Daddr:      NginxIP,
+				Saddr:      "127.0.0.1",
+				Daddr:      "127.0.0.1",
 			}
 
 			normalize := func(e *toptcpTypes.Stats) {
@@ -68,8 +57,9 @@ func TestTopTcp(t *testing.T) {
 	}
 
 	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
 		topTCPCmd,
-		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
+		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -36,14 +36,20 @@ func TestTraceNetwork(t *testing.T) {
 	}
 
 	RunTestSteps(commandsPreTest, t)
-	nginxIP := GetTestPodIP(ns, "nginx-pod")
+	nginxIP, err := GetTestPodIP(ns, "nginx-pod")
+	if err != nil {
+		t.Fatalf("failed to get pod ip %s", err)
+	}
 
 	traceNetworkCmd := &Command{
 		Name:         "StartTraceNetworkGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace network -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			testPodIP := GetTestPodIP(ns, "test-pod")
+			testPodIP, err := GetTestPodIP(ns, "test-pod")
+			if err != nil {
+				return fmt.Errorf("getting pod ip: %w", err)
+			}
 
 			expectedEntries := []*tracenetworkTypes.Event{
 				{

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -28,29 +28,18 @@ func TestTraceTcpconnect(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
-		CreateTestNamespaceCommand(ns),
-		PodCommand("nginx-pod", "nginx", ns, "", ""),
-		WaitUntilPodReadyCommand(ns, "nginx-pod"),
-	}
-
-	RunTestSteps(commandsPreTest, t)
-	NginxIP := GetTestPodIP(ns, "nginx-pod")
-
 	traceTcpconnectCmd := &Command{
 		Name:         "StartTraceTcpconnectGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			TestPodIP := GetTestPodIP(ns, "test-pod")
-
 			expectedEntry := &tracetcpconnectTypes.Event{
 				Event:     BuildBaseEvent(ns),
-				Comm:      "wget",
+				Comm:      "curl",
 				IPVersion: 4,
 				Dport:     80,
-				Saddr:     TestPodIP,
-				Daddr:     NginxIP,
+				Saddr:     "127.0.0.1",
+				Daddr:     "127.0.0.1",
 			}
 
 			normalize := func(e *tracetcpconnectTypes.Event) {
@@ -65,8 +54,9 @@ func TestTraceTcpconnect(t *testing.T) {
 	}
 
 	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
 		traceTcpconnectCmd,
-		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
+		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}

--- a/integration/local-gadget/k8s/trace_network_test.go
+++ b/integration/local-gadget/k8s/trace_network_test.go
@@ -34,14 +34,20 @@ func TestTraceNetwork(t *testing.T) {
 	}
 
 	RunTestSteps(commandsPreTest, t)
-	nginxIP := GetTestPodIP(ns, "nginx-pod")
+	nginxIP, err := GetTestPodIP(ns, "nginx-pod")
+	if err != nil {
+		t.Fatalf("failed to get pod ip %s", err)
+	}
 
 	traceNetworkCmd := &Command{
 		Name:         "TraceNetwork",
 		Cmd:          fmt.Sprintf("local-gadget trace network -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			testPodIP := GetTestPodIP(ns, "test-pod")
+			testPodIP, err := GetTestPodIP(ns, "test-pod")
+			if err != nil {
+				return fmt.Errorf("getting pod ip: %w", err)
+			}
 
 			expectedEntries := []*networkTypes.Event{
 				{

--- a/integration/local-gadget/k8s/trace_tcpconnect_test.go
+++ b/integration/local-gadget/k8s/trace_tcpconnect_test.go
@@ -26,28 +26,17 @@ func TestTraceTcpconnect(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-tcpconnect")
 
-	commandsPreTest := []*Command{
-		CreateTestNamespaceCommand(ns),
-		PodCommand("nginx-pod", "nginx", ns, "", ""),
-		WaitUntilPodReadyCommand(ns, "nginx-pod"),
-	}
-
-	RunTestSteps(commandsPreTest, t)
-	NginxIP := GetTestPodIP(ns, "nginx-pod")
-
 	tcpconnectCmd := &Command{
 		Name:         "StartTcpconnectGadget",
 		Cmd:          fmt.Sprintf("local-gadget trace tcpconnect -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			TestPodIP := GetTestPodIP(ns, "test-pod")
-
 			expectedEntry := &tcpconnectTypes.Event{
 				Event:     BuildBaseEvent(ns),
-				Comm:      "wget",
+				Comm:      "curl",
 				IPVersion: 4,
-				Saddr:     TestPodIP,
-				Daddr:     NginxIP,
+				Saddr:     "127.0.0.1",
+				Daddr:     "127.0.0.1",
 				Dport:     80,
 			}
 
@@ -68,9 +57,10 @@ func TestTraceTcpconnect(t *testing.T) {
 	}
 
 	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
 		tcpconnectCmd,
 		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
-		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", NginxIP)),
+		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}


### PR DESCRIPTION
It's possible that GetTestPodIP() fails as in https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/3986343020/jobs/6834925048. This PR introduces a better way to handle errors in this function, hence avoiding weird test failures messages like:

```
invalid command output(StartTraceTcpconnectGadget): verifying output with custom function: output doesn't contain the expected entry: &{Event:{CommonData:{Node: Namespace:test-tcpconnect-2634895312520334714 Pod:test-pod Container:test-pod} Timestamp:1970-01-01T00:00:00.000000000Z Type:normal Message:} Pid:0 UID:0 Comm:wget IPVersion:4 Saddr:failed to get Pod IP: exit status 1 Daddr:172.17.0.11 Dport:80 MountNsID:0}
```