### PR TITLE
cmd: Check ig is run as root.

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,6 +37,13 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "ig",
 		Short: "Collection of gadgets for containers",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if os.Geteuid() != 0 {
+				return fmt.Errorf("%s must be run as root to be able to run eBPF programs", os.Args[0])
+			}
+
+			return nil
+		},
 	}
 
 	rootCmd.AddCommand(


### PR DESCRIPTION
```
Otherwise an error message is printed explaining why the tool should be run as root.
```