### PR TITLE
gadgets: Initial bpftrace support

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -8,6 +8,10 @@ inputs:
   image_tag:
     description: 'The image tag used as inspektor gadget deployment image tag.'
     required: true
+  image_flavour:
+    description: 'The image flavour used.'
+    required: true
+    default: "default"
   kubernetes_distribution:
     description: 'The kubernetes distribution used to select distro specific config in tests.'
     required: true
@@ -67,6 +71,7 @@ runs:
           CONTAINER_REPO=${{ inputs.container_repo }} \
           IMAGE_TAG=${{ inputs.image_tag }} \
           DNSTESTER_IMAGE=${{ inputs.dnstester_image }} \
+          IMAGE_FLAVOUR=${{ inputs.image_flavour }} \
           -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
     - name: Prepare and publish test reports

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -841,6 +841,7 @@ jobs:
         kubernetes_architecture: "${{ matrix.arch }}"
         container_repo: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}
         image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        image_flavour: "default"
     - name: Delete AKS cluster ${{ env.CLUSTER_NAME }}
       if: always()
       shell: bash
@@ -940,6 +941,7 @@ jobs:
         kubernetes_architecture: "amd64"
         container_repo: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}
         image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        image_flavour: ${{ matrix.type }}
         dnstester_image: ${{ needs.build-helper-images.outputs.dnstester_image }}
     - if: ${{ matrix.type == 'default' && matrix.runtime == 'docker' }}
       name: Check that README is up-to-date

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -8,7 +8,11 @@ ARG BUILDER_IMAGE=golang:1.19
 # See BCC section in docs/devel/CONTRIBUTING.md for further details.
 ARG BCC="quay.io/kinvolk/bcc:gadget"
 
+# bpftrace upstream image
+ARG BPFTRACE="quay.io/iovisor/bpftrace:v0.17.0"
+
 FROM ${BCC} as bcc
+FROM ${BPFTRACE} as bpftrace
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETARCH
@@ -68,6 +72,13 @@ COPY gadget-container/hooks/nri/conf.json /opt/hooks/nri/
 
 # BTF files
 COPY hack/btfs /btfs/
+
+# bpftrace binary
+# TODO: this work because both bcc and bpftrace are based on the same ubuntu version:
+# https://github.com/kinvolk/bcc/blob/72b4247d7333df499a727987fde4e7903fc344d0/.github/workflows/publish.yml#L28
+# https://github.com/iovisor/bpftrace/blob/cd8c1b188df149277c09ebfb208de623a1aeaebb/docker/Dockerfile.focal#L1
+# We should consider building bpftrace ourselves to avoid this issue.
+COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
 
 # Mitigate https://github.com/kubernetes/kubernetes/issues/106962.
 RUN rm -f /var/run

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ EBPF_BUILDER ?= ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder
 
 DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
 
+IMAGE_FLAVOUR ?= "default"
+
 # Adds a '-dirty' suffix to version string if there are uncommitted changes
 changes := $(shell git status --porcelain)
 ifeq ($(changes),)
@@ -193,6 +195,7 @@ integration-tests: kubectl-gadget
 			-k8s-arch $(KUBERNETES_ARCHITECTURE) \
 			-image $(CONTAINER_REPO):$(IMAGE_TAG) \
 			-dnstester-image $(DNSTESTER_IMAGE) \
+			-image-flavour $(IMAGE_FLAVOUR) \
 			$$INTEGRATION_TESTS_PARAMS
 
 .PHONY: generate-documentation

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Explore the following documentation to find out which tools can help you in your
 	- [`tcp`](docs/gadgets/trace/tcp.md)
 	- [`tcpconnect`](docs/gadgets/trace/tcpconnect.md)
 	- [`tcpdrop`](docs/gadgets/trace/tcpdrop.md)
+- [`script`](docs/gadgets/script.md)
 - [`traceloop`](docs/gadgets/traceloop.md)
 
 ## Installation
@@ -95,6 +96,7 @@ Available Commands:
   deploy         Deploy Inspektor Gadget on the cluster
   help           Help about any command
   profile        Profile different subsystems
+  script         Run a bpftrace-compatible scripts
   snapshot       Take a snapshot of a subsystem and print it
   top            Gather, sort and periodically report events according to a given criteria
   trace          Trace and print system events

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -29,6 +29,8 @@ import (
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+	// The script is not included in the all gadgets package.
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script"
 )
 
 // common params for all gadgets

