### PR TITLE
tree-wide: Rename UID fields to Uid

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
+    # Ignore rule about ID vs Id: https://github.com/golang/lint/issues/89
+    - text: "ST1003:"
+      linters:
+        - stylecheck
 
 linters:
   disable-all: true

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -54,7 +54,7 @@ func TestTraceCapabilities(t *testing.T) {
 
 				e.Timestamp = 0
 				e.Pid = 0
-				e.UID = 0
+				e.Uid = 0
 				e.MountNsID = 0
 				// Do not check InsetID to avoid introducing dependency on the kernel version
 				e.InsetID = nil

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -64,7 +64,7 @@ func TestTraceExec(t *testing.T) {
 				e.Timestamp = 0
 				e.Pid = 0
 				e.Ppid = 0
-				e.UID = 0
+				e.Uid = 0
 				e.Retval = 0
 				e.MountNsID = 0
 			}

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -50,7 +50,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Timestamp = 0
 				e.MountNsID = 0
 				e.Pid = 0
-				e.UID = 0
+				e.Uid = 0
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -55,7 +55,7 @@ func TestTraceCapabilities(t *testing.T) {
 				e.Timestamp = 0
 				e.Node = ""
 				e.Pid = 0
-				e.UID = 0
+				e.Uid = 0
 				e.MountNsID = 0
 				// Do not check InsetID to avoid introducing dependency on the kernel version
 				e.InsetID = nil

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -68,7 +68,7 @@ func TestTraceExec(t *testing.T) {
 				e.Node = ""
 				e.Pid = 0
 				e.Ppid = 0
-				e.UID = 0
+				e.Uid = 0
 				e.Retval = 0
 				e.MountNsID = 0
 			}

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -47,7 +47,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Node = ""
 				e.MountNsID = 0
 				e.Pid = 0
-				e.UID = 0
+				e.Uid = 0
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/internal/test/runner.go
+++ b/internal/test/runner.go
@@ -34,7 +34,7 @@ import (
 // namespace, running on a different group ID, etc.
 type RunnerConfig struct {
 	// User ID to run under
-	UID int
+	Uid int
 
 	// HostNetwork prevents the runner from creating a new network namespace
 	HostNetwork bool
@@ -47,7 +47,7 @@ type RunnerInfo struct {
 	Pid         int
 	Tid         int
 	Comm        string
-	UID         int
+	Uid         int
 	MountNsID   uint64
 	NetworkNsID uint64
 	UserNsID    uint64
@@ -128,12 +128,12 @@ func (r *Runner) runLoop() {
 		}
 	}
 
-	if r.config.UID != 0 {
+	if r.config.Uid != 0 {
 		// syscall.Setuid() can't be used here because it'll
 		// change the UID of all threads and we only need to
 		// change the one of this thread.
 		// https://github.com/golang/go/commit/d1b1145cace8b968307f9311ff611e4bb810710c
-		_, _, errno := syscall.Syscall(syscall.SYS_SETUID, uintptr(r.config.UID), 0, 0)
+		_, _, errno := syscall.Syscall(syscall.SYS_SETUID, uintptr(r.config.Uid), 0, 0)
 		if errno != 0 {
 			r.replies <- fmt.Errorf("setting uid: %w", err)
 			return
@@ -156,7 +156,7 @@ func (r *Runner) runLoop() {
 		Pid:         os.Getpid(),
 		Tid:         unix.Gettid(),
 		Comm:        filepath.Base(comm),
-		UID:         r.config.UID,
+		Uid:         r.config.Uid,
 		MountNsID:   mountnsid,
 		NetworkNsID: netnsid,
 		UserNsID:    userNsID,

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -306,7 +306,7 @@ func (t *Tracer) run() {
 			CurrentUserNs: bpfEvent.CurrentUserns,
 			Pid:           bpfEvent.Pid,
 			Cap:           int(bpfEvent.Cap),
-			UID:           bpfEvent.Uid,
+			Uid:           bpfEvent.Uid,
 			Audit:         audit,
 			InsetID:       insetID,
 			Comm:          gadgets.FromCString(bpfEvent.Task[:]),

--- a/pkg/gadgets/trace/capabilities/tracer/tracer_test.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer_test.go
@@ -89,7 +89,7 @@ func TestCapabilitiesTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Syscall:       "fchownat",
 					CapName:       "CHOWN",
@@ -128,7 +128,7 @@ func TestCapabilitiesTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Syscall:       "fchownat",
 					CapName:       "CHOWN",
@@ -158,7 +158,7 @@ func TestCapabilitiesTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Syscall:       "bind",
 					CapName:       "NET_BIND_SERVICE",
@@ -179,7 +179,7 @@ func TestCapabilitiesTracer(t *testing.T) {
 					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
 				}
 			},
-			runnerConfig: &utilstest.RunnerConfig{UID: 1245},
+			runnerConfig: &utilstest.RunnerConfig{Uid: 1245},
 			generateEvent: func() error {
 				if err := chown(); err == nil {
 					return fmt.Errorf("chwon should have failed")
@@ -194,7 +194,7 @@ func TestCapabilitiesTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Syscall:       "fchownat",
 					CapName:       "CHOWN",

--- a/pkg/gadgets/trace/capabilities/types/types.go
+++ b/pkg/gadgets/trace/capabilities/types/types.go
@@ -39,7 +39,7 @@ type Event struct {
 	Pid           uint32   `json:"pid,omitempty" column:"pid,template:pid"`
 	Comm          string   `json:"comm,omitempty" column:"comm,template:comm"`
 	Syscall       string   `json:"syscall,omitempty" column:"syscall,template:syscall"`
-	UID           uint32   `json:"uid,omitempty" column:"uid,minWidth:6"`
+	Uid           uint32   `json:"uid,omitempty" column:"uid,minWidth:6"`
 	Cap           int      `json:"cap,omitempty" column:"cap,width:3,fixed"`
 	CapName       string   `json:"capName,omitempty" column:"capName,width:18,fixed"`
 	Audit         int      `json:"audit,omitempty" column:"audit,minWidth:5"`

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -160,7 +160,7 @@ func (t *Tracer) run() {
 			},
 			Pid:           bpfEvent.Pid,
 			Ppid:          bpfEvent.Ppid,
-			UID:           bpfEvent.Uid,
+			Uid:           bpfEvent.Uid,
 			WithMountNsID: eventtypes.WithMountNsID{MountNsID: bpfEvent.MntnsId},
 			Retval:        int(bpfEvent.Retval),
 			Comm:          gadgets.FromCString(bpfEvent.Comm[:]),

--- a/pkg/gadgets/trace/exec/tracer/tracer_test.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer_test.go
@@ -88,7 +88,7 @@ func TestExecTracer(t *testing.T) {
 					},
 					Pid:           uint32(catPid),
 					Ppid:          uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Retval:        0,
 					Comm:          "cat",
@@ -119,7 +119,7 @@ func TestExecTracer(t *testing.T) {
 					},
 					Pid:           uint32(catPid),
 					Ppid:          uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Retval:        0,
 					Comm:          "cat",
@@ -133,14 +133,14 @@ func TestExecTracer(t *testing.T) {
 					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
 				}
 			},
-			runnerConfig:  &utilstest.RunnerConfig{UID: unprivilegedUID},
+			runnerConfig:  &utilstest.RunnerConfig{Uid: unprivilegedUID},
 			generateEvent: generateEvent,
 			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
 				if len(events) != 1 {
 					t.Fatalf("One event expected")
 				}
 
-				utilstest.Equal(t, uint32(info.UID), events[0].UID,
+				utilstest.Equal(t, uint32(info.Uid), events[0].Uid,
 					"Event has bad UID")
 			},
 		},

--- a/pkg/gadgets/trace/exec/types/types.go
+++ b/pkg/gadgets/trace/exec/types/types.go
@@ -30,7 +30,7 @@ type Event struct {
 	Comm   string   `json:"comm,omitempty" column:"comm,template:comm"`
 	Retval int      `json:"ret,omitempty" column:"ret,width:3,fixed"`
 	Args   []string `json:"args,omitempty" column:"args,width:40"`
-	UID    uint32   `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
+	Uid    uint32   `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -199,7 +199,7 @@ func (t *Tracer) run() {
 			},
 			WithMountNsID: eventtypes.WithMountNsID{MountNsID: bpfEvent.MntnsId},
 			Pid:           bpfEvent.Pid,
-			UID:           bpfEvent.Uid,
+			Uid:           bpfEvent.Uid,
 			Comm:          gadgets.FromCString(bpfEvent.Comm[:]),
 			Ret:           ret,
 			Fd:            fd,

--- a/pkg/gadgets/trace/open/tracer/tracer_test.go
+++ b/pkg/gadgets/trace/open/tracer/tracer_test.go
@@ -95,7 +95,7 @@ func TestOpenTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Fd:            fd,
 					Ret:           fd,
@@ -127,7 +127,7 @@ func TestOpenTracer(t *testing.T) {
 					},
 					WithMountNsID: eventtypes.WithMountNsID{MountNsID: info.MountNsID},
 					Pid:           uint32(info.Pid),
-					UID:           uint32(info.UID),
+					Uid:           uint32(info.Uid),
 					Comm:          info.Comm,
 					Fd:            fd,
 					Ret:           fd,
@@ -142,14 +142,14 @@ func TestOpenTracer(t *testing.T) {
 					MountnsMap: utilstest.CreateMntNsFilterMap(t, info.MountNsID),
 				}
 			},
-			runnerConfig:  &utilstest.RunnerConfig{UID: unprivilegedUID},
+			runnerConfig:  &utilstest.RunnerConfig{Uid: unprivilegedUID},
 			generateEvent: generateEvent,
 			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, _ int, events []types.Event) {
 				if len(events) != 1 {
 					t.Fatalf("One event expected")
 				}
 
-				utilstest.Equal(t, uint32(info.UID), events[0].UID,
+				utilstest.Equal(t, uint32(info.Uid), events[0].Uid,
 					"Captured event has bad UID")
 			},
 		},

--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -24,7 +24,7 @@ type Event struct {
 	eventtypes.WithMountNsID
 
 	Pid  uint32 `json:"pid,omitempty" column:"pid,minWidth:7"`
-	UID  uint32 `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
+	Uid  uint32 `json:"uid,omitempty" column:"uid,minWidth:10,hide"`
 	Comm string `json:"comm,omitempty" column:"comm,maxWidth:16"`
 	Fd   int    `json:"fd,omitempty" column:"fd,minWidth:2,width:3"`
 	Ret  int    `json:"ret,omitempty" column:"ret,width:3,fixed,hide"`

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -177,7 +177,7 @@ func (t *Tracer) run() {
 			},
 			WithMountNsID: eventtypes.WithMountNsID{MountNsID: bpfEvent.MntnsId},
 			Pid:           bpfEvent.Pid,
-			UID:           bpfEvent.Uid,
+			Uid:           bpfEvent.Uid,
 			Comm:          gadgets.FromCString(bpfEvent.Task[:]),
 			Dport:         gadgets.Htons(bpfEvent.Dport),
 		}

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -24,7 +24,7 @@ type Event struct {
 	eventtypes.WithMountNsID
 
 	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
-	UID       uint32 `json:"uid,omitempty" column:"uid,minWidth:6,hide"`
+	Uid       uint32 `json:"uid,omitempty" column:"uid,minWidth:6,hide"`
 	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
 	IPVersion int    `json:"ipversion,omitempty" column:"ip,width:2,fixed"`
 	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr"`


### PR DESCRIPTION
The official go packages call it Uid rather than UID:
- https://github.com/golang/go/blob/bdccb85f509d24789694df198fe7bde948aa7955/src/syscall/ztypes_linux_amd64.go#L106
- https://github.com/golang/go/blob/bdccb85f509d24789694df198fe7bde948aa7955/src/os/user/user.go#L39

I also consider Uid is way better than UID, so I prefer to make this change now before it's impossible to make in the feature.

ref https://github.com/golang/lint/issues/89