### PR TITLE
snapshot socket: improve performances

### DIFF
--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -83,10 +83,29 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 
 	allSockets := []*socketcollectortypes.Event{}
 
+	protocol := socketcollectortypes.ALL
+	if trace.Spec.Parameters != nil {
+		if val, ok := trace.Spec.Parameters["protocol"]; ok {
+			var err error
+			protocol, err = socketcollectortypes.ParseProtocol(val)
+			if err != nil {
+				trace.Status.OperationError = err.Error()
+				return
+			}
+		}
+	}
+
 	// Given that the socket-collector tracer works per network namespace and
 	// all the containers inside a namespace/pod share the network namespace,
 	// we only need to run the tracer with one valid PID per namespace/pod
 	visitedPods := make(map[string]struct{})
+
+	socketTracer, err := tracer.NewTracer(protocol)
+	if err != nil {
+		trace.Status.OperationError = err.Error()
+		return
+	}
+	defer socketTracer.CloseIters()
 
 	for _, container := range filteredContainers {
 		key := container.Namespace + "/" + container.Podname
@@ -105,21 +124,8 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 			log.Debugf("Gadget %s: Using PID %d to retrieve network namespace of Pod %q in Namespace %q",
 				trace.Spec.Gadget, container.Pid, container.Podname, container.Namespace)
 
-			protocol := socketcollectortypes.ALL
-
-			if trace.Spec.Parameters != nil {
-				if val, ok := trace.Spec.Parameters["protocol"]; ok {
-					var err error
-					protocol, err = socketcollectortypes.ParseProtocol(val)
-					if err != nil {
-						trace.Status.OperationError = err.Error()
-						return
-					}
-				}
-			}
-
-			podSockets, err := tracer.RunCollector(container.Pid, container.Podname,
-				container.Namespace, trace.Spec.Node, protocol)
+			podSockets, err := socketTracer.RunCollector(container.Pid, container.Podname,
+				container.Namespace, trace.Spec.Node)
 			if err != nil {
 				trace.Status.OperationError = err.Error()
 				return


### PR DESCRIPTION
# snapshot socket: improve performances

Creates the BPF iterators only once for all network namespaces.

This patch improves the performances of the snapshot socket gadget by 98.93% when we have 100 containers.

## How to use

```
$ git checkout alban_perf_snapshot_socket
$ go test -exec sudo \
    -bench='^BenchmarkAllGadgetsWithContainers$/^container100$/snapshot-socket' \
    -run=Benchmark -count 8 \
    ./internal/benchmarks/...  | tee patched.bench
$ git checkout main
$ go test -exec sudo \
    -bench='^BenchmarkAllGadgetsWithContainers$/^container100$/snapshot-socket' \
    -run=Benchmark -count 8 \
    ./internal/benchmarks/...  | tee main.bench
$ benchstat main.bench patched.bench
goos: linux
goarch: amd64
pkg: github.com/inspektor-gadget/inspektor-gadget/internal/benchmarks
cpu: Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
                                                        │   main.bench   │           patched.bench            │
                                                        │     sec/op     │   sec/op     vs base               │
AllGadgetsWithContainers/container100/snapshot-socket-4   40972.4m ± 12%   439.1m ± 7%  -98.93% (p=0.000 n=8)
```

## Testing done

I tested manually with 2 containers that it reported tcp and udp 
```
$ go run -exec sudo ./cmd/ig/... snapshot socket --proto tcp
$ go run -exec sudo ./cmd/ig/... snapshot socket --proto udp
$ go run -exec sudo ./cmd/ig/... snapshot socket --proto all
```