### PR TITLE
Add support for crun and podman

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -99,6 +99,7 @@ type RuntimesSocketPathConfig struct {
 	Docker     string
 	Containerd string
 	Crio       string
+	Podman     string
 }
 
 func AddRuntimesSocketPathFlags(command *cobra.Command, config *RuntimesSocketPathConfig) {
@@ -121,5 +122,12 @@ func AddRuntimesSocketPathFlags(command *cobra.Command, config *RuntimesSocketPa
 		"crio-socketpath", "",
 		runtimeclient.CrioDefaultSocketPath,
 		"CRI-O CRI Unix socket path",
+	)
+
+	command.PersistentFlags().StringVarP(
+		&config.Podman,
+		"podman-socketpath", "",
+		runtimeclient.PodmanDefaultSocketPath,
+		"Podman Unix socket path",
 	)
 }

--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -65,6 +65,8 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 				socketPath = commonFlags.RuntimesSocketPathConfig.Containerd
 			case runtimeclient.CrioName:
 				socketPath = commonFlags.RuntimesSocketPathConfig.Crio
+			case runtimeclient.PodmanName:
+				socketPath = commonFlags.RuntimesSocketPathConfig.Podman
 			default:
 				return commonutils.WrapInErrInvalidArg("--runtime / -r",
 					fmt.Errorf("runtime %q is not supported", p))

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -421,6 +421,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					gadgetContainer.Env[i].Value = runtimesConfig.Crio
 				case utils.GadgetEnvironmentDockerSocketpath:
 					gadgetContainer.Env[i].Value = runtimesConfig.Docker
+				case utils.GadgetEnvironmentPodmanSocketpath:
+					gadgetContainer.Env[i].Value = runtimesConfig.Podman
 				}
 			}
 

