### PR TITLE
Simplify `ig` build process

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -204,6 +204,11 @@ jobs:
       uses: ./.github/actions/install-debian-packages
     - name: Build ${{ matrix.ig-target }}
       run: |
+        if [ "${{ matrix.ig-target}}" = 'ig-linux-arm64' ]; then
+          sudo apt-get update
+          sudo apt-get install qemu-user-static
+        fi
+
         make ${{ matrix.ig-target }}
 
         # Prepare assets for release and actions artifacts

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -1,23 +1,42 @@
-FROM ghcr.io/inspektor-gadget/ig-builder:latest
+ARG BUILDER_IMAGE=golang:1.19
+ARG BASE_IMAGE=gcr.io/distroless/static-debian11
 
-WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
-ARG GOOS=linux
-ENV GOOS=${GOOS}
-
-ARG GOARCH=amd64
-ENV GOARCH=${GOARCH}
-
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=undefined
 ENV VERSION=${VERSION}
 
 RUN \
+	dpkg --add-architecture ${TARGETARCH} && \
+	apt-get update && \
+	apt-get install -y build-essential libseccomp2:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
+	if [ ${TARGETARCH} = 'arm64' ]; then \
+		apt-get install -y gcc-aarch64-linux-gnu crossbuild-essential-arm64 ; \
+	fi
+
+COPY go.mod go.sum /cache/
+RUN cd /cache && go mod download
+ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget
+
+WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget
+
+RUN \
 	export CGO_ENABLED=1 ; \
-	if [ "${GOOS}-${GOARCH}" != "linux-amd64" ] ; then \
+	if [ "${TARGETARCH}" = 'arm64' ] ; then \
 		export CC=aarch64-linux-gnu-gcc ; \
 		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig ; \
 	fi ; \
-	go build \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 		-ldflags "-X main.version=${VERSION} -extldflags '-static'" \
-		-o ig-${GOOS}-${GOARCH} \
+		-o ig-${TARGETOS}-${TARGETARCH} \
 		github.com/inspektor-gadget/inspektor-gadget/cmd/ig
+
+FROM ${BASE_IMAGE}
+
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY --from=builder /go/src/github.com/inspektor-gadget/inspektor-gadget/ig-${TARGETOS}-${TARGETARCH} /usr/bin/ig
+ENTRYPOINT ["/usr/bin/ig"]

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,13 @@ ig: ig-$(GOHOSTOS)-$(GOHOSTARCH)
 	cp ig-$(GOHOSTOS)-$(GOHOSTARCH) ig
 
 ig-%: phony_explicit
-	echo Building ig-$* && \
-	export GOOS=$(shell echo $* |cut -f1 -d-) GOARCH=$(shell echo $* |cut -f2 -d-) && \
-	docker buildx build -t ig-$*-builder -f Dockerfiles/ig.Dockerfile \
-		--build-arg GOOS=$${GOOS} --build-arg GOARCH=$${GOARCH} --build-arg VERSION=$(VERSION) . && \
-	docker run --rm --entrypoint cat ig-$*-builder ig-$* > ig-$* && \
-	chmod +x ig-$*
+	echo Building $@
+	docker buildx build --load --platform=$(subst -,/,$*) -t $@ -f Dockerfiles/ig.Dockerfile \
+		--build-arg VERSION=$(VERSION) . ;\
+	docker create --name ig-$*-container $@
+	docker cp ig-$*-container:/usr/bin/ig $@
+	docker rm ig-$*-container
+	chmod +x $@
 
 KUBECTL_GADGET_TARGETS = \
 	kubectl-gadget-linux-amd64 \


### PR DESCRIPTION
Hi.


This PR simplifies the whole process to build `ig`.
Before, we would need to pull the `ig-builder` as we would rely on this image in another `Dockerfile` to actually build the image.
Nonetheless, this image was not available for `arm64` and even if we would have published a version for this architecture it would have needed some modifications as `aarch64-linux-gnu-gcc` is not available on `arm64`.

So, this commit modifies the `ig` image to make it `buildx` aware.
Note that, this image can be extended to `ln -s` the `ig` binary, so in a future where it would have sense people would be able to `docker run --rm -ti --privileged ig trace exec`.

We can go even further if the whole simplification of this to just have:

```Makefile
ig-$*:
        GOOS=$(parse $*) GOARCH=$(parse $*) go build \
		-ldflags "-X main.version=${VERSION} -extldflags '-static'" \
		-o ig-${GOOS}-${GOARCH} \
		github.com/inspektor-gadget/inspektor-gadget/cmd/ig
```

And it would just been called with:

```bash
# Build for host OS and architecture:
$ make ig
# Cross building:
$ CC=cross-compiler make ig-crossos-crossarch
```

Best regards.