### PR TITLE
Test non-k8s containerd API

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -736,7 +736,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ docker ]
+        runtime: [ docker, containerd ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup go

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -758,6 +758,7 @@ jobs:
         run: |
           set -o pipefail
           make -C integration/ig/non-k8s \
+            CONTAINER_RUNTIME=${{ matrix.runtime }} \
             DNSTESTER_IMAGE=${{ needs.build-helper-images.outputs.dnstester_image }} \
             -o build test-${{ matrix.runtime }} |& tee integration.log
       - name: Prepare and publish test report for container runtime ${{ matrix.runtime }}

--- a/integration/container_interface.go
+++ b/integration/container_interface.go
@@ -1,0 +1,88 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+)
+
+type ContainerSpec struct {
+	Name         string
+	Cmd          string
+	Options      []containerOption
+	Cleanup      bool
+	StartAndStop bool
+}
+
+type ContainerFactory interface {
+	NewContainer(ContainerSpec) ContainerInterface
+}
+
+type ContainerInterface interface {
+	Run(t *testing.T)
+	Start(t *testing.T)
+	Stop(t *testing.T)
+	IsCleanup() bool
+	IsStartAndStop() bool
+	Running() bool
+}
+
+func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
+	switch containerRuntime {
+	case runtimeclient.DockerName:
+		return &DockerManager{}, nil
+	case runtimeclient.ContainerdName:
+		return &ContainerdManager{}, nil
+	default:
+		return nil, fmt.Errorf("unknown container runtime %q", containerRuntime)
+	}
+}
+
+// containerdOption wraps testutils.Option to allow certain values only
+type containerOption struct {
+	opt          testutils.Option
+	Name         string
+	Cmd          string
+	Cleanup      bool
+	StartAndStop bool
+}
+
+func NewContainerOptions(opts ...containerOption) []containerOption {
+	return opts
+}
+
+func optionsFromContainerOptions(containerOption []containerOption) []testutils.Option {
+	var opts []testutils.Option
+	for _, do := range containerOption {
+		opts = append(opts, do.opt)
+	}
+	return opts
+}
+
+func WithName(name string) containerOption {
+	return containerOption{opt: testutils.WithName(name)}
+}
+
+func WithContainerImage(image string) containerOption {
+	return containerOption{opt: testutils.WithImage(image)}
+}
+
+func WithContainerSeccompProfile(profile string) containerOption {
+	return containerOption{opt: testutils.WithSeccompProfile(profile)}
+}

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+)
+
+type ContainerdManager struct{}
+
+func (*ContainerdManager) NewContainer(spec ContainerSpec) ContainerInterface {
+	return &ContainerdContainer{
+		ContainerSpec: spec,
+	}
+}
+
+// ContainerdContainer implements TestStep for containerd containers
+type ContainerdContainer struct {
+	ContainerSpec
+	started bool
+}
+
+func (d *ContainerdContainer) Run(t *testing.T) {
+	opts := append(optionsFromContainerOptions(d.Options), testutils.WithName(d.Name))
+	testutils.RunContainerdContainer(context.Background(), t, d.Cmd, opts...)
+}
+
+func (d *ContainerdContainer) Start(t *testing.T) {
+	if d.started {
+		t.Logf("Warn(%s): trying to start already running container\n", d.Name)
+		return
+	}
+	opts := append(optionsFromContainerOptions(d.Options), testutils.WithName(d.Name), testutils.WithoutRemoval(), testutils.WithoutWait())
+	testutils.RunContainerdContainer(context.Background(), t, d.Cmd, opts...)
+	d.started = true
+}
+
+func (d *ContainerdContainer) Stop(t *testing.T) {
+	testutils.RemoveContainerdContainer(context.Background(), t, d.Name)
+	d.started = false
+}
+
+func (d *ContainerdContainer) IsCleanup() bool {
+	return d.Cleanup
+}
+
+func (d *ContainerdContainer) IsStartAndStop() bool {
+	return d.StartAndStop
+}
+
+func (d *ContainerdContainer) Running() bool {
+	return d.started
+}

--- a/integration/ig/non-k8s/Makefile
+++ b/integration/ig/non-k8s/Makefile
@@ -1,14 +1,25 @@
 DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+CONTAINER_RUNTIME ?= docker
 
 # build
 build:
 	make -C $(shell pwd)/../../.. ig
 
