### PR TITLE
[RFC] New generic benchmarks measuring ebpf execution

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -548,6 +548,65 @@ jobs:
       run: |
         make controller-tests
 
+  benchmarks:
+    name: Benchmarks
+    # level: 0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+      id: go
+    - name: Install debian packages
+      uses: ./.github/actions/install-debian-packages
+    - name: Show repository setup
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+        echo "github.event.pull_request.head.repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
+        echo "github.repository: ${{ github.repository }}"
+    - name: Run benchmarks
+      run: go test -exec sudo -bench=. -run=Benchmark ./pkg/gadgets/... ./internal/benchmarks/... | tee output.txt
+    #- name: Download previous benchmark data
+    #  uses: actions/cache@v1
+    #  with:
+    #    path: ./cache
+    #    key: ${{ runner.os }}-benchmark
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      # Disable push from forks or PR from forks.
+      # $BENCHMARKS_TOKEN will not be available in those cases.
+      if: |
+        (github.event_name == 'push' &&
+          github.repository == 'inspektor-gadget/inspektor-gadget') ||
+        (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == 'inspektor-gadget/inspektor-gadget')
+      with:
+        name: Gadget benchmarks
+        # What benchmark tool the output.txt came from
+        tool: 'go'
+        # Where the output from the benchmark tool is stored
+        output-file-path: output.txt
+        # Where the previous data file is stored
+        # external-data-json-path: ./cache/benchmark-data.json
+        # Workflow will fail when an alert happens
+        fail-on-alert: false
+        # GitHub API token to make a commit comment
+        github-token: ${{ secrets.BENCHMARKS_TOKEN }}
+        # Enable alert commit comment
+        comment-on-alert: true
+        # Enable Job Summary for PRs
+        # summary-always: true
+        # Mention people in the commit comment
+        alert-comment-cc-users: '@alban'
+        # Push and deploy GitHub pages branch automatically
+        auto-push: ${{ github.repository == 'inspektor-gadget/inspektor-gadget' }}
+        gh-pages-branch: gh-pages
+        gh-repository: github.com/inspektor-gadget/ig-benchmarks
+        benchmark-data-dir-path: dev/bench
+
   test-ig:
     name: Unit tests for ig
     # level: 0

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,12 @@ controller-tests: kube-apiserver etcd kubectl
 gadgets-unit-tests:
 	go test -test.v -exec sudo ./pkg/gadgets/...
 
+# IG_BENCHMARKS_GADGET_REGEX can be used to select gadgets to test
+# IG_BENCHMARKS_GADGET_REGEX='trace-[ds]n[si]' make gadgets-benchmarks
+.PHONY: gadgets-benchmarks
+gadgets-benchmarks:
+	go test -exec 'sudo -E' -bench=. -run=Benchmark ./pkg/gadgets/... ./internal/benchmarks/...
+
 .PHONY: ig-tests
 ig-tests:
 	# Compile and execute in separate commands because Go might not be

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -17,11 +17,17 @@ package gadgets
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/tracer"
 
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
@@ -272,6 +278,227 @@ func BenchmarkAllGadgetsWithContainers(b *testing.B) {
 					}
 				})
 			}
