### PR TITLE
top/ebpf: Print all information about processes

### DIFF
--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/go-units"
@@ -52,21 +53,27 @@ func GetColumns() *columns.Columns[Stats] {
 	col.Visible = false
 
 	cols.MustSetExtractor("pid", func(stats *Stats) (ret string) {
-		if len(stats.Pids) > 0 {
-			return fmt.Sprint(stats.Pids[0].Pid)
+		pids := []string{}
+
+		for _, pid := range stats.Pids {
+			pids = append(pids, fmt.Sprint(pid.Pid))
 		}
-		return ""
+
+		return strings.Join(pids, ",")
 	})
 	cols.MustAddColumn(columns.Column[Stats]{
-		Name:     "comm",
-		MaxWidth: 16,
-		Visible:  true,
-		Order:    1000,
+		Name:    "comm",
+		Width:   16,
+		Visible: true,
+		Order:   1000,
 		Extractor: func(stats *Stats) string {
-			if len(stats.Pids) > 0 {
-				return fmt.Sprint(stats.Pids[0].Comm)
+			comms := []string{}
+
+			for _, comm := range stats.Pids {
+				comms = append(comms, comm.Comm)
 			}
-			return ""
+
+			return strings.Join(comms, ",")
 		},
 	})
 	cols.MustSetExtractor("runtime", func(stats *Stats) (ret string) {


### PR DESCRIPTION
Instead of only printing the information for the first process, let's print all the PIDs and comms that are using a given ebpf program. The columns library will take care of "cutting" the output if it's too long:

```
$ sudo ./local-gadget top ebpf
PROGID      TYPE        NAME        PID         COMM           RUNTIME RUNCO…  MAPMEMORY MAPCOUNT
75          Tracing     ig_top_ebp… 159953      local-gadge  784.377µs 8684         4KiB 1
3           CGroupSKB               1           systemd             0s 0              0B 0
68          Kprobe      kprobe_exe… 156948,159… kprobe,foo          0s 0            4KiB 1
```

