### PR TITLE
cmd/kubectl-gadget/advise: add locks to writes for policy output

### DIFF
--- a/cmd/kubectl-gadget/advise/network-policy.go
+++ b/cmd/kubectl-gadget/advise/network-policy.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -94,11 +95,16 @@ func runNetworkPolicyMonitor(cmd *cobra.Command, args []string) error {
 		TraceOutputState: gadgetv1alpha1.TraceStateStarted,
 		CommonFlags:      &params,
 	}
+
+	var mu sync.Mutex
+
 	count := 0
 	transform := func(line string) string {
 		line = strings.Replace(line, "\r", "\n", -1)
+		mu.Lock()
 		w.Write([]byte(line))
 		w.Flush()
+		mu.Unlock()
 		count += 1
 		if outputFileName != "-" {
 			fmt.Printf("\033[2K\rRecording %d events into file %q...", count, outputFileName)


### PR DESCRIPTION
Concurrent writes (from different nodes) to the underlying file/bufio.Buffer could lead to scrambled output. Adding a mutex makes sure that a line gets written as whole, before the next line is written.

We should check this behavior also for the new architecture, but in the meantime, this should fix #1487.