### PR TITLE
entrypoint.sh: fix dpkg error on alpine

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -82,3 +82,5 @@ COPY hack/btfs /btfs/
 
 # Mitigate https://github.com/kubernetes/kubernetes/issues/106962.
 RUN rm -f /var/run
+
+ENV GADGET_IMAGE_FLAVOUR=core

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -75,3 +75,5 @@ COPY hack/btfs /btfs/
 
 # Mitigate https://github.com/kubernetes/kubernetes/issues/106962.
 RUN rm -f /var/run
+
+ENV GADGET_IMAGE_FLAVOUR=default

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -30,11 +30,16 @@ KERNEL=$(uname -r)
 echo -n "Kernel detected: "
 echo $KERNEL
 
-echo -n "bcc detected: "
-dpkg-query --show libbcc | awk '{print $2}' || true
+# The gadget-core image does not provide bcc.
+if [ "$GADGET_IMAGE_FLAVOUR" = "default" ] ; then
+	echo -n "bcc detected: "
+	dpkg-query --show libbcc | awk '{print $2}' || true
+fi
 
 echo -n "Gadget image: "
 echo $GADGET_IMAGE
+
+echo "Gadget image flavour: ${GADGET_IMAGE_FLAVOUR}"
 
 echo "Deployment options:"
 env | grep '^INSPEKTOR_GADGET_OPTION_.*='


### PR DESCRIPTION
Symptoms:
```
+ kubectl logs -n gadget pod/gadget-jlgvt
/entrypoint.sh: line 34: dpkg-query: not found
```

See https://github.com/inspektor-gadget/inspektor-gadget/pull/1337#issuecomment-1436849662