### PR TITLE
integration: Allow using PR image for dnstester

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -14,6 +14,9 @@ inputs:
   kubernetes_architecture:
     description: 'The CPU architecture used to select arch specific config in tests.'
     required: true
+  dnstester_image:
+    description: 'The image used for the dnstester.'
+    default: 'ghcr.io/inspektor-gadget/dnstester:latest'
 
 runs:
   using: "composite"
@@ -63,6 +66,7 @@ runs:
           KUBERNETES_ARCHITECTURE=${{ inputs.kubernetes_architecture }} \
           CONTAINER_REPO=${{ inputs.container_repo }} \
           IMAGE_TAG=${{ inputs.image_tag }} \
+          DNSTESTER_IMAGE=${{ inputs.dnstester_image }} \
           -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
     - name: Prepare and publish test reports

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -4,6 +4,7 @@ env:
   CONTAINER_REPO: ${{ github.repository }}
   GO_VERSION: 1.19.6
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-
+  DEFAULT_DNSTESTER_IMAGE: ghcr.io/inspektor-gadget/dnstester:latest
 concurrency:
   group: ${{ github.ref }}
   # We do not want to cancel job in progress on main to be sure to catch new
@@ -419,8 +420,9 @@ jobs:
   build-helper-images:
     # level: 0
     name: Build helper images
-    if: github.repository == 'inspektor-gadget/inspektor-gadget'
     runs-on: ubuntu-latest
+    outputs:
+      dnstester_image: ${{ steps.image-tag.outputs.dnstester || env.DEFAULT_DNSTESTER_IMAGE }}
     permissions:
       # allow publishing container image
       # in case of public fork repo/packages permissions will always be read
@@ -452,21 +454,28 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Set container repository and determine image tag
+      if: steps.filter.outputs.pattern == 'true'
       id: set-repo-determine-image-tag
       uses: ./.github/actions/set-container-repo-and-determine-image-tag
       with:
         registry: ${{ env.REGISTRY }}
-        container-image: inspektor-gadget/${{ matrix.image.name }}
+        container-image: ${{ github.repository_owner }}/${{ matrix.image.name }}
         co-re: false
     - name: Build ${{ matrix.image.name }} image
+      id: build-image
       if: steps.filter.outputs.pattern == 'true'
       uses: docker/build-push-action@v4
       with:
         context: ${{ matrix.image.dockerfile-dir }}
         file: ${{ matrix.image.dockerfile-dir }}/Dockerfile
-        push: true
+        push: ${{ vars.PUSH_HELPERS == 'ENABLE_PUSH_HELPERS' }}
         tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         platforms: ${{ matrix.image.platform }}
+    - name: Save ${{ matrix.image.name }} image tag output
+      id: image-tag
+      if: steps.build-image.outputs.digest != ''
+      run: |
+        echo "${{ matrix.image.name }}=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}" >> $GITHUB_OUTPUT
 
   build-examples:
     name: Build examples
@@ -704,7 +713,7 @@ jobs:
   test-integration-k8s-ig:
     name: Integration tests for ig with Kubernetes Containers
     # level: 2
