### PR TITLE
Fix error handling

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -227,7 +227,7 @@ func (p *parser[T]) writeLogMessage(severity logger.Level, fmt string, params ..
 	if p.logCallback == nil {
 		return
 	}
-	p.logCallback(severity, fmt, params)
+	p.logCallback(severity, fmt, params...)
 }
 
 func (p *parser[T]) combineEventsArrayCallback(events []*T) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -158,6 +158,14 @@ func (e Event) GetBaseEvent() *Event {
 	return &e
 }
 
+func (e *Event) GetType() EventType {
+	return e.Type
+}
+
+func (e *Event) GetMessage() string {
+	return e.Message
+}
+
 func Err(msg string) Event {
 	return Event{
 		CommonData: CommonData{


### PR DESCRIPTION
    Handle error events
    
    Add logic to handle the events that are use to provide debug information.
    Before this commit those events were erroneously handled as normal events
    printing wrong data to the terminal. For instance, for the DNS gadget:
    
    ```
    $ go build . && sudo ./ig trace dns
    WARN[0000] Runtime enricher (cri-o): couldn't get current containers
    CONTAINER                       PID        TID        COMM             QR NAMESERVER      TYPE      QTYPE      NAME                           RCODE
                                    0          0
                                    0          0
                                    0          0
    ```

### Testing

"broke" the dns gadget by applying the following diff

```diff
$ git diff
diff --git pkg/gadgets/trace/dns/tracer/tracer.go pkg/gadgets/trace/dns/tracer/tracer.go
index be5a5af5..9842ae02 100644
--- pkg/gadgets/trace/dns/tracer/tracer.go
+++ pkg/gadgets/trace/dns/tracer/tracer.go
@@ -286,7 +286,7 @@ func (t *Tracer) install() error {
 
        parseAndEnrichDNSEvent := func(rawSample []byte, netns uint64) (*types.Event, error) {
                bpfEvent := (*dnsEventT)(unsafe.Pointer(&rawSample[0]))
-               if len(rawSample) < int(unsafe.Sizeof(*bpfEvent)) {
+               if len(rawSample) != int(unsafe.Sizeof(*bpfEvent)) {
                        return nil, errors.New("invalid sample size")
                }
```

With this patch messages are now printed to the terminal:

```bash
$ go build . && sudo ./ig trace dns 
WARN[0000] Runtime enricher (cri-o): couldn't get current containers 
CONTAINER                       PID        TID        COMM             QR NAMESERVER      TYPE      QTYPE      NAME                           RCODE           
ERRO[0003] invalid sample size                          
ERRO[0003] invalid sample size                          
ERRO[0003] invalid sample size                          
```

```bash 
$ go build . && sudo ./ig trace dns -o json
WARN[0000] Runtime enricher (cri-o): couldn't get current containers 
{"type":"err","message":"invalid sample size"}
{"type":"err","message":"invalid sample size"}
{"type":"err","message":"invalid sample size"}
```




 


