### PR TITLE
dependabot: Specify Dockerfiles directory.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     commit-message:
       prefix: "go:"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/Dockerfiles"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Hi.


This PR fixes a previous commit adding `dependabot` checks for Dockerfiles.
Indeed, it was not useful as the bot was not able to find any Dockerfile:
![image](https://user-images.githubusercontent.com/12171754/222442621-9508aa5c-4b04-4e02-bca4-de4cfadece8f.png)
https://github.com/inspektor-gadget/inspektor-gadget/network/updates/616705256


Best regards.