+		})
+	}
+}
+func generateEvent(b *testing.B, categoryAndName string) error {
+	switch categoryAndName {
+	case "trace-open":
+		fd, err := unix.Open("/dev/null", 0, 0)
+		if err != nil {
+			return fmt.Errorf("opening file: %w", err)
+		}
+		unix.Close(fd)
+
+	case "trace-bind":
+		bindSocketFn("127.0.0.1", unix.AF_INET, unix.SOCK_STREAM, 5556)()
+	default:
+		time.Sleep(time.Second)
+	}
+	return nil
+}
+
+// bindSocketFn returns a function that creates a socket, binds it and
+// returns the port the socket was bound to.
+func bindSocketFn(ipStr string, domain, typ int, port int) func() (uint16, error) {
+	return func() (uint16, error) {
+		return bindSocket(ipStr, domain, typ, port)
+	}
+}
+
+func bindSocket(ipStr string, domain, typ int, port int) (uint16, error) {
+	return bindSocketWithOpts(ipStr, domain, typ, port)
+}
+
+func bindSocketWithOpts(ipStr string, domain, typ int, port int) (uint16, error) {
+	fd, err := unix.Socket(domain, typ, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer unix.Close(fd)
+
+	var sa unix.Sockaddr
+
+	ip := net.ParseIP(ipStr)
+
+	if ip.To4() != nil {
+		sa4 := &unix.SockaddrInet4{Port: port}
+		copy(sa4.Addr[:], ip.To4())
+		sa = sa4
+	} else if ip.To16() != nil {
+		sa6 := &unix.SockaddrInet6{Port: port}
+		copy(sa6.Addr[:], ip.To16())
+		sa = sa6
+	} else {
+		return 0, fmt.Errorf("invalid IP address")
+	}
+
+	if err := unix.Bind(fd, sa); err != nil {
+		return 0, fmt.Errorf("Bind: %w", err)
+	}
+
+	sa2, err := unix.Getsockname(fd)
+	if err != nil {
+		return 0, fmt.Errorf("Getsockname: %w", err)
+	}
+
+	if ip.To4() != nil {
+		return uint16(sa2.(*unix.SockaddrInet4).Port), nil
+	} else if ip.To16() != nil {
+		return uint16(sa2.(*unix.SockaddrInet6).Port), nil
+	} else {
+		return 0, fmt.Errorf("invalid IP address")
+	}
+}
+
+func BenchmarkAllGadgetsWithEvents(b *testing.B) {
+	utilstest.RequireRoot(b)
+
+	// Prepare runtime
+	runtime := &local.Runtime{}
+	err := runtime.Init(nil)
+	if err != nil {
+		b.Fatalf("initializing runtime: %s", err)
+	}
+	defer runtime.Close()
+
+	// Prepare fake container
+	runnerConfig := &utilstest.RunnerConfig{}
+	var containers []*containercollection.Container
+	runner := utilstest.NewRunnerWithTest(b, runnerConfig)
+	container := &containercollection.Container{
+		ID:    "container1",
+		Mntns: runner.Info.MountNsID,
+		Netns: runner.Info.NetworkNsID,
+		Pid:   uint32(runner.Info.Tid),
+	}
+	containers = append(containers, container)
+
+	allGadgets := gadgetregistry.GetAll()
+
+	for _, gadgetDesc := range allGadgets {
+		gadgetDesc := gadgetDesc
+
+		// Skip unwanted gadgets
+		categoryAndName := fmt.Sprintf("%s-%s", gadgetDesc.Category(), gadgetDesc.Name())
+		skipRegex := os.Getenv("IG_BENCHMARKS_GADGET_REGEX")
+		if skipRegex != "" {
+			matched, _ := regexp.Match(skipRegex, []byte(categoryAndName))
+			if !matched {
+				continue
+			}
+		}
+
+		if _, ok := gadgetDesc.(gadgets.GadgetInstantiate); !ok {
+			continue
+		}
+
+		validOperators := operators.GetOperatorsForGadget(gadgetDesc)
+		operatorsParamCollection := validOperators.ParamCollection()
+
+		err = validOperators.Init(nil)
+		if err != nil {
+			b.Fatalf("initializing operators: %s", err)
+		}
+		defer validOperators.Close()
+
+		b.Run(categoryAndName, func(b *testing.B) {
+			ctx, cancel := context.WithCancel(context.TODO())
+			ctx = context.WithValue(ctx, TestOperatorContext("containers"), containers)
+			ctx = context.WithValue(ctx, TestOperatorContext("testing.TB"), b)
+
+			paramDescs := gadgetDesc.ParamDescs()
+
+			parser := gadgetDesc.Parser()
+			if parser != nil {
+				parser.SetEventCallback(func(any) {})
+				paramDescs = append(paramDescs, gadgets.GadgetParams(gadgetDesc, parser)...)
+			}
+
+			gadgetParams := paramDescs.ToParams()
+
+			gadgetCtx := gadgetcontext.New(
+				ctx,
+				"",
+				runtime,
+				gadgetDesc,
+				gadgetParams,
+				operatorsParamCollection,
+				parser,
+				logger.DefaultLogger(),
+			)
+
+			config := &tracer.Config{
+				MaxRows:  0,   // no max
+				Interval: 0,   // no ticker
+				SortBy:   nil, // no need to sort
+			}
+			ebpftracer, err := tracer.NewTracer(config, nil, nil)
+			if err != nil {
+				b.Fatalf("starting ebpf tracer: %s", err)
+			}
+
+			// Due to the way the tracer works, it needs to be called once to
+			// initialize startStats
+			_, _ = ebpftracer.NextStats()
+
+			var wg sync.WaitGroup
+			go func() {
+				wg.Add(1)
+				defer wg.Done()
+				_, err = runtime.RunGadget(gadgetCtx)
+				if err != nil {
+					b.Fatalf("running gadget: %s", err)
+				}
+			}()
+
+			// Wait until runtime.RunGadget() has finished starting with Start()
+			// TODO: Fix RunGadget() so we can get notified without sleeping.
+			time.Sleep(time.Second)
+
+			// This benchmark is not about the setup time but about measuring
+			// event processing in ebpf
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				utilstest.RunWithRunner(b, runner, func() error {
+					return generateEvent(b, categoryAndName)
+				})
+
+			}
+			stats, err := ebpftracer.NextStats()
+			if err != nil {
+				b.Fatalf("reading stats from ebpf tracer: %s", err)
+			}
+			totalRuntime := int64(0)
+			totalRunCount := uint64(0)
+			for _, stat := range stats {
+				ours := false
+				if stat.Name == "ig_top_ebpf_it" {
+					continue
+				}
+				for _, p := range stat.Processes {
+					if int(p.Pid) == os.Getpid() {
+						ours = true
+					}
+				}
+				if ours {
+					//fmt.Printf("%s: program %s: runtime=%d runcount=%d (N=%d)\n",
+					//	categoryAndName, stat.Name,
+					//	stat.CumulativeRuntime, stat.CumulativeRunCount,
+					//	b.N)
+					totalRuntime += stat.CumulativeRuntime
+					totalRunCount += stat.CumulativeRunCount
+				}
+			}
+
+			cancel()
+			wg.Wait()
+
+			b.ReportMetric(float64(totalRuntime)/float64(b.N), "ebpfns/op")
+			b.ReportMetric(float64(totalRunCount)/float64(b.N), "ebpfexec/op")
+			//fmt.Printf("%s: Reporting %d/%d %d/%d\n",
+			//	categoryAndName, totalRuntime, b.N, totalRunCount, b.N)
 		})
 	}
 }

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -1,0 +1,274 @@
+// Copyright 2019-2021 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
+
+	// TODO: find out why those gadgets don't work in the tests
+	//_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/tracer"
+	//_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/block-io/tracer"
+
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/seccomp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/audit/seccomp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/cpu/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/ebpf/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/file/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/top/tcp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/bind/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/capabilities/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/fsslower/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/mount/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/network/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/oomkill/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/open/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/signal/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/sni/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcp/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpconnect/tracer"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
+
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+)
+
+type Attacher interface {
+	AttachContainer(container *containercollection.Container) error
+	DetachContainer(*containercollection.Container) error
+}
+
+type MountNsMapSetter interface {
+	SetMountNsMap(*ebpf.Map)
+}
+
+type TestOperator struct{}
+
+type TestOperatorContext string
+
+func (t *TestOperator) Name() string {
+	return "TestOperator"
+}
+
+func (t *TestOperator) Description() string {
+	return "TestOperator allows to run tests with many fake containers"
+}
+
+func (t *TestOperator) GlobalParamDescs() params.ParamDescs {
+	return nil
+}
+
+func (t *TestOperator) ParamDescs() params.ParamDescs {
+	return nil
+}
+
+func (t *TestOperator) Dependencies() []string {
+	return nil
+}
+
+func (t *TestOperator) CanOperateOn(desc gadgets.GadgetDesc) bool {
+	// Accept all gadgets. Check for interfaces later in PreGadgetRun.
+	return true
+}
+
+func (t *TestOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (t *TestOperator) Close() error {
+	return nil
+}
+
+func (t *TestOperator) Instantiate(gadgetContext operators.GadgetContext, gadgetInstance any, params *params.Params) (operators.OperatorInstance, error) {
+	attacher, _ := gadgetInstance.(Attacher)
+	mountNsMapSetter, _ := gadgetInstance.(MountNsMapSetter)
+	return &TestOperatorInstance{
+		TestOperator:     t, // for Name()
+		attacher:         attacher,
+		mountNsMapSetter: mountNsMapSetter,
+		containers:       gadgetContext.Context().Value(TestOperatorContext("containers")).([]*containercollection.Container),
+		testingTB:        gadgetContext.Context().Value(TestOperatorContext("testing.TB")).(testing.TB),
+	}, nil
+}
+
+type TestOperatorInstance struct {
+	*TestOperator
+	attacher         Attacher
+	mountNsMapSetter MountNsMapSetter
+	containers       []*containercollection.Container
+	testingTB        testing.TB
+	tc               *tracercollection.TracerCollection
+}
+
+func (t *TestOperatorInstance) PreGadgetRun() error {
+	if t.attacher != nil {
+		for i := range t.containers {
+			err := t.attacher.AttachContainer(t.containers[i])
+			if err != nil {
+				t.testingTB.Fatal(err)
+			}
+		}
+	}
+	if t.mountNsMapSetter != nil {
+		tc, err := tracercollection.NewTracerCollectionTest(nil)
+		if err != nil {
+			t.testingTB.Fatal(err)
+		}
+		t.tc = tc
+		tc.AddTracer("test-tracer", containercollection.ContainerSelector{})
+
+		mountnsmap, err := tc.TracerMountNsMap("test-tracer")
+		if err != nil {
+			t.testingTB.Fatal(err)
+		}
+		t.mountNsMapSetter.SetMountNsMap(mountnsmap)
+	}
+	return nil
+}
+
+func (t *TestOperatorInstance) PostGadgetRun() error {
+	if t.attacher != nil {
+		for i := range t.containers {
+			err := t.attacher.DetachContainer(t.containers[i])
+			if err != nil {
+				t.testingTB.Fatal(err)
+			}
+
+		}
+	}
+	if t.mountNsMapSetter != nil {
+		t.tc.Close()
+	}
+	return nil
+}
+
+func (t *TestOperatorInstance) EnrichEvent(ev any) error {
+	return nil
+}
+
+func init() {
+	operators.Register(&TestOperatorInstance{})
+}
+
+func BenchmarkAllGadgetsManyContainers(b *testing.B) {
+	utilstest.RequireRoot(b)
+
+	const containerCount = 100
+
+	// Prepare runtime
+	runtime := &local.Runtime{}
+	err := runtime.Init(nil)
+	if err != nil {
+		b.Fatalf("initializing runtime: %s", err)
+	}
+	defer runtime.Close()
+
+	// Prepare fake containers
+	runnerConfig := &utilstest.RunnerConfig{}
+	var containers []*containercollection.Container
+	for i := 0; i < containerCount; i++ {
+		runner := utilstest.NewRunnerWithTest(b, runnerConfig)
+		container := &containercollection.Container{
+			ID:    fmt.Sprintf("container%d", i),
+			Mntns: runner.Info.MountNsID,
+			Netns: runner.Info.NetworkNsID,
+			Pid:   uint32(runner.Info.Tid),
+		}
+		containers = append(containers, container)
+	}
+
+	allGadgets := gadgetregistry.GetAll()
+
+	for _, gadgetDesc := range allGadgets {
+		gadgetDesc := gadgetDesc
+
+		// Skip unwanted gadgets
+		categoryAndName := fmt.Sprintf("%s-%s", gadgetDesc.Category(), gadgetDesc.Name())
+		skipRegex := os.Getenv("IG_BENCHMARKS_GADGET_REGEX")
+		if skipRegex != "" {
+			matched, _ := regexp.Match(skipRegex, []byte(categoryAndName))
+			if !matched {
+				continue
+			}
+		}
+
+		if _, ok := gadgetDesc.(gadgets.GadgetInstantiate); !ok {
+			continue
+		}
+
+		validOperators := operators.GetOperatorsForGadget(gadgetDesc)
+		operatorsParamCollection := validOperators.ParamCollection()
+
+		err = validOperators.Init(nil)
+		if err != nil {
+			b.Fatalf("initializing operators: %s", err)
+		}
+		defer validOperators.Close()
+
+		b.Run(categoryAndName, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				ctx, cancel := context.WithTimeout(context.TODO(), 0)
+				ctx = context.WithValue(ctx, TestOperatorContext("containers"), containers)
+				ctx = context.WithValue(ctx, TestOperatorContext("testing.TB"), b)
+
+				paramDescs := gadgetDesc.ParamDescs()
+
+				parser := gadgetDesc.Parser()
+				if parser != nil {
+					parser.SetEventCallback(func(any) {})
+					paramDescs = append(paramDescs, gadgets.GadgetParams(gadgetDesc, parser)...)
+				}
+
+				gadgetParams := paramDescs.ToParams()
+
+				gadgetCtx := gadgetcontext.New(
+					ctx,
+					"",
+					runtime,
+					gadgetDesc,
+					gadgetParams,
+					operatorsParamCollection,
+					parser,
+					logger.DefaultLogger(),
+				)
+
+				_, err := runtime.RunGadget(gadgetCtx)
+				if err != nil {
+					b.Fatalf("running gadget: %s", err)
+				}
+
+				cancel()
+			}
+		})
+	}
+}

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -77,7 +77,7 @@ func RequireKernelVersion(t testing.TB, expectedVersion *kernel.VersionInfo) {
 	}
 }
 
