### PR TITLE
registry: Make mandatory parameters required cmd flags

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -550,6 +550,9 @@ func addFlags(cmd *cobra.Command, params *params.Params, skipParams []params.Val
 		}
 
 		flag := cmd.PersistentFlags().VarPF(p, p.Key, p.Alias, desc)
+		if p.IsMandatory {
+			cmd.MarkPersistentFlagRequired(p.Key)
+		}
 
 		// Allow passing a boolean flag as --foo instead of having to use --foo=true
 		if p.IsBoolFlag() {

--- a/pkg/gadgets/snapshot/socket/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/socket/tracer/gadget.go
@@ -59,7 +59,6 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			Title:          "Protocol",
 			DefaultValue:   "all",
 			Description:    fmt.Sprintf("Show only sockets using this protocol (%s)", strings.Join(protocols, ", ")),
-			IsMandatory:    true,
 			PossibleValues: protocols,
 		},
 	}

--- a/pkg/gadgets/top/file/tracer/gadget.go
+++ b/pkg/gadgets/top/file/tracer/gadget.go
@@ -47,7 +47,6 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			Title:        "Show all files",
 			DefaultValue: "false",
 			Description:  "include non-regular file types (sockets, FIFOs, etc)",
-			IsMandatory:  true,
 			TypeHint:     params.TypeBool,
 		},
 	}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -73,7 +73,6 @@ func (l *LocalManager) GlobalParamDescs() params.ParamDescs {
 			DefaultValue: strings.Join(containerutils.AvailableRuntimes, ","),
 			Description: fmt.Sprintf("Container runtimes to be used separated by comma. Supported values are: %s",
 				strings.Join(containerutils.AvailableRuntimes, ", ")),
-			IsMandatory: true,
 			// PossibleValues: containerutils.AvailableRuntimes, // TODO
 		},
 	}
@@ -85,7 +84,6 @@ func (l *LocalManager) ParamDescs() params.ParamDescs {
 			Key:         ContainerName,
 			Alias:       "c",
 			Description: "Show only data from containers with that name",
-			IsMandatory: false,
 			ValueHint:   gadgets.LocalContainer,
 		},
 	}


### PR DESCRIPTION
  
    Before:
    
    ```
    $ ./kubectl-gadget script
    NODE                               OUTPUT
    Error: running gadget: rpc error: code = Unknown desc = setting gadget parameters: expected value for "program"
    ```
    
    ^^^ validation was performed in the server side
    
    Now:
    
    ```
    $ ./kubectl-gadget script
    Error: required flag(s) "program" not set
    ```
    
    Validation is done by cobra on the client side.


Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/1370#pullrequestreview-1383795267
