### PR TITLE
CI: Fix docker upgrade for cri-o

### DIFF
--- a/.github/actions/setup-minikube/action.yml
+++ b/.github/actions/setup-minikube/action.yml
@@ -21,7 +21,7 @@ runs:
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
         sudo apt-get update
-        sudo apt-get install docker-ce
+        sudo apt-get install docker-ce containerd.io
     - name: Start minikube
       shell: bash
       run: |


### PR DESCRIPTION
Currently we need `docker-ce` >= 23.0.0 for minikube to work for `cri-o` runtime. Something changed in upstream docker packages and now we need to specify `containerd.io` in packages to avoid conflicts. Should have done in the first place as mentioned on their [guide](https://docs.docker.com/engine/install/ubuntu/). :see_no_evil:  

Hopefully, GH action will upgrade to `docker-ce` 23.0.0 and we can get rid of this workaround.

## Failed logs:

```
The following packages have unmet dependencies:
 containerd.io : Conflicts: containerd
                 Conflicts: runc
 moby-containerd : Conflicts: containerd
                   Conflicts: containerd.io
 moby-runc : Conflicts: runc
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
Error: Process completed with exit code 100.
```

