### PR TITLE
cri: Support CRI API v1/v1alpha2 simultaneously

### DIFF
--- a/pkg/container-utils/cri/conversion.go
+++ b/pkg/container-utils/cri/conversion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* See:
+ * https://github.com/kubernetes/kubernetes/blob/v1.25.9/pkg/kubelet/cri/remote/conversion.go
+ */
+
+package cri
+
+import (
+	"unsafe"
+
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func fromV1alpha2ListContainersResponse(from *v1alpha2.ListContainersResponse) *runtimeapi.ListContainersResponse {
+	return (*runtimeapi.ListContainersResponse)(unsafe.Pointer(from))
+}
+
+func fromV1alpha2ContainerStatusResponse(from *v1alpha2.ContainerStatusResponse) *runtimeapi.ContainerStatusResponse {
+	return (*runtimeapi.ContainerStatusResponse)(unsafe.Pointer(from))
+}

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -23,11 +23,15 @@ import (
 	"strings"
 	"time"
 
-	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"google.golang.org/grpc/status"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeV1alpha2 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
 // CRIClient implements the ContainerRuntimeClient interface using the CRI
@@ -37,8 +41,9 @@ type CRIClient struct {
 	SocketPath  string
 	ConnTimeout time.Duration
 
-	conn   *grpc.ClientConn
-	client pb.RuntimeServiceClient
+	conn           *grpc.ClientConn
+	client         runtime.RuntimeServiceClient
+	clientV1alpha2 runtimeV1alpha2.RuntimeServiceClient
 }
 
 func NewCRIClient(name, socketPath string, timeout time.Duration) (CRIClient, error) {
@@ -54,17 +59,46 @@ func NewCRIClient(name, socketPath string, timeout time.Duration) (CRIClient, er
 		return CRIClient{}, err
 	}
 
-	return CRIClient{
+	cc := CRIClient{
 		Name:        name,
 		SocketPath:  socketPath,
 		ConnTimeout: timeout,
 		conn:        conn,
-		client:      pb.NewRuntimeServiceClient(conn),
-	}, nil
+		client:      runtime.NewRuntimeServiceClient(conn),
+	}
+
+	// determine CRI API version to use
+	if _, err = cc.client.Version(context.Background(), &runtime.VersionRequest{}); err == nil {
+		log.Debugf("Using CRI v1 for %s CRI client", name)
+	} else if status.Code(err) == codes.Unimplemented {
+		log.Debugf("Using CRI v1alpha2 for %s CRI client", name)
+		cc.client = nil
+		cc.clientV1alpha2 = runtimeV1alpha2.NewRuntimeServiceClient(conn)
+	} else {
+		log.Warnf("Failed to determine CRI API version: %v", err)
+	}
+
+	return cc, nil
 }
 
-func listContainers(c *CRIClient, filter *pb.ContainerFilter) ([]*pb.Container, error) {
-	request := &pb.ListContainersRequest{}
+func listContainers(c *CRIClient, filter *runtime.ContainerFilter) ([]*runtime.Container, error) {
+	if c.useV1alpha2() {
+		request := &runtimeV1alpha2.ListContainersRequest{}
+		if filter != nil {
+			request.Filter = &runtimeV1alpha2.ContainerFilter{
+				Id: filter.Id,
+			}
+		}
+		res, err := c.clientV1alpha2.ListContainers(context.Background(), request)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list containers with request %+v: %w",
+				request, err)
+		}
+
+		return fromV1alpha2ListContainersResponse(res).Containers, nil
+	}
+
+	request := &runtime.ListContainersRequest{}
 	if filter != nil {
 		request.Filter = filter
 	}
@@ -94,7 +128,7 @@ func (c *CRIClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
 }
 
 func (c *CRIClient) GetContainer(containerID string) (*runtimeclient.ContainerData, error) {
-	containers, err := listContainers(c, &pb.ContainerFilter{
+	containers, err := listContainers(c, &runtime.ContainerFilter{
 		Id: containerID,
 	})
 	if err != nil {
@@ -118,7 +152,21 @@ func (c *CRIClient) GetContainerDetails(containerID string) (*runtimeclient.Cont
 		return nil, err
 	}
 
-	request := &pb.ContainerStatusRequest{
+	if c.useV1alpha2() {
+		request := &runtimeV1alpha2.ContainerStatusRequest{
+			ContainerId: containerID,
+			Verbose:     true,
+		}
+
+		res, err := c.clientV1alpha2.ContainerStatus(context.Background(), request)
+		if err != nil {
+			return nil, err
+		}
+
+		return parseContainerDetailsData(c.Name, fromV1alpha2ContainerStatusResponse(res).Status, res.Info)
+	}
+
+	request := &runtime.ContainerStatusRequest{
 		ContainerId: containerID,
 		Verbose:     true,
 	}
@@ -139,9 +187,13 @@ func (c *CRIClient) Close() error {
 	return nil
 }
 
+func (c *CRIClient) useV1alpha2() bool {
+	return c.clientV1alpha2 != nil
+}
+
 // parseContainerDetailsData parses the container status and extra information
 // returned by ContainerStatus() into a ContainerDetailsData structure.
-func parseContainerDetailsData(runtimeName string, containerStatus *pb.ContainerStatus,
+func parseContainerDetailsData(runtimeName string, containerStatus *runtime.ContainerStatus,
 	extraInfo map[string]string,
 ) (*runtimeclient.ContainerDetailsData, error) {
 	// Create container details structure to be filled.
@@ -264,15 +316,15 @@ func parseExtraInfo(extraInfo map[string]string,
 }
 
 // Convert the state from container status to state of runtime client.
-func containerStatusStateToRuntimeClientState(containerStatusState pb.ContainerState) (runtimeClientState string) {
+func containerStatusStateToRuntimeClientState(containerStatusState runtime.ContainerState) (runtimeClientState string) {
 	switch containerStatusState {
-	case pb.ContainerState_CONTAINER_CREATED:
+	case runtime.ContainerState_CONTAINER_CREATED:
 		runtimeClientState = runtimeclient.StateCreated
-	case pb.ContainerState_CONTAINER_RUNNING:
+	case runtime.ContainerState_CONTAINER_RUNNING:
 		runtimeClientState = runtimeclient.StateRunning
-	case pb.ContainerState_CONTAINER_EXITED:
+	case runtime.ContainerState_CONTAINER_EXITED:
 		runtimeClientState = runtimeclient.StateExited
-	case pb.ContainerState_CONTAINER_UNKNOWN:
+	case runtime.ContainerState_CONTAINER_UNKNOWN:
 		runtimeClientState = runtimeclient.StateUnknown
 	default:
 		runtimeClientState = runtimeclient.StateUnknown
@@ -280,7 +332,7 @@ func containerStatusStateToRuntimeClientState(containerStatusState pb.ContainerS
 	return
 }
 
-func CRIContainerToContainerData(runtimeName string, container *pb.Container) *runtimeclient.ContainerData {
+func CRIContainerToContainerData(runtimeName string, container *runtime.Container) *runtimeclient.ContainerData {
 	containerData := &runtimeclient.ContainerData{
 		ID:      container.Id,
 		Name:    strings.TrimPrefix(container.GetMetadata().Name, "/"),


### PR DESCRIPTION
containerd/crio will only support CRI API v1 in future releases so it makes sense to support v1/v1alpha2 simultaneously. This change will make v1 as the default version to talk to CRI and fallback to v1alpha2 in case v1 is unimplemented. It is mainly based on the implementation in [kubelet](https://github.com/kubernetes/kubernetes/commit/de37b9d293613aac194cf522561d19ee1829e87b).

Fixes #1507 

## Testing done

### older containerd version (v1alpha2 only)

```bash
$ make MINIKUBE_VERSION=v1.25.0 KUBERNETES_VERSION=v1.23.0 CONTAINER_RUNTIME=containerd minikube-start
# build/copy/verify ig
$ make ig && docker cp ig minikube-containerd:/bin/ig
$ docker exec -it minikube-containerd ig list-containers -r containerd -v
...
DEBU[0000] Using CRI v1alpha2 for containerd CRI client 
...
$ make MINIKUBE_VERSION=v1.25.0  minikube-clean
```

### newer containerd version (v1alpha2/v1)

```bash
$ make CONTAINER_RUNTIME=containerd minikube-start
# build/copy/verify ig
$ make ig && docker cp ig minikube-containerd:/bin/ig
$ docker exec -it minikube-containerd ig list-containers -r containerd -v
...
DEBU[0000] Using CRI v1 for containerd CRI client  
...
$ make minikube-clean
```




