### PR TITLE
pkg/ig-manager: Check ig manager is run as root.

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,13 +36,6 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "ig",
 		Short: "Collection of gadgets for containers",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if os.Geteuid() != 0 {
-				return fmt.Errorf("%s must be run as root to be able to run eBPF programs", os.Args[0])
-			}
-
-			return nil
-		},
 	}
 
 	rootCmd.AddCommand(

--- a/pkg/runtime/local/local.go
+++ b/pkg/runtime/local/local.go
@@ -17,6 +17,8 @@ package local
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -51,6 +53,10 @@ func prepareCatalog() *runtime.Catalog {
 }
 
 func (r *Runtime) Init(globalRuntimeParams *params.Params) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
```
ig version does not run any eBPF program so it does not need to be run as root.

Fixes: 13cf80d62765 ("cmd: Check ig is run as root.")
```