### PR TITLE
[RFC] json: preserve fields order

### DIFF
--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -43,6 +43,12 @@ func GetColumns() *columns.Columns[Event] {
 	return execColumns
 }
 
+func (e *Event) MarshalJSON() (res []byte, err error) {
+	cols := GetColumns()
+	res, err = eventtypes.MarshalJSONFunc(cols, e)
+	return
+}
+
 func Base(ev eventtypes.Event) *Event {
 	return &Event{
 		Event: ev,


### PR DESCRIPTION
The json and yaml outputs don't preserve the order of fields. This makes the output more difficult to read.

This patch is an attempt to preserve the order.

```
$ go run -exec sudo ./cmd/ig/... trace exec -r docker -c netem -o jsonpretty
{
  "node": "",
  "namespace": "",
  "pod": "",
  "container": "netem",
  "timestamp": 1681830365178939709,
  "type": "normal",
  "message": "",
  "mountnsid": 4026533679,
  "pid": 4026131,
  "ppid": 3429307,
  "comm": "ls",
  "ret": 0,
  "args": [
    "/bin/ls"
  ],
  "uid": 0
}
```

TODO:
* Respect json's omitempty.
* Make it work for yaml too
* Use the order provided by the columns package