### PR TITLE
New pkg to sort events by timestamps

### DIFF
--- a/pkg/event-sorter/doc.go
+++ b/pkg/event-sorter/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package eventsorter is a library that helps to sort streams of events
+chronologically according to their timestamps.
+
+This is motivated by events coming from a eBPF program via perf ring buffers.
+Since perf ring buffer maps have one buffer per cpu, it might be that the
+userland reader reads events out-of-order if they come from different per-cpu
+buffers.
+
+This package is generic and does not need to know the type of your events.
+Instead of using references to an event, it just calls a callback. The caller
+can use closures to handle the events.
+
+This package re-order events based on a uint64 timestamp. It does not need to
+know the clock used for the timestamp. It only compares timestamps between
+themselves and not with other clocks such as time.Now(). In this way, users of
+this library are free to use bpf_ktime_get_ns(), bpf_ktime_get_boot_ns() or
+event a simple counter.
+
+# How does it work?
+
+	// Create the event sorter
+	es = eventsorter.NewEventSorter()
+
+	// Add events. The callbacks will be called asynchronously in the
+	// right order after a short delay
+	event := types.Event{
+		Event: eventtypes.Event{
+			Type:      eventtypes.NORMAL,
+			Timestamp: gadgets.WallTimeFromBootTime(bpfEvent.Timestamp),
+		},
+		MountNsID: bpfEvent.MntnsId,
+	}
+	eventSorter.Append(uint64(event.Timestamp), func() {
+		t.eventCallback(&event)
+	})
+
+	// Close the event sorter
+	eventSorter.Close()
+*/
+package eventsorter

