### PR TITLE
trace network: don't hide host netns traffic

### DIFF
--- a/cmd/local-gadget/trace/network.go
+++ b/cmd/local-gadget/trace/network.go
@@ -142,11 +142,6 @@ func printEvents(
 	}
 
 	for _, event := range newEvents {
-		// for now, ignore events on the host netns
-		if event.Container == "" {
-			continue
-		}
-
 		switch commonFlags.OutputMode {
 		case commonutils.OutputModeJSON:
 			b, err := json.Marshal(event)

--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,progid,type,name,pid,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,hostnetwork,progid,type,name,pid,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,pid,tid,comm,reads,writes,rbytes,wbytes,mountnsid,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,hostnetwork,pid,tid,comm,reads,writes,rbytes,wbytes,mountnsid,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - pid: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -370,6 +370,9 @@ func (cc *ContainerCollection) EnrichByNetNs(event *eventtypes.CommonData, netns
 	if len(containers) == 0 || containers[0].HostNetwork {
 		return
 	}
+	if containers[0].HostNetwork {
+		event.HostNetwork = true
+	}
 	if len(containers) == 1 {
 		event.Container = containers[0].Name
 		event.Pod = containers[0].Podname

--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -195,10 +195,7 @@ func (t *Trace) update(trace *gadgetv1alpha1.Trace) bool {
 	t.enricher.Enrich(newEvents)
 
 	for _, event := range newEvents {
-		// for now, ignore events on the host netns
-		if event.Pod != "" {
-			t.publishEvent(trace, event)
-		}
+		t.publishEvent(trace, event)
 	}
 	return true
 }

--- a/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
+++ b/pkg/gadgets/advise/networkpolicy/advisor/advisor.go
@@ -283,6 +283,10 @@ func (a *NetworkPolicyAdvisor) GeneratePolicies() {
 		if e.PktType != "HOST" && e.PktType != "OUTGOING" {
 			continue
 		}
+		// ignore events on the host netns
+		if e.HostNetwork {
+			continue
+		}
 
 		// Kubernetes Network Policies can't block traffic from a pod's
 		// own resident node. Therefore we must not generate a network

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -41,7 +41,7 @@ type Event struct {
 	PodHostIP string            `json:"podHostIP,omitempty" column:"podhostip,template:ipaddr,hide"`
 	PodIP     string            `json:"podIP,omitempty" column:"podip,template:ipaddr,hide"`
 	PodOwner  string            `json:"podOwner,omitempty" column:"podowner,hide"`
-	PodLabels map[string]string `json:"podLabels,omitempty" column:"padlabels,hide"`
+	PodLabels map[string]string `json:"podLabels,omitempty" column:"podlabels,hide"`
 
 	/* Remote */
 	RemoteKind RemoteKind `json:"remoteKind,omitempty" column:"remoteKind,maxWidth:5,hide"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -76,6 +76,9 @@ type CommonData struct {
 	// Container where the event comes from, or empty for host-level or
 	// pod-level event
 	Container string `json:"container,omitempty" column:"container,template:container" columnTags:"kubernetes,runtime"`
+
+	// HostNetwork is true if the container uses the host network namespace
+	HostNetwork bool `json:"hostNetwork,omitempty" column:"hostnetwork,hide"`
 }
 
 const (


### PR DESCRIPTION
The trace network gadget currently doesn't capture traffic from pods with hostNetwork set to true. This was intentional because this gadget was initially designed for the needs of the network policy advisor. Kubernetes network policies don't apply on the host network namespace, so capturing the host network traffic was not necessary. However, the trace network gadget has use cases outside of the network policy advisor.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/1334

TODO:
- [x] Check if it works both with single-container pods and multiple-container pods

cc @johananl 