-func NewRunnerWithTest(t *testing.T, config *RunnerConfig) *Runner {
+func NewRunnerWithTest(t testing.TB, config *RunnerConfig) *Runner {
 	t.Helper()
 
 	runner, err := NewRunner(config)
@@ -90,7 +90,7 @@ func NewRunnerWithTest(t *testing.T, config *RunnerConfig) *Runner {
 	return runner
 }
 
-func RunWithRunner(t *testing.T, runner *Runner, f func() error) {
+func RunWithRunner(t testing.TB, runner *Runner, f func() error) {
 	t.Helper()
 
 	if err := runner.Run(f); err != nil {

--- a/pkg/gadget-registry/gadget-registry.go
+++ b/pkg/gadget-registry/gadget-registry.go
@@ -16,6 +16,7 @@ package gadgetregistry
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 )
@@ -38,5 +39,12 @@ func GetAll() (gadgets []gadgets.GadgetDesc) {
 	for _, g := range gadgetRegistry {
 		gadgets = append(gadgets, g)
 	}
+
+	// Return gadgets in deterministic order
+	sort.Slice(gadgets, func(i, j int) bool {
+		a := fmt.Sprintf("%s-%s", gadgets[i].Category(), gadgets[i].Name())
+		b := fmt.Sprintf("%s-%s", gadgets[j].Category(), gadgets[j].Name())
+		return a < b
+	})
 	return
 }

--- a/pkg/gadgets/internal/socketenricher/tracer_test.go
+++ b/pkg/gadgets/internal/socketenricher/tracer_test.go
@@ -20,14 +20,12 @@ package socketenricher
 import (
 	"fmt"
 	"net"
-	"os"
 	"reflect"
 	"testing"
 
 	"golang.org/x/sys/unix"
 
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 )
 
 func TestSocketEnricherCreate(t *testing.T) {
@@ -77,11 +75,6 @@ func TestSocketEnricherBind(t *testing.T) {
 		expectedEvent func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry
 	}
 
-	netns, err := containerutils.GetNetNs(os.Getpid())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	stringToSlice := func(s string) (ret [16]int8) {
 		for i := 0; i < 16; i++ {
 			if i >= len(s) {
@@ -98,7 +91,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET,
 						Proto:  unix.IPPROTO_UDP,
 						Port:   port,
@@ -116,7 +109,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET6,
 						Proto:  unix.IPPROTO_UDP,
 						Port:   port,
@@ -134,7 +127,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET,
 						Proto:  unix.IPPROTO_TCP,
 						Port:   port,
@@ -152,7 +145,7 @@ func TestSocketEnricherBind(t *testing.T) {
 			expectedEvent: func(info *utilstest.RunnerInfo, port uint16) *socketEnricherMapEntry {
 				return &socketEnricherMapEntry{
 					Key: socketenricherSocketsKey{
-						Netns:  uint32(netns),
+						Netns:  uint32(info.NetworkNsID),
 						Family: unix.AF_INET6,
 						Proto:  unix.IPPROTO_TCP,
 						Port:   port,


### PR DESCRIPTION
# New generic benchmarks measuring ebpf execution

Re-using the top-ebpf tracer.

## How to use

```
$ IG_BENCHMARKS_GADGET_REGEX='bind' go test -exec 'sudo -E' -bench=BenchmarkAllGadgetsWithEvents -run=Benchmark ./internal/benchmarks/...
...
BenchmarkAllGadgetsWithEvents/trace-bind-4                 25429             57081 ns/op                 2.000 ebpfexec/op            5105 ebpfns/op
```

In this example, each bind() event, the 'trace bind' gadget executes two ebpf programs (ig_bind_ipv4_e and ig_bind_ipv4_x) and in average it takes 5105 nanoseconds.

## Testing done

