### PR TITLE
integration: Print logs when test fails

### DIFF
--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -135,5 +135,5 @@ spec:
 		},
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(nsServer, nsClient)))
 }

--- a/integration/inspektor-gadget/advise_seccompprofile_test.go
+++ b/integration/inspektor-gadget/advise_seccompprofile_test.go
@@ -38,5 +38,5 @@ func TestAdviseSeccompProfile(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/audit_seccomp_test.go
+++ b/integration/inspektor-gadget/audit_seccomp_test.go
@@ -109,5 +109,5 @@ EOF
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/profile_blockio_test.go
+++ b/integration/inspektor-gadget/profile_blockio_test.go
@@ -44,5 +44,5 @@ func TestProfileBlockIO(t *testing.T) {
 		},
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn()))
 }

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -55,5 +55,5 @@ func TestProfileCpu(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/snapshot_process_test.go
+++ b/integration/inspektor-gadget/snapshot_process_test.go
@@ -55,5 +55,5 @@ func TestSnapshotProcess(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -70,5 +70,5 @@ func TestSnapshotSocket(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/top_blockio_test.go
+++ b/integration/inspektor-gadget/top_blockio_test.go
@@ -66,5 +66,5 @@ func TestTopBlockIO(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -68,5 +68,5 @@ func TestTopEbpf(t *testing.T) {
 		SleepForSecondsCommand(2),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn()))
 }

--- a/integration/inspektor-gadget/top_file_test.go
+++ b/integration/inspektor-gadget/top_file_test.go
@@ -63,5 +63,5 @@ func TestTopFile(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -64,5 +64,5 @@ func TestTopTcp(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_bind_test.go
+++ b/integration/inspektor-gadget/trace_bind_test.go
@@ -62,5 +62,5 @@ func TestTraceBind(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -86,5 +86,5 @@ func TestTraceCapabilities(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -110,5 +110,5 @@ func TestTraceDns(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -87,5 +87,5 @@ func TestTraceExec(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -67,5 +67,5 @@ func TestTraceFsslower(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_mount_test.go
+++ b/integration/inspektor-gadget/trace_mount_test.go
@@ -67,5 +67,5 @@ func TestTraceMount(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -105,5 +105,5 @@ func TestTraceNetwork(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -85,5 +85,5 @@ spec:
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -62,5 +62,5 @@ func TestTraceOpen(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_signal_test.go
+++ b/integration/inspektor-gadget/trace_signal_test.go
@@ -60,5 +60,5 @@ func TestTraceSignal(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -63,5 +63,5 @@ func TestTraceSni(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -65,5 +65,5 @@ func TestTraceTcp(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -61,5 +61,5 @@ func TestTraceTcpconnect(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/inspektor-gadget/traceloop_test.go
+++ b/integration/inspektor-gadget/traceloop_test.go
@@ -72,5 +72,5 @@ func TestTraceloop(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/list_containers_test.go
+++ b/integration/local-gadget/k8s/list_containers_test.go
@@ -70,7 +70,7 @@ func TestListContainers(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }
 
 func TestFilterByContainerName(t *testing.T) {
@@ -122,7 +122,7 @@ func TestFilterByContainerName(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }
 
 func TestWatchCreatedContainers(t *testing.T) {
@@ -180,7 +180,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }
 
 func TestWatchDeletedContainers(t *testing.T) {
@@ -241,5 +241,5 @@ func TestWatchDeletedContainers(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/profile_bio_test.go
+++ b/integration/local-gadget/k8s/profile_bio_test.go
@@ -45,5 +45,5 @@ func TestProfileBio(t *testing.T) {
 		profileBioCmd,
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn()))
 }

--- a/integration/local-gadget/k8s/profile_cpu_test.go
+++ b/integration/local-gadget/k8s/profile_cpu_test.go
@@ -61,5 +61,5 @@ func TestProfileCpu(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/snapshot_process_test.go
+++ b/integration/local-gadget/k8s/snapshot_process_test.go
@@ -59,5 +59,5 @@ func TestSnapshotProcess(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/top_block_io_test.go
+++ b/integration/local-gadget/k8s/top_block_io_test.go
@@ -65,5 +65,5 @@ func TestTopBlockIO(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/top_ebpf_test.go
+++ b/integration/local-gadget/k8s/top_ebpf_test.go
@@ -63,5 +63,5 @@ func TestTopEbpf(t *testing.T) {
 		topEbpfCmd,
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn()))
 }

--- a/integration/local-gadget/k8s/top_file_test.go
+++ b/integration/local-gadget/k8s/top_file_test.go
@@ -67,5 +67,5 @@ func TestTopFile(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/top_tcp_test.go
+++ b/integration/local-gadget/k8s/top_tcp_test.go
@@ -67,5 +67,5 @@ func TestTopTCP(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_bind_test.go
+++ b/integration/local-gadget/k8s/trace_bind_test.go
@@ -67,5 +67,5 @@ func TestTraceBind(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_capabilities_test.go
+++ b/integration/local-gadget/k8s/trace_capabilities_test.go
@@ -86,5 +86,5 @@ func TestTraceCapabilities(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_dns_test.go
+++ b/integration/local-gadget/k8s/trace_dns_test.go
@@ -133,5 +133,5 @@ func TestTraceDns(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_exec_test.go
+++ b/integration/local-gadget/k8s/trace_exec_test.go
@@ -82,5 +82,5 @@ func TestTraceExec(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_fsslower_test.go
+++ b/integration/local-gadget/k8s/trace_fsslower_test.go
@@ -69,5 +69,5 @@ func TestTraceFsslower(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_mount_test.go
+++ b/integration/local-gadget/k8s/trace_mount_test.go
@@ -71,5 +71,5 @@ func TestTraceMount(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_network_test.go
+++ b/integration/local-gadget/k8s/trace_network_test.go
@@ -99,5 +99,5 @@ func TestTraceNetwork(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_oomkill_test.go
+++ b/integration/local-gadget/k8s/trace_oomkill_test.go
@@ -89,5 +89,5 @@ spec:
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_open_test.go
+++ b/integration/local-gadget/k8s/trace_open_test.go
@@ -66,5 +66,5 @@ func TestTraceOpen(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_signal_test.go
+++ b/integration/local-gadget/k8s/trace_signal_test.go
@@ -64,5 +64,5 @@ func TestTraceSignal(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_sni_test.go
+++ b/integration/local-gadget/k8s/trace_sni_test.go
@@ -63,5 +63,5 @@ func TestTraceSni(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_tcp_test.go
+++ b/integration/local-gadget/k8s/trace_tcp_test.go
@@ -67,5 +67,5 @@ func TestTraceTCP(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/integration/local-gadget/k8s/trace_tcpconnect_test.go
+++ b/integration/local-gadget/k8s/trace_tcpconnect_test.go
@@ -65,5 +65,5 @@ func TestTraceTcpconnect(t *testing.T) {
 		DeleteTestNamespaceCommand(ns),
 	}
 
-	RunTestSteps(commands, t)
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }


### PR DESCRIPTION
Reuse the current cleanup logic we have to print the logs when a test fails.
It implements logic to print the logs when running tests on a K8s env, and leaves a TODO to implement this for local container in local-gadget tests.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/687
Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/567