### PR TITLE
ig,kubectl-gadget: clean up blank imports

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -25,13 +25,10 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 
-	// This is a blank include that actually imports all gadgets - needs to be moved into another package; TODO
-	// This includes traceloop which is only available via gadget-collection
-	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection"
-
 	// This is a blank include that actually imports all gadgets
-	// This includes tcpdrop which is only available via all-gadgets
+	// TODO: traceloop is imported separately because it is not in all-gadgets
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer"
 
 	// Another blank import for the used operator
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager"

--- a/gadget-container/gadgettracermanager/controller.go
+++ b/gadget-container/gadgettracermanager/controller.go
@@ -29,9 +29,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	// tcpdrop is only available in all-gadgets and not gadget-collection
-	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
-
 	gadgetkinvolkiov1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/controllers"
 	gadgetcollection "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection"

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -36,6 +36,9 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	// This is a blank include that actually imports all gadgets
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager"
 	pb "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager/api"


### PR DESCRIPTION
- gadgettracermanager: move the imports from the controller to main.go
- ig: do not import gadget-collection anymore

xref https://github.com/inspektor-gadget/inspektor-gadget/pull/1469#discussion_r1162023912
xref https://github.com/inspektor-gadget/inspektor-gadget/pull/1469#discussion_r1162023217
