### PR TITLE
testutils: Print stderr logs for docker containers

### DIFF
--- a/integration/local-gadget/non-k8s/Makefile
+++ b/integration/local-gadget/non-k8s/Makefile
@@ -4,7 +4,7 @@ build:
 
 # test
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
-# INTEGRATION_TESTS_PARAMS="-test.run TestFilterByContainerName" make -C integration/local-gadget/docker test
+# INTEGRATION_TESTS_PARAMS="-test.run TestFilterByContainerName" make -C integration/local-gadget/non-k8s test-docker
 test-docker: build
 	cp ../../../local-gadget-linux-amd64 local-gadget
 	go test -c -o ./local-gadget-docker-integration.test ./...

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -75,7 +75,7 @@ func RunDockerContainer(ctx context.Context, t *testing.T, command string, optio
 	}
 
 	if opts.logs {
-		out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})
+		out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
 		if err != nil {
 			t.Fatalf("Failed to get container logs: %s", err)
 		}


### PR DESCRIPTION
It seems we were only printing `stdout` in case of docker tests. This PR will allow printing `stderr` so we can get complete test logs.