--- a/docs/gadgets/script.md
+++ b/docs/gadgets/script.md
@@ -1,0 +1,108 @@
+---
+title: 'Using script gadget'
+weight: 30
+description: >
+  Run bpftrace-compatible scripts using Inspektor Gadget.
+---
+
+### On kubernetes
+
+The script gadget allows to run [bpftrace](https://github.com/iovisor/bpftrace)-compatible scripts
+on a Kubernetes cluster. To get more information about bpftrace and its features please check the
+bpftrace documentation.
+
+Currently, only running one-liners is supported:
+
+```bash
+# Files opened by process
+$ kubectl gadget script -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
+NODE                             OUTPUT
+minikube-m02                     Attaching 1 probe...
+minikube-m02                     bpftrace /sys/devices/system/cpu/online
+minikube-m02                     bpftrace /sys/devices/system/cpu/online
+minikube-m03                     Attaching 1 probe...
+minikube-m02                     bpftrace /dev/null
+minikube-m02                     bpftrace /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat/id
+minikube-m02                     bpftrace /sys/devices/system/cpu/online
+minikube-m03                     bpftrace /sys/devices/system/cpu/online
+minikube-m03                     bpftrace /sys/devices/system/cpu/online
+minikube-m02                     bpftrace /sys/devices/system/cpu/online
+minikube                         Attaching 1 probe...
+minikube-m02                     bpftrace /dev/null
+minikube-m02                     bpftrace /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat/id
+minikube-m02                     runc /usr/bin/runc
+minikube-m02                     runc /proc/sys/kernel/cap_last_cap
+minikube                         runc /proc/sys/kernel/cap_last_cap
+minikube-m03                     runc /proc/sys/kernel/cap_last_cap
+minikube-m02                     runc
+...
+
+# Run on a single node
+$ kubectl gadget script --node minikube -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
+NODE                             OUTPUT
+minikube                         Attaching 1 probe...
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/besteffort/poddc2af8ce-f414
+minikube                         kubelet /proc/1645/fd
+minikube                         coredns /etc/hosts
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/besteffort/pod26b59ae5-f76b
+minikube                         kubelet /proc/1565/fd
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/podbd495b7643dfc9
+minikube                         kubelet /proc/1894/fd
+minikube                         kubelet /sys/fs/cgroup/devices/kubepods/besteffort
+minikube                         kubelet /sys/fs/cgroup/devices/kubepods/burstable
+minikube                         kubelet /sys/fs/cgroup/devices/kubepods
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/besteffort
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/burstable
+minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods
+minikube                         kubelet /sys/fs/cgroup/misc/kubepods/besteffort
+minikube                         kubelet /sys/fs/cgroup/misc/kubepods/burstable
+minikube                         kubelet /sys/fs/cgroup/misc/kubepods
+minikube                         kubelet /sys/fs/cgroup/systemd/kubepods/besteffort
+minikube                         kubelet /sys/fs/cgroup/systemd/kubepods/burstable
+minikube                         kubelet /sys/fs/cgroup/systemd/kubepods
+minikube                         kubelet /sys/fs/cgroup/memory/kubepods/besteffort
+minikube                         kubelet /sys/fs/cgroup/memory/kubepods/burstable
+minikube                         kubelet /sys/fs/cgroup/memory/kubepods
+...
+
+# Syscall count by program
+$ kubectl gadget script -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
+
+NODE                             OUTPUT
+minikube-m03                     Attaching 1 probe...
+minikube-m02                     Attaching 1 probe...
+minikube                         Attaching 1 probe...
+^Cminikube-m02
+minikube
+minikube
+minikube-m02
+minikube-m02                     @[LIST_LEGACY]: 1
+minikube-m02                     @[wpa_supplicant]: 1
+minikube-m02                     @[HangWatcher]: 2
+minikube-m02                     @[SharedWorker th]: 2
+minikube-m02                     @[WebRTC_Worker]: 2
+minikube-m03                     @[cri-dockerd]: 7345
+minikube-m03                     @[EMT-0]: 8105
+minikube-m03                     @[containerd-shim]: 8237
+minikube-m03                     @[gadgettracerman]: 8470
+minikube-m03                     @[runc]: 14030
+minikube-m03                     @[EMT-7]: 15583
+minikube-m03                     @[dockerd]: 22937
+minikube-m03                     @[kubelet]: 27455
+...
+```
+
+### Limitations
+
+Given that `bpftrace` is executed inside the Inspektor Gadget container, it's needed to append
+`/host` to the binary path in order to use uprobes.
+
+``` bash
+$ kubectl gadget script -e 'uretprobe:/host/bin/bash:readline { printf("read a line\n"); }'
+```
+
+### Future improvements
+
+We plan to make the bpftrace and Inspektor Gadget more powerful in the future. Please check
+https://github.com/inspektor-gadget/inspektor-gadget/issues/1433 issue that contains more details
+about the planned features.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -74,7 +74,10 @@ listed in the following table:
 | `trace tcp`              | 4.15 (BCC only)         |                         |
 | `trace tcpconnect`       | 4.15 (BCC), 5.8 (CO-RE) | `KPROBES`, `KRETPROBES` |
 | `trace tcpdrop`          | 5.17 (CO-RE only)       |                         |
+| `script`                 | [4.9][1]                |                         |
 | `traceloop`              | 4.15                    | `KPROBES`               |
 
 If the kernel version is U.U, it means we do not have this information at the
 moment.
+
+[1]: https://github.com/iovisor/bpftrace/blob/master/INSTALL.md#linux-kernel-requirements

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -38,6 +38,8 @@ import (
 
 	// This is a blank include that actually imports all gadgets
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+	// The script gadget is designed only to work in k8s, hence it's not part of all-gadgets
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script"
 
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager"

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -36,6 +36,11 @@ const (
 	K8sDistroMinikubeGH = "minikube-github"
 )
 
+const (
+	DefaultImageFlavour = "default"
+	CoreImageFlavour    = "core"
+)
+
 const securityProfileOperatorNamespace = "security-profiles-operator"
 
 var (
@@ -48,6 +53,7 @@ var (
 
 	// image such as ghcr.io/inspektor-gadget/inspektor-gadget:latest
 	image          = flag.String("image", "", "gadget container image")
+	imageFlavour   = flag.String("image-flavour", DefaultImageFlavour, "gadget container image flavour.")
 	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
 
 	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")
@@ -109,6 +115,14 @@ func testMain(m *testing.M) int {
 		if !found {
 			fmt.Fprintf(os.Stderr, "Error: invalid argument '-k8s-distro': %q. Valid values: %s\n",
 				*k8sDistro, strings.Join(supportedK8sDistros, ", "))
+			return -1
+		}
+	}
+
+	if *imageFlavour != "" {
+		if *imageFlavour != DefaultImageFlavour && *imageFlavour != CoreImageFlavour {
+			fmt.Fprintf(os.Stderr, "Error: invalid argument '-image-flavour': %q. Valid values: %s, %s\n",
+				*imageFlavour, DefaultImageFlavour, CoreImageFlavour)
 			return -1
 		}
 	}

--- a/integration/inspektor-gadget/script_test.go
+++ b/integration/inspektor-gadget/script_test.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestScript(t *testing.T) {
+	ns := GenerateTestNamespaceName("test-script")
+
+	if *imageFlavour != DefaultImageFlavour {
+		t.Skip("Skipping script test because it's only supported in the default image")
+	}
+
+	t.Parallel()
+
+	prog := `kretprobe:inet_bind { printf("fofofofof %s\n", comm); }`
+
+	traceOpenCmd := &Command{
+		Name:         "StartScriptGadget",
+		Cmd:          fmt.Sprintf("$KUBECTL_GADGET script -o json -e '%s'", prog),
+		StartAndStop: true,
+		ExpectedOutputFn: func(output string) error {
+			if strings.Contains(output, "fofofofof nc") {
+				return nil
+			}
+
+			return fmt.Errorf("output doesn't contain 'fofofofof nc': %s", output)
+		},
+	}
+
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		traceOpenCmd,
+		BusyboxPodRepeatCommand(ns, "nc -l 127.0.0.1 -p 9090 -w 1"),
+		WaitUntilTestPodReadyCommand(ns),
+		DeleteTestNamespaceCommand(ns),
+	}
+
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+}

--- a/pkg/all-gadgets/allgadgets.go
+++ b/pkg/all-gadgets/allgadgets.go
@@ -18,6 +18,9 @@ import (
 	// Advise Category & traceloop are missing for now. They will be added after
 	// refactoring the CR handling. Currently, they are still handled by CRs.
 
+	// script can't be added because it's designed only to work in kubectl-gadget for the time
+	// being
+
 	// Audit Category
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/audit/seccomp/tracer"
 

--- a/pkg/gadgets/script/gadget.go
+++ b/pkg/gadgets/script/gadget.go
@@ -1,0 +1,70 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
+)
+
+const (
+	ParamProgram = "program"
+)
+
+type GadgetDesc struct{}
+
+func (g *GadgetDesc) Name() string {
+	return "script"
+}
+
+func (g *GadgetDesc) Category() string {
+	return gadgets.CategoryNone
+}
+
+func (g *GadgetDesc) Type() gadgets.GadgetType {
+	return gadgets.TypeTrace
+}
+
+func (g *GadgetDesc) Description() string {
+	return "Run a bpftrace-compatible scripts"
+}
+
+func (g *GadgetDesc) ParamDescs() params.ParamDescs {
+	return params.ParamDescs{
+		{
+			Key:         ParamProgram,
+			Title:       "program",
+			Alias:       "e",
+			Description: "program to run",
+			TypeHint:    params.TypeString,
+			IsMandatory: true,
+		},
+	}
+}
+
+func (g *GadgetDesc) EventPrototype() any {
+	return &types.Event{}
+}
+
+func (g *GadgetDesc) Parser() parser.Parser {
+	return parser.NewParser[types.Event](types.GetColumns())
+}
+
+func init() {
+	gadgetregistry.Register(&GadgetDesc{})
+}

--- a/pkg/gadgets/script/tracer.go
+++ b/pkg/gadgets/script/tracer.go
@@ -1,0 +1,120 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !withoutebpf
+
+package tracer
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script/types"
+)
+
+type Config struct {
+	Program string
+}
+
+type Tracer struct {
+	eventCallback func(ev *types.Event)
+	config        Config
+}
+
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	flavour := os.Getenv("GADGET_IMAGE_FLAVOUR")
+	if flavour != "default" {
+		return fmt.Errorf("script is not supported on the %q flavour of the container image. Only \"default\" is supported for now",
+			flavour)
+	}
+
+	params := gadgetCtx.GadgetParams()
+	t.config.Program = params.Get(ParamProgram).AsString()
+	log := gadgetCtx.Logger()
+
+	// TODO: Consider using CommandContext() once we support Go 1.20
+	cmd := exec.Command("bpftrace", "-e", t.config.Program)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("getting stdout pipe: %w", err)
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("getting stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("running bpftrace: %w", err)
+	}
+
+	// read and send stdout as events
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+
+		for scanner.Scan() {
+			t.eventCallback(&types.Event{
+				Output: scanner.Text(),
+			})
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Error("error reading bpftrace output: %s", err)
+		}
+	}()
+
+	// print stderr through logger
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+
+		for scanner.Scan() {
+			log.Error(scanner.Text())
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Error("error reading bpftrace output: %s", err)
+		}
+	}()
+
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
+
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		log.Errorf("failed to stop process: %s", err)
+		return nil
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Errorf("failed to wait process: %s", err)
+		return nil
+	}
+
+	return nil
+}
+
+func (t *Tracer) SetEventHandler(handler any) {
+	nh, ok := handler.(func(ev *types.Event))
+	if !ok {
+		panic("event handler invalid")
+	}
+	t.eventCallback = nh
+}
+
+func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
+	return &Tracer{}, nil
+}

