### PR TITLE
integration: sni: add timeout to wget

### DIFF
--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -53,7 +53,7 @@ func TestTraceSni(t *testing.T) {
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
 		traceSniCmd,
-		BusyboxPodRepeatCommand(ns, "wget -q -O /dev/null https://inspektor-gadget.io"),
+		BusyboxPodRepeatCommand(ns, "wget --no-check-certificate -T 2 -q -O /dev/null https://inspektor-gadget.io"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}

--- a/integration/local-gadget/k8s/trace_sni_test.go
+++ b/integration/local-gadget/k8s/trace_sni_test.go
@@ -53,7 +53,7 @@ func TestTraceSni(t *testing.T) {
 		CreateTestNamespaceCommand(ns),
 		traceSNICmd,
 		SleepForSecondsCommand(2), // wait to ensure local-gadget has started
-		BusyboxPodRepeatCommand(ns, "wget -q -O /dev/null https://kubernetes.default.svc.cluster.local"),
+		BusyboxPodRepeatCommand(ns, "wget --no-check-certificate -T 2 -q -O /dev/null https://kubernetes.default.svc.cluster.local"),
 		WaitUntilTestPodReadyCommand(ns),
 		DeleteTestNamespaceCommand(ns),
 	}


### PR DESCRIPTION
Sometimes, the command 'wget https://inspektor-gadget.io' blocks on a read() syscall forever. In my tests, it blocks only in the busybox container (not on ubuntu or on the host), and only with that website (https://wikipedia.org works fine).

This patch adds a timeout to the 'wget', so that the command terminates and the loop can reexecute the next wget.

How to reproduce with the integration test:
```
INTEGRATION_TESTS_PARAMS="-run TestTraceSni -no-deploy-ig -no-deploy-spo" make integration-tests
```
How to reproduce manually:
```
$ docker run -ti --rm busybox
/ # wget https://inspektor-gadget.io
```
The last strace logs are:
```
[pid 3777692] write(3, "GET / HTTP/1.1\r\nHost: inspektor-"..., 82 <unfinished ...>
[pid 3777692] <... write resumed>)      = 82
[pid 3777692] shutdown(3, SHUT_WR <unfinished ...>
[pid 3777692] <... shutdown resumed>)   = 0
[pid 3777692] alarm(900 <unfinished ...>
[pid 3777692] <... alarm resumed>)      = 900
[pid 3777692] read(3,  <unfinished ...>
```
And it blocks there.
