### PR TITLE
socket-enricher: fix compilation warnings

### DIFF
--- a/pkg/gadgets/internal/socketenricher/bpf/sockets-map.h
+++ b/pkg/gadgets/internal/socketenricher/bpf/sockets-map.h
@@ -36,11 +36,11 @@
 
 const volatile __u32 current_netns = 0;
 
-unsigned long long load_byte(void *skb,
+unsigned long long load_byte(const void *skb,
 			     unsigned long long off) asm("llvm.bpf.load.byte");
-unsigned long long load_half(void *skb,
+unsigned long long load_half(const void *skb,
 			     unsigned long long off) asm("llvm.bpf.load.half");
-unsigned long long load_word(void *skb,
+unsigned long long load_word(const void *skb,
 			     unsigned long long off) asm("llvm.bpf.load.word");
 
 #define L4_OFF (ETH_HLEN + sizeof(struct iphdr))
@@ -73,7 +73,7 @@ struct {
 
 #ifdef GADGET_TYPE_NETWORKING
 static __always_inline struct sockets_value *
-gadget_socket_lookup(struct __sk_buff *skb)
+gadget_socket_lookup(const struct __sk_buff *skb)
 {
 	// Only IPv4 is supported for now
 	if (load_half(skb, offsetof(struct ethhdr, h_proto)) != ETH_P_IP)
@@ -106,7 +106,7 @@ gadget_socket_lookup(struct __sk_buff *skb)
 
 #ifdef GADGET_TYPE_TRACING
 static __always_inline struct sockets_value *
-gadget_socket_lookup(struct sock *sk, __u32 netns)
+gadget_socket_lookup(const struct sock *sk, __u32 netns)
 {
 	struct sockets_key key = {0,};
 	key.netns = netns;


### PR DESCRIPTION
When tcpretrans used vmlinux.h's trace_event_raw_tcp_event_sk_skb instead of a custom struct (see https://github.com/inspektor-gadget/inspektor-gadget/pull/1561#discussion_r1176919879), the skb field changed in this way:
```diff
- 	void *skbaddr;
-	void *skaddr;
+       const void *skbaddr;
+       const void *skaddr;
```
This caused compilation warnings such as:

> /work/pkg/gadgets/trace/tcpretrans/tracer/bpf/tcpretrans.bpf.c:105:55: warning: passing 'const struct sock *' to parameter of type 'struct sock *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
>         struct sockets_value *skb_val = gadget_socket_lookup(sk, event.netns);
>                                                             ^~
> ../../../internal/socketenricher/bpf/sockets-map.h:109:35: note: passing argument to parameter 'sk' here
> gadget_socket_lookup(struct sock *sk, __u32 netns)
>                                   ^
> 1 warning generated.

gadget_socket_lookup() does not actually modify the skb so adding the 'const' qualifier as appropriate.

