### PR TITLE
githubactions: Disable fail-fast

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -86,6 +86,7 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
@@ -147,6 +148,7 @@ jobs:
     # level: 0
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         local-gadget-target: [local-gadget-linux-amd64, local-gadget-linux-arm64]
     steps:
@@ -195,6 +197,7 @@ jobs:
       digest-core-amd64: ${{ steps.published-gadget-container-images.outputs.core-amd64 }}
       digest-core-arm64: ${{ steps.published-gadget-container-images.outputs.core-arm64 }}
     strategy:
+      fail-fast: false
       matrix:
         type: [default, core]
         os: [ linux ]
@@ -305,6 +308,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         type: [ default, core ]
     steps:
@@ -348,6 +352,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         example: [runc-hook, kube-container-collection]
     steps:
@@ -598,6 +603,7 @@ jobs:
     if: needs.check-secrets.outputs.aks == 'true'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os-sku: [Ubuntu, Mariner]
         arch: [amd64, arm64]
@@ -714,6 +720,7 @@ jobs:
     needs: [test-unit, build-kubectl-gadget, build-local-gadget, build-gadget-container-images]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         type: [default, core]
         driver: [none, docker]


### PR DESCRIPTION
From documentation [0]:

"jobs.<job_id>.strategy.fail-fast applies to the entire matrix. If jobs.<job_id>.strategy.fail-fast is set to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to true."

"fast-failing" hides the result of other jobs on the same matrix, hence we don't know if the issue is specific to that job or something more generic. For instance, in [1] we not that the "Integration tests on AKS (Ubuntu, amd64)" test failed, however we don't know the result of other OS / arch combinations, and that information could help to have a better understanding of what's going on.

[0]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
[1]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/4115766320/jobs/7105471579
