### PR TITLE
Show error for bpftrace when not running on amd64

### DIFF
--- a/integration/inspektor-gadget/script_test.go
+++ b/integration/inspektor-gadget/script_test.go
@@ -29,6 +29,10 @@ func TestScript(t *testing.T) {
 		t.Skip("Skipping script test because it's only supported in the default image")
 	}
 
+	if *k8sArch != "amd64" {
+		t.Skip("Skipping script test because it's only supported in amd64")
+	}
+
 	t.Parallel()
 
 	prog := `kretprobe:inet_bind { printf("fofofofof %s\n", comm); }`

--- a/pkg/gadgets/script/tracer.go
+++ b/pkg/gadgets/script/tracer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -41,6 +42,11 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 	if flavour != "default" {
 		return fmt.Errorf("script is not supported on the %q flavour of the container image. Only \"default\" is supported for now",
 			flavour)
+	}
+
+	if runtime.GOARCH != "amd64" {
+		return fmt.Errorf("script is not supported on the %q architecture. Only \"amd64\" is supported for now",
+			runtime.GOARCH)
 	}
 
 	params := gadgetCtx.GadgetParams()


### PR DESCRIPTION
So far only amd64 is supported, skip the tests and show a clear error in that platform. 