### PR TITLE
ci: Only run dependencies checks for PR on PR.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -84,6 +84,8 @@ jobs:
   dependencies-checks:
     name: Dependencies checks
     # level: 0
+    # Only run this on PR.
+    if: ${{ github.event.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Hi.


This PR fixes a commit introduced in a previous PR to only run dependencies checks for PR on... PR :sweat_smile:.


Best regards.