-    needs: [ test-unit, test-ig, build-ig ]
+    needs: [ test-unit, test-ig, build-ig, build-helper-images ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -734,7 +743,10 @@ jobs:
         id: integration-tests
         run: |
           set -o pipefail
-          make -C integration/ig/k8s CONTAINER_RUNTIME=${{ matrix.runtime }} -o build test |& tee integration.log
+          make -C integration/ig/k8s \
+            CONTAINER_RUNTIME=${{ matrix.runtime }} \
+            DNSTESTER_IMAGE=${{ needs.build-helper-images.outputs.dnstester_image }} \
+            -o build test |& tee integration.log
       - name: Prepare and publish test report for container runtime ${{ matrix.runtime }}
         if: always()
         continue-on-error: true
@@ -746,7 +758,7 @@ jobs:
   test-integration-non-k8s-ig:
     name: Integration tests for ig with non-Kubernetes Containers
     # level: 2
-    needs: [ test-unit, test-ig, build-ig ]
+    needs: [ test-unit, test-ig, build-ig, build-helper-images ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -772,7 +784,9 @@ jobs:
         id: integration-tests
         run: |
           set -o pipefail
-          make -C integration/ig/non-k8s -o build test-${{ matrix.runtime }} |& tee integration.log
+          make -C integration/ig/non-k8s \
+            DNSTESTER_IMAGE=${{ needs.build-helper-images.outputs.dnstester_image }} \
+            -o build test-${{ matrix.runtime }} |& tee integration.log
       - name: Prepare and publish test report for container runtime ${{ matrix.runtime }}
         if: always()
         continue-on-error: true
@@ -902,7 +916,7 @@ jobs:
   test-integration-minikube:
     name: Integration tests
     # level: 1
-    needs: [test-unit, build-kubectl-gadget, build-ig, build-gadget-container-images]
+    needs: [test-unit, build-kubectl-gadget, build-ig, build-gadget-container-images, build-helper-images ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -945,6 +959,7 @@ jobs:
         kubernetes_architecture: "amd64"
         container_repo: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}
         image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        dnstester_image: ${{ needs.build-helper-images.outputs.dnstester_image }}
 
   release:
     name: Release

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ LINTER_VERSION ?= v1.49.0
 
 EBPF_BUILDER ?= ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder
 
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+
 # Adds a '-dirty' suffix to version string if there are uncommitted changes
 changes := $(shell git status --porcelain)
 ifeq ($(changes),)
@@ -190,6 +192,7 @@ integration-tests: kubectl-gadget
 			-k8s-distro $(KUBERNETES_DISTRIBUTION) \
 			-k8s-arch $(KUBERNETES_ARCHITECTURE) \
 			-image $(CONTAINER_REPO):$(IMAGE_TAG) \
+			-dnstester-image $(DNSTESTER_IMAGE) \
 			$$INTEGRATION_TESTS_PARAMS
 
 .PHONY: generate-documentation

--- a/integration/ig/k8s/Makefile
+++ b/integration/ig/k8s/Makefile
@@ -1,5 +1,7 @@
 include $(shell pwd)/../../../minikube.mk
 
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+
 # make does not allow implicit rules (with '%') to be phony so let's use
 # the 'phony_explicit' dependency to make implicit rules inherit the phony
 # attribute
@@ -45,4 +47,4 @@ test-%: build build-tests
 	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ln -sf /var/lib/minikube/binaries/$(KUBERNETES_VERSION)/kubectl /bin/kubectl" && \
 	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ln -sf /etc/kubernetes/admin.conf /root/.kube/config" && \
 	echo "Running test in minikube with profile $${MINIKUBE_PROFILE} ..." && \
-	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ig-integration.test -test.v -integration -container-runtime $* $${INTEGRATION_TESTS_PARAMS}"
+	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ig-integration.test -test.v -integration -container-runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}"

--- a/integration/ig/k8s/integration_test.go
+++ b/integration/ig/k8s/integration_test.go
@@ -36,6 +36,7 @@ var supportedContainerRuntimes = []string{ContainerRuntimeDocker, ContainerRunti
 var (
 	integration      = flag.Bool("integration", false, "run integration tests")
 	containerRuntime = flag.String("container-runtime", "", "allows to do validation for expected runtime in the tests")
+	dnsTesterImage   = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
 )
 
 func init() {

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -29,7 +29,7 @@ func TestTraceDns(t *testing.T) {
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),
-		PodCommand("dnstester", "ghcr.io/inspektor-gadget/dnstester:latest", ns, "", ""),
+		PodCommand("dnstester", *dnsTesterImage, ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "dnstester"),
 	}
 

--- a/integration/ig/non-k8s/Makefile
+++ b/integration/ig/non-k8s/Makefile
@@ -1,3 +1,5 @@
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+
 # build
 build:
 	make -C $(shell pwd)/../../.. ig
@@ -8,5 +10,5 @@ build:
 test-docker: build
 	cp ../../../ig-linux-amd64 ig
 	go test -c -o ./ig-docker-integration.test ./...
-	sudo ./ig-docker-integration.test -test.v -integration $${INTEGRATION_TESTS_PARAMS}
+	sudo ./ig-docker-integration.test -test.v -integration -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}
 	rm -f ./ig-docker-integration.test ./ig

--- a/integration/ig/non-k8s/integration_test.go
+++ b/integration/ig/non-k8s/integration_test.go
@@ -23,7 +23,10 @@ import (
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 )
 
-var integration = flag.Bool("integration", false, "run integration tests")
+var (
+	integration    = flag.Bool("integration", false, "run integration tests")
+	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
+)
 
 func init() {
 	DefaultTestComponent = IgTestComponent

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -127,7 +127,7 @@ func TestTraceDns(t *testing.T) {
 		&DockerContainer{
 			Name:    cn,
 			Cmd:     strings.Join(dnsCmds, " ; "),
-			Options: NewDockerOptions(WithDockerImage("ghcr.io/inspektor-gadget/dnstester:latest")),
+			Options: NewDockerOptions(WithDockerImage(*dnsTesterImage)),
 		},
 	}
 

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -47,7 +47,8 @@ var (
 	integration = flag.Bool("integration", false, "run integration tests")
 
 	// image such as ghcr.io/inspektor-gadget/inspektor-gadget:latest
-	image = flag.String("image", "", "gadget container image")
+	image          = flag.String("image", "", "gadget container image")
+	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
 
 	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")
 	doNotDeploySPO = flag.Bool("no-deploy-spo", false, "don't deploy the Security Profiles Operator (SPO)")

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -31,7 +31,7 @@ func TestTraceDns(t *testing.T) {
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),
-		PodCommand("dnstester", "ghcr.io/inspektor-gadget/dnstester:latest", ns, "", ""),
+		PodCommand("dnstester", *dnsTesterImage, ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "dnstester"),
 	}
 


### PR DESCRIPTION
This PR introduces a way to test changes to dnstester in a PR and on a fork. The idea is to save the dnstester image tag if changes are detected and pass it as a flag to integration tests. The push is disabled by default on forks and for external contributors by using `PUSH_HELPERS` secret. 

## Testing done

I tested the changes on a fork after setting `PUSH_HELPERS = ENABLE_PUSH_HELPERS` secret as:

- [Without custom PR image](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4511808818) - [logs](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4511808818/jobs/7944477217#step:6:1741)
- [With custom PR image](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4512232476) - [logs](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/4512232476/jobs/7945491138#step:6:132)

## Todo
- [ ] Create `PUSH_HELPERS` variable in the repository
