### PR TITLE
Better validation for -o columns

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -238,7 +238,15 @@ func buildCommandFromGadget(
 
 			formatter := parser.GetTextColumnsFormatter()
 			if outputModeParams != "" {
-				formatter.SetShowColumns(strings.Split(outputModeParams, ","))
+				valid, invalid := parser.VerifyColumnNames(strings.Split(outputModeParams, ","))
+
+				for _, c := range invalid {
+					log.Warnf("column %q not found", c)
+				}
+
+				if err := formatter.SetShowColumns(valid); err != nil {
+					return err
+				}
 			}
 			parser.SetLogCallback(fe.Logf)
 

--- a/pkg/columns/formatter/textcolumns/textcolumns.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns.go
@@ -15,6 +15,7 @@
 package textcolumns
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -90,22 +91,28 @@ func (tf *TextColumnsFormatter[T]) SetShowDefaultColumns() {
 	tf.rebuild()
 }
 
-// SetShowColumns takes a comma separated list of column names that will be displayed when using the output methods
-func (tf *TextColumnsFormatter[T]) SetShowColumns(columns []string) {
+// SetShowColumns takes a list of column names that will be displayed when using the output methods
+// Returns an error if any of the columns is not available.
+func (tf *TextColumnsFormatter[T]) SetShowColumns(columns []string) error {
 	if columns == nil {
 		tf.SetShowDefaultColumns()
-		return
+		return nil
 	}
 
 	newColumns := make([]*Column[T], 0)
 	for _, c := range columns {
-		if column, ok := tf.columns[strings.ToLower(c)]; ok {
-			newColumns = append(newColumns, column)
+		column, ok := tf.columns[strings.ToLower(c)]
+		if !ok {
+			return fmt.Errorf("column %q is invalid", strings.ToLower(c))
 		}
+
+		newColumns = append(newColumns, column)
 	}
 	tf.showColumns = newColumns
 
 	tf.rebuild()
+
+	return nil
 }
 
 // SetAutoScale enables or disables the AutoScale option for the formatter. This will recalculate the widths.

--- a/pkg/columns/formatter/textcolumns/textcolumns_test.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns_test.go
@@ -184,3 +184,61 @@ func TestWithTypeDefinition(t *testing.T) {
 		assert.Equal(t, string(entry.Name), formatter.FormatEntry(entry))
 	}
 }
+
+func TestTextColumnsFormatter_SetShownColumns(t *testing.T) {
+	type test struct {
+		name     string
+		setShown []string
+		expected []string
+		err      bool
+	}
+
+	tests := []test{
+		{
+			name:     "default",
+			setShown: nil,
+			expected: []string{"name", "age", "size", "balance", "canDance"},
+		},
+		{
+			name:     "empty",
+			setShown: []string{},
+			expected: []string{},
+		},
+		{
+			name:     "shown-columns-match",
+			setShown: []string{"name"},
+			expected: []string{"name"},
+		},
+		{
+			name:     "multipe-shown-columns-match",
+			setShown: []string{"name", "canDance"},
+			expected: []string{"name", "canDance"},
+		},
+		{
+			name:     "column-not-found",
+			setShown: []string{"foo"},
+			err:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			formatter := NewFormatter(testColumns)
+
+			err := formatter.SetShowColumns(test.setShown)
+			if test.err {
+				require.NotNil(t, err, "SetShowColumns should have failed")
+				return
+			}
+
+			require.Nil(t, err, "SetShowColumns failed: %s", err)
+
+			found := []string{}
+			for _, c := range formatter.showColumns {
+				found = append(found, c.col.Name)
+			}
+
+			require.Equal(t, test.expected, found, "shown columns doesn't match the expected ones")
+		})
+	}
+}

--- a/pkg/parser/outputhelpers.go
+++ b/pkg/parser/outputhelpers.go
@@ -23,7 +23,7 @@ import (
 // TextColumnsFormatter is the interface used for outputHelper
 type TextColumnsFormatter interface {
 	FormatHeader() string
-	SetShowColumns([]string)
+	SetShowColumns([]string) error
 	TransformEvent(string) (string, error)
 	EventHandlerFunc() any
 	EventHandlerFuncArray(...func()) any
@@ -97,8 +97,8 @@ func (oh *outputHelper[T]) TransformEvent(line string) (string, error) {
 	return oh.FormatEntry(ev), nil
 }
 
-func (oh *outputHelper[T]) SetShowColumns(cols []string) {
-	oh.TextColumnsFormatter.SetShowColumns(cols)
+func (oh *outputHelper[T]) SetShowColumns(cols []string) error {
+	return oh.TextColumnsFormatter.SetShowColumns(cols)
 }
 
 func (oh *outputHelper[T]) SetEnableExtraLines(newVal bool) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -47,6 +47,11 @@ type Parser interface {
 	// GetColumns returns the underlying columns definition (mainly used for serialization)
 	GetColumns() any
 
+	// VerifyColumnNames takes a list of column names and returns two lists, one containing the
+	// valid column names and another containing the invalid column names. Prefixes like "-" for
+	// descending sorting will be ignored.
+	VerifyColumnNames(columnNames []string) (valid []string, invalid []string)
+
 	// SetColumnFilters sets additional column filters that will be used whenever one of the other methods of this
 	// interface are called. This is for example used to filter columns with information on kubernetes in a non-k8s
 	// environment like local-gadget
@@ -234,6 +239,10 @@ func (p *parser[T]) GetDefaultColumns() []string {
 		cols = append(cols, column.Name)
 	}
 	return cols
+}
+
+func (p *parser[T]) VerifyColumnNames(columnNames []string) (valid []string, invalid []string) {
+	return p.columns.VerifyColumnNames(columnNames)
 }
 
 func (p *parser[T]) SetSorting(sortBy []string) error {


### PR DESCRIPTION
Print a warning in case the user passes columns that are not available:

Before:
```
$ sudo ./local-gadget  trace exec -o columns=container,sdasadafd
WARN[0000] Runtime enricher (cri-o): couldn't get current containers
CONTAINER
...
```

Now:
```
$ sudo ./local-gadget  trace exec -o columns=container,sdasadafd
WARN[0000] Runtime enricher (cri-o): couldn't get current containers
WARN[0000] column "sdasadafd" is invalid
CONTAINER
```

