### PR TITLE
tools: dnstester for arm64

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -416,6 +416,58 @@ jobs:
               ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-default-arm64 }}
           fi
 
+  build-helper-images:
+    # level: 0
+    name: Build helper images
+    if: github.repository == 'inspektor-gadget/inspektor-gadget'
+    runs-on: ubuntu-latest
+    permissions:
+      # allow publishing container image
+      # in case of public fork repo/packages permissions will always be read
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: "dnstester"
+            dockerfile-dir: "tools/dnstester"
+            platform: "linux/amd64,linux/arm64"
+            filter-pattern: "tools/dnstester/*"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          pattern: ${{ matrix.image.filter-pattern }}
+    - name: Set up Docker Buildx
+      if: steps.filter.outputs.pattern == 'true'
+      uses: docker/setup-buildx-action@v2
+    - name: Login to Container Registry
+      if: steps.filter.outputs.pattern == 'true'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set container repository and determine image tag
+      id: set-repo-determine-image-tag
+      uses: ./.github/actions/set-container-repo-and-determine-image-tag
+      with:
+        registry: ${{ env.REGISTRY }}
+        container-image: inspektor-gadget/${{ matrix.image.name }}
+        co-re: false
+    - name: Build ${{ matrix.image.name }} image
+      if: steps.filter.outputs.pattern == 'true'
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ matrix.image.dockerfile-dir }}
+        file: ${{ matrix.image.dockerfile-dir }}/Dockerfile
+        push: true
+        tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        platforms: ${{ matrix.image.platform }}
+
   build-examples:
     name: Build examples
     # level: 0

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.19-alpine AS builder
-WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
+FROM --platform=${BUILDPLATFORM} golang:1.19-alpine AS builder
 
+ARG TARGETARCH
+
+WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
 COPY go.mod go.sum dnstester.go /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester/
-RUN go build -o /dnstester /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
+RUN GOARCH=${TARGETARCH} go build -o /dnstester /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
 
 # Final image
 FROM alpine:3.14

--- a/tools/dnstester/build.sh
+++ b/tools/dnstester/build.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-docker build -t ghcr.io/inspektor-gadget/dnstester:latest -f Dockerfile .
-docker push ghcr.io/inspektor-gadget/dnstester:latest
+docker buildx build --platform=linux/amd64,linux/arm64 -t ghcr.io/inspektor-gadget/dnstester:latest -f Dockerfile --push .

--- a/tools/dnstester/build.sh
+++ b/tools/dnstester/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-docker buildx build --platform=linux/amd64,linux/arm64 -t ghcr.io/inspektor-gadget/dnstester:latest -f Dockerfile --push .


### PR DESCRIPTION
As mentioned [here](https://github.com/inspektor-gadget/inspektor-gadget/pull/1411#issuecomment-1462359438) we need to create arm64 images for dnstester. This PR reworks the image to handle multi platform support. The corresponding arm64 [jobs](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/4376025214/jobs/7661323843) seems to be passing fine now. 