### PR TITLE
Revert "CI: Workaround for buildkit error while pushing to registry"

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -207,10 +207,6 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
-      # FIXME: remove this when https://github.com/docker/build-push-action/issues/761 is fixed
-      with:
-        driver-opts: |
-          image=moby/buildkit:v0.10.6
     - name: Cache Docker layers
       uses: actions/cache@v3.2.3
       with:


### PR DESCRIPTION
Reverts inspektor-gadget/inspektor-gadget#1276 since upsteam https://github.com/docker/build-push-action/issues/761 issue is fixed.