### PR TITLE
Update to golang 1.19

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2,7 +2,7 @@ name: Inspektor Gadget CI
 env:
   REGISTRY: ghcr.io
   CONTAINER_REPO: ${{ github.repository }}
-  GO_VERSION: 1.18.3
+  GO_VERSION: 1.19.6
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-
 concurrency:
   group: ${{ github.ref }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,12 +27,12 @@ linters:
 
 linters-settings:
   gofumpt:
-    lang-version: "1.18"
+    lang-version: "1.19"
   staticcheck:
-    go: "1.18"
+    go: "1.19"
     checks: ["all"]
   stylecheck:
-    go: "1.18"
+    go: "1.19"
     checks: ["all"]
   errorlint:
     # https://github.com/polyfloyd/go-errorlint

--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 # clang and llvm are needed by bpf2go.
 # gcc-multilib is needed for <asm/types.h>.
 # libelf-dev is needed to compile libbpf.

--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -20,9 +20,9 @@ RUN set -ex; \
 	echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list && \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
-	apt-get install -y golang-1.18 libelf-dev:${TARGETARCH} \
+	apt-get install -y golang-1.19 libelf-dev:${TARGETARCH} \
 		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
-	ln -s /usr/lib/go-1.18/bin/go /bin/go && \
+	ln -s /usr/lib/go-1.19/bin/go /bin/go && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		apt-get install -y gcc-aarch64-linux-gnu; \
 	fi

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -20,9 +20,9 @@ RUN set -ex; \
 	echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list && \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
-	apt-get install -y golang-1.18 libelf-dev:${TARGETARCH} \
+	apt-get install -y golang-1.19 libelf-dev:${TARGETARCH} \
 		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
-	ln -s /usr/lib/go-1.18/bin/go /bin/go && \
+	ln -s /usr/lib/go-1.19/bin/go /bin/go && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		apt-get install -y gcc-aarch64-linux-gnu; \
 	fi

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -6,7 +6,7 @@
 # image is valid, even scratch. Alpine is used by default as a tradeoff
 # between size and tools available in the image.
 
-ARG BUILDER_IMAGE=golang:1.18-bullseye
+ARG BUILDER_IMAGE=golang:1.19-bullseye
 ARG BASE_IMAGE=alpine:3.14
 
 FROM ${BUILDER_IMAGE} as builder

--- a/Dockerfiles/local-gadget-builder.Dockerfile
+++ b/Dockerfiles/local-gadget-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 RUN \
 	dpkg --add-architecture arm64 && \

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,7 +57,7 @@ $ kubectl gadget version
 ### Compile from source
 
 To build Inspektor Gadget from source, you'll need to have a Golang version
-1.18 or higher installed.
+1.19 or higher installed.
 
 ```bash
 $ git clone https://github.com/inspektor-gadget/inspektor-gadget.git

--- a/examples/kube-container-collection/Dockerfile
+++ b/examples/kube-container-collection/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 as builder
+FROM golang:1.19 as builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/

--- a/examples/runc-hook/Dockerfile
+++ b/examples/runc-hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 as builder
+FROM golang:1.19 as builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/inspektor-gadget/inspektor-gadget
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cilium/ebpf v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1742,6 +1742,7 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -35,14 +35,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -35,14 +35,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/tools/testjson2md/go.mod
+++ b/tools/testjson2md/go.mod
@@ -1,5 +1,5 @@
 module github.com/inspektor-gadget/inspektor-gadget/tools/testjson2md
 
-go 1.18
+go 1.19
 
 require github.com/medyagh/gopogh v0.13.0


### PR DESCRIPTION
The only specific reason to update is to have [0] in that automatically increases the number of open file descriptors we can have. I didn't updated to 1.20 because the base docker images we use don't have this version available yet.

