### PR TITLE
top/ebpf: Rename Pids to Processes in Stats struct

### DIFF
--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,progid,type,name,pid,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -48,7 +48,7 @@ func TestTopEbpf(t *testing.T) {
 				e.Container = ""
 				e.Namespace = ""
 				e.ProgramID = 0
-				e.Pids = nil
+				e.Processes = nil
 				e.CurrentRuntime = 0
 				e.CurrentRunCount = 0
 				e.CumulativeRuntime = 0

--- a/integration/local-gadget/k8s/top_ebpf_test.go
+++ b/integration/local-gadget/k8s/top_ebpf_test.go
@@ -44,7 +44,7 @@ func TestTopEbpf(t *testing.T) {
 				e.Container = ""
 				e.Namespace = ""
 				e.ProgramID = 0
-				e.Pids = nil
+				e.Processes = nil
 				e.CurrentRuntime = 0
 				e.CurrentRunCount = 0
 				e.CumulativeRuntime = 0

--- a/integration/local-gadget/non-k8s/top_ebpf_test.go
+++ b/integration/local-gadget/non-k8s/top_ebpf_test.go
@@ -38,7 +38,7 @@ func TestTopEbpf(t *testing.T) {
 
 			normalize := func(e *topebpfTypes.Stats) {
 				e.ProgramID = 0
-				e.Pids = nil
+				e.Processes = nil
 				e.CurrentRuntime = 0
 				e.CurrentRunCount = 0
 				e.CumulativeRuntime = 0


### PR DESCRIPTION
PidInfo was a struct with a Pid and a Comm. It seems a bit misleading. This commit renames PidInfo to Process to make it clear that this includes the PID and the command.

--- 

This is somehow related to https://github.com/inspektor-gadget/inspektor-gadget/pull/1361, but I prefer to have separated PRs to keep the discussion independent. 