### PR TITLE
runtime/local: Move context and timeout management from runtime to tracers

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -15,7 +15,6 @@
 package common
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -165,6 +164,8 @@ func buildCommandFromGadget(
 
 			ctx := fe.GetContext()
 
+			timeoutDuration := time.Duration(0)
+
 			// Handle timeout parameter by adding a timeout to the context
 			if timeout != 0 {
 				if gadgetDesc.Type().IsPeriodic() {
@@ -177,9 +178,7 @@ func buildCommandFromGadget(
 					}
 				}
 
-				tmpCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-				defer cancel()
-				ctx = tmpCtx
+				timeoutDuration = time.Duration(timeout) * time.Second
 			}
 
 			gadgetCtx := gadgetcontext.New(
@@ -191,6 +190,7 @@ func buildCommandFromGadget(
 				operatorsParamCollection,
 				parser,
 				logger.DefaultLogger(),
+				timeoutDuration,
 			)
 
 			outputModeInfo := strings.SplitN(outputMode, "=", 2)

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -192,6 +192,7 @@ func buildCommandFromGadget(
 				logger.DefaultLogger(),
 				timeoutDuration,
 			)
+			defer gadgetCtx.Cancel()
 
 			outputModeInfo := strings.SplitN(outputMode, "=", 2)
 			outputModeName := outputModeInfo[0]

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -167,6 +167,16 @@ func buildCommandFromGadget(
 
 			// Handle timeout parameter by adding a timeout to the context
 			if timeout != 0 {
+				if gadgetDesc.Type().IsPeriodic() {
+					interval := gadgetParams.Get(gadgets.ParamInterval).AsInt()
+					if timeout < interval {
+						return fmt.Errorf("timeout must be greater than interval")
+					}
+					if timeout%interval != 0 {
+						return fmt.Errorf("timeout must be a multiple of interval")
+					}
+				}
+
 				tmpCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 				defer cancel()
 				ctx = tmpCtx

--- a/integration/ig/k8s/integration_test.go
+++ b/integration/ig/k8s/integration_test.go
@@ -28,6 +28,7 @@ const (
 	ContainerRuntimeDocker     = "docker"
 	ContainerRuntimeContainerd = "containerd"
 	ContainerRuntimeCRIO       = "cri-o"
+	timeout                    = 10
 )
 
 var supportedContainerRuntimes = []string{ContainerRuntimeDocker, ContainerRuntimeContainerd, ContainerRuntimeCRIO}

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,49 +23,88 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
+func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
+	expectedOutputFn := func(output string) error {
+		expectedEntry := &types.Stats{
+			CommonData: eventtypes.CommonData{
+				Namespace: ns,
+				Pod:       "test-pod",
+			},
+			// echo is built-in
+			Comm:     "sh",
+			Filename: "bar",
+			FileType: 'R',
+		}
+
+		normalize := func(e *types.Stats) {
+			e.Container = ""
+			e.Pid = 0
+			e.Tid = 0
+			e.MountNsID = 0
+			e.Reads = 0
+			e.ReadBytes = 0
+			e.Writes = 0
+			e.WriteBytes = 0
+		}
+
+		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+	}
+
+	return &Command{
+		Name:             "TopFile",
+		ExpectedOutputFn: expectedOutputFn,
+		Cmd:              cmd,
+		StartAndStop:     startAndStop,
+	}
+}
+
 func TestTopFile(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-top-file")
 
-	topFileCmd := &Command{
-		Name:         "TopFile",
-		Cmd:          fmt.Sprintf("ig top file -o json -m 999 --runtimes=%s", *containerRuntime),
-		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
-			expectedEntry := &types.Stats{
-				CommonData: eventtypes.CommonData{
-					Namespace: ns,
-					Pod:       "test-pod",
-				},
-				// echo is built-in
-				Comm:     "sh",
-				Filename: "bar",
-				FileType: 'R',
-			}
-
-			normalize := func(e *types.Stats) {
-				e.Container = ""
-				e.Pid = 0
-				e.Tid = 0
-				e.MountNsID = 0
-				e.Reads = 0
-				e.ReadBytes = 0
-				e.Writes = 0
-				e.WriteBytes = 0
-			}
-
-			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
-		},
-	}
-
-	commands := []*Command{
+	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),
-		topFileCmd,
-		SleepForSecondsCommand(2), // wait to ensure ig has started
 		BusyboxPodRepeatCommand(ns, "echo foo > bar"),
 		WaitUntilTestPodReadyCommand(ns),
-		DeleteTestNamespaceCommand(ns),
 	}
+	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
-	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	t.Cleanup(func() {
+		commandsPostTest := []*Command{
+			DeleteTestNamespaceCommand(ns),
+		}
+		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	// TODO: Filter by namespace to avoid interferences with events from other
+	// tests. In the meanwhile, given that we are generating events by writing
+	// into a file:
+	// 	(1) Increase max-rows to 999 (default is 20)
+	// 	(2) Sort by "-writes,-wbytes" (default is "-reads,-writes,-rbytes,-wbytes")
+
+	t.Run("StartAndStop", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := fmt.Sprintf("ig top file -o json --sort-by -writes,-wbytes -m 999 --runtimes=%s", *containerRuntime)
+		topFileCmd := newTopFileCmd(ns, cmd, true)
+		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := fmt.Sprintf("ig top file -o json --sort-by -writes,-wbytes -m 999 --runtimes=%s --timeout %d",
+			*containerRuntime, timeout)
+		topFileCmd := newTopFileCmd(ns, cmd, false)
+		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("Interval=Timeout", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := fmt.Sprintf("ig top file -o json --sort-by -writes,-wbytes -m 999 --runtimes=%s --timeout %d --interval %d",
+			*containerRuntime, timeout, timeout)
+		topFileCmd := newTopFileCmd(ns, cmd, false)
+		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
 }

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -271,6 +271,7 @@ func BenchmarkAllGadgetsWithContainers(b *testing.B) {
 							b.Fatalf("running gadget: %s", err)
 						}
 
+						gadgetCtx.Cancel()
 						cancel()
 					}
 				})

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -263,6 +263,7 @@ func BenchmarkAllGadgetsWithContainers(b *testing.B) {
 							operatorsParamCollection,
 							parser,
 							logger.DefaultLogger(),
+							0,
 						)
 
 						_, err := runtime.RunGadget(gadgetCtx)

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -20,6 +20,7 @@ package gadgetcontext
 
 import (
 	"context"
+	"time"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
@@ -43,6 +44,7 @@ type GadgetContext struct {
 	logger                   logger.Logger
 	result                   []byte
 	resultError              error
+	timeout                  time.Duration
 }
 
 func New(
@@ -54,6 +56,7 @@ func New(
 	operatorsParamCollection params.Collection,
 	parser parser.Parser,
 	logger logger.Logger,
+	timeout time.Duration,
 ) *GadgetContext {
 	return &GadgetContext{
 		ctx:                      ctx,
@@ -65,6 +68,7 @@ func New(
 		logger:                   logger,
 		operators:                operators.GetOperatorsForGadget(gadget),
 		operatorsParamCollection: operatorsParamCollection,
+		timeout:                  timeout,
 	}
 }
 
@@ -102,4 +106,15 @@ func (r *GadgetContext) GadgetParams() *params.Params {
 
 func (r *GadgetContext) OperatorsParamCollection() params.Collection {
 	return r.operatorsParamCollection
+}
+
+func (r *GadgetContext) Timeout() time.Duration {
+	return r.timeout
+}
+
+func WithTimeoutOrCancel(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout == 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
 }

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -72,44 +72,44 @@ func New(
 	}
 }
 
-func (r *GadgetContext) ID() string {
-	return r.id
+func (c *GadgetContext) ID() string {
+	return c.id
 }
 
-func (r *GadgetContext) Context() context.Context {
-	return r.ctx
+func (c *GadgetContext) Context() context.Context {
+	return c.ctx
 }
 
-func (r *GadgetContext) Parser() parser.Parser {
-	return r.parser
+func (c *GadgetContext) Parser() parser.Parser {
+	return c.parser
 }
 
-func (r *GadgetContext) Runtime() runtime.Runtime {
-	return r.runtime
+func (c *GadgetContext) Runtime() runtime.Runtime {
+	return c.runtime
 }
 
-func (r *GadgetContext) GadgetDesc() gadgets.GadgetDesc {
-	return r.gadget
+func (c *GadgetContext) GadgetDesc() gadgets.GadgetDesc {
+	return c.gadget
 }
 
-func (r *GadgetContext) Operators() operators.Operators {
-	return r.operators
+func (c *GadgetContext) Operators() operators.Operators {
+	return c.operators
 }
 
-func (r *GadgetContext) Logger() logger.Logger {
-	return r.logger
+func (c *GadgetContext) Logger() logger.Logger {
+	return c.logger
 }
 
-func (r *GadgetContext) GadgetParams() *params.Params {
-	return r.gadgetParams
+func (c *GadgetContext) GadgetParams() *params.Params {
+	return c.gadgetParams
 }
 
-func (r *GadgetContext) OperatorsParamCollection() params.Collection {
-	return r.operatorsParamCollection
+func (c *GadgetContext) OperatorsParamCollection() params.Collection {
+	return c.operatorsParamCollection
 }
 
-func (r *GadgetContext) Timeout() time.Duration {
-	return r.timeout
+func (c *GadgetContext) Timeout() time.Duration {
+	return c.timeout
 }
 
 func WithTimeoutOrCancel(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -117,4 +117,10 @@ func WithTimeoutOrCancel(ctx context.Context, timeout time.Duration) (context.Co
 		return context.WithCancel(ctx)
 	}
 	return context.WithTimeout(ctx, timeout)
+}
+
+func WaitForTimeoutOrDone(c gadgets.GadgetContext) {
+	ctx, cancel := WithTimeoutOrCancel(c.Context(), c.Timeout())
+	defer cancel()
+	<-ctx.Done()
 }

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -34,6 +34,7 @@ import (
 // instance and communicates with gadget and runtime.
 type GadgetContext struct {
 	ctx                      context.Context
+	cancel                   context.CancelFunc
 	id                       string
 	gadget                   gadgets.GadgetDesc
 	gadgetParams             *params.Params
@@ -58,8 +59,11 @@ func New(
 	logger logger.Logger,
 	timeout time.Duration,
 ) *GadgetContext {
+	gCtx, cancel := context.WithCancel(ctx)
+
 	return &GadgetContext{
-		ctx:                      ctx,
+		ctx:                      gCtx,
+		cancel:                   cancel,
 		id:                       id,
 		runtime:                  runtime,
 		gadget:                   gadget,
@@ -78,6 +82,10 @@ func (c *GadgetContext) ID() string {
 
 func (c *GadgetContext) Context() context.Context {
 	return c.ctx
+}
+
+func (c *GadgetContext) Cancel() {
+	c.cancel()
 }
 
 func (c *GadgetContext) Parser() parser.Parser {

--- a/pkg/gadgets/advise/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/advise/seccomp/tracer/tracer.go
@@ -147,13 +147,10 @@ func (t *Tracer) RunWithResult(gadgetCtx gadgets.GadgetContext) ([]byte, error) 
 		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	// Notice this Tracer starts collecting data for all containers as soon as
 	// it is installed, and uses the attach/detach mechanism to know which
 	// containers to report data from.
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return t.collectResult()
 }

--- a/pkg/gadgets/advise/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/advise/seccomp/tracer/tracer.go
@@ -26,6 +26,7 @@ import (
 	libseccomp "github.com/seccomp/libseccomp-golang"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 )
 
@@ -55,7 +56,7 @@ type Tracer struct {
 func NewTracer() (*Tracer, error) {
 	t := &Tracer{}
 
-	if err := t.start(); err != nil {
+	if err := t.install(); err != nil {
 		t.Close()
 		return nil, err
 	}
@@ -63,7 +64,7 @@ func NewTracer() (*Tracer, error) {
 	return t, nil
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadSeccomp()
 	if err != nil {
 		return fmt.Errorf("failed to load asset: %w", err)
@@ -124,6 +125,8 @@ func (t *Tracer) Delete(mntns uint64) {
 	t.objs.SyscallsPerMntns.Delete(mntns)
 }
 
+// Close closes the tracer
+// TODO: Unexport this function when the refactoring is done
 func (t *Tracer) Close() {
 	t.progLink = gadgets.CloseLink(t.progLink)
 	t.objs.Close()
@@ -138,19 +141,21 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 	return t, nil
 }
 
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
-}
-
-func (t *Tracer) Stop() {
-}
-
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) RunWithResult(gadgetCtx gadgets.GadgetContext) ([]byte, error) {
+	defer t.Close()
+	if err := t.install(); err != nil {
+		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
-	return nil
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	// Notice this Tracer starts collecting data for all containers as soon as
+	// it is installed, and uses the attach/detach mechanism to know which
+	// containers to report data from.
+	<-ctx.Done()
+
+	return t.collectResult()
 }
 
 func (t *Tracer) AttachContainer(container *containercollection.Container) error {
@@ -168,7 +173,7 @@ func (t *Tracer) DetachContainer(container *containercollection.Container) error
 	return nil
 }
 
-func (t *Tracer) Result() ([]byte, error) {
+func (t *Tracer) collectResult() ([]byte, error) {
 	out := make(map[string][]string)
 	for container, result := range t.containers {
 		out[container.Name] = result

--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -177,11 +177,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -174,10 +174,7 @@ func (t *Tracer) RunWithResult(gadgetCtx gadgets.GadgetContext) ([]byte, error) 
 		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return t.collectResult()
 }

--- a/pkg/gadgets/profile/cpu/tracer/tracer.go
+++ b/pkg/gadgets/profile/cpu/tracer/tracer.go
@@ -410,10 +410,7 @@ func (t *TracerWrap) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	res, err := t.collectResult()
 	if err != nil {

--- a/pkg/gadgets/runner.go
+++ b/pkg/gadgets/runner.go
@@ -16,6 +16,7 @@ package gadgets
 
 import (
 	"context"
+	"time"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
@@ -26,4 +27,5 @@ type GadgetContext interface {
 	Context() context.Context
 	GadgetParams() *params.Params
 	Logger() logger.Logger
+	Timeout() time.Duration
 }

--- a/pkg/gadgets/snapshot/process/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer.go
@@ -271,12 +271,6 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 	return tracer, nil
 }
 
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	params := gadgetCtx.GadgetParams()
-	t.config.ShowThreads = params.Get(ParamThreads).AsBool()
-	return nil
-}
-
 func (t *Tracer) SetEventHandlerArray(handler any) {
 	nh, ok := handler.(func(ev []*processcollectortypes.Event))
 	if !ok {
@@ -289,10 +283,12 @@ func (t *Tracer) SetMountNsMap(mntnsMap *ebpf.Map) {
 	t.config.MountnsMap = mntnsMap
 }
 
-func (t *Tracer) Run() error {
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	t.config.ShowThreads = gadgetCtx.GadgetParams().Get(ParamThreads).AsBool()
+
 	processes, err := RunCollector(t.config, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("running snapshotter: %w", err)
 	}
 	t.eventHandler(processes)
 	return nil

--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -18,6 +18,7 @@ package tracer
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -40,6 +41,7 @@ import (
 type Config struct {
 	MaxRows    int
 	Interval   time.Duration
+	Iterations int
 	SortBy     []string
 	MountnsMap *ebpf.Map
 }
@@ -66,22 +68,30 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		done:          make(chan bool),
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
 
 	statCols, err := columns.NewColumns[types.Stats]()
 	if err != nil {
-		t.Stop()
+		t.close()
 		return nil, err
 	}
 	t.colMap = statCols.GetColumnMap()
 
+	go t.run(context.TODO())
+
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	close(t.done)
 
 	t.ioStartLink = gadgets.CloseLink(t.ioStartLink)
@@ -131,7 +141,7 @@ func isKernelSymbol(sym string, kernelSymbols map[string]int) bool {
 	return ok
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadBiotop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -194,8 +204,6 @@ func (t *Tracer) start() error {
 	if err != nil {
 		return fmt.Errorf("error opening kprobe: %w", err)
 	}
-
-	t.run()
 
 	return nil
 }
@@ -273,32 +281,56 @@ func (t *Tracer) nextStats() ([]*types.Stats, error) {
 	return stats, nil
 }
 
-func (t *Tracer) run() {
+func (t *Tracer) run(ctx context.Context) error {
+	// Don't use a context with a timeout but a counter to avoid having to deal
+	// with two timers: one for the timeout and another for the ticker.
+	count := t.config.Iterations
 	ticker := time.NewTicker(t.config.Interval)
+	defer ticker.Stop()
 
-	go func() {
-	loop:
-		for {
-			select {
-			case <-t.done:
-				break loop
-			case <-ticker.C:
-				stats, err := t.nextStats()
-				if err != nil {
-					t.eventCallback(&top.Event[types.Stats]{
-						Error: err.Error(),
-					})
-					return
-				}
+	for {
+		select {
+		case <-t.done:
+			// TODO: Once we completely move to use Run instead of NewTracer,
+			// we can remove this as nobody will directly call Stop (cleanup).
+			return nil
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			stats, err := t.nextStats()
+			if err != nil {
+				return fmt.Errorf("getting next stats: %w", err)
+			}
 
-				n := len(stats)
-				if n > t.config.MaxRows {
-					n = t.config.MaxRows
+			n := len(stats)
+			if n > t.config.MaxRows {
+				n = t.config.MaxRows
+			}
+			t.eventCallback(&top.Event[types.Stats]{Stats: stats[:n]})
+
+			// Count down only if user requested a finite number of iterations
+			// through a timeout.
+			if t.config.Iterations > 0 {
+				count--
+				if count == 0 {
+					return nil
 				}
-				t.eventCallback(&top.Event[types.Stats]{Stats: stats[:n]})
 			}
 		}
-	}()
+	}
+}
+
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	if err := t.init(gadgetCtx); err != nil {
+		return fmt.Errorf("initializing tracer: %w", err)
+	}
+
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
+	}
+
+	return t.run(gadgetCtx.Context())
 }
 
 func (t *Tracer) SetEventHandlerArray(handler any) {
@@ -332,25 +364,22 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 	return tracer, nil
 }
 
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
+func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
 	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
-	return nil
-}
 
-func (t *Tracer) Start() error {
+	var err error
+	if t.config.Iterations, err = top.ComputeIterations(t.config.Interval, gadgetCtx.Timeout()); err != nil {
+		return err
+	}
+
 	statCols, err := columns.NewColumns[types.Stats]()
 	if err != nil {
 		return err
 	}
 	t.colMap = statCols.GetColumnMap()
-
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
-	}
 
 	return nil
 }

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -17,6 +17,7 @@
 package tracer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"syscall"
@@ -41,6 +42,7 @@ type Config struct {
 	TargetFamily int32
 	MaxRows      int
 	Interval     time.Duration
+	Iterations   int
 	SortBy       []string
 }
 
@@ -53,7 +55,6 @@ type Tracer struct {
 	eventCallback      func(*top.Event[types.Stats])
 	done               chan bool
 	colMap             columns.ColumnMap[types.Stats]
-	gadgetCtx          gadgets.GadgetContext
 }
 
 func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
@@ -66,22 +67,30 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		done:          make(chan bool),
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
 
 	statCols, err := columns.NewColumns[types.Stats]()
 	if err != nil {
-		t.Stop()
+		t.close()
 		return nil, err
 	}
 	t.colMap = statCols.GetColumnMap()
 
+	go t.run(context.TODO())
+
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	close(t.done)
 
 	t.tcpSendmsgLink = gadgets.CloseLink(t.tcpSendmsgLink)
@@ -90,7 +99,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadTcptop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -131,8 +140,6 @@ func (t *Tracer) start() error {
 	if err != nil {
 		return fmt.Errorf("error opening kprobe: %w", err)
 	}
-
-	t.run()
 
 	return nil
 }
@@ -218,47 +225,56 @@ func (t *Tracer) nextStats() ([]*types.Stats, error) {
 	return stats, nil
 }
 
-func (t *Tracer) run() {
+func (t *Tracer) run(ctx context.Context) error {
+	// Don't use a context with a timeout but a counter to avoid having to deal
+	// with two timers: one for the timeout and another for the ticker.
+	count := t.config.Iterations
 	ticker := time.NewTicker(t.config.Interval)
+	defer ticker.Stop()
 
-	go func() {
-		for {
-			select {
-			case <-t.done:
-				return
-			case <-ticker.C:
-				stats, err := t.nextStats()
-				if err != nil {
-					t.eventCallback(&top.Event[types.Stats]{
-						Error: err.Error(),
-					})
-					return
-				}
+	for {
+		select {
+		case <-t.done:
+			// TODO: Once we completely move to use Run instead of NewTracer,
+			// we can remove this as nobody will directly call Stop (cleanup).
+			return nil
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			stats, err := t.nextStats()
+			if err != nil {
+				return fmt.Errorf("getting next stats: %w", err)
+			}
 
-				n := len(stats)
-				if n > t.config.MaxRows {
-					n = t.config.MaxRows
+			n := len(stats)
+			if n > t.config.MaxRows {
+				n = t.config.MaxRows
+			}
+			t.eventCallback(&top.Event[types.Stats]{Stats: stats[:n]})
+
+			// Count down only if user requested a finite number of iterations
+			// through a timeout.
+			if t.config.Iterations > 0 {
+				count--
+				if count == 0 {
+					return nil
 				}
-				t.eventCallback(&top.Event[types.Stats]{Stats: stats[:n]})
 			}
 		}
-	}()
+	}
 }
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	if err := t.init(gadgetCtx); err != nil {
+		return fmt.Errorf("initializing tracer: %w", err)
 	}
 
-	statCols, err := columns.NewColumns[types.Stats]()
-	if err != nil {
-		t.Stop()
-		return err
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
-	t.colMap = statCols.GetColumnMap()
 
-	return nil
+	return t.run(gadgetCtx.Context())
 }
 
 func (t *Tracer) SetEventHandlerArray(handler any) {
@@ -267,9 +283,9 @@ func (t *Tracer) SetEventHandlerArray(handler any) {
 		panic("event handler invalid")
 	}
 
+	// TODO: add errorHandler
 	t.eventCallback = func(ev *top.Event[types.Stats]) {
 		if ev.Error != "" {
-			t.gadgetCtx.Logger().Errorf("event error: %s", ev.Error)
 			return
 		}
 		nh(ev.Stats)
@@ -291,13 +307,24 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 	return tracer, nil
 }
 
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
+func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.gadgetCtx = gadgetCtx
 	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
 	t.config.TargetFamily, _ = types.ParseFilterByFamily(params.Get(types.FamilyParam).AsString())
 	t.config.TargetPid = params.Get(types.PidParam).AsInt32()
+
+	var err error
+	if t.config.Iterations, err = top.ComputeIterations(t.config.Interval, gadgetCtx.Timeout()); err != nil {
+		return err
+	}
+
+	statCols, err := columns.NewColumns[types.Stats]()
+	if err != nil {
+		return err
+	}
+	t.colMap = statCols.GetColumnMap()
+
 	return nil
 }

--- a/pkg/gadgets/top/top.go
+++ b/pkg/gadgets/top/top.go
@@ -15,6 +15,9 @@
 package top
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	columnssort "github.com/inspektor-gadget/inspektor-gadget/pkg/columns/sort"
 )
@@ -35,4 +38,19 @@ type Event[T any] struct {
 
 func SortStats[T any](stats []*T, sortBy []string, colMap *columns.ColumnMap[T]) {
 	columnssort.SortEntries(*colMap, stats, sortBy)
+}
+
+// ComputeIterations returns the number of iterations to perform to get the
+// desired timeout. It returns zero if timeout is zero.
+func ComputeIterations(interval, timeout time.Duration) (int, error) {
+	if timeout <= 0 {
+		return 0, nil
+	}
+	if timeout < interval {
+		return 0, fmt.Errorf("timeout must be greater than interval")
+	}
+	if timeout%interval != 0 {
+		return 0, fmt.Errorf("timeout must be a multiple of interval")
+	}
+	return int(timeout / interval), nil
 }

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/vishvananda/netlink"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/bind/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -63,15 +64,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.ipv4Entry = gadgets.CloseLink(t.ipv4Entry)
 	t.ipv4Exit = gadgets.CloseLink(t.ipv4Exit)
 	t.ipv6Entry = gadgets.CloseLink(t.ipv6Entry)
@@ -84,7 +93,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadBindsnoop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -153,8 +162,6 @@ func (t *Tracer) start() error {
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
-
-	go t.run()
 
 	return nil
 }
@@ -288,11 +295,25 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	params := gadgetCtx.GadgetParams()
+	t.config.TargetPid = params.Get(ParamPID).AsInt32()
+	t.config.TargetPorts = params.Get(ParamPorts).AsUint16Slice()
+	t.config.IgnoreErrors = params.Get(ParamIgnoreErrors).AsBool()
+
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	// TODO: Rework this to be able to stop the gadget when an error occurs in
+	// run(). Notice it is the same for most of gadgets in the trace category.
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -313,12 +334,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	params := gadgetCtx.GadgetParams()
-	t.config.TargetPid = params.Get(ParamPID).AsInt32()
-	t.config.TargetPorts = params.Get(ParamPorts).AsUint16Slice()
-	t.config.IgnoreErrors = params.Get(ParamIgnoreErrors).AsBool()
-	return nil
 }

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -306,13 +306,10 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	// TODO: Rework this to be able to stop the gadget when an error occurs in
 	// run(). Notice it is the same for most of gadgets in the trace category.
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -337,11 +337,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -29,6 +29,7 @@ import (
 	libseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/syndtr/gocapability/capability"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/capabilities/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -108,15 +109,23 @@ func NewTracer(c *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.capEnterLink = gadgets.CloseLink(t.capEnterLink)
 	t.capExitLink = gadgets.CloseLink(t.capExitLink)
 	t.tpSysEnter = gadgets.CloseLink(t.tpSysEnter)
@@ -129,7 +138,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	runningKernelVersion, err := features.LinuxVersionCode()
 	if err != nil {
 		return fmt.Errorf("error getting kernel version: %w", err)
@@ -206,8 +215,6 @@ func (t *Tracer) start() error {
 	}
 	t.reader = reader
 
-	go t.run()
-
 	return nil
 }
 
@@ -238,6 +245,7 @@ func (t *Tracer) run() {
 		record, err := t.reader.Read()
 		if err != nil {
 			if errors.Is(err, perf.ErrClosed) {
+				// nothing to do, we're done
 				return
 			}
 
@@ -319,11 +327,22 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	params := gadgetCtx.GadgetParams()
+	t.config.Unique = params.Get(ParamUnique).AsBool()
+	t.config.AuditOnly = params.Get(ParamAuditOnly).AsBool()
+
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -344,11 +363,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	params := gadgetCtx.GadgetParams()
-	t.config.Unique = params.Get(ParamUnique).AsBool()
-	t.config.AuditOnly = params.Get(ParamAuditOnly).AsBool()
-	return nil
 }

--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -17,6 +17,7 @@
 package tracer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"syscall"
@@ -24,6 +25,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/networktracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
@@ -40,55 +42,20 @@ const (
 
 type Tracer struct {
 	*networktracer.Tracer[types.Event]
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func NewTracer() (*Tracer, error) {
-	spec, err := loadDns()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load asset: %w", err)
+	t := &Tracer{}
+
+	if err := t.install(); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
 
-	latencyCalc, err := newDNSLatencyCalculator()
-	if err != nil {
-		return nil, err
-	}
-
-	parseAndEnrichDNSEvent := func(rawSample []byte, netns uint64) (*types.Event, error) {
-		bpfEvent := (*dnsEventT)(unsafe.Pointer(&rawSample[0]))
-		if len(rawSample) < int(unsafe.Sizeof(*bpfEvent)) {
-			return nil, errors.New("invalid sample size")
-		}
-
-		event, err := bpfEventToDNSEvent(bpfEvent, netns)
-		if err != nil {
-			return nil, err
-		}
-
-		// Derive latency from the query/response timestamps.
-		// Filter by packet type (OUTGOING for queries and HOST for responses) to exclude cases where
-		// the packet is forwarded between containers in the host netns.
-		if bpfEvent.Qr == 0 && bpfEvent.PktType == unix.PACKET_OUTGOING {
-			latencyCalc.storeDNSQueryTimestamp(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
-		} else if bpfEvent.Qr == 1 && bpfEvent.PktType == unix.PACKET_HOST {
-			event.Latency = latencyCalc.calculateDNSResponseLatency(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
-		}
-
-		return event, nil
-	}
-
-	networkTracer, err := networktracer.NewTracer(
-		spec,
-		BPFProgName,
-		BPFPerfMapName,
-		BPFSocketAttach,
-		types.Base,
-		parseAndEnrichDNSEvent,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating network tracer: %w", err)
-	}
-
-	return &Tracer{Tracer: networkTracer}, nil
+	return t, nil
 }
 
 // pkt_type definitions:
@@ -297,11 +264,73 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 }
 
 func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	// TODO: Clean up
-	tracer, err := NewTracer()
+	if err := t.install(); err != nil {
+		t.Close()
+		return fmt.Errorf("installing tracer: %w", err)
+	}
+
+	t.ctx, t.cancel = gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	return nil
+}
+
+func (t *Tracer) install() error {
+	spec, err := loadDns()
+	if err != nil {
+		return fmt.Errorf("failed to load asset: %w", err)
+	}
+
+	latencyCalc, err := newDNSLatencyCalculator()
 	if err != nil {
 		return err
 	}
-	t.Tracer = tracer.Tracer
+
+	parseAndEnrichDNSEvent := func(rawSample []byte, netns uint64) (*types.Event, error) {
+		bpfEvent := (*dnsEventT)(unsafe.Pointer(&rawSample[0]))
+		if len(rawSample) < int(unsafe.Sizeof(*bpfEvent)) {
+			return nil, errors.New("invalid sample size")
+		}
+
+		event, err := bpfEventToDNSEvent(bpfEvent, netns)
+		if err != nil {
+			return nil, err
+		}
+
+		// Derive latency from the query/response timestamps.
+		// Filter by packet type (OUTGOING for queries and HOST for responses) to exclude cases where
+		// the packet is forwarded between containers in the host netns.
+		if bpfEvent.Qr == 0 && bpfEvent.PktType == unix.PACKET_OUTGOING {
+			latencyCalc.storeDNSQueryTimestamp(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
+		} else if bpfEvent.Qr == 1 && bpfEvent.PktType == unix.PACKET_HOST {
+			event.Latency = latencyCalc.calculateDNSResponseLatency(netns, bpfEvent.Id, uint64(event.Event.Timestamp))
+		}
+
+		return event, nil
+	}
+
+	networkTracer, err := networktracer.NewTracer(
+		spec,
+		BPFProgName,
+		BPFPerfMapName,
+		BPFSocketAttach,
+		types.Base,
+		parseAndEnrichDNSEvent,
+	)
+	if err != nil {
+		return fmt.Errorf("creating network tracer: %w", err)
+	}
+	t.Tracer = networkTracer
 	return nil
+}
+
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	<-t.ctx.Done()
+	return nil
+}
+
+func (t *Tracer) Close() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+
+	t.Tracer.Close()
 }

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -57,15 +58,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.enterLink = gadgets.CloseLink(t.enterLink)
 	t.exitLink = gadgets.CloseLink(t.exitLink)
 
@@ -76,7 +85,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadExecsnoop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -118,8 +127,6 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
 	t.reader = reader
-
-	go t.run()
 
 	return nil
 }
@@ -183,11 +190,18 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -208,8 +222,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
 }

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -196,11 +196,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/fsslower/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -100,15 +101,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	// read
 	t.readEnterLink = gadgets.CloseLink(t.readEnterLink)
 	t.readExitLink = gadgets.CloseLink(t.readExitLink)
@@ -132,7 +141,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	var err error
 
 	spec, err := loadFsslower()
@@ -217,9 +226,6 @@ func (t *Tracer) start() error {
 	if err != nil {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
-
-	go t.run()
-
 	return nil
 }
 
@@ -233,6 +239,7 @@ func (t *Tracer) run() {
 				// nothing to do, we're done
 				return
 			}
+
 			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
 			t.eventCallback(types.Base(eventtypes.Err(msg)))
 			return
@@ -271,11 +278,22 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	params := gadgetCtx.GadgetParams()
+	t.config.Filesystem = params.Get(ParamFilesystem).AsString()
+	t.config.MinLatency = params.Get(ParamMinLatency).AsUint()
+
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -296,11 +314,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	params := gadgetCtx.GadgetParams()
-	t.config.Filesystem = params.Get(ParamFilesystem).AsString()
-	t.config.MinLatency = params.Get(ParamMinLatency).AsUint()
-	return nil
 }

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -288,11 +288,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -216,11 +216,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -172,11 +172,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/oomkill/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -53,19 +54,23 @@ func NewTracer(c *Config, enricher gadgets.DataEnricherByMntNs, eventCallback fu
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
-	t.stop()
+	t.close()
 }
 
-func (t *Tracer) stop() {
+func (t *Tracer) close() {
 	t.oomLink = gadgets.CloseLink(t.oomLink)
 
 	if t.reader != nil {
@@ -75,7 +80,7 @@ func (t *Tracer) stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadOomkill()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -119,8 +124,6 @@ func (t *Tracer) start() error {
 	}
 	t.reader = reader
 
-	go t.run()
-
 	return nil
 }
 
@@ -129,6 +132,7 @@ func (t *Tracer) run() {
 		record, err := t.reader.Read()
 		if err != nil {
 			if errors.Is(err, perf.ErrClosed) {
+				// nothing to do, we're done
 				return
 			}
 
@@ -162,11 +166,18 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -187,8 +198,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
 }

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -60,15 +61,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.openEnterLink = gadgets.CloseLink(t.openEnterLink)
 	t.openAtEnterLink = gadgets.CloseLink(t.openAtEnterLink)
 	t.openExitLink = gadgets.CloseLink(t.openExitLink)
@@ -81,7 +90,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadOpensnoop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -148,8 +157,6 @@ func (t *Tracer) start() error {
 	}
 	t.reader = reader
 
-	go t.run()
-
 	return nil
 }
 
@@ -210,11 +217,18 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -235,8 +249,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
 }

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -223,11 +223,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -252,11 +252,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -74,15 +75,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.enterKillLink = gadgets.CloseLink(t.enterKillLink)
 	t.exitKillLink = gadgets.CloseLink(t.exitKillLink)
 
@@ -101,7 +110,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadSigsnoop()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -183,8 +192,6 @@ func (t *Tracer) start() error {
 		return fmt.Errorf("error creating perf ring buffer: %w", err)
 	}
 
-	go t.run()
-
 	return nil
 }
 
@@ -233,11 +240,24 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	params := gadgetCtx.GadgetParams()
+	t.config.TargetPid = params.Get(ParamPID).AsInt32()
+	t.config.FailedOnly = params.Get(ParamFailedOnly).AsBool()
+	t.config.KillOnly = params.Get(ParamKillOnly).AsBool()
+	t.config.TargetSignal = params.Get(ParamTargetSignal).AsString()
+
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -258,13 +278,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	params := gadgetCtx.GadgetParams()
-	t.config.TargetPid = params.Get(ParamPID).AsInt32()
-	t.config.FailedOnly = params.Get(ParamFailedOnly).AsBool()
-	t.config.KillOnly = params.Get(ParamKillOnly).AsBool()
-	t.config.TargetSignal = params.Get(ParamTargetSignal).AsString()
-	return nil
 }

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -243,11 +243,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"golang.org/x/sys/unix"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -65,15 +66,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.tcpv4connectEnterLink = gadgets.CloseLink(t.tcpv4connectEnterLink)
 	t.tcpv4connectExitLink = gadgets.CloseLink(t.tcpv4connectExitLink)
 	t.tcpv6connectEnterLink = gadgets.CloseLink(t.tcpv6connectEnterLink)
@@ -89,7 +98,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	spec, err := loadTcptracer()
 	if err != nil {
 		return fmt.Errorf("failed to load ebpf program: %w", err)
@@ -163,8 +172,6 @@ func (t *Tracer) start() error {
 	}
 	t.reader = reader
 
-	go t.run()
-
 	return nil
 }
 
@@ -230,11 +237,18 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -255,8 +269,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
 }

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -207,11 +207,8 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 		return fmt.Errorf("installing tracer: %w", err)
 	}
 
-	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
-	defer cancel()
-
 	go t.run()
-	<-ctx.Done()
+	gadgetcontext.WaitForTimeoutOrDone(gadgetCtx)
 
 	return nil
 }

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"golang.org/x/sys/unix"
 
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpconnect/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -60,15 +61,23 @@ func NewTracer(config *Config, enricher gadgets.DataEnricherByMntNs,
 		eventCallback: eventCallback,
 	}
 
-	if err := t.start(); err != nil {
-		t.Stop()
+	if err := t.install(); err != nil {
+		t.close()
 		return nil, err
 	}
+
+	go t.run()
 
 	return t, nil
 }
 
+// Stop stops the tracer
+// TODO: Remove after refactoring
 func (t *Tracer) Stop() {
+	t.close()
+}
+
+func (t *Tracer) close() {
 	t.v4EnterLink = gadgets.CloseLink(t.v4EnterLink)
 	t.v4ExitLink = gadgets.CloseLink(t.v4ExitLink)
 	t.v6EnterLink = gadgets.CloseLink(t.v6EnterLink)
@@ -77,7 +86,7 @@ func (t *Tracer) Stop() {
 	t.objs.Close()
 }
 
-func (t *Tracer) start() error {
+func (t *Tracer) install() error {
 	var err error
 	spec, err := loadTcpconnect()
 	if err != nil {
@@ -136,8 +145,6 @@ func (t *Tracer) start() error {
 	}
 	t.reader = reader
 
-	go t.run()
-
 	return nil
 }
 
@@ -194,11 +201,18 @@ func (t *Tracer) run() {
 
 // --- Registry changes
 
-func (t *Tracer) Start() error {
-	if err := t.start(); err != nil {
-		t.Stop()
-		return err
+func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
+	defer t.close()
+	if err := t.install(); err != nil {
+		return fmt.Errorf("installing tracer: %w", err)
 	}
+
+	ctx, cancel := gadgetcontext.WithTimeoutOrCancel(gadgetCtx.Context(), gadgetCtx.Timeout())
+	defer cancel()
+
+	go t.run()
+	<-ctx.Done()
+
 	return nil
 }
 
@@ -219,8 +233,4 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 		config: &Config{},
 	}
 	return tracer, nil
-}
-
-func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
-	return nil
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
@@ -33,6 +34,7 @@ type GadgetContext interface {
 	Logger() logger.Logger
 	GadgetParams() *params.Params
 	OperatorsParamCollection() params.Collection
+	Timeout() time.Duration
 }
 
 // Runtime is the interface for gadget runtimes like kubectl-gadget, ig


### PR DESCRIPTION
# runtime/local: Move context and timeout management from runtime to tracers

This PR tries to uniform and make more evident the lifecycle of gadgets by defining the following four gadget types:

1. Gadgets that collect insights from the system and, as soon as a new event is captured, they emit it through a callback. An example of this kind of gadget is the audit/seccomp gadget and the tracer category gadgets (except the dns, network and sni):

	<details>
	<summary><b>Code skeleton for Run() gadget with timeout</b></summary>

	```go
	func (t *Tracer) run(ctx context.Context) {
		for {
			record, err := t.reader.Read()
			if err != nil {
				if errors.Is(err, perf.ErrClosed) {
					// nothing to do, we're done
					return
				}

				// Report error
				return
			}
			
			[...]
			// Parse and emit events through the callback
			[...]
		}
	}

	func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
		// Parse parameters
		[...]

		defer t.cleanup()
		if err := t.install(); err != nil {
			return nil, fmt.Errorf("installing tracer: %w", err)
		}

		go t.run()
		gadgetCtx.WaitForTimeoutOrDone()

		return nil
	}
	```

	</details>

	Notice that the gadget lifecycle is clearly defined in `Run()` :

	1. It parses the parameters if any.
	2. Install the eBPF program in the system.
	3. Runs a new go routine to communicate with the eBPF program and emit the events through the callback.
	4. Block the main go routine until the context is done/cancelled. For `ig`, users hit Ctrl+C (managed in front-end), or the timeout is reached.

2. A second type of gadget is the one the top category gadgets follow, which doesn't emit events as soon as they occur but emit them every X time (interval). So, they also use the `Run()` interface, which follows mostly the same flow as (1) but doesn't start the timer for the timeout to avoid dealing with two timers. Instead, it uses an internal counter and passes a `cancel` function to the `t.run()` so that it can notify when the counter (timeout) is reached:

	<details>
	<summary><b>Code skeleton for Run() gadget with ticker and counter</b></summary>

	```go
	func (t *Tracer) run(ctx context.Context) error {
		// Do not use a context with a timeout but use a counter
		count := t.config.Count
		ticker := time.NewTicker(t.config.Interval)
		defer ticker.Stop()

		for {
			select {
			case <-ctx.Done():
				return nil
			case <-ticker.C:
				[...]
				# Capture and emit events through the callback
				[...]

				if count > 0 {
					count--
					if count == 0 {
						return nil
					}
				}
			}
		}
	}

	func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
		if err := t.init(gadgetCtx); err != nil {
			return nil, fmt.Errorf("initializing tracer: %w", err)
		}
		
		defer t.cleanup()
		if err := t.install(); err != nil {
			return nil, fmt.Errorf("installing tracer: %w", err)
		}

		return t.run(gadgetCtx.Context())
	}

	func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
		// Parse parameters
		[...]

		var err error
		if t.config.Count, err = top.ComputeCount(t.config.Interval, gadgetCtx.Timeout()); err != nil {
			return err
		}

		[...]
	}

	func ComputeCount(interval, timeout time.Duration) (int, error) {
		if timeout <= 0 {
			return 0, nil
		}
		if timeout < interval {
			return 0, fmt.Errorf("timeout must be greater than interval")
		}
		if timeout%interval != 0 {
			return 0, fmt.Errorf("timeout must be a multiple of interval")
		}
		return int(timeout / interval), nil
	}
	```

	</details>


3. The third set of gadgets doesn't emit events as soon as they occur but not through a callback. Instead, they return the result only when the gadget is stopped. An example of this kind of gadget is the advise/seccomp and profile/block-io gadgets:

	<details>
	<summary><b>Code skeleton for RunWithResult</b></summary>

	```go
	func (t *Tracer) collectResult() ([]byte, error) {
		[...]
		# Collect data from eBPF program
		[...]

		return json.Marshal(result)
	}

	func (t *Tracer) RunWithResult(gadgetCtx gadgets.GadgetContext) ([]byte, error) {
		// Parse parameters
		[...]
		
		defer t.cleanup()
		if err := t.install(); err != nil {
			return nil, fmt.Errorf("installing tracer: %w", err)
		}

		gadgetCtx.WaitForTimeoutOrDone()
		
		return t.collectResult()
	}
	```

	</details>


4. Additionally, The `RunGadget` and `RunWithResultGadget` gadgets can also implement the `InitCloseGadget`. It is useful for gadgets that uses the `AttachContainer`/`DetachContainer` mechanism to trace containers. They are different because they must be initialized and configured before the operators are installed. It is because the operators will start calling `AttachContainer`/`DetachContainer` during their installation.

	<details>
	<summary><b>Code skeleton for InitClose</b></summary>

	```go
	func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
		// Parse parameters
		[...]

		if err := t.install(); err != nil {
			t.cleanup()
			return fmt.Errorf("installing tracer: %w", err)
		}
		
		// Context must be created before the first call to AttachContainer
		t.ctx, t.cancel = gadgetcontext.WithTimeout(gadgetCtx.Context(), gadgetCtx.Timeout())
		return nil
	}

	func (t *Tracer) Close() error {
		t.cancel()
		t.cleanup()
		return nil
	}

	func (t *Tracer) Run() error { // It can also be RunWithResult
		<-t.ctx.Done()
		return nil
	}

	func (t *Tracer) AttachContainer(container *containercollection.Container) error {
		[...]
		# Setup things for this new container that needs to be traced
		[...]
		
		go func() {
			for {
				if t.ctx.Err() != nil {
					return
				}
				
				[...]
				# Capture and emit events through the callback (or store it to send it later when the context is done in RunWithResult)
				[...]
		}()
	}

	func (t *Tracer) DetachContainer(container *containercollection.Container) error {
		[...]
		# Cleanup for this specific container
		[...]
	}
	```

	</details>

And finally, this is how the local runtime looks with these new interfaces:

<details>
<summary><b>Code skeleton for local.RunGadget</b></summary>

```go
func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext) (out []byte, err error) {
	[...]

	// Create gadget instance
	gadgetInstance, err := gadget.NewInstance()
	if err != nil {
		return out, fmt.Errorf("instantiating gadget: %w", err)
	}

	// Initialize gadgets, if needed
	if initClose, ok := gadgetInstance.(gadgets.InitCloseGadget); ok {
		log.Debugf("calling gadget.Init()")
		err = initClose.Init(gadgetCtx)
		if err != nil {
			return out, fmt.Errorf("initializing gadget: %w", err)
		}
		defer func() {
			log.Debugf("calling gadget.Close()")
			initClose.Close()
		}()
	} else {
		log.Debugf("gadget does not implement gadget.Init() and gadget.Close()")
	}

	[...]
	# All the things we need to do with the operators
	[...]

	if run, ok := gadgetInstance.(gadgets.RunGadget); ok {
		log.Debugf("calling gadget.Run()")

		err := run.Run(gadgetCtx)
		if err != nil {
			return out, fmt.Errorf("running gadget: %w", err)
		}
	} else if runWithResult, ok := gadgetInstance.(gadgets.RunWithResultGadget); ok {
		log.Debugf("calling gadget.RunWithResult()")

		out, err = runWithResult.RunWithResult(gadgetCtx)
		if err != nil {
			return out, fmt.Errorf("running (with result) gadget: %w", err)
		}
	} else {
		return nil, errors.New("gadget not runnable")
	}

	return
}
```

</details>

TODO (It will be managed in another PR):

- [ ] Add this description to the developer [documentation](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/ig-fix-intervarl-timeout/docs/devel/how-to-write-a-gadget.md).