### PR TITLE
test snapshot process gadget: increase timeout

### DIFF
--- a/pkg/gadgets/snapshot/process/tracer/tracer_test.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer_test.go
@@ -219,7 +219,7 @@ func testTracer(t *testing.T, runCollector collectorFunc) {
 
 // Function that runs a "sleep" process.
 func generateEvent() (int, error) {
-	cmd := exec.Command("/bin/sleep", "3")
+	cmd := exec.Command("/bin/sleep", "5")
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("running command: %w", err)
 	}


### PR DESCRIPTION
Under heavy load, tracers might take a few seconds to start. The sleep of 3 seconds is not always enough.

How to reproduce:
```
    $ go test -test.v -exec sudo ./pkg/gadgets/...
```
So it tests all gadgets at the same time, generating enough load.

The following is not generating heavy load enough to reproduce the bug:
```
    $ go test -test.v -exec sudo ./pkg/gadgets/snapshot/process/...
```

Example of output:
```
--- FAIL: TestSnapshotProcessEBPFTracer (0.00s)
    --- PASS: TestSnapshotProcessEBPFTracer/no_threads_are_captured (2.37s)
    --- FAIL: TestSnapshotProcessEBPFTracer/captures_events_with_matching_filter (3.24s)
    --- FAIL: TestSnapshotProcessEBPFTracer/captures_all_events_with_no_filters_configured (3.35s)
    --- FAIL: TestSnapshotProcessEBPFTracer/captures_events_with_matching_filter_threads (3.40s)
    --- PASS: TestSnapshotProcessEBPFTracer/captures_no_events_with_no_matching_filter (1.56s)
```