--- a/pkg/event-sorter/event-sorter.go
+++ b/pkg/event-sorter/event-sorter.go
@@ -1,0 +1,186 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventsorter
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultDelay is the time the event sorter should wait to see if
+	// another event is coming with an earlier timestamp.
+	//
+	// Note: some tests have this code pattern:
+	//         // Give some time for the tracer to capture the events
+	//         time.Sleep(100 * time.Millisecond)
+	//
+	// defaultDelay should be smaller to make sure that the tests wait
+	// enough time.
+	defaultDelay = 50 * time.Millisecond
+)
+
+type scheduledCallback struct {
+	// Timestamp is used to compare the timestamps of scheduled callback
+	// with each others
+	Timestamp uint64
+
+	// AppendTime is the time when the scheduled callback was appended in
+	// the event sorter
+	AppendTime time.Time
+	Callback   func()
+}
+
+type EventSorter struct {
+	delay time.Duration
+
+	ticker *time.Ticker
+	done   chan bool
+	closed bool
+
+	mu                 sync.Mutex
+	scheduledCallbacks []scheduledCallback
+}
+
+// EventSorterOption are options to pass to
+// NewEventSorter using the functional option code pattern.
+type EventSorterOption func(*EventSorter)
+
+// NewEventSorter creates a new event sorter
+func NewEventSorter(options ...EventSorterOption) *EventSorter {
+	es := &EventSorter{
+		delay:  defaultDelay,
+		ticker: time.NewTicker(defaultDelay),
+		done:   make(chan bool),
+	}
+
+	// Call functional options.
+	for _, o := range options {
+		o(es)
+	}
+
+	go es.run()
+	return es
+}
+
+func WithCustomDelay(delay time.Duration) EventSorterOption {
+	return func(es *EventSorter) {
+		es.delay = delay
+	}
+}
+
+func (es *EventSorter) Append(timestamp uint64, callback func()) {
+	resetTicker := es.appendAtTime(timestamp, time.Now(), callback)
+	if resetTicker {
+		es.ticker.Reset(es.delay)
+	}
+}
+
+func (es *EventSorter) appendAtTime(timestamp uint64, now time.Time, callback func()) bool {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	es.scheduledCallbacks = append(es.scheduledCallbacks, scheduledCallback{
+		Timestamp:  timestamp,
+		AppendTime: now,
+		Callback:   callback,
+	})
+
+	return len(es.scheduledCallbacks) == 1
+}
+
+// process checks callbacks that are due to be called in the right order.
+//
+// It is deterministic so it can be easily tested in unit tests. It does not
+// call time.Now() or ticker.Reset() but let the caller do that.
+//
+// Returns when the next ticker should run, or zero if it should be disabled.
+func (es *EventSorter) process(now time.Time) time.Duration {
+	callNow := []scheduledCallback{}
+	maxTimestamp := uint64(0)
+
+	es.mu.Lock()
+	// find maxTimestamp
+	for i := len(es.scheduledCallbacks) - 1; i >= 0; i-- {
+		if now.After(es.scheduledCallbacks[i].AppendTime.Add(es.delay)) {
+			if maxTimestamp < es.scheduledCallbacks[i].Timestamp {
+				maxTimestamp = es.scheduledCallbacks[i].Timestamp
+			}
+		}
+	}
+
+	// extract callbacks
+	var nextTick time.Duration
+	for i := len(es.scheduledCallbacks) - 1; i >= 0; i-- {
+		if es.scheduledCallbacks[i].Timestamp <= maxTimestamp {
+			// if this callback is due, extract it
+			callNow = append([]scheduledCallback{es.scheduledCallbacks[i]}, callNow...)
+			es.scheduledCallbacks = append(es.scheduledCallbacks[:i], es.scheduledCallbacks[i+1:]...)
+		} else {
+			// if this callback is not due yet, calculate when
+			// should be the next processing
+			next := es.scheduledCallbacks[i].AppendTime.Add(es.delay).Sub(now)
+			if nextTick == 0 || nextTick > next {
+				nextTick = next
+			}
+		}
+	}
+
+	es.mu.Unlock()
+
+	sort.Slice(callNow, func(i, j int) bool {
+		return callNow[i].Timestamp < callNow[j].Timestamp
+	})
+	for _, c := range callNow {
+		c.Callback()
+	}
+
+	return nextTick
+}
+
+func (es *EventSorter) run() {
+	for {
+		select {
+		case <-es.done:
+			return
+		case t := <-es.ticker.C:
+			nextTick := es.process(t)
+			if nextTick == 0 {
+				// Since the mutex was released, it's possible
+				// that a new entry was added in
+				// scheduledCallbacks while we were not looking
+				es.mu.Lock()
+				if len(es.scheduledCallbacks) == 0 {
+					es.ticker.Stop()
+				}
+				es.mu.Unlock()
+			} else {
+				es.ticker.Reset(nextTick)
+			}
+		}
+	}
+}
+
+func (es *EventSorter) Close() {
+	if es == nil {
+		return
+	}
+	if es.closed {
+		return
+	}
+	es.closed = true
+	close(es.done)
+}

