### PR TITLE
test: Fix trace dns test

### DIFF
--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -118,6 +118,7 @@ func TestTraceDns(t *testing.T) {
 		"/dnstester & sleep 2", // wait to ensure dns server is running
 		"nslookup -type=a fake.test.com. 127.0.0.1",
 		"nslookup -type=aaaa fake.test.com. 127.0.0.1",
+		"sleep 2", // give time to the tracer to capture events before the container is done
 	}
 
 	testSteps := []TestStep{


### PR DESCRIPTION
Add a delay so the container is not finished immediately, this gives more time to the tracer to capture the events.