--- a/pkg/gadgets/script/types/types.go
+++ b/pkg/gadgets/script/types/types.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+
+type Event struct {
+	// Node where the event comes from
+	Node   string `json:"node,omitempty" column:"node,template:node" columnTags:"kubernetes"`
+	Output string `json:"output" column:"output,width:120"`
+}
+
+func GetColumns() *columns.Columns[Event] {
+	return columns.MustCreateColumns[Event]()
+}
+
+func (ev *Event) SetNode(node string) {
+	ev.Node = node
+}


### PR DESCRIPTION
This PR implements a basic support for bpftrace. 

```bash
$ kubectl gadget bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
NODE                             OUTPUT
minikube-m02                     Attaching 1 probe...
minikube-m02                     bpftrace /sys/devices/system/cpu/online
minikube-m02                     bpftrace /sys/devices/system/cpu/online
minikube-m03                     Attaching 1 probe...
minikube-m02                     bpftrace /dev/null
minikube-m02                     bpftrace /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat/id
minikube-m02                     bpftrace /sys/devices/system/cpu/online
minikube-m03                     bpftrace /sys/devices/system/cpu/online
minikube-m03                     bpftrace /sys/devices/system/cpu/online
minikube-m02                     bpftrace /sys/devices/system/cpu/online
minikube                         Attaching 1 probe...
minikube-m02                     bpftrace /dev/null
minikube-m02                     bpftrace /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat/id
minikube-m02                     runc /usr/bin/runc
minikube-m02                     runc /proc/sys/kernel/cap_last_cap
minikube                         runc /proc/sys/kernel/cap_last_cap
minikube-m03                     runc /proc/sys/kernel/cap_last_cap
minikube-m02                     runc
...
```

TODO: (for future PRs?)
- [ ] Support arbitrary parameters, i.e, make  kubectl-gadget transparent to bpftrace, just pass parameters around. 
- [ ] Support `-o json`
- [X] Documentation
- [X] Tests

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1432
