### PR TITLE
GithubActions: Check that website is built correctly

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -46,6 +46,27 @@ jobs:
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          docs:
+            - 'docs/**'
+    - name: Setup Hugo
+      if: steps.filter.outputs.docs == 'true'
+      uses: peaceiris/actions-hugo@v2
+      with:
+        hugo-version: '0.89.0'
+        extended: true
+    - name: Check website build
+      if: steps.filter.outputs.docs == 'true'
+      run: |
+        cd $RUNNER_TEMP
+        git clone https://github.com/inspektor-gadget/website/
+        cd website
+        mkdir -p external-docs/
+        ln -s $GITHUB_WORKSPACE external-docs/inspektor-gadget.git_mainlatest
+        make
 
   lint:
     name: Lint


### PR DESCRIPTION
Sometimes it happens that the changes to our docs break the website build, let's check if this work fine here.

### Testing done

- The action fails when the website can't be built -> https://github.com/mauriciovasquezbernal/inspektor-gadget/actions/runs/4357810587/jobs/7617577958