--- a/cmd/kubectl-gadget/utils/consts.go
+++ b/cmd/kubectl-gadget/utils/consts.go
@@ -20,4 +20,5 @@ const (
 	GadgetEnvironmentContainerdSocketpath string = "INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"
 	GadgetEnvironmentCRIOSocketpath       string = "INSPEKTOR_GADGET_CRIO_SOCKETPATH"
 	GadgetEnvironmentDockerSocketpath     string = "INSPEKTOR_GADGET_DOCKER_SOCKETPATH"
+	GadgetEnvironmentPodmanSocketpath     string = "INSPEKTOR_GADGET_PODMAN_SOCKETPATH"
 )

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -31,7 +31,7 @@ func TestTraceFsslower(t *testing.T) {
 
 	traceFsslowerCmd := &Command{
 		Name:         "TraceFsslower",
-		Cmd:          fmt.Sprintf("ig trace fsslower -f %s -m 0 -o json", fsType),
+		Cmd:          fmt.Sprintf("ig trace fsslower -f %s --runtimes=%s -m 0 -o json", fsType, *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntry := &fsslowerTypes.Event{

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -28,8 +28,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 // ContainerCollection holds a set of containers. It can be embedded as an
@@ -161,7 +162,6 @@ func (cc *ContainerCollection) RemoveContainer(id string) {
 func (cc *ContainerCollection) AddContainer(container *Container) {
 	for _, enricher := range cc.containerEnrichers {
 		ok := enricher(container)
-
 		// Enrichers can decide to drop a container
 		if !ok {
 			return

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/containerd"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/crio"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/podman"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
@@ -36,6 +37,7 @@ var AvailableRuntimes = []string{
 	runtimeclient.DockerName,
 	runtimeclient.ContainerdName,
 	runtimeclient.CrioName,
+	runtimeclient.PodmanName,
 }
 
 type RuntimeConfig struct {
@@ -63,6 +65,12 @@ func NewContainerRuntimeClient(runtime *RuntimeConfig) (runtimeclient.ContainerR
 			socketPath = envsp
 		}
 		return crio.NewCrioClient(socketPath)
+	case runtimeclient.PodmanName:
+		socketPath := runtime.SocketPath
+		if envsp := os.Getenv("INSPEKTOR_GADGET_PODMAN_SOCKETPATH"); envsp != "" && socketPath == "" {
+			socketPath = envsp
+		}
+		return podman.NewPodmanClient(socketPath), nil
 	default:
 		return nil, fmt.Errorf("unknown container runtime: %s (available %s)",
 			runtime, strings.Join(AvailableRuntimes, ", "))

--- a/pkg/container-utils/oci-annotations/types.go
+++ b/pkg/container-utils/oci-annotations/types.go
@@ -49,7 +49,7 @@ func NewResolver(runtime string) (Resolver, error) {
 
 // NewResolverFromAnnotations creates a Resolver by detecting runtime from annotations
 func NewResolverFromAnnotations(annotations map[string]string) (Resolver, error) {
-	if cm := annotations[crioContainerManagerAnnotation]; cm != "" {
+	if cm := annotations[crioContainerManagerAnnotation]; cm == "cri-o" {
 		return crioResolver{}, nil
 	}
 	if _, isContainerd := annotations[containerdContainerTypeAnnotation]; isContainerd {

--- a/pkg/container-utils/podman/podman.go
+++ b/pkg/container-utils/podman/podman.go
@@ -1,0 +1,172 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podman
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+)
+
+const (
+	defaultConnectionTimeout = 2 * time.Second
+	containerListAllURL      = "http://d/v4.0.0/libpod/containers/json?all=true"
+	containerInspectURL      = "http://d/v4.0.0/libpod/containers/%s/json"
+)
+
+type PodmanClient struct {
+	client http.Client
+}
+
+func NewPodmanClient(socketPath string) runtimeclient.ContainerRuntimeClient {
+	if socketPath == "" {
+		socketPath = runtimeclient.PodmanDefaultSocketPath
+	}
+
+	return &PodmanClient{
+		client: http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (conn net.Conn, err error) {
+					return net.Dial("unix", socketPath)
+				},
+			},
+			Timeout: defaultConnectionTimeout,
+		},
+	}
+}
+
+func (p *PodmanClient) listContainers(containerID string) ([]*runtimeclient.ContainerData, error) {
+	var filters string
+	if containerID != "" {
+		f, err := json.Marshal(map[string][]string{"id": {containerID}})
+		if err != nil {
+			return nil, fmt.Errorf("setting up filters: %w", err)
+		}
+		filters = "&filters=" + url.QueryEscape(string(f))
+	}
+
+	resp, err := p.client.Get(containerListAllURL + filters)
+	if err != nil {
+		return nil, fmt.Errorf("listing containers: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("listing containers via rest api: %s", resp.Status)
+	}
+
+	var containers []struct {
+		ID    string   `json:"Id"`
+		Names []string `json:"Names"`
+		State string   `json:"State"`
+	}
+	if err = json.NewDecoder(resp.Body).Decode(&containers); err != nil {
+		return nil, fmt.Errorf("decoding containers: %w", err)
+	}
+
+	ret := make([]*runtimeclient.ContainerData, len(containers))
+	for i, c := range containers {
+		ret[i] = &runtimeclient.ContainerData{
+			ID:      c.ID,
+			Name:    c.Names[0],
+			State:   containerStatusStateToRuntimeClientState(c.State),
+			Runtime: runtimeclient.PodmanName,
+		}
+	}
+	return ret, nil
+}
+
+func (p *PodmanClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
+	return p.listContainers("")
+}
+
+func (p *PodmanClient) GetContainer(containerID string) (*runtimeclient.ContainerData, error) {
+	containers, err := p.listContainers(containerID)
+	if err != nil {
+		return nil, err
+	}
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+	if len(containers) > 1 {
+		log.Warnf("PodmanClient: multiple containers (%d) with ID %q. Taking the first one: %+v",
+			len(containers), containerID, containers)
+	}
+	return containers[0], nil
+}
+
+func (p *PodmanClient) GetContainerDetails(containerID string) (*runtimeclient.ContainerDetailsData, error) {
+	resp, err := p.client.Get(fmt.Sprintf(containerInspectURL, containerID))
+	if err != nil {
+		return nil, fmt.Errorf("inspecting container %q: %w", containerID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("inspecting container via rest api %q: %s", containerID, resp.Status)
+	}
+
+	var container struct {
+		ID    string `json:"Id"`
+		Name  string `json:"Name"`
+		State struct {
+			Status     string `json:"Status"`
+			Pid        int    `json:"Pid"`
+			CgroupPath string `json:"CgroupPath"`
+		} `json:"State"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&container); err != nil {
+		return nil, fmt.Errorf("decoding container %q: %w", containerID, err)
+	}
+
+	return &runtimeclient.ContainerDetailsData{
+		ContainerData: runtimeclient.ContainerData{
+			ID:      container.ID,
+			Name:    container.Name,
+			State:   containerStatusStateToRuntimeClientState(container.State.Status),
+			Runtime: runtimeclient.PodmanName,
+		},
+		Pid:         container.State.Pid,
+		CgroupsPath: container.State.CgroupPath,
+	}, nil
+}
+
+func (p *PodmanClient) Close() error {
+	return nil
+}
+
+func containerStatusStateToRuntimeClientState(containerState string) string {
+	switch containerState {
+	case "created":
+		return runtimeclient.StateCreated
+	case "running":
+		return runtimeclient.StateRunning
+	case "exited":
+		return runtimeclient.StateExited
+	case "dead":
+		return runtimeclient.StateExited
+	default:
+		return runtimeclient.StateUnknown
+	}
+}

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -25,6 +25,9 @@ const (
 	CrioName              = "cri-o"
 	CrioDefaultSocketPath = "/run/crio/crio.sock"
 
+	PodmanName              = "podman"
+	PodmanDefaultSocketPath = "/run/podman/podman.sock"
+
 	ContainerdName              = "containerd"
 	ContainerdDefaultSocketPath = "/run/containerd/containerd.sock"
 

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -40,6 +40,7 @@ const (
 	DockerSocketPath     = "docker-socketpath"
 	ContainerdSocketPath = "containerd-socketpath"
 	CrioSocketPath       = "crio-socketpath"
+	PodmanSocketPath     = "podman-socketpath"
 )
 
 type MountNsMapSetter interface {
@@ -92,6 +93,11 @@ func (l *LocalManager) GlobalParamDescs() params.ParamDescs {
 			Key:          CrioSocketPath,
 			DefaultValue: runtimeclient.CrioDefaultSocketPath,
 			Description:  "CRI-O CRI Unix socket path",
+		},
+		{
+			Key:          PodmanSocketPath,
+			DefaultValue: runtimeclient.PodmanDefaultSocketPath,
+			Description:  "Podman Unix socket path",
 		},
 	}
 }
@@ -153,6 +159,8 @@ partsLoop:
 			socketPath = operatorParams.Get(ContainerdSocketPath).AsString()
 		case runtimeclient.CrioName:
 			socketPath = operatorParams.Get(CrioSocketPath).AsString()
+		case runtimeclient.PodmanName:
+			socketPath = operatorParams.Get(PodmanSocketPath).AsString()
 		default:
 			return commonutils.WrapInErrInvalidArg("--runtime / -r",
 				fmt.Errorf("runtime %q is not supported", p))


### PR DESCRIPTION
# Add support for crun and podman

* runcfanotify adds support for crun.
* runtime-client adds support for podman.

## How to use



## Testing done

```
$ make ig && sudo ./ig list-containers -w
...
...
TIMESTAMP                      EVENT      RUNTIME    ID                                               NAME                                                                                                         
2023-05-02T17:47:41+02:00      CREATED    docker     ba4b260ec89864a1cd2de86dc0b918c04c9da7bc1d8139a… boring_ride                                                                                                  
2023-05-02T17:47:41+02:00      DELETED    docker     ba4b260ec89864a1cd2de86dc0b918c04c9da7bc1d8139a… boring_ride                                                                                                  
2023-05-02T17:47:54+02:00      CREATED    podman     dd781ba32f86a4240a0cc1197e8fb6dfb1557fc131c9393… sad_goldwasser                                                                                               
2023-05-02T17:47:54+02:00      DELETED    podman     dd781ba32f86a4240a0cc1197e8fb6dfb1557fc131c9393… sad_goldwasser                                                                                               
2023-05-02T17:48:04+02:00      CREATED    podman     941d3176bb6e9584a2b700a3a669f83de69dd69c950b453… wizardly_curie                                                                                               
2023-05-02T17:48:04+02:00      DELETED    podman     941d3176bb6e9584a2b700a3a669f83de69dd69c950b453… wizardly_curie                                                                                                                                
```

```
$ docker run -ti --rm busybox echo
$ podman --runtime=crun run -ti busybox echo
$ podman --runtime=runc run -ti busybox echo
```

## Notes

* It is not possible to call "podman inspect" when fanotify is blocking the runc/crun execution: this leads to a deadlock. To solve this, the runcfanotify package returns the additional field "ContainerName" found in the conmon command line so that runtime-client does not need to find it. runtime-client would only call "podman inspect" for initial containers, not for containers found via runcfanotify.

* The `ig list-containers` command has a field "RUNTIME". We should distinguish OCI Runtime (crun, runc) and high level runtime (docker, containerd, cri-o).

* I wanted to use the podman Go package but I didn't get it to work, so for this proof-of-concept, I use a workaround by executing an external command (e.g. `podman inspect ...`).

* I use `sudo -u alban` because by default podman uses rootless containers and `ig` runs as root, so they don't find the same containers. I am not sure what's the right way to do that. Maybe it will be solved when using the podman Go library?

## Updates:

> The ig list-containers command has a field "RUNTIME". We should distinguish OCI Runtime (crun, runc) and high level runtime (docker, containerd, cri-o). 

For now I used `io.container.manager` annotation to detect if the container is coming from `podman` and we can open a separate issue to track support for OCI Runtime in container events to make things simpler in this PR ? 

>> I wanted to use the podman Go package but I didn't get it to work, so for this proof-of-concept, I use a workaround by executing an external command (e.g. podman inspect ...).

> Switching to [podman bindings](https://github.com/containers/podman/tree/main/pkg/bindings) seems to be working fine but had to introduce [build tags](https://github.com/inspektor-gadget/inspektor-gadget/pull/1532/files#diff-c23efbf33144b7235d4b1139e17791167fb0de9ddadd72eab4a8cbfe54ee111eR98) to keep the build time dependencies simple. 

I used [podman restapi ](https://docs.podman.io/en/latest/_static/api.html) directly to keep things simple. It allows to use the same API as podman bindings but we can avoid introducing [build-tags](https://github.com/inspektor-gadget/inspektor-gadget/pull/1532/commits/781f4ee2531527f538d94b8c9ba0520e2068b99c) everywhere. Also, we can set timeouts for the `http.Client` to avoid running into deadlocks. 

> I use sudo -u alban because by default podman uses rootless containers and ig runs as root, so they don't find the same containers. I am not sure what's the right way to do that. Maybe it will be solved when using the podman Go library?

Introducing `podman-socketpath` helps supporting rootless containers by specifying socketPath `/run/user/$UID/podman/podman.sock` as:

```bash
# ensure user socket is present
$ systemctl start --user podman.socket
$ sudo ./ig list-containers --podman-socketpath /run/user/$UID/podman/podman.sock -r podman
```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1515