### PR TITLE
kubeipresolver: refactor in preparation for use in tcpdrop

### DIFF
--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -47,40 +47,25 @@ type Event struct {
 	RemoteLabels    map[string]string `json:"remoteLabels,omitempty" column:"remotelabels,hide"`
 }
 
-func (e *Event) SetPodOwner(s string) {
-	e.PodOwner = s
+func (e *Event) SetLocalPodDetails(owner, hostIP, podIP string, labels map[string]string) {
+	e.PodOwner = owner
+	e.PodHostIP = hostIP
+	e.PodIP = podIP
+	e.PodLabels = labels
 }
 
-func (e *Event) SetPodHostIP(s string) {
-	e.PodHostIP = s
+func (e *Event) GetRemoteIPs() []string {
+	return []string{e.RemoteAddr}
 }
 
-func (e *Event) SetPodIP(s string) {
-	e.PodIP = s
-}
-
-func (e *Event) SetPodLabels(l map[string]string) {
-	e.PodLabels = l
-}
-
-func (e *Event) GetRemoteIP() string {
-	return e.RemoteAddr
-}
-
-func (e *Event) SetRemoteName(name string) {
-	e.RemoteName = name
-}
-
-func (e *Event) SetRemoteNamespace(s string) {
-	e.RemoteNamespace = s
-}
-
-func (e *Event) SetRemoteKind(k eventtypes.RemoteKind) {
-	e.RemoteKind = k
-}
-
-func (e *Event) SetRemotePodLabels(l map[string]string) {
-	e.RemoteLabels = l
+func (e *Event) SetEndpointsDetails(endpoints []eventtypes.EndpointDetails) {
+	if len(endpoints) == 0 {
+		return
+	}
+	e.RemoteName = endpoints[0].Name
+	e.RemoteNamespace = endpoints[0].Namespace
+	e.RemoteLabels = endpoints[0].PodLabels
+	e.RemoteKind = endpoints[0].Kind
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -117,6 +117,13 @@ func (c *CommonData) GetContainer() string {
 	return c.Container
 }
 
+type EndpointDetails struct {
+	Namespace string
+	Name      string
+	Kind      RemoteKind
+	PodLabels map[string]string
+}
+
 const (
 	// Indicates a generic event produced by a gadget. Gadgets extend
 	// the base event to contain the specific data the gadget provides


### PR DESCRIPTION
Currently, kubeipresolver is only used by the 'trace network' gadget and it can resolve 1 local IP and 1 remote IP. In the 'trace tcpdrop' gadget, we will need to resolve 2 IPs (source IP and destination IP) and they might not be local IPs (i.e. not tied to a pod).

This refactoring does not change anything for the 'trace network' gadget but will allow kubeipresolver to be used by other gadgets.

## How to use

No changes.

## Testing done

Only the CI