### PR TITLE
container-collection: support ephemeral containers

### DIFF
--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -84,6 +84,7 @@ func (k *K8sClient) GetNonRunningContainers(pod *v1.Pod) []string {
 
 	containerStatuses := append([]v1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
 	containerStatuses = append(containerStatuses, pod.Status.ContainerStatuses...)
+	containerStatuses = append(containerStatuses, pod.Status.EphemeralContainerStatuses...)
 
 	for _, s := range containerStatuses {
 		if s.ContainerID != "" && s.State.Running == nil {
@@ -106,6 +107,7 @@ func (k *K8sClient) PodToContainers(pod *v1.Pod) []Container {
 
 	containerStatuses := append([]v1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
 	containerStatuses = append(containerStatuses, pod.Status.ContainerStatuses...)
+	containerStatuses = append(containerStatuses, pod.Status.EphemeralContainerStatuses...)
 
 	for _, s := range containerStatuses {
 		if s.ContainerID == "" || s.State.Running == nil {


### PR DESCRIPTION
# container-collection: support ephemeral containers

[Ephemeral Containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) were introduced in Kubernetes v1.25 [stable], see [KEP-277: Ephemeral Containers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md).

They allow to introduce a container to an existing pod for debugging. This ephemeral container is listed in the podSpec in the `ephemeralContainers` section. But so far, Inspektor Gadget only looked in the `containers` section and `initContainers` section (init containers added by https://github.com/inspektor-gadget/inspektor-gadget/pull/549).

This PR adds support for ephemeral containers.

## How to use

Example of command to start an ephemeral container:
```
$ kubectl debug -it -n seccomp-demo hello-python --image=ubuntu --target=hello-python
root@hello-python:/# /bin/ls
```

Example of output:
```
$ kubectl gadget trace exec  -n seccomp-demo
NODE             NAMESPACE     POD           CONTAINER       PID      PPID     COMM  RET ARGS
minikube-docker  seccomp-demo  hello-python  debugger-l6s5h  1978516  1584722  ls    0   /bin/ls
```

## Testing done

I tested that it can distinguish the regular container and the ephemeral container:

```
$ ./kubectl-gadget trace exec  -n seccomp-demo
NODE                   NAMESPACE              POD                    CONTAINER              PID        PPID       COMM        RET ARGS
minikube-docker        seccomp-demo           hello-python           debugger-l6s5h         1999714    1584722    echo        0   /bin/echo ephemeral
minikube-docker        seccomp-demo           hello-python           hello-python           1999918    1978043    echo        0   /bin/echo container
```