### PR TITLE
gadgets: call btf.LoadKernelSpec once

### DIFF
--- a/pkg/gadgets/advise/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/advise/seccomp/tracer/tracer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	libseccomp "github.com/seccomp/libseccomp-golang"
 )
 
@@ -60,7 +61,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load asset: %w", err)
 	}
 
-	if err := spec.LoadAndAssign(&t.objs, nil); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, ebpfoptions.CollectionOptions()); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/audit/seccomp/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -90,11 +91,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/internal/ebpfoptions/ebpfoptions.go
+++ b/pkg/gadgets/internal/ebpfoptions/ebpfoptions.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpfoptions
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+)
+
+var spec *btf.Spec
+
+func init() {
+	spec, _ = btf.LoadKernelSpec()
+}
+
+func CollectionOptions() *ebpf.CollectionOptions {
+	return &ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: spec,
+		},
+	}
+}

--- a/pkg/gadgets/internal/networktracer/tracer.go
+++ b/pkg/gadgets/internal/networktracer/tracer.go
@@ -26,6 +26,7 @@ import (
 
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/rawsock"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -69,7 +70,7 @@ func newAttachment(
 		}
 	}()
 
-	a.collection, err = ebpf.NewCollection(spec)
+	a.collection, err = ebpf.NewCollectionWithOptions(spec, *ebpfoptions.CollectionOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BPF collection: %w", err)
 	}

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/moby/moby/pkg/parsers/kernel"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
 )
 
@@ -125,7 +126,7 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 
-	if err := spec.LoadAndAssign(&t.objs, nil); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, ebpfoptions.CollectionOptions()); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/profile/cpu/tracer/tracer.go
+++ b/pkg/gadgets/profile/cpu/tracer/tracer.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/types"
 )
 
@@ -337,11 +338,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -28,6 +28,7 @@ import (
 
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	processcollectortypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -87,11 +88,10 @@ func runeBPFCollector(config *Config, enricher gadgets.DataEnricherByMntNs) ([]*
 	}
 
 	objs := processCollectorObjects{}
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&objs, opts); err != nil {
 		return nil, fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 	defer objs.Close()

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/ebpf/link"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	socketcollectortypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/netnsenter"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -72,7 +73,7 @@ func parseStatus(proto string, statusUint uint8) (string, error) {
 
 func getTCPIter() (*link.Iter, error) {
 	objs := iterTCPv4Objects{}
-	if err := loadIterTCPv4Objects(&objs, nil); err != nil {
+	if err := loadIterTCPv4Objects(&objs, ebpfoptions.CollectionOptions()); err != nil {
 		return nil, fmt.Errorf("failed to load TCP BPF objects: %w", err)
 	}
 	defer objs.Close()
@@ -89,7 +90,7 @@ func getTCPIter() (*link.Iter, error) {
 
 func getUDPIter() (*link.Iter, error) {
 	objs := iterUDPv4Objects{}
-	if err := loadIterUDPv4Objects(&objs, nil); err != nil {
+	if err := loadIterUDPv4Objects(&objs, ebpfoptions.CollectionOptions()); err != nil {
 		return nil, fmt.Errorf("failed to load UDP BPF objects: %w", err)
 	}
 	defer objs.Close()

--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/block-io/types"
 )
@@ -154,11 +155,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/top/ebpf/piditer/iter.go
+++ b/pkg/gadgets/top/ebpf/piditer/iter.go
@@ -25,11 +25,11 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET -cc clang -type pid_iter_entry piditer ./bpf/pid_iter.bpf.c -- -I./bpf/ -I../../../../${TARGET}
@@ -126,9 +126,9 @@ func NewTracer() (iter *PidIter, err error) {
 		return nil, fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{}
+	opts := ebpfoptions.CollectionOptions()
 
-	if err = spec.LoadAndAssign(&p.objs, &opts); err != nil {
+	if err = spec.LoadAndAssign(&p.objs, opts); err != nil {
 		return nil, fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/top/file/tracer/tracer.go
+++ b/pkg/gadgets/top/file/tracer/tracer.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/types"
 )
@@ -112,11 +113,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/tcp/types"
 )
@@ -113,11 +114,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/bind/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -122,11 +123,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -156,11 +158,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -100,11 +102,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/fsslower/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -159,11 +161,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/mount/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -105,11 +107,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/oomkill/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -99,11 +101,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -105,11 +107,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -18,7 +18,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
@@ -147,11 +149,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -114,11 +115,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpconnect/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -103,11 +104,10 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error RewriteConstants: %w", err)
 	}
 
-	opts := ebpf.CollectionOptions{
-		MapReplacements: mapReplacements,
-	}
+	opts := ebpfoptions.CollectionOptions()
+	opts.MapReplacements = mapReplacements
 
-	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, opts); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 

--- a/pkg/gadgets/traceloop/tracer/tracer.go
+++ b/pkg/gadgets/traceloop/tracer/tracer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/ebpfoptions"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	libseccomp "github.com/seccomp/libseccomp-golang"
@@ -133,7 +134,7 @@ func NewTracer(enricher gadgets.DataEnricherByMntNs) (*Tracer, error) {
 		})
 	}
 
-	if err := spec.LoadAndAssign(&t.objs, nil); err != nil {
+	if err := spec.LoadAndAssign(&t.objs, ebpfoptions.CollectionOptions()); err != nil {
 		return nil, fmt.Errorf("loading ebpf program: %w", err)
 	}
 


### PR DESCRIPTION
When loading a ebpf module, btf.LoadKernelSpec() is called for each ebpf program. Even if cilium/ebpf has a cache mechanism, btf.(*Spec).Copy() is still called and it is taking a significant time (e.g. 237ms).

Cache mechanism:
https://github.com/cilium/ebpf/blob/dc0c82204f210e73e853bd0ad96060bb33ec3901/btf/btf.go#L290

Functions spec.LoadAndAssign(), ebpf.NewCollectionWithOptions() and loadSeccompObjects() take a ebpf.CollectionOptions parameter where it is possible to pass our own kernel spec. When doing so, btf.(*Spec).Copy() does not need to be called and we improve performance significantly.

This patch introduces a ebpfoptions package to provide a reasonable ebpf.CollectionOptions for all gadgets with a kernel spec created only one time without copying it for each program.

------

See https://github.com/inspektor-gadget/inspektor-gadget/pull/1201#issuecomment-1403598719

TODO:
- [ ] Tests