### PR TITLE
cmd: Use Interrupted() rather than deprecated ErrWaitTimeout.

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -525,7 +525,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	})
 
 	if err != nil {
-		if errors.Is(err, utilwait.ErrWaitTimeout) && debug {
+		if utilwait.Interrupted(err) && debug {
 			fmt.Println("DUMP PODS:")
 			fmt.Println(getGadgetPodsDebug(k8sClient))
 			fmt.Println("DUMP EVENTS:")

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -657,7 +657,7 @@ func waitForCondition(traceID string, conditionFunction func(*gadgetv1alpha1.Tra
 	}
 
 	if err != nil {
-		if !errors.Is(err, wait.ErrWaitTimeout) {
+		if !wait.Interrupted(err) {
 			return nil, err
 		}
 


### PR DESCRIPTION
```
ErrWaitTimeout is now deprecated [1].
The Interrupted() function was thought replace it [2].

[1]: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#pkg-variables
[2]: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#Interrupted
```