### PR TITLE
trace network gadget: fix typo

### DIFF
--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -41,7 +41,7 @@ type Event struct {
 	PodHostIP string            `json:"podHostIP,omitempty" column:"podhostip,template:ipaddr,hide"`
 	PodIP     string            `json:"podIP,omitempty" column:"podip,template:ipaddr,hide"`
 	PodOwner  string            `json:"podOwner,omitempty" column:"podowner,hide"`
-	PodLabels map[string]string `json:"podLabels,omitempty" column:"padlabels,hide"`
+	PodLabels map[string]string `json:"podLabels,omitempty" column:"podlabels,hide"`
 
 	/* Remote */
 	RemoteKind RemoteKind `json:"remoteKind,omitempty" column:"remoteKind,maxWidth:5,hide"`


### PR DESCRIPTION
Currently the column is called padlabels:
```
$ kubectl gadget trace network -o custom-columns=node,padlabels
NODE  PADLABELS
```

This patch renames it to podlabels.