--- a/pkg/event-sorter/event-sorter_test.go
+++ b/pkg/event-sorter/event-sorter_test.go
@@ -1,0 +1,225 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventsorter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEventSorter(t *testing.T) {
+	t.Parallel()
+
+	type event struct {
+		name       string
+		timestamp  uint64
+		appendTime string
+	}
+
+	timeFormat := time.RFC3339Nano
+	tests := []struct {
+		name             string
+		events           []event
+		eventsAppendTime []uint64
+		processTime      string
+		expectedOutput   string
+		expectedNextTick string
+	}{
+		{
+			name:             "no events",
+			events:           []event{},
+			processTime:      "2022-12-15T11:00:00.000000000Z",
+			expectedOutput:   "",
+			expectedNextTick: "0s",
+		},
+		{
+			name: "events already sorted",
+			events: []event{
+				{
+					name:       "A",
+					timestamp:  1000,
+					appendTime: "2022-12-15T11:00:00.000000000Z",
+				},
+				{
+					name:       "B",
+					timestamp:  2000,
+					appendTime: "2022-12-15T11:00:01.000000000Z",
+				},
+				{
+					name:       "C",
+					timestamp:  3000,
+					appendTime: "2022-12-15T11:00:02.000000000Z",
+				},
+			},
+			processTime:      "2022-12-15T11:00:10.000000000Z",
+			expectedOutput:   "ABC",
+			expectedNextTick: "0s",
+		},
+		{
+			name: "events already sorted but one too recent",
+			events: []event{
+				{
+					name:       "A",
+					timestamp:  1000,
+					appendTime: "2022-12-15T11:00:00.000000000Z",
+				},
+				{
+					name:       "B",
+					timestamp:  2000,
+					appendTime: "2022-12-15T11:00:01.000000000Z",
+				},
+				{
+					name:       "C",
+					timestamp:  3000,
+					appendTime: "2022-12-15T11:00:02.000000000Z",
+				},
+				{
+					name:       "D",
+					timestamp:  4000,
+					appendTime: "2022-12-15T11:00:09.500000000Z",
+				},
+			},
+			processTime:      "2022-12-15T11:00:10.000000000Z",
+			expectedOutput:   "ABC",
+			expectedNextTick: "500ms",
+		},
+		{
+			name: "events not sorted",
+			events: []event{
+				{
+					name:       "C",
+					timestamp:  3000,
+					appendTime: "2022-12-15T11:00:01.000000000Z",
+				},
+				{
+					name:       "B",
+					timestamp:  2000,
+					appendTime: "2022-12-15T11:00:02.000000000Z",
+				},
+				{
+					name:       "A",
+					timestamp:  1000,
+					appendTime: "2022-12-15T11:00:03.000000000Z",
+				},
+			},
+			processTime:      "2022-12-15T11:00:10.000000000Z",
+			expectedOutput:   "ABC",
+			expectedNextTick: "0s",
+		},
+		{
+			name: "events not sorted but one too recent",
+			events: []event{
+				{
+					name:       "C",
+					timestamp:  3000,
+					appendTime: "2022-12-15T11:00:01.000000000Z",
+				},
+				{
+					name:       "B",
+					timestamp:  2000,
+					appendTime: "2022-12-15T11:00:02.000000000Z",
+				},
+				{
+					name:       "A",
+					timestamp:  1000,
+					appendTime: "2022-12-15T11:00:03.000000000Z",
+				},
+				{
+					name:       "D",
+					timestamp:  4000,
+					appendTime: "2022-12-15T11:00:09.500000000Z",
+				},
+			},
+			processTime:      "2022-12-15T11:00:10.000000000Z",
+			expectedOutput:   "ABC",
+			expectedNextTick: "500ms",
+		},
+		{
+			name: "events not sorted and several too recent",
+			events: []event{
+				{
+					name:       "C",
+					timestamp:  3000,
+					appendTime: "2022-12-15T11:00:01.000000000Z",
+				},
+				{
+					name:       "B",
+					timestamp:  2000,
+					appendTime: "2022-12-15T11:00:02.000000000Z",
+				},
+				{
+					name:       "A",
+					timestamp:  1000,
+					appendTime: "2022-12-15T11:00:03.000000000Z",
+				},
+				{
+					name:       "E",
+					timestamp:  5000,
+					appendTime: "2022-12-15T11:00:09.500000000Z",
+				},
+				{
+					name:       "D",
+					timestamp:  4000,
+					appendTime: "2022-12-15T11:00:09.600000000Z",
+				},
+				{
+					name:       "F",
+					timestamp:  6000,
+					appendTime: "2022-12-15T11:00:09.700000000Z",
+				},
+			},
+			processTime:      "2022-12-15T11:00:10.000000000Z",
+			expectedOutput:   "ABC",
+			expectedNextTick: "500ms",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Logf("Test %q\n", tt.name)
+		es := NewEventSorter(WithCustomDelay(time.Second))
+		output := ""
+		for i, e := range tt.events {
+			e := e
+			appendTime, err := time.Parse(timeFormat, e.appendTime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			callback := func() {
+				output += e.name
+			}
+			resetTicker := es.appendAtTime(e.timestamp, appendTime, callback)
+			if resetTicker != (i == 0) {
+				t.Fatal("appendAtTime didn't rearm the ticker")
+			}
+		}
+		processTime, err := time.Parse(timeFormat, tt.processTime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nextTick := es.process(processTime)
+		if output != tt.expectedOutput {
+			t.Fatalf("test %q failed: found %q, expected %q", tt.name, output, tt.expectedOutput)
+		}
+		expectedNextTick, err := time.ParseDuration(tt.expectedNextTick)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if nextTick != expectedNextTick {
+			t.Fatalf("test %q failed: next tick %q, expected %q", tt.name, nextTick.String(), tt.expectedNextTick)
+		}
+
+		es.Close()
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -113,6 +113,14 @@ type Event struct {
 	Message string `json:"message,omitempty"`
 }
 
+type EventWithTimestamp interface {
+	GetTimestamp() Time
+}
+
+func (e Event) GetTimestamp() Time {
+	return e.Timestamp
+}
+
 // GetBaseEvent is needed to implement commonutils.BaseElement and
 // snapshot.SnapshotEvent interfaces.
 func (e Event) GetBaseEvent() *Event {


### PR DESCRIPTION
This is the same code as the first patch of #1277 but without touching the gadgets. I am filing a separate PR in order to keep the other patches from #1277 easily accessible. This PR should be mergeable before #1281 without causing conflicts. The other changes from #1277 can be re-implemented later using an operator as defined in #1281.

-----

Events can be unsorted for different reasons:
- perf ring buffers use a different buffer for each cpu
- networking gadgets use a different perf ring buffer for each network namespace

How to reproduce the bug easily:

* In the first terminal:
```
$ go run -exec sudo ./cmd/local-gadget/... trace dns -r docker -o custom-columns=timestamp,qr,name
TIMESTAMP                           QR NAME
^Z
```
* In the second terminal:
```
$ docker run -ti --rm --name test1 busybox
/ # for i in `seq 10` ; do taskset -c $(($i % 4)) nslookup -type=a svc$i.10.0.0.1.nip.io ; done
```

* Back to the first terminal:
```
$ fg %1
2023-01-18T15:08:08.677820284+01:00 Q  svc3.10.0.0.1.nip.io.
2023-01-18T15:08:08.790717728+01:00 Q  svc7.10.0.0.1.nip.io.
2023-01-18T15:08:08.613460083+01:00 Q  svc1.10.0.0.1.nip.io.
2023-01-18T15:08:08.709986563+01:00 Q  svc5.10.0.0.1.nip.io.
2023-01-18T15:08:08.831027415+01:00 Q  svc9.10.0.0.1.nip.io.
2023-01-18T15:08:08.624624594+01:00 R  svc1.10.0.0.1.nip.io.
2023-01-18T15:08:08.674216648+01:00 R  svc2.10.0.0.1.nip.io.
2023-01-18T15:08:08.692204281+01:00 R  svc3.10.0.0.1.nip.io.
2023-01-18T15:08:08.695384170+01:00 Q  svc4.10.0.0.1.nip.io.
2023-01-18T15:08:08.707398320+01:00 R  svc4.10.0.0.1.nip.io.
2023-01-18T15:08:08.747448019+01:00 R  svc5.10.0.0.1.nip.io.
2023-01-18T15:08:08.788357359+01:00 R  svc6.10.0.0.1.nip.io.
2023-01-18T15:08:08.806841824+01:00 R  svc7.10.0.0.1.nip.io.
2023-01-18T15:08:08.809255967+01:00 Q  svc8.10.0.0.1.nip.io.
2023-01-18T15:08:08.828446626+01:00 R  svc8.10.0.0.1.nip.io.
2023-01-18T15:08:08.846491396+01:00 R  svc9.10.0.0.1.nip.io.
2023-01-18T15:08:08.899635475+01:00 R  svc10.10.0.0.1.nip.io.
2023-01-18T15:08:08.633105917+01:00 Q  svc2.10.0.0.1.nip.io.
2023-01-18T15:08:08.750021549+01:00 Q  svc6.10.0.0.1.nip.io.
2023-01-18T15:08:08.851341853+01:00 Q  svc10.10.0.0.1.nip.io.
```
This patch will allow to sort events correctly.

## Testing done

None, but it was tested in #1277.