### PR TITLE
CI: Fix test report status/conclusion

### DIFF
--- a/.github/actions/prepare-and-publish-test-reports/action.yml
+++ b/.github/actions/prepare-and-publish-test-reports/action.yml
@@ -5,6 +5,9 @@ inputs:
   test-log-file:
     description: "Test log file to be used to generate reports"
     required: true
+  test-step-conclusion:
+    description: "Conclusion of the test step"
+    required: true
 
 runs:
   using: "composite"
@@ -21,5 +24,5 @@ runs:
     - name: Publish test reports as markdown
       shell: bash
       run: |
-        testjson2md -in ./test-report.json -out ./test-report.md
+        testjson2md -in ./test-report.json -out ./test-report.md -conclusion ${{ inputs.test-step-conclusion }}
         cat test-report.md >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -24,6 +24,7 @@ runs:
         name: kubectl-gadget-linux-amd64-tar-gz
         path: /home/runner/work/inspektor-gadget/inspektor-gadget/
     - name: Integration tests
+      id: integration-tests
       shell: bash
       run: |
         tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
@@ -70,4 +71,4 @@ runs:
       uses: ./.github/actions/prepare-and-publish-test-reports
       with:
         test-log-file: integration.log
-
+        test-step-conclusion: ${{ steps.integration-tests.conclusion }}

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -597,6 +597,7 @@ jobs:
         with:
           runtime: ${{ matrix.runtime }}
       - name: Run integration for container runtime ${{ matrix.runtime }}
+        id: integration-tests
         run: |
           set -o pipefail
           make -C integration/local-gadget/k8s CONTAINER_RUNTIME=${{ matrix.runtime }} -o build test |& tee integration.log
@@ -606,6 +607,7 @@ jobs:
         uses: ./.github/actions/prepare-and-publish-test-reports
         with:
           test-log-file: integration.log
+          test-step-conclusion: ${{ steps.integration-tests.conclusion }}
 
   test-integration-non-k8s-local-gadget:
     name: Integration tests for local gadget with non-Kubernetes Containers
@@ -633,6 +635,7 @@ jobs:
           tar zxvf /home/runner/work/inspektor-gadget/local-gadget-linux-amd64.tar.gz
           mv local-gadget local-gadget-linux-amd64
       - name: Run integration for container runtime ${{ matrix.runtime }}
+        id: integration-tests
         run: |
           set -o pipefail
           make -C integration/local-gadget/non-k8s -o build test-${{ matrix.runtime }} |& tee integration.log
@@ -642,6 +645,7 @@ jobs:
         uses: ./.github/actions/prepare-and-publish-test-reports
         with:
           test-log-file: integration.log
+          test-step-conclusion: ${{ steps.integration-tests.conclusion }}
 
   test-integration-aks:
     name: Integration tests on AKS


### PR DESCRIPTION
Currently, we mark test report as red only when we have failed test cases but there can be scenarios when test run failed because of [timeout or some setup issues](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/4233214077/attempts/1#summary-11491881666) but no failing tests have been reported. This PR use the test step conclusion to mark the test report correctly. 

### Testing done
- [test commit](https://github.com/mqasimsarfraz/inspektor-gadget/pull/23/commits/0d3d9708efa9b1122f05a431b9fe5b62e2b1d03f): [Timed out test](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4254216230/jobs/7400279629) run with [red job summary](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4254216230/attempts/1#summary-11552704511)
- [normal failing tests](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/4253659290/attempts/1#summary-11550998599)