### PR TITLE
gadgets/snapshot/socket: Remove unneeded validation

### DIFF
--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -274,11 +274,7 @@ func (t *Tracer) openIters() error {
 }
 
 func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
-	protoParam := gadgetCtx.GadgetParams().Get(ParamProto)
-	protocols := protoParam.AsString()
-	if err := protoParam.Validate(protocols); err != nil {
-		return err
-	}
+	protocols := gadgetCtx.GadgetParams().Get(ParamProto).AsString()
 	t.protocols, _ = socketcollectortypes.ProtocolsMap[protocols]
 
 	defer t.CloseIters()


### PR DESCRIPTION
Server side validation is implemented in service.go, so each gadget doesn't have to implemented it.

ref https://github.com/inspektor-gadget/inspektor-gadget/pull/1370#discussion_r1154641697

