### PR TITLE
CI: benchmarks all gadgets and publish graphs

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -548,6 +548,65 @@ jobs:
       run: |
         make controller-tests
 
+  benchmarks:
+    name: Benchmarks
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+      id: go
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
+    - name: Show repository setup
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+        echo "github.event.pull_request.head.repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
+        echo "github.repository: ${{ github.repository }}"
+    - name: Run benchmarks
+      run: go test -exec sudo -bench=. -run=Benchmark ./pkg/gadgets/... ./internal/benchmarks/... | tee output.txt
+    #- name: Download previous benchmark data
+    #  uses: actions/cache@v1
+    #  with:
+    #    path: ./cache
+    #    key: ${{ runner.os }}-benchmark
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      # Disable push from forks or PR from forks.
+      # $BENCHMARKS_TOKEN will not be available in those cases.
+      if: |
+        (github.event_name == 'push' &&
+          github.repository == 'inspektor-gadget/inspektor-gadget') ||
+        (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == 'inspektor-gadget/inspektor-gadget')
+      with:
+        name: Gadget benchmarks
+        # What benchmark tool the output.txt came from
+        tool: 'go'
+        # Where the output from the benchmark tool is stored
+        output-file-path: output.txt
+        # Where the previous data file is stored
+        # external-data-json-path: ./cache/benchmark-data.json
+        # Workflow will fail when an alert happens
+        fail-on-alert: false
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.BENCHMARKS_TOKEN }}
+        # Enable alert commit comment
+        comment-on-alert: true
+        # Enable Job Summary for PRs
+        # summary-always: true
+        # Mention people in the commit comment
+        alert-comment-cc-users: '@alban'
+        # Push and deploy GitHub pages branch automatically
+        auto-push: ${{ github.repository == 'inspektor-gadget/inspektor-gadget' }}
+        gh-pages-branch: gh-pages
+        gh-repository: github.com/inspektor-gadget/ig-benchmarks
+        benchmark-data-dir-path: dev/bench
+
   test-ig:
     name: Unit tests for ig
     # level: 0

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,12 @@ controller-tests: kube-apiserver etcd kubectl
 gadgets-unit-tests:
 	go test -test.v -exec sudo ./pkg/gadgets/...
 
