### PR TITLE
integration: Use 'dnstester' for k8s tests

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -205,19 +205,6 @@ func GetTestPodIP(ns string, podname string) (string, error) {
 	return ip[1 : len(ip)-1], nil
 }
 
-func GetServiceIP(ns string, svcname string) (string, error) {
-	cmd := exec.Command("kubectl", "-n", ns, "get", "svc", svcname, "-o", "jsonpath='{.spec.clusterIP}'")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	r, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, stderr.String())
-	}
-
-	ip := string(r)
-	return ip[1 : len(ip)-1], nil
-}
-
 func CheckNamespace(ns string) bool {
 	cmd := exec.Command("kubectl", "get", "ns", ns)
 	return cmd.Run() == nil

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -7,3 +7,5 @@ RUN go build -o /dnstester /go/src/github.com/inspektor-gadget/inspektor-gadget/
 # Final image
 FROM alpine:3.14
 COPY --from=builder /dnstester /dnstester
+
+CMD ["/dnstester"]

--- a/tools/dnstester/dnstester.go
+++ b/tools/dnstester/dnstester.go
@@ -27,17 +27,21 @@ func main() {
 
 		var rr dns.RR
 		var err error
-		switch r.Question[0].Qtype {
-		case dns.TypeA:
-			rr, err = dns.NewRR("fake.test.com. A 127.0.0.1")
-		case dns.TypeAAAA:
-			rr, err = dns.NewRR("fake.test.com. AAAA ::1")
-		}
-		if err != nil {
-			log.Fatalf("Failed to create RR %s\n", err)
+		if r.Question[0].Name == "fake.test.com." {
+			switch r.Question[0].Qtype {
+			case dns.TypeA:
+				rr, err = dns.NewRR("fake.test.com. A 127.0.0.1")
+			case dns.TypeAAAA:
+				rr, err = dns.NewRR("fake.test.com. AAAA ::1")
+			}
+			if err != nil {
+				log.Fatalf("Failed to create RR %s\n", err)
+			}
+			m.Answer = append(m.Answer, rr)
+		} else {
+			m.SetRcode(r, dns.RcodeNameError)
 		}
 
-		m.Answer = append(m.Answer, rr)
 		if err = w.WriteMsg(m); err != nil {
 			log.Fatalf("Failed to write msg %s\n", err)
 		}


### PR DESCRIPTION
As mentioned [here](https://github.com/inspektor-gadget/inspektor-gadget/pull/1407#issuecomment-1461623922) we had issues getting `kube-dns` service on ARO so I switched to using local dns in all the tests.

Related #1378 