### PR TITLE
pkg/histogram: Create new package for all gadgets using histograms

### DIFF
--- a/integration/ig/k8s/profile_bio_test.go
+++ b/integration/ig/k8s/profile_bio_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 	bioprofileTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
 )
 
 func TestProfileBio(t *testing.T) {
@@ -28,13 +29,10 @@ func TestProfileBio(t *testing.T) {
 		Name: "ProfileBio",
 		Cmd:  "ig profile block-io -o json --timeout 10",
 		ExpectedOutputFn: func(output string) error {
-			expectedEntry := &bioprofileTypes.Report{
-				ValType: "usecs",
-			}
+			expectedEntry := bioprofileTypes.NewReport(histogram.UnitMicroseconds, nil)
 
 			normalize := func(e *bioprofileTypes.Report) {
-				e.Data = nil
-				e.Time = ""
+				e.Intervals = nil
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/profile_blockio_test.go
+++ b/integration/inspektor-gadget/profile_blockio_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Inspektor Gadget authors
+// Copyright 2019-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	bioprofileTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 )
@@ -30,13 +31,10 @@ func TestProfileBlockIO(t *testing.T) {
 			Name: "RunProfileBlockIOGadget",
 			Cmd:  "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15 -o json",
 			ExpectedOutputFn: func(output string) error {
-				expectedEntry := &bioprofileTypes.Report{
-					ValType: "usecs",
-				}
+				expectedEntry := bioprofileTypes.NewReport(histogram.UnitMicroseconds, nil)
 
 				normalize := func(e *bioprofileTypes.Report) {
-					e.Data = nil
-					e.Time = ""
+					e.Intervals = nil
 				}
 
 				return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/pkg/gadgets/profile/block-io/tracer/gadget.go
+++ b/pkg/gadgets/profile/block-io/tracer/gadget.go
@@ -91,22 +91,12 @@ func starsToString(val, valMax, width uint64) string {
 		return strings.Repeat(" ", int(width))
 	}
 
-	minVal := uint64(0)
-	if val < valMax {
-		minVal = val
-	} else {
-		minVal = valMax
-	}
-
-	stars := minVal * width / valMax
+	stars := val * width / valMax
 	spaces := width - stars
 
 	var sb strings.Builder
 	sb.WriteString(strings.Repeat("*", int(stars)))
 	sb.WriteString(strings.Repeat(" ", int(spaces)))
-	if val > valMax {
-		sb.WriteByte('+')
-	}
 
 	return sb.String()
 }

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -82,6 +82,12 @@ func getReport(histMap *ebpf.Map) (types.Report, error) {
 		})
 	}
 
+	// The element data[:indexMax] is the last element with a non-zero value.
+	// So, we need to use data[:indexMax+1] to include it.
+	if indexMax > 0 {
+		indexMax++
+	}
+
 	report.Data = data[:indexMax]
 
 	return report, nil

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -38,8 +38,6 @@ type Tracer struct {
 	blockRqCompleteLink link.Link
 	blockRqInsertLink   link.Link
 	blockRqIssueLink    link.Link
-	result              string
-	err                 error
 }
 
 func NewTracer() (*Tracer, error) {

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -28,6 +28,7 @@ import (
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/profile/block-io/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target $TARGET -type hist -type hist_key -cc clang biolatency ./bpf/biolatency.bpf.c -- -I./bpf/ -I../../../../${TARGET}
@@ -51,52 +52,18 @@ func NewTracer() (*Tracer, error) {
 	return t, nil
 }
 
-func getReport(histMap *ebpf.Map) (types.Report, error) {
-	report := types.Report{
-		ValType: "usecs",
-	}
-
+func getReport(histMap *ebpf.Map) (*types.Report, error) {
 	key := biolatencyHistKey{}
-
-	err := histMap.NextKey(nil, unsafe.Pointer(&key))
-	if err != nil {
-		return types.Report{}, fmt.Errorf("error getting next key: %w", err)
+	if err := histMap.NextKey(nil, unsafe.Pointer(&key)); err != nil {
+		return nil, fmt.Errorf("getting next key: %w", err)
 	}
 
 	hist := biolatencyHist{}
 	if err := histMap.Lookup(key, unsafe.Pointer(&hist)); err != nil {
-		return types.Report{}, err
+		return nil, fmt.Errorf("getting histogram: %w", err)
 	}
 
-	data := []types.Data{}
-	indexMax := 0
-	for i, val := range hist.Slots {
-		if val > 0 {
-			indexMax = i
-		}
-
-		start := uint64(1) << i
-		end := 2*start - 1
-		if start == 1 {
-			start = 0
-		}
-
-		data = append(data, types.Data{
-			Count:         uint64(val),
-			IntervalStart: start,
-			IntervalEnd:   end,
-		})
-	}
-
-	// The element data[:indexMax] is the last element with a non-zero value.
-	// So, we need to use data[:indexMax+1] to include it.
-	if indexMax > 0 {
-		indexMax++
-	}
-
-	report.Data = data[:indexMax]
-
-	return report, nil
+	return types.NewReport(histogram.UnitMicroseconds, hist.Slots[:]), nil
 }
 
 func (t *Tracer) Stop() (string, error) {

--- a/pkg/gadgets/profile/block-io/tracer/tracer.go
+++ b/pkg/gadgets/profile/block-io/tracer/tracer.go
@@ -75,10 +75,16 @@ func getReport(histMap *ebpf.Map) (types.Report, error) {
 			indexMax = i
 		}
 
+		start := uint64(1) << i
+		end := 2*start - 1
+		if start == 1 {
+			start = 0
+		}
+
 		data = append(data, types.Data{
 			Count:         uint64(val),
-			IntervalStart: (uint64(1) << (i + 1)) >> 1,
-			IntervalEnd:   (uint64(1) << (i + 1)) - 1,
+			IntervalStart: start,
+			IntervalEnd:   end,
 		})
 	}
 

--- a/pkg/gadgets/profile/block-io/types/types.go
+++ b/pkg/gadgets/profile/block-io/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Inspektor Gadget authors
+// Copyright 2019-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,19 @@
 
 package types
 
-type Data struct {
-	Count         uint64 `json:"count"`
-	IntervalStart uint64 `json:"intervalStart"`
-	IntervalEnd   uint64 `json:"intervalEnd,omitempty"`
-}
+import (
+	histogram "github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
+)
 
 type Report struct {
-	ValType string `json:"valType,omitempty"`
-	Data    []Data `json:"data,omitempty"`
-	Time    string `json:"ts,omitempty"`
+	*histogram.Histogram `json:",inline"`
+}
+
+func NewReport(unit histogram.Unit, slots []uint32) *Report {
+	return &Report{
+		Histogram: &histogram.Histogram{
+			Unit:      unit,
+			Intervals: histogram.NewIntervalsFromExp2Slots(slots),
+		},
+	}
 }

--- a/pkg/histogram/histogram.go
+++ b/pkg/histogram/histogram.go
@@ -1,0 +1,129 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package histogram provides a Histogram struct that represents a histogram of
+// the number of events that occurred in each interval. It also provides a way
+// to transform a Histogram struct into a graphical representation. In addition,
+// it allows to create a Histogram struct from an exp-2 histogram.
+package histogram
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Unit string
+
+const (
+	UnitMilliseconds Unit = "ms"
+	UnitMicroseconds Unit = "µs"
+)
+
+type Interval struct {
+	Count uint64 `json:"count"`
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
+// Histogram represents a histogram of the number of events that occurred in
+// each interval.
+type Histogram struct {
+	Unit      Unit       `json:"unit,omitempty"`
+	Intervals []Interval `json:"intervals,omitempty"`
+}
+
+// NewIntervalsFromExp2Slots creates a new Interval array from an exp-2
+// histogram represented in slots.
+func NewIntervalsFromExp2Slots(slots []uint32) []Interval {
+	if len(slots) == 0 {
+		return nil
+	}
+
+	intervals := make([]Interval, 0, len(slots))
+	indexMax := 0
+	for i, val := range slots {
+		if val > 0 {
+			indexMax = i
+		}
+
+		start := uint64(1) << i
+		end := 2*start - 1
+		if start == 1 {
+			start = 0
+		}
+
+		intervals = append(intervals, Interval{
+			Count: uint64(val),
+			Start: start,
+			End:   end,
+		})
+	}
+
+	// The element parsedIntervals[indexMax] is the last element with a non-zero
+	// value. So, we need to use parsedIntervals[:indexMax+1] to include it in
+	// the returned array.
+	return intervals[:indexMax+1]
+}
+
+// String returns a string representation of the histogram. It is a golang
+// adaption of iovisor/bcc print_log2_hist():
+// https://github.com/iovisor/bcc/blob/13b5563c11f7722a61a17c6ca0a1a387d2fa7788/libbpf-tools/trace_helpers.c#L895-L932
+func (h *Histogram) String() string {
+	if len(h.Intervals) == 0 {
+		return ""
+	}
+
+	valMax := uint64(0)
+	for _, b := range h.Intervals {
+		if b.Count > valMax {
+			valMax = b.Count
+		}
+	}
+
+	spaceBefore := 8
+	spaceAfter := 16
+	width := 10
+	stars := 40
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%*s%-*s : count    distribution\n", spaceBefore,
+		"", spaceAfter, h.Unit))
+
+	for _, b := range h.Intervals {
+		sb.WriteString(fmt.Sprintf("%*d -> %-*d : %-8d |%s|\n", width,
+			b.Start, width, b.End, b.Count,
+			starsToString(b.Count, valMax, uint64(stars))))
+	}
+
+	return sb.String()
+}
+
+// starsToString returns a string with the number of stars and spaces needed to
+// represent the value in the histogram. It is a golang adaption of iovisor/bcc
+// print_stars():
+// https://github.com/iovisor/bcc/blob/13b5563c11f7722a61a17c6ca0a1a387d2fa7788/libbpf-tools/trace_helpers.c#L878-L893
+func starsToString(val, valMax, width uint64) string {
+	if valMax == 0 {
+		return strings.Repeat(" ", int(width))
+	}
+
+	stars := val * width / valMax
+	spaces := width - stars
+
+	var sb strings.Builder
+	sb.WriteString(strings.Repeat("*", int(stars)))
+	sb.WriteString(strings.Repeat(" ", int(spaces)))
+
+	return sb.String()
+}

--- a/pkg/histogram/histogram_test.go
+++ b/pkg/histogram/histogram_test.go
@@ -1,0 +1,232 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistogram_NewIntervalsFromExp2Slots(t *testing.T) {
+	t.Parallel()
+
+	const unit = UnitMicroseconds
+
+	testTable := []struct {
+		description string
+		slots       []uint32
+		expected    *Histogram
+	}{
+		{
+			description: "Nil slots",
+			slots:       nil,
+			expected: &Histogram{
+				Unit:      unit,
+				Intervals: nil,
+			},
+		},
+		{
+			description: "Empty slots",
+			slots:       []uint32{},
+			expected: &Histogram{
+				Unit:      unit,
+				Intervals: nil,
+			},
+		},
+		{
+			description: "With 1 slot",
+			slots:       []uint32{333},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 333, Start: 0, End: 1},
+				},
+			},
+		},
+		{
+			description: "With 2 slots",
+			slots:       []uint32{777, 555},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 777, Start: 0, End: 1},
+					{Count: 555, Start: 2, End: 3},
+				},
+			},
+		},
+		{
+			description: "With zero slots",
+			slots:       []uint32{222, 0, 111},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 222, Start: 0, End: 1},
+					{Count: 0, Start: 2, End: 3},
+					{Count: 111, Start: 4, End: 7},
+				},
+			},
+		},
+		{
+			description: "Zero at first slot",
+			slots:       []uint32{0, 888, 0, 666},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 0, Start: 0, End: 1},
+					{Count: 888, Start: 2, End: 3},
+					{Count: 0, Start: 4, End: 7},
+					{Count: 666, Start: 8, End: 15},
+				},
+			},
+		},
+		{
+			description: "Multiple zeros at first slots",
+			slots:       []uint32{0, 0, 0, 111},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 0, Start: 0, End: 1},
+					{Count: 0, Start: 2, End: 3},
+					{Count: 0, Start: 4, End: 7},
+					{Count: 111, Start: 8, End: 15},
+				},
+			},
+		},
+		{
+			description: "Multiple zeros at last slots",
+			slots:       []uint32{0, 888, 0, 111, 0, 0, 0},
+			expected: &Histogram{
+				Unit: unit,
+				Intervals: []Interval{
+					{Count: 0, Start: 0, End: 1},
+					{Count: 888, Start: 2, End: 3},
+					{Count: 0, Start: 4, End: 7},
+					{Count: 111, Start: 8, End: 15},
+				},
+			},
+		},
+	}
+
+	for _, test := range testTable {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Histogram{
+				Unit:      unit,
+				Intervals: NewIntervalsFromExp2Slots(test.slots),
+			}
+			require.Equal(t, test.expected, h, "creating histogram from exp2 slots")
+		})
+	}
+}
+
+func TestHistogram_String(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		description string
+		histogram   *Histogram
+		expected    string
+	}{
+		{
+			description: "Empty histogram",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: []Interval{},
+			},
+			expected: "",
+		},
+		{
+			description: "With 1 slot value 1",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{1}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 1        |****************************************|\n",
+		},
+		{
+			description: "With 1 slot value 55",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{55}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 55       |****************************************|\n",
+		},
+		{
+			description: "scale",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{1, 2, 3}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 1        |*************                           |\n" +
+				"         2 -> 3          : 2        |**************************              |\n" +
+				"         4 -> 7          : 3        |****************************************|\n",
+		},
+		{
+			description: "scale with empty slots",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{1, 0, 3}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 1        |*************                           |\n" +
+				"         2 -> 3          : 0        |                                        |\n" +
+				"         4 -> 7          : 3        |****************************************|\n",
+		},
+		{
+			description: "scale with empty slots and same values 1",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{1, 0, 1}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 1        |****************************************|\n" +
+				"         2 -> 3          : 0        |                                        |\n" +
+				"         4 -> 7          : 1        |****************************************|\n",
+		},
+		{
+			description: "scale with empty slots and same values 100",
+			histogram: &Histogram{
+				Unit:      UnitMicroseconds,
+				Intervals: NewIntervalsFromExp2Slots([]uint32{100, 0, 100}),
+			},
+			expected: "" +
+				"        µs               : count    distribution\n" +
+				"         0 -> 1          : 100      |****************************************|\n" +
+				"         2 -> 3          : 0        |                                        |\n" +
+				"         4 -> 7          : 100      |****************************************|\n",
+		},
+	}
+
+	for _, test := range testTable {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			actual := test.histogram.String()
+			require.Equal(t, test.expected, actual, "histogram string representation")
+		})
+	}
+}


### PR DESCRIPTION
This PR moves the functions that allow generating and printing a histogram from the profile block-io gadget to an internal package. It also adds unit-tests for such package.

This new package will be used also by the upcoming gadget: [profile tcprtt](https://github.com/inspektor-gadget/inspektor-gadget/pull/1517).