+# Individual tests can be selected with a command such as:
+# go test -exec sudo -bench='^BenchmarkAllGadgetsWithContainers$/^container10$/trace-tcpconnect' -run=Benchmark ./internal/benchmarks/...
+.PHONY: gadgets-benchmarks
+gadgets-benchmarks:
+	go test -exec sudo -bench=. -run=Benchmark ./pkg/gadgets/... ./internal/benchmarks/...
+
 .PHONY: ig-tests
 ig-tests:
 	# Compile and execute in separate commands because Go might not be

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -1,0 +1,279 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gadgets provides benchmarks for all gadgets. They can be executed
+// with the command:
+//
+//	$ make gadgets-benchmarks
+//
+// Results are published automatically by the GitHub Action:
+// https://inspektor-gadget.github.io/ig-benchmarks/dev/bench/index.html
+package gadgets
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
+
+	// TODO: find out why those gadgets don't work in the tests
+	//_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/tracer"
+	//_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/block-io/tracer"
+
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/seccomp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/audit/seccomp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/tcp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/bind/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/capabilities/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/fsslower/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/mount/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/network/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/oomkill/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpconnect/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
+
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+)
+
+type Attacher interface {
+	AttachContainer(container *containercollection.Container) error
+	DetachContainer(*containercollection.Container) error
+}
+
+type MountNsMapSetter interface {
+	SetMountNsMap(*ebpf.Map)
+}
+
+type TestOperator struct{}
+
+type TestOperatorContext string
+
+func (t *TestOperator) Name() string {
+	return "TestOperator"
+}
+
+func (t *TestOperator) Description() string {
+	return "TestOperator allows to run tests with many fake containers"
+}
+
+func (t *TestOperator) GlobalParamDescs() params.ParamDescs {
+	return nil
+}
+
+func (t *TestOperator) ParamDescs() params.ParamDescs {
+	return nil
+}
+
+func (t *TestOperator) Dependencies() []string {
+	return nil
+}
+
+func (t *TestOperator) CanOperateOn(desc gadgets.GadgetDesc) bool {
+	// Accept all gadgets. Check for interfaces later in PreGadgetRun.
+	return true
+}
+
+func (t *TestOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (t *TestOperator) Close() error {
+	return nil
+}
+
+func (t *TestOperator) Instantiate(gadgetContext operators.GadgetContext, gadgetInstance any, params *params.Params) (operators.OperatorInstance, error) {
+	attacher, _ := gadgetInstance.(Attacher)
+	mountNsMapSetter, _ := gadgetInstance.(MountNsMapSetter)
+	return &TestOperatorInstance{
+		TestOperator:     t, // for Name()
+		attacher:         attacher,
+		mountNsMapSetter: mountNsMapSetter,
+		containers:       gadgetContext.Context().Value(TestOperatorContext("containers")).([]*containercollection.Container),
+		testingTB:        gadgetContext.Context().Value(TestOperatorContext("testing.TB")).(testing.TB),
+	}, nil
+}
+
+type TestOperatorInstance struct {
+	*TestOperator
+	attacher         Attacher
+	mountNsMapSetter MountNsMapSetter
+	containers       []*containercollection.Container
+	testingTB        testing.TB
+	tc               *tracercollection.TracerCollection
+}
+
+func (t *TestOperatorInstance) PreGadgetRun() error {
+	if t.attacher != nil {
+		for i := range t.containers {
+			err := t.attacher.AttachContainer(t.containers[i])
+			if err != nil {
+				t.testingTB.Fatal(err)
+			}
+		}
+	}
+	if t.mountNsMapSetter != nil {
+		tc, err := tracercollection.NewTracerCollectionTest(nil)
+		if err != nil {
+			t.testingTB.Fatal(err)
+		}
+		t.tc = tc
+		tc.AddTracer("test-tracer", containercollection.ContainerSelector{})
+
+		mountnsmap, err := tc.TracerMountNsMap("test-tracer")
+		if err != nil {
+			t.testingTB.Fatal(err)
+		}
+		t.mountNsMapSetter.SetMountNsMap(mountnsmap)
+	}
+	return nil
+}
+
+func (t *TestOperatorInstance) PostGadgetRun() error {
+	if t.attacher != nil {
+		for i := range t.containers {
+			err := t.attacher.DetachContainer(t.containers[i])
+			if err != nil {
+				t.testingTB.Fatal(err)
+			}
+
+		}
+	}
+	if t.mountNsMapSetter != nil {
+		t.tc.Close()
+	}
+	return nil
+}
+
+func (t *TestOperatorInstance) EnrichEvent(ev any) error {
+	return nil
+}
+
+func init() {
+	operators.Register(&TestOperatorInstance{})
+}
+
+// BenchmarkAllGadgetsWithContainers measures the performance of all gadget
+// startups with various amount of containers.
+func BenchmarkAllGadgetsWithContainers(b *testing.B) {
+	utilstest.RequireRoot(b)
+
+	// Prepare runtime
+	runtime := &local.Runtime{}
+	err := runtime.Init(nil)
+	if err != nil {
+		b.Fatalf("initializing runtime: %s", err)
+	}
+	defer runtime.Close()
+
+	containerCounts := []int{0, 1, 10, 100}
+	for _, containerCount := range containerCounts {
+		b.Run(fmt.Sprintf("container%d", containerCount), func(b *testing.B) {
+			// Prepare fake containers
+			runnerConfig := &utilstest.RunnerConfig{}
+			var containers []*containercollection.Container
+			for i := 0; i < containerCount; i++ {
+				runner := utilstest.NewRunnerWithTest(b, runnerConfig)
+				container := &containercollection.Container{
+					ID:    fmt.Sprintf("container%d", i),
+					Mntns: runner.Info.MountNsID,
+					Netns: runner.Info.NetworkNsID,
+					Pid:   uint32(runner.Info.Tid),
+				}
+				containers = append(containers, container)
+			}
+
+			allGadgets := gadgetregistry.GetAll()
+			for _, gadgetDesc := range allGadgets {
+				gadgetDesc := gadgetDesc
+
+				if _, ok := gadgetDesc.(gadgets.GadgetInstantiate); !ok {
+					continue
+				}
+
+				validOperators := operators.GetOperatorsForGadget(gadgetDesc)
+				operatorsParamCollection := validOperators.ParamCollection()
+
+				err = validOperators.Init(nil)
+				if err != nil {
+					b.Fatalf("initializing operators: %s", err)
+				}
+				defer validOperators.Close()
+
+				categoryAndName := fmt.Sprintf("%s-%s", gadgetDesc.Category(), gadgetDesc.Name())
+				b.Run(categoryAndName, func(b *testing.B) {
+					for n := 0; n < b.N; n++ {
+						// This benchmark only measure gadget startup time.
+						// Use a timeout of 0s, so it will immediately timeout
+						// and runtime.RunGadget() will be stopped immediately
+						// via '<-gadgetCtx.Context().Done()' once the gadget
+						// is started.
+						ctx, cancel := context.WithTimeout(context.TODO(), 0)
+						ctx = context.WithValue(ctx, TestOperatorContext("containers"), containers)
+						ctx = context.WithValue(ctx, TestOperatorContext("testing.TB"), b)
+
+						paramDescs := gadgetDesc.ParamDescs()
+
+						parser := gadgetDesc.Parser()
+						if parser != nil {
+							parser.SetEventCallback(func(any) {})
+							paramDescs = append(paramDescs, gadgets.GadgetParams(gadgetDesc, parser)...)
+						}
+
+						gadgetParams := paramDescs.ToParams()
+
+						gadgetCtx := gadgetcontext.New(
+							ctx,
+							"",
+							runtime,
+							gadgetDesc,
+							gadgetParams,
+							operatorsParamCollection,
+							parser,
+							logger.DefaultLogger(),
+						)
+
+						_, err := runtime.RunGadget(gadgetCtx)
+						if err != nil {
+							b.Fatalf("running gadget: %s", err)
+						}
+
+						cancel()
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -77,7 +77,7 @@ func RequireKernelVersion(t testing.TB, expectedVersion *kernel.VersionInfo) {
 	}
 }
 
-func NewRunnerWithTest(t *testing.T, config *RunnerConfig) *Runner {
+func NewRunnerWithTest(t testing.TB, config *RunnerConfig) *Runner {
 	t.Helper()
 
 	runner, err := NewRunner(config)
@@ -90,7 +90,7 @@ func NewRunnerWithTest(t *testing.T, config *RunnerConfig) *Runner {
 	return runner
 }
 
-func RunWithRunner(t *testing.T, runner *Runner, f func() error) {
+func RunWithRunner(t testing.TB, runner *Runner, f func() error) {
 	t.Helper()
 
 	if err := runner.Run(f); err != nil {

--- a/pkg/gadget-registry/gadget-registry.go
+++ b/pkg/gadget-registry/gadget-registry.go
@@ -16,6 +16,7 @@ package gadgetregistry
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 )
@@ -38,5 +39,12 @@ func GetAll() (gadgets []gadgets.GadgetDesc) {
 	for _, g := range gadgetRegistry {
 		gadgets = append(gadgets, g)
 	}
+
+	// Return gadgets in deterministic order
+	sort.Slice(gadgets, func(i, j int) bool {
+		a := fmt.Sprintf("%s-%s", gadgets[i].Category(), gadgets[i].Name())
+		b := fmt.Sprintf("%s-%s", gadgets[j].Category(), gadgets[j].Name())
+		return a < b
+	})
 	return
 }

--- a/pkg/gadgets/internal/socketenricher/tracer_test.go
+++ b/pkg/gadgets/internal/socketenricher/tracer_test.go
@@ -20,14 +20,12 @@ package socketenricher
 import (
 	"fmt"
 	"net"
-	"os"
 	"reflect"
 	"testing"
 
 	"golang.org/x/sys/unix"
 
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 )
 
 func TestSocketEnricherCreate(t *testing.T) {
@@ -77,11 +75,6 @@ func TestSocketEnricherBind(t *testing.T) {
 		expectedEvent func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry
 	}
 
-	netns, err := containerutils.GetNetNs(os.Getpid())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	stringToSlice := func(s string) (ret [16]int8) {
 		for i := 0; i < 16; i++ {
 			if i >= len(s) {
@@ -98,7 +91,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET,
 						Proto:  unix.IPPROTO_UDP,
 						Port:   port,
@@ -116,7 +109,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET6,
 						Proto:  unix.IPPROTO_UDP,
 						Port:   port,
@@ -134,7 +127,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET,
 						Proto:  unix.IPPROTO_TCP,
 						Port:   port,
@@ -152,7 +145,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET6,
 						Proto:  unix.IPPROTO_TCP,
 						Port:   port,


### PR DESCRIPTION
# CI: benchmarks all gadgets and publish graphs

This PR runs benchmarks for (almost) all gadgets with 100 fake containers. It uses the GitHub Action https://github.com/benchmark-action/github-action-benchmark to publish the graphs on a website automatically.

## How to use

### Locally

Run benchmarks locally:
```
$ make gadgets-benchmarks
```

### GitHub Action

Use the CI, and check the results:

![image](https://user-images.githubusercontent.com/27575/224390555-651c43b4-ce92-48d5-9523-6c217744f281.png)
[screenshot source](https://github.com/alban/inspektor-gadget/actions/runs/4387055722/jobs/7681888513)

### Graphs

Check the graphs automatically updated for each commit pushed on the repository:
https://alban.github.io/ig-benchmarks/dev/bench/

## Testing done

```
BenchmarkAllGadgetsManyContainers/-traceloop-4         	       1	2023389297 ns/op
BenchmarkAllGadgetsManyContainers/advise-seccomp-4     	      26	  68125372 ns/op
BenchmarkAllGadgetsManyContainers/audit-seccomp-4      	      15	  67188176 ns/op
BenchmarkAllGadgetsManyContainers/profile-cpu-4        	       3	 522453773 ns/op
BenchmarkAllGadgetsManyContainers/snapshot-process-4   	       4	 496787210 ns/op
BenchmarkAllGadgetsManyContainers/snapshot-socket-4    	       1	82992027975 ns/op
BenchmarkAllGadgetsManyContainers/trace-bind-4         	       4	 285769542 ns/op
BenchmarkAllGadgetsManyContainers/trace-capabilities-4 	       4	 598973148 ns/op
BenchmarkAllGadgetsManyContainers/trace-dns-4          	       1	5628080722 ns/op
BenchmarkAllGadgetsManyContainers/trace-exec-4         	      12	  90112159 ns/op
BenchmarkAllGadgetsManyContainers/trace-fsslower-4     	       2	 624439805 ns/op
BenchmarkAllGadgetsManyContainers/trace-mount-4        	       7	 187561950 ns/op
BenchmarkAllGadgetsManyContainers/trace-network-4      	       2	 871403534 ns/op
BenchmarkAllGadgetsManyContainers/trace-oomkill-4      	      18	  63202527 ns/op
BenchmarkAllGadgetsManyContainers/trace-open-4         	       7	 259903084 ns/op
BenchmarkAllGadgetsManyContainers/trace-signal-4       	      10	 176863255 ns/op
BenchmarkAllGadgetsManyContainers/trace-sni-4          	       1	10987273427 ns/op
BenchmarkAllGadgetsManyContainers/trace-tcp-4          	       2	 736935149 ns/op
BenchmarkAllGadgetsManyContainers/trace-tcpconnect-4   	       5	 376750061 ns/op
```

We can see that the slowest gadgets are:
- traceloop
- snapshot socket
- trace dns
- trace sni

This is because they currently load one ebpf program per container.
See explanation in https://github.com/inspektor-gadget/inspektor-gadget/issues/1394#issuecomment-1456421534

## TODO

- [ ] Enable benchmarks for missing gadgets (see TODO in the code)
- [ ] Publish the results in a different repository than https://alban.github.io/ig-benchmarks/dev/bench/
- [ ] Update [index.html](https://github.com/alban/ig-benchmarks/blob/gh-pages/dev/bench/index.html) to add a graph to compare gadgets with each other

cc @flyth 