### PR TITLE
cmd: Replace -U and -K by --stack/-S for profile cpu.

### DIFF
--- a/docs/builtin-gadgets/profile/cpu.md
+++ b/docs/builtin-gadgets/profile/cpu.md
@@ -18,11 +18,11 @@ pod/random created
 
 Using the profile cpu gadget, we can see the list of stack traces.
 The following command filters only for pods named "random", execute the command
-and interrupt it after ~30 seconds. The `-K` option is passed to show only the
+and interrupt it after ~30 seconds. The `-S kernel` option is passed to show only the
 kernel stack traces.
 
 ```bash
-$ kubectl gadget profile cpu --podname random -K
+$ kubectl gadget profile cpu --podname random -S kernel
 Capturing stack traces... Hit Ctrl-C to end.^C
 ```
 
@@ -58,7 +58,7 @@ Linux function `urandom_read`.
 Instead of waiting, you can use the `--timeout` argument:
 
 ```bash
-$ kubectl gadget profile cpu --timeout 5 --podname random -K
+$ kubectl gadget profile cpu --timeout 5 --podname random -S kernel
 Capturing stack traces...
 K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
 minikube         default          random                         random           340800  cat              1
@@ -146,13 +146,13 @@ $ docker run -d --rm --name random busybox cat /dev/urandom > /dev/null
 * Start `ig`:
 
 ```bash
-$ sudo ./ig profile cpu -K --containername random --runtimes docker
+$ sudo ./ig profile cpu -S kernel --containername random --runtimes docker
 ```
 
 * Observe the results:
 
 ```bash
-sudo ./ig profile cpu -K --containername random --runtimes docker
+sudo ./ig profile cpu -S kernel --containername random --runtimes docker
 Capturing stack traces... Hit Ctrl-C to end.^C
 RUNTIME.CONTAINERNAME                                                                        COMM             PID        COUNT
 random                                                                                       cat              641045     1

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -29,7 +29,7 @@ func TestProfileCpu(t *testing.T) {
 
 	profileCPUCmd := &Command{
 		Name: "ProfileCpu",
-		Cmd:  fmt.Sprintf("ig profile cpu -K -o json --runtimes=%s --timeout 10", *containerRuntime),
+		Cmd:  fmt.Sprintf("ig profile cpu -S kernel -o json --runtimes=%s --timeout 10", *containerRuntime),
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &cpuprofileTypes.Report{

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -37,7 +37,7 @@ func TestProfileCpu(t *testing.T) {
 		WaitUntilTestPodReadyCommand(ns),
 		{
 			Name: "RunProfileCpuGadget",
-			Cmd:  fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -K --timeout 15 -o json", ns),
+			Cmd:  fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -S kernel --timeout 15 -o json", ns),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &profilecpuTypes.Report{
 					CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),

--- a/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
+++ b/pkg/gadget-collection/gadgets/profile/cpu/gadget.go
@@ -95,12 +95,15 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
-	_, userStackOnly := trace.Spec.Parameters[types.ProfileUserParam]
-	_, kernelStackOnly := trace.Spec.Parameters[types.ProfileKernelParam]
+	paramStack, ok := trace.Spec.Parameters[types.ProfileParamStack]
+	if !ok {
+		paramStack = types.ProfileParamStackBoth
+	}
+
 	config := &tracer.Config{
 		MountnsMap:      mountNsMap,
-		UserStackOnly:   userStackOnly,
-		KernelStackOnly: kernelStackOnly,
+		UserStackOnly:   paramStack == types.ProfileParamStackUser,
+		KernelStackOnly: paramStack == types.ProfileParamStackKernel,
 	}
 
 	t.tracer, err = tracer.NewTracer(t.helpers, config)

--- a/pkg/gadgets/profile/cpu/tracer/gadget.go
+++ b/pkg/gadgets/profile/cpu/tracer/gadget.go
@@ -15,16 +15,14 @@
 package tracer
 
 import (
+	"fmt"
+	"strings"
+
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
-)
-
-const (
-	ParamUserStack   = "user-stack"
-	ParamKernelStack = "kernel-stack"
 )
 
 type GadgetDesc struct{}
@@ -48,20 +46,13 @@ func (g *GadgetDesc) Description() string {
 func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 	return params.ParamDescs{
 		{
-			Key:          ParamUserStack,
-			Alias:        "U",
-			Title:        "User Stack",
-			DefaultValue: "false",
-			Description:  "Show stacks from user space only (no kernel space stacks)",
-			TypeHint:     params.TypeBool,
-		},
-		{
-			Key:          ParamKernelStack,
-			Alias:        "K",
-			Title:        "Kernel Stack",
-			DefaultValue: "false",
-			Description:  "Show stacks from kernel space only (no user space stacks)",
-			TypeHint:     params.TypeBool,
+			Key:            types.ProfileParamStack,
+			Alias:          "S",
+			Title:          "Stack Type",
+			DefaultValue:   types.ProfileParamStackBoth,
+			Description:    fmt.Sprintf("Show stack, possibles values are: %s", strings.Join(types.ProfileParamPossibleStacks, ", ")),
+			PossibleValues: []string{types.ProfileParamStackBoth, types.ProfileParamStackUser, types.ProfileParamStackKernel},
+			TypeHint:       params.TypeString,
 		},
 	}
 }

--- a/pkg/gadgets/profile/cpu/tracer/tracer.go
+++ b/pkg/gadgets/profile/cpu/tracer/tracer.go
@@ -305,8 +305,9 @@ type TracerWrap struct {
 
 func (t *TracerWrap) Run(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.config.UserStackOnly = params.Get(ParamUserStack).AsBool()
-	t.config.KernelStackOnly = params.Get(ParamKernelStack).AsBool()
+	stack := params.Get(types.ProfileParamStack).AsString()
+	t.config.UserStackOnly = stack == types.ProfileParamStackUser
+	t.config.KernelStackOnly = stack == types.ProfileParamStackKernel
 
 	defer t.close()
 	if err := t.install(); err != nil {

--- a/pkg/gadgets/profile/cpu/types/types.go
+++ b/pkg/gadgets/profile/cpu/types/types.go
@@ -20,9 +20,13 @@ import (
 )
 
 const (
-	ProfileUserParam   = "user"
-	ProfileKernelParam = "kernel"
+	ProfileParamStack       = "stack"
+	ProfileParamStackBoth   = "both"
+	ProfileParamStackUser   = "user"
+	ProfileParamStackKernel = "kernel"
 )
+
+var ProfileParamPossibleStacks = []string{ProfileParamStackUser, ProfileParamStackKernel}
 
 type Report struct {
 	eventtypes.CommonData


### PR DESCRIPTION
Hi.


In this PR, I replaced the two boolean flags `-U` and `-K` in favor of a string flag which takes the stack we want to print as argument.


Best regards.