### PR TITLE
go.mod: update cilium/ebpf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,4 +147,4 @@ replace (
 	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
 )
 
-replace github.com/cilium/ebpf => github.com/inspektor-gadget/ebpf v0.0.0-20230117151558-ea299d354cf6
+replace github.com/cilium/ebpf => github.com/inspektor-gadget/ebpf v0.0.0-20230228112829-b66c967fcf6c

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/inspektor-gadget/ebpf v0.0.0-20230117151558-ea299d354cf6 h1:QfMaRsqfjOnSr7sCfYTcWxRRFRIufmYmYMFHTAjyuyY=
-github.com/inspektor-gadget/ebpf v0.0.0-20230117151558-ea299d354cf6/go.mod h1:DPiVdY/kT534dgc9ERmvP8mWA+9gvwgKfRvk4nNWnoE=
+github.com/inspektor-gadget/ebpf v0.0.0-20230228112829-b66c967fcf6c h1:+HjJysKdCcY+s1SKdGPoJ9nwAGhu0ZnvT9Li/lvob3w=
+github.com/inspektor-gadget/ebpf v0.0.0-20230228112829-b66c967fcf6c/go.mod h1:DPiVdY/kT534dgc9ERmvP8mWA+9gvwgKfRvk4nNWnoE=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/pkg/gadgets/internal/socketenricher/tracer.go
+++ b/pkg/gadgets/internal/socketenricher/tracer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -57,20 +56,7 @@ func (se *SocketEnricher) start() error {
 		return fmt.Errorf("failed to load asset: %w", err)
 	}
 
-	kernelSpec, err := btf.LoadKernelSpec()
-	if err != nil {
-		return fmt.Errorf("failed to load kernel spec: %w", err)
-	}
-	opts := &ebpf.CollectionOptions{
-		Programs: ebpf.ProgramOptions{
-			// Optimization: only one copy of kernelSpec necessary
-			// for all kprobes.
-			// TODO: remove this once cilium/ebpf#920 is merged
-			//       https://github.com/cilium/ebpf/pull/920
-			KernelTypes: kernelSpec,
-		},
-	}
-	if err := spec.LoadAndAssign(&se.objs, opts); err != nil {
+	if err := spec.LoadAndAssign(&se.objs, nil); err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
 	}
 


### PR DESCRIPTION
This includes the changes that have been merged upstream:
https://github.com/cilium/ebpf/pull/920

This should improve the performances of loading bpf modules.

This PR removes the temporary performance workaround introduced in the SocketEnricher (https://github.com/inspektor-gadget/inspektor-gadget/pull/1201) since it is now done by cilium/ebpf directly.

Note: deprecated tags in generated files are removed, see: https://github.com/cilium/ebpf/pull/888

