### PR TITLE
docs: add unit tests requirements

### DIFF
--- a/docs/devel/CONTRIBUTING.md
+++ b/docs/devel/CONTRIBUTING.md
@@ -109,6 +109,12 @@ registry.
 
 ### Unit tests
 
+#### Requirements
+
+For running unit tests, the following additional requirements need to be installed and configured on your system: 
+- gcc compiler
+- `pkg-config` and `libseccomp-dev` libraries
+
 You can run the different unit tests with:
 
 ```bash


### PR DESCRIPTION
# Add minimal build requirements for compiling from source

I suggest adding these minimal build requirements for compiling from source for avoiding spending too much time debugging 
 in case one of the requirements is missing. It was the case for me when I did an upgrade to golang 1.20.3 and tried to run the tests. The error message wasn't clearly stating that gcc was missing from my system. 

**LE:** Realized that the these requirements were actually needed for the unit tests and moved them to contributing.