+
 # test
+
+TEST_TARGETS = \
+	test-docker
+
+.PHONY: test-all
+test-all: $(TEST_TARGETS)
+
+test: test-$(CONTAINER_RUNTIME)
+
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
 # INTEGRATION_TESTS_PARAMS="-test.run TestFilterByContainerName" make -C integration/ig/non-k8s test-docker
-test-docker: build
+test-%: build
 	cp ../../../ig-linux-amd64 ig
 	go test -c -o ./ig-docker-integration.test ./...
-	sudo ./ig-docker-integration.test -test.v -integration -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}
+	sudo ./ig-docker-integration.test -test.v -integration -runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}
 	rm -f ./ig-docker-integration.test ./ig

--- a/integration/ig/non-k8s/Makefile
+++ b/integration/ig/non-k8s/Makefile
@@ -9,6 +9,7 @@ build:
 # test
 
 TEST_TARGETS = \
+	test-containerd \
 	test-docker
 
 .PHONY: test-all

--- a/integration/ig/non-k8s/integration_test.go
+++ b/integration/ig/non-k8s/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,11 @@ import (
 )
 
 var (
+	containerFactory ContainerFactory
+	// flags
 	integration    = flag.Bool("integration", false, "run integration tests")
 	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
+	runtime        = flag.String("runtime", "docker", "which runtime to use (docker)")
 )
 
 func init() {
@@ -37,6 +40,13 @@ func TestMain(m *testing.M) {
 	if !*integration {
 		fmt.Println("Skipping integration test.")
 		os.Exit(0)
+	}
+
+	var err error
+	containerFactory, err = NewContainerFactory(*runtime)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Start running tests:")

--- a/integration/ig/non-k8s/integration_test.go
+++ b/integration/ig/non-k8s/integration_test.go
@@ -28,7 +28,7 @@ var (
 	// flags
 	integration    = flag.Bool("integration", false, "run integration tests")
 	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
-	runtime        = flag.String("runtime", "docker", "which runtime to use (docker)")
+	runtime        = flag.String("runtime", "docker", "which runtime to use (docker, containerd)")
 )
 
 func init() {

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -29,7 +29,7 @@ func TestSnapshotProcess(t *testing.T) {
 
 	snapshotProcessCmd := &Command{
 		Name: "SnapshotProcess",
-		Cmd:  fmt.Sprintf("./ig snapshot process -o json --runtimes=docker -c %s", cn),
+		Cmd:  fmt.Sprintf("./ig snapshot process -o json --runtimes=%s -c %s", *runtime, cn),
 		ExpectedOutputFn: func(output string) error {
 			expectedEntry := &snapshotprocessTypes.Event{
 				Event: eventtypes.Event{
@@ -53,11 +53,11 @@ func TestSnapshotProcess(t *testing.T) {
 	}
 
 	testSteps := []TestStep{
-		&DockerContainer{
+		containerFactory.NewContainer(ContainerSpec{
 			Name:         cn,
 			Cmd:          "nc -l -p 9090",
 			StartAndStop: true,
-		},
+		}),
 		snapshotProcessCmd,
 	}
 

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -30,7 +30,7 @@ func TestTraceDns(t *testing.T) {
 
 	traceDNSCmd := &Command{
 		Name:         "TraceDns",
-		Cmd:          fmt.Sprintf("./ig trace dns -o json --runtimes=docker -c %s", cn),
+		Cmd:          fmt.Sprintf("./ig trace dns -o json --runtimes=%s -c %s", *runtime, cn),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntries := []*dnsTypes.Event{
@@ -128,11 +128,11 @@ func TestTraceDns(t *testing.T) {
 	testSteps := []TestStep{
 		traceDNSCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		&DockerContainer{
+		containerFactory.NewContainer(ContainerSpec{
 			Name:    cn,
 			Cmd:     strings.Join(dnsCmds, " ; "),
-			Options: NewDockerOptions(WithDockerImage(*dnsTesterImage)),
-		},
+			Options: NewContainerOptions(WithContainerImage(*dnsTesterImage)),
+		}),
 	}
 
 	RunTestSteps(testSteps, t)

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -29,7 +29,7 @@ func TestTraceNetwork(t *testing.T) {
 
 	traceNetworkCmd := &Command{
 		Name:         "TraceNetwork",
-		Cmd:          fmt.Sprintf("./ig trace network -o json --runtimes=docker -c %s", cn),
+		Cmd:          fmt.Sprintf("./ig trace network -o json --runtimes=%s -c %s", *runtime, cn),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntries := []*networkTypes.Event{
@@ -71,11 +71,11 @@ func TestTraceNetwork(t *testing.T) {
 	testSteps := []TestStep{
 		traceNetworkCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		&DockerContainer{
+		containerFactory.NewContainer(ContainerSpec{
 			Name:    cn,
 			Cmd:     "nginx && curl 127.0.0.1",
-			Options: NewDockerOptions(WithDockerImage("docker.io/library/nginx")),
-		},
+			Options: NewContainerOptions(WithContainerImage("docker.io/library/nginx")),
+		}),
 	}
 
 	RunTestSteps(testSteps, t)

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -1,0 +1,185 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	// TODO containerd currently only works on k8s.io namespace
+	defaultNamespace = "k8s.io"
+)
+
+func RunContainerdContainer(ctx context.Context, t *testing.T, command string, options ...Option) {
+	opts := defaultContainerOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	nsCtx := namespaces.WithNamespace(ctx, defaultNamespace)
+	fullImage := getFullImage(opts)
+
+	client, err := containerd.New("/run/containerd/containerd.sock",
+		containerd.WithTimeout(3*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("Failed to connect to containerd: %s", err)
+	}
+
+	// Download and unpack the image
+	image, err := client.Pull(nsCtx, fullImage)
+	if err != nil {
+		t.Fatalf("Failed to pull the image %q: %s", fullImage, err)
+	}
+
+	unpacked, err := image.IsUnpacked(nsCtx, "")
+	if err != nil {
+		t.Fatalf("image.IsUnpacked: %v", err)
+	}
+	if !unpacked {
+		if err := image.Unpack(nsCtx, ""); err != nil {
+			t.Fatalf("image.Unpack: %v", err)
+		}
+	}
+
+	// Create the container
+	var specOpts []oci.SpecOpts
+	specOpts = append(specOpts, oci.WithDefaultSpec())
+	specOpts = append(specOpts, oci.WithDefaultUnixDevices)
+	specOpts = append(specOpts, oci.WithImageConfig(image))
+	if len(command) != 0 {
+		specOpts = append(specOpts, oci.WithProcessArgs("/bin/sh", "-c", command))
+	}
+	if opts.seccompProfile != "" {
+		t.Fatalf("testutils/containerd: seccomp profiles are not supported yet")
+	}
+
+	var spec specs.Spec
+	container, err := client.NewContainer(nsCtx, opts.name,
+		containerd.WithImage(image),
+		containerd.WithImageConfigLabels(image),
+		containerd.WithAdditionalContainerLabels(image.Labels()),
+		containerd.WithSnapshotter(""),
+		containerd.WithNewSnapshot(opts.name, image, snapshots.WithLabels(map[string]string{})),
+		containerd.WithImageStopSignal(image, "SIGTERM"),
+		containerd.WithSpec(&spec, specOpts...),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create container %q: %s", opts.name, err)
+	}
+
+	containerIO := cio.NullIO
+	output := &strings.Builder{}
+	if opts.logs {
+		containerIO = cio.NewCreator(cio.WithStreams(nil, output, output))
+	}
+	// Now create and start the task
+	task, err := container.NewTask(nsCtx, containerIO)
+	if err != nil {
+		container.Delete(nsCtx, containerd.WithSnapshotCleanup)
+		t.Fatalf("Failed to create task %q: %s", opts.name, err)
+	}
+
+	err = task.Start(nsCtx)
+	if err != nil {
+		container.Delete(nsCtx, containerd.WithSnapshotCleanup)
+		t.Fatalf("Failed to start task %q: %s", opts.name, err)
+	}
+
+	if opts.wait {
+		exitStatus, err := task.Wait(nsCtx)
+		if err != nil {
+			t.Fatalf("Failed to wait on task %q: %s", opts.name, err)
+		}
+		s := <-exitStatus
+		if s.ExitCode() != 0 {
+			t.Logf("Exitcode for task %q: %d", opts.name, s.ExitCode())
+		}
+	}
+
+	if opts.logs {
+		t.Logf("Container %q output:\n%s", opts.name, output.String())
+	}
+
+	if opts.removal {
+		task.Kill(nsCtx, syscall.SIGKILL)
+		_, err = task.Delete(nsCtx)
+		if err != nil {
+			t.Fatalf("Failed to delete task %q: %s", opts.name, err)
+		}
+		err = container.Delete(nsCtx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			t.Fatalf("Failed to delete container %q: %s", opts.name, err)
+		}
+	}
+}
+
+func RunContainerdFailedContainer(ctx context.Context, t *testing.T) {
+	RunContainerdContainer(ctx, t,
+		"/none",
+		WithName("test-ig-failed-container"),
+		WithoutLogs(),
+		WithoutWait(),
+	)
+}
+
+func RemoveContainerdContainer(ctx context.Context, t *testing.T, name string) {
+	client, err := containerd.New("/run/containerd/containerd.sock",
+		containerd.WithTimeout(3*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("Failed to connect to containerd: %s", err)
+	}
+
+	nsCtx := namespaces.WithNamespace(ctx, defaultNamespace)
+	container, err := client.LoadContainer(nsCtx, name)
+	if err != nil {
+		t.Fatalf("Failed to get container %q: %s", name, err)
+	}
+
+	task, err := container.Task(nsCtx, nil)
+	if err != nil {
+		t.Fatalf("Failed to get task %q: %s", name, err)
+	}
+
+	task.Kill(nsCtx, syscall.SIGKILL)
+	_, err = task.Delete(nsCtx)
+	if err != nil {
+		t.Fatalf("Failed to delete task %q: %s", name, err)
+	}
+	err = container.Delete(nsCtx, containerd.WithSnapshotCleanup)
+	if err != nil {
+		t.Fatalf("Failed to delete container %q: %s", name, err)
+	}
+}
+
+func getFullImage(opts *containerOptions) string {
+	if strings.Contains(opts.image, ":") {
+		return opts.image
+	}
+	return opts.image + ":" + opts.imageTag
+}

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -15,8 +15,9 @@
 package testutils
 
 const (
-	DefaultContainerName  = "test-container"
-	DefaultContainerImage = "docker.io/library/busybox"
+	DefaultContainerName     = "test-container"
+	DefaultContainerImage    = "docker.io/library/busybox"
+	DefaultContainerImageTag = "latest"
 )
 
 type Option func(*containerOptions)
@@ -24,6 +25,7 @@ type Option func(*containerOptions)
 type containerOptions struct {
 	name           string
 	image          string
+	imageTag       string
 	seccompProfile string
 	wait           bool
 	logs           bool
@@ -32,11 +34,12 @@ type containerOptions struct {
 
 func defaultContainerOptions() *containerOptions {
 	return &containerOptions{
-		name:    DefaultContainerName,
-		image:   DefaultContainerImage,
-		logs:    true,
-		wait:    true,
-		removal: true,
+		name:     DefaultContainerName,
+		image:    DefaultContainerImage,
+		imageTag: DefaultContainerImageTag,
+		logs:     true,
+		wait:     true,
+		removal:  true,
 	}
 }
 
@@ -49,6 +52,12 @@ func WithName(name string) Option {
 func WithImage(image string) Option {
 	return func(opts *containerOptions) {
 		opts.image = image
+	}
+}
+
+func WithImageTag(tag string) Option {
+	return func(opts *containerOptions) {
+		opts.imageTag = tag
 	}
 }
 

--- a/pkg/container-utils/testutils/options_test.go
+++ b/pkg/container-utils/testutils/options_test.go
@@ -13,6 +13,9 @@ func TestContainerOptions(t *testing.T) {
 	if opts.image != DefaultContainerImage {
 		t.Errorf("Expected default container image to be %q", DefaultContainerImage)
 	}
+	if opts.imageTag != DefaultContainerImageTag {
+		t.Errorf("Expected default container image tag to be %q", DefaultContainerImageTag)
+	}
 	if opts.seccompProfile != "" {
 		t.Errorf("Expected default seccompProfile to be empty")
 	}


### PR DESCRIPTION
# Test non-k8s containerd API

This will be merged into a branch that is an open PR #1233 

The `non-k8s` intergration tests for `ig` were restructured to generalize around the runtime. 