### PR TITLE
Dockerfile: Use golang:1.19 as builder image.

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -5,7 +5,7 @@
 # and is designed to be used on systems that support BTF
 # (CONFIG_DEBUG_INFO_BTF).
 
-ARG BUILDER_IMAGE=debian:bullseye
+ARG BUILDER_IMAGE=golang:1.19
 ARG BASE_IMAGE=alpine:3.14
 
 # Prepare and build gadget artifacts in a container
@@ -15,14 +15,10 @@ ARG TARGETARCH
 # We need a cross compiler and libraries for TARGETARCH due to CGO.
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
-	apt-get update && \
-	apt-get install -y gcc make ca-certificates git && \
-	echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list && \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
-	apt-get install -y golang-1.19 libelf-dev:${TARGETARCH} \
+	apt-get install -y gcc make ca-certificates git libelf-dev:${TARGETARCH} \
 		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
-	ln -s /usr/lib/go-1.19/bin/go /bin/go && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		apt-get install -y gcc-aarch64-linux-gnu; \
 	fi

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -2,7 +2,7 @@
 # This image contains CO-RE and BCC-based gadgets. Its base image is the
 # BCC image. It's the default image that is deployed in Inspektor Gadget.
 
-ARG BUILDER_IMAGE=debian:bullseye
+ARG BUILDER_IMAGE=golang:1.19
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/devel/CONTRIBUTING.md for further details.
@@ -15,14 +15,10 @@ ARG TARGETARCH
 # We need a cross compiler and libraries for TARGETARCH due to CGO.
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
-	apt-get update && \
-	apt-get install -y gcc make ca-certificates git && \
-	echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list && \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
-	apt-get install -y golang-1.19 libelf-dev:${TARGETARCH} \
+	apt-get install -y gcc make ca-certificates git libelf-dev:${TARGETARCH} \
 		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
-	ln -s /usr/lib/go-1.19/bin/go /bin/go && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		apt-get install -y gcc-aarch64-linux-gnu; \
 	fi


### PR DESCRIPTION
Before this commit, we used debian:bullseye as base image. This image was used because it permits easily to cross-build by installing package for foreign architecture as done in commit 8b261be730ab ("Dockerfile: Use debian as builder instead of ubuntu.") Nonetheless, we would need to download golang from a PPA which does not deliver an up to date golang version as pointed by docker scout [1].

So, in this commit, we use golang:1.19 as base image. This offers us the best of both world as we would have an up to date golang and it is also easy to cross build as golang docker image are based on debian.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1]: https://github.com/kubernetes/minikube/pull/15869#issuecomment-1499649317