### PR TITLE
Implement node enrichment in grpc runtime

### DIFF
--- a/pkg/container-collection/operator.go
+++ b/pkg/container-collection/operator.go
@@ -18,10 +18,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 )
 
-func (cc *ContainerCollection) EnrichEventWithNode(event operators.ContainerNodeSetter) {
-	event.SetNode(cc.nodeName)
-}
-
 func (cc *ContainerCollection) EnrichEventByMntNs(event operators.ContainerInfoFromMountNSID) {
 	event.SetNode(cc.nodeName)
 

--- a/pkg/gadgets/trace/tcpdrop/tracer/gadget.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/gadget.go
@@ -52,18 +52,6 @@ func (g *GadgetDesc) EventPrototype() any {
 	return &types.Event{}
 }
 
-func (g *GadgetDesc) SkipParams() []params.ValueHint {
-	return []params.ValueHint{
-		// ig parameters
-		gadgets.LocalContainer,
-		// kubectl-gadget parameters
-		gadgets.K8SPodName,
-		gadgets.K8SNamespace,
-		gadgets.K8SContainerName,
-		gadgets.K8SLabels,
-	}
-}
-
 func init() {
 	gadgetregistry.Register(&GadgetDesc{})
 }

--- a/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
@@ -168,10 +168,8 @@ func (t *Tracer) run() {
 		}
 
 		event := types.Event{
-			Event: eventtypes.Event{
-				Type:      eventtypes.NORMAL,
-				Timestamp: gadgets.WallTimeFromBootTime(bpfEvent.Timestamp),
-			},
+			Type:      eventtypes.NORMAL,
+			Timestamp: gadgets.WallTimeFromBootTime(bpfEvent.Timestamp),
 			// mount namespace not actually related to the container that created the connection
 			// Dropping the mount namespace ID for now
 			// TODO: add a way to get the mount namespace ID of the container that created the connection

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -126,10 +126,9 @@ func (k *KubeManager) Dependencies() []string {
 func (k *KubeManager) CanOperateOn(gadget gadgets.GadgetDesc) bool {
 	// We need to be able to get MountNSID or NetNSID, and set ContainerInfo, so
 	// check for that first
-	_, canEnrichEventWithNode := gadget.EventPrototype().(operators.ContainerNodeSetter)
 	_, canEnrichEventFromMountNs := gadget.EventPrototype().(operators.ContainerInfoFromMountNSID)
 	_, canEnrichEventFromNetNs := gadget.EventPrototype().(operators.ContainerInfoFromNetNSID)
-	canEnrichEvent := canEnrichEventWithNode || canEnrichEventFromMountNs || canEnrichEventFromNetNs
+	canEnrichEvent := canEnrichEventFromMountNs || canEnrichEventFromNetNs
 
 	// Secondly, we need to be able to inject the ebpf map onto the tracer
 	gi, ok := gadget.(gadgets.GadgetInstantiate)
@@ -146,13 +145,12 @@ func (k *KubeManager) CanOperateOn(gadget gadgets.GadgetDesc) bool {
 	_, isAttacher := instance.(Attacher)
 
 	log.Debugf("> canEnrichEvent: %v", canEnrichEvent)
-	log.Debugf(" > canEnrichEventWithNode: %v", canEnrichEventWithNode)
 	log.Debugf(" > canEnrichEventFromMountNs: %v", canEnrichEventFromMountNs)
 	log.Debugf(" > canEnrichEventFromNetNs: %v", canEnrichEventFromNetNs)
 	log.Debugf("> isMountNsMapSetter: %v", isMountNsMapSetter)
 	log.Debugf("> isAttacher: %v", isAttacher)
 
-	return isMountNsMapSetter || canEnrichEvent || isAttacher
+	return (isMountNsMapSetter && canEnrichEvent) || isAttacher
 }
 
 func (k *KubeManager) Init(params *params.Params) error {
@@ -164,10 +162,9 @@ func (k *KubeManager) Close() error {
 }
 
 func (k *KubeManager) Instantiate(gadgetContext operators.GadgetContext, gadgetInstance any, params *params.Params) (operators.OperatorInstance, error) {
-	_, canEnrichEventWithNode := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerNodeSetter)
 	_, canEnrichEventFromMountNs := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerInfoFromMountNSID)
 	_, canEnrichEventFromNetNs := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerInfoFromNetNSID)
-	canEnrichEvent := canEnrichEventWithNode || canEnrichEventFromMountNs || canEnrichEventFromNetNs
+	canEnrichEvent := canEnrichEventFromMountNs || canEnrichEventFromNetNs
 
 	traceInstance := &KubeManagerInstance{
 		id:             uuid.New().String(),
@@ -313,9 +310,6 @@ func (m *KubeManagerInstance) PostGadgetRun() error {
 }
 
 func (m *KubeManagerInstance) enrich(ev any) {
-	if event, canEnrichEventWithNode := ev.(operators.ContainerNodeSetter); canEnrichEventWithNode {
-		m.manager.gadgetTracerManager.ContainerCollection.EnrichEventWithNode(event)
-	}
 	if event, canEnrichEventFromMountNs := ev.(operators.ContainerInfoFromMountNSID); canEnrichEventFromMountNs {
 		m.manager.gadgetTracerManager.ContainerCollection.EnrichEventByMntNs(event)
 	}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -94,10 +94,9 @@ func (l *LocalManager) ParamDescs() params.ParamDescs {
 func (l *LocalManager) CanOperateOn(gadget gadgets.GadgetDesc) bool {
 	// We need to be able to get MountNSID or NetNSID, and set ContainerInfo, so
 	// check for that first
-	_, canEnrichEventWithNode := gadget.EventPrototype().(operators.ContainerNodeSetter)
 	_, canEnrichEventFromMountNs := gadget.EventPrototype().(operators.ContainerInfoFromMountNSID)
 	_, canEnrichEventFromNetNs := gadget.EventPrototype().(operators.ContainerInfoFromNetNSID)
-	canEnrichEvent := canEnrichEventWithNode || canEnrichEventFromMountNs || canEnrichEventFromNetNs
+	canEnrichEvent := canEnrichEventFromMountNs || canEnrichEventFromNetNs
 
 	// Secondly, we need to be able to inject the ebpf map onto the gadget instance
 	gi, ok := gadget.(gadgets.GadgetInstantiate)
@@ -114,13 +113,12 @@ func (l *LocalManager) CanOperateOn(gadget gadgets.GadgetDesc) bool {
 	_, isAttacher := instance.(Attacher)
 
 	log.Debugf("> canEnrichEvent: %v", canEnrichEvent)
-	log.Debugf("\t> canEnrichEventWithNode: %v", canEnrichEventWithNode)
 	log.Debugf("\t> canEnrichEventFromMountNs: %v", canEnrichEventFromMountNs)
 	log.Debugf("\t> canEnrichEventFromNetNs: %v", canEnrichEventFromNetNs)
 	log.Debugf("> isMountNsMapSetter: %v", isMountNsMapSetter)
 	log.Debugf("> isAttacher: %v", isAttacher)
 
-	return isMountNsMapSetter || canEnrichEvent || isAttacher
+	return (isMountNsMapSetter && canEnrichEvent) || isAttacher
 }
 
 func (l *LocalManager) Init(operatorParams *params.Params) error {
@@ -174,10 +172,9 @@ func (l *LocalManager) Close() error {
 }
 
 func (l *LocalManager) Instantiate(gadgetContext operators.GadgetContext, gadgetInstance any, params *params.Params) (operators.OperatorInstance, error) {
-	_, canEnrichEventWithNode := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerNodeSetter)
 	_, canEnrichEventFromMountNs := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerInfoFromMountNSID)
 	_, canEnrichEventFromNetNs := gadgetContext.GadgetDesc().EventPrototype().(operators.ContainerInfoFromNetNSID)
-	canEnrichEvent := canEnrichEventWithNode || canEnrichEventFromMountNs || canEnrichEventFromNetNs
+	canEnrichEvent := canEnrichEventFromMountNs || canEnrichEventFromNetNs
 
 	traceInstance := &localManagerTrace{
 		manager:            l,
@@ -303,9 +300,6 @@ func (l *localManagerTrace) PostGadgetRun() error {
 }
 
 func (l *localManagerTrace) enrich(ev any) {
-	if event, canEnrichEventWithNode := ev.(operators.ContainerNodeSetter); canEnrichEventWithNode {
-		l.manager.igManager.ContainerCollection.EnrichEventWithNode(event)
-	}
 	if event, canEnrichEventFromMountNs := ev.(operators.ContainerInfoFromMountNSID); canEnrichEventFromMountNs {
 		l.manager.igManager.ContainerCollection.EnrichEventByMntNs(event)
 	}

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -99,11 +99,7 @@ type ContainerInfoFromNetNSID interface {
 }
 
 type ContainerInfoSetters interface {
-	ContainerNodeSetter
 	SetContainerInfo(pod, namespace, container string)
-}
-
-type ContainerNodeSetter interface {
 	SetNode(string)
 }
 

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -99,7 +99,11 @@ type ContainerInfoFromNetNSID interface {
 }
 
 type ContainerInfoSetters interface {
+	NodeSetter
 	SetContainerInfo(pod, namespace, container string)
+}
+
+type NodeSetter interface {
 	SetNode(string)
 }
 


### PR DESCRIPTION
Perform the node enrichment in the grpc runtime instead of the kubemanager operator as discussed in https://github.com/inspektor-gadget/inspektor-gadget/pull/1469#discussion_r1157291531.

Check individual commits to get more details:
- pkg/grpc-runtime: Enrich event node
- Revert "operators: node enrichment"
- Don't use eventtypes.Event as base