### PR TITLE
Allow hiding columns based on selected features / parameters

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	runtime := local.New()
 	// columnFilters for ig
-	columnFilters := []columns.ColumnFilter{columns.Or(columns.WithTag("runtime"), columns.WithNoTags())}
+	columnFilters := []columns.ColumnFilter{columns.WithoutExceptTag("kubernetes", "runtime")}
 	common.AddCommandsFromRegistry(rootCmd, runtime, columnFilters)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -67,7 +67,7 @@ func main() {
 	runtime.SetDefaultValue(gadgets.K8SNamespace, namespace)
 
 	// columnFilters for kubectl-gadget
-	columnFilters := []columns.ColumnFilter{columns.Or(columns.WithTag("kubernetes"), columns.WithNoTags())}
+	columnFilters := []columns.ColumnFilter{columns.WithoutExceptTag("runtime", "kubernetes")}
 	common.AddCommandsFromRegistry(rootCmd, runtime, columnFilters)
 
 	// Advise category is still being handled by CRs for now

--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -40,13 +40,12 @@ type subField struct {
 	isPtr bool
 }
 
-type Column[T any] struct {
+type Attributes struct {
 	Name         string                // Name of the column; case-insensitive for most use cases
 	Width        int                   // Width to reserve for this column
 	MinWidth     int                   // MinWidth will be the minimum width this column will be scaled to when using auto-scaling
 	MaxWidth     int                   // MaxWidth will be the maximum width this column will be scaled to when using auto-scaling
 	Alignment    Alignment             // Alignment of this column (left or right)
-	Extractor    func(*T) string       // Extractor to be used; this can be defined to transform the output before retrieving the actual value
 	Visible      bool                  // Visible defines whether a column is to be shown by default
 	GroupType    GroupType             // GroupType defines the aggregation method used when grouping this column
 	EllipsisType ellipsis.EllipsisType // EllipsisType defines how to abbreviate this column if the value needs more space than is available
@@ -55,6 +54,11 @@ type Column[T any] struct {
 	Description  string                // Description can hold a short description of the field that can be used to aid the user
 	Order        int                   // Order defines the default order in which columns are shown
 	Tags         []string              // Tags can be used to dynamically include or exclude columns
+}
+
+type Column[T any] struct {
+	Attributes
+	Extractor func(*T) string // Extractor to be used; this can be defined to transform the output before retrieving the actual value
 
 	offset        uintptr
 	fieldIndex    int          // used for the main struct
@@ -63,6 +67,10 @@ type Column[T any] struct {
 	columnType    reflect.Type // cached type info from reflection
 	useTemplate   bool         // if a template has been set, this will be true
 	template      string       // defines the template that will be used. Non-typed templates will be applied first.
+}
+
+func (ci *Column[T]) GetAttributes() *Attributes {
+	return &ci.Attributes
 }
 
 func (ci *Column[T]) getWidthFromType() int {
@@ -317,7 +325,7 @@ func (ci *Column[T]) Type() reflect.Type {
 }
 
 func (ci *Column[T]) HasTag(tag string) bool {
-	for _, curTag := range ci.Tags {
+	for _, curTag := range ci.Attributes.Tags {
 		if curTag == tag {
 			return true
 		}
@@ -326,7 +334,7 @@ func (ci *Column[T]) HasTag(tag string) bool {
 }
 
 func (ci *Column[T]) HasNoTags() bool {
-	if len(ci.Tags) == 0 {
+	if len(ci.Attributes.Tags) == 0 {
 		return true
 	}
 	return false

--- a/pkg/columns/columns_test.go
+++ b/pkg/columns/columns_test.go
@@ -362,37 +362,33 @@ func TestVirtualColumns(t *testing.T) {
 
 	cols := expectColumnsSuccess[testStruct](t)
 
-	err := cols.AddColumn(Column[testStruct]{
+	err := cols.AddColumn(Attributes{
 		Name: "vcol",
-	})
+	}, nil)
 	if err == nil {
 		t.Errorf("Expected error when adding column without extractor func")
 	}
 
-	err = cols.AddColumn(Column[testStruct]{
-		Extractor: func(_ *testStruct) string {
-			return ""
-		},
+	err = cols.AddColumn(Attributes{}, func(_ *testStruct) string {
+		return ""
 	})
 	if err == nil {
 		t.Errorf("Expected error when adding column without name")
 	}
 
-	err = cols.AddColumn(Column[testStruct]{
+	err = cols.AddColumn(Attributes{
 		Name: "stringfield",
-		Extractor: func(_ *testStruct) string {
-			return ""
-		},
+	}, func(_ *testStruct) string {
+		return ""
 	})
 	if err == nil {
 		t.Errorf("Expected error when adding column with already existing name")
 	}
 
-	err = cols.AddColumn(Column[testStruct]{
+	err = cols.AddColumn(Attributes{
 		Name: "foobar",
-		Extractor: func(t *testStruct) string {
-			return "FooBar"
-		},
+	}, func(t *testStruct) string {
+		return "FooBar"
 	})
 	if err != nil {
 		t.Errorf("could not add virtual column")

--- a/pkg/columns/doc.go
+++ b/pkg/columns/doc.go
@@ -74,12 +74,11 @@ Say that for example you have a struct with a (by default) not printable member 
 
 You can do that by adding a virtual column:
 
-	cols.AddColumn(columns.ColumnInfo[Event]{
+	cols.AddColumn(columns.Attributes{
 		Name:  "foo",
 		Width: 14,
-		Extractor: func(e *Event) string {
-			return string(e.Foo)
-		},
+	}, func(e *Event) string {
+		return string(e.Foo)
 	})
 
 This will convert the []byte to a string before printing it.

--- a/pkg/columns/filter.go
+++ b/pkg/columns/filter.go
@@ -86,11 +86,20 @@ func WithTag(tag string) ColumnFilter {
 	}
 }
 
-// WithoutTag makes sure that all returned columns contain none of the given tag
+// WithoutTag makes sure that all returned columns don't contain the given tag
 func WithoutTag(tag string) ColumnFilter {
 	tag = strings.ToLower(tag)
 	return func(matcher ColumnMatcher) bool {
 		return !matcher.HasTag(tag)
+	}
+}
+
+// WithoutExceptTag makes sure that all returned columns don't contain the given
+// tag, except when it also includes the exception given
+func WithoutExceptTag(tag, exception string) ColumnFilter {
+	tag = strings.ToLower(tag)
+	return func(matcher ColumnMatcher) bool {
+		return !matcher.HasTag(tag) || matcher.HasTag(exception)
 	}
 }
 

--- a/pkg/columns/sort/sort_test.go
+++ b/pkg/columns/sort/sort_test.go
@@ -46,11 +46,10 @@ func getTestCol(t *testing.T) *columns.Columns[testData] {
 	cols.MustSetExtractor("extractor", func(t *testData) string {
 		return fmt.Sprint(t.Extractor)
 	})
-	cols.MustAddColumn(columns.Column[testData]{
+	cols.MustAddColumn(columns.Attributes{
 		Name: "virtual_column",
-		Extractor: func(*testData) string {
-			return ""
-		},
+	}, func(*testData) string {
+		return ""
 	})
 
 	return cols

--- a/pkg/gadgets/snapshot/process/types/process-collector.go
+++ b/pkg/gadgets/snapshot/process/types/process-collector.go
@@ -34,7 +34,7 @@ type Event struct {
 
 	Command   string `json:"comm" column:"comm,template:comm"`
 	Pid       int    `json:"pid" column:"pid,template:pid"`
-	Tid       int    `json:"tid" column:"tid,template:pid,hide"`
+	Tid       int    `json:"tid" column:"tid,template:pid" columnTags:"param:threads"`
 	Uid       uint32 `json:"uid" column:"uid,template:uid"`
 	Gid       uint32 `json:"gid" column:"gid,template:gid"`
 	ParentPid int    `json:"ppid" column:"ppid,template:pid,hide"`

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -60,26 +60,24 @@ func GetColumns() *columns.Columns[Event] {
 		col.Visible = false
 	}
 
-	cols.MustAddColumn(columns.Column[Event]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:     "local",
 		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
 		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
 		Visible:  true,
 		Order:    1000,
-		Extractor: func(e *Event) string {
-			return fmt.Sprintf("%s:%d", e.LocalAddress, e.LocalPort)
-		},
+	}, func(e *Event) string {
+		return fmt.Sprintf("%s:%d", e.LocalAddress, e.LocalPort)
 	})
 
-	cols.MustAddColumn(columns.Column[Event]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:     "remote",
 		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
 		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
 		Visible:  true,
 		Order:    1001,
-		Extractor: func(e *Event) string {
-			return fmt.Sprintf("%s:%d", e.RemoteAddress, e.RemotePort)
-		},
+	}, func(e *Event) string {
+		return fmt.Sprintf("%s:%d", e.RemoteAddress, e.RemotePort)
 	})
 
 	return cols

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/ellipsis"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -58,38 +59,36 @@ func GetColumns() *columns.Columns[Stats] {
 	col, _ = cols.GetColumn("container")
 	col.Visible = false
 
-	cols.MustAddColumn(columns.Column[Stats]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:         "pid",
 		Width:        16,
 		EllipsisType: ellipsis.End,
 		Visible:      true,
 		Order:        999,
-		Extractor: func(stats *Stats) string {
-			pids := []string{}
+	}, func(stats *Stats) string {
+		pids := []string{}
 
-			for _, pid := range stats.Processes {
-				pids = append(pids, fmt.Sprint(pid.Pid))
-			}
+		for _, pid := range stats.Processes {
+			pids = append(pids, fmt.Sprint(pid.Pid))
+		}
 
-			return strings.Join(pids, ",")
-		},
+		return strings.Join(pids, ",")
 	})
 
-	cols.MustAddColumn(columns.Column[Stats]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:         "comm",
 		Width:        16,
 		EllipsisType: ellipsis.End,
 		Visible:      true,
 		Order:        1000,
-		Extractor: func(stats *Stats) string {
-			comms := []string{}
+	}, func(stats *Stats) string {
+		comms := []string{}
 
-			for _, comm := range stats.Processes {
-				comms = append(comms, comm.Comm)
-			}
+		for _, comm := range stats.Processes {
+			comms = append(comms, comm.Comm)
+		}
 
-			return strings.Join(comms, ",")
-		},
+		return strings.Join(comms, ",")
 	})
 	cols.MustSetExtractor("runtime", func(stats *Stats) (ret string) {
 		return fmt.Sprint(time.Duration(stats.CurrentRuntime))

--- a/pkg/gadgets/top/tcp/types/types.go
+++ b/pkg/gadgets/top/tcp/types/types.go
@@ -74,25 +74,23 @@ func GetColumns() *columns.Columns[Stats] {
 		return fmt.Sprint(units.BytesSize(float64(stats.Received)))
 	})
 
-	cols.MustAddColumn(columns.Column[Stats]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:     "local",
 		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
 		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
 		Visible:  true,
 		Order:    1000,
-		Extractor: func(s *Stats) string {
-			return fmt.Sprintf("%s:%d", s.Saddr, s.Sport)
-		},
+	}, func(s *Stats) string {
+		return fmt.Sprintf("%s:%d", s.Saddr, s.Sport)
 	})
-	cols.MustAddColumn(columns.Column[Stats]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:     "remote",
 		MinWidth: 21, // 15(ipv4) + 1(:) + 5(port)
 		MaxWidth: 51, // 45(ipv4 mapped ipv6) + 1(:) + 5(port)
 		Visible:  true,
 		Order:    1000,
-		Extractor: func(s *Stats) string {
-			return fmt.Sprintf("%s:%d", s.Daddr, s.Dport)
-		},
+	}, func(s *Stats) string {
+		return fmt.Sprintf("%s:%d", s.Daddr, s.Dport)
 	})
 
 	return cols

--- a/pkg/gadgets/trace/mount/types/types.go
+++ b/pkg/gadgets/trace/mount/types/types.go
@@ -43,24 +43,23 @@ type Event struct {
 func GetColumns() *columns.Columns[Event] {
 	cols := columns.MustCreateColumns[Event]()
 
-	cols.MustAddColumn(columns.Column[Event]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:    "call",
 		Width:   80,
 		Visible: true,
 		Order:   1000,
-		Extractor: func(e *Event) string {
-			switch e.Operation {
-			case "mount":
-				format := `mount("%s", "%s", "%s", %s, "%s") = %d`
-				return fmt.Sprintf(format, e.Source, e.Target, e.Fs, strings.Join(e.Flags, " | "),
-					e.Data, e.Retval)
-			case "umount":
-				format := `umount("%s", %s) = %d`
-				return fmt.Sprintf(format, e.Target, strings.Join(e.Flags, " | "), e.Retval)
-			}
+	}, func(e *Event) string {
+		switch e.Operation {
+		case "mount":
+			format := `mount("%s", "%s", "%s", %s, "%s") = %d`
+			return fmt.Sprintf(format, e.Source, e.Target, e.Fs, strings.Join(e.Flags, " | "),
+				e.Data, e.Retval)
+		case "umount":
+			format := `umount("%s", %s) = %d`
+			return fmt.Sprintf(format, e.Target, strings.Join(e.Flags, " | "), e.Retval)
+		}
 
-			return ""
-		},
+		return ""
 	})
 
 	cols.MustSetExtractor("flags", func(event *Event) string {

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -71,25 +71,24 @@ func (e *Event) SetEndpointsDetails(endpoints []eventtypes.EndpointDetails) {
 func GetColumns() *columns.Columns[Event] {
 	cols := columns.MustCreateColumns[Event]()
 
-	cols.MustAddColumn(columns.Column[Event]{
+	cols.MustAddColumn(columns.Attributes{
 		Name:         "remote",
 		Width:        32,
 		MinWidth:     21,
 		Visible:      true,
 		Order:        1000,
 		EllipsisType: ellipsis.Start,
-		Extractor: func(e *Event) string {
-			switch e.RemoteKind {
-			case eventtypes.RemoteKindPod:
-				return fmt.Sprintf("pod %s/%s", e.RemoteNamespace, e.RemoteName)
-			case eventtypes.RemoteKindService:
-				return fmt.Sprintf("svc %s/%s", e.RemoteNamespace, e.RemoteName)
-			case eventtypes.RemoteKindOther:
-				return fmt.Sprintf("endpoint %s", e.RemoteAddr)
-			default:
-				return e.RemoteAddr
-			}
-		},
+	}, func(e *Event) string {
+		switch e.RemoteKind {
+		case eventtypes.RemoteKindPod:
+			return fmt.Sprintf("pod %s/%s", e.RemoteNamespace, e.RemoteName)
+		case eventtypes.RemoteKindService:
+			return fmt.Sprintf("svc %s/%s", e.RemoteNamespace, e.RemoteName)
+		case eventtypes.RemoteKindOther:
+			return fmt.Sprintf("endpoint %s", e.RemoteAddr)
+		default:
+			return e.RemoteAddr
+		}
 	})
 
 	// Hide container column for kubernetes environment

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -33,7 +33,7 @@ type Event struct {
 	Daddr     string        `json:"daddr,omitempty" column:"daddr,template:ipaddr"`
 	Sport     uint16        `json:"sport,omitempty" column:"sport,template:ipport"`
 	Dport     uint16        `json:"dport,omitempty" column:"dport,template:ipport"`
-	Latency   time.Duration `json:"latency,omitempty" column:"latency,minWidth:8"`
+	Latency   time.Duration `json:"latency,omitempty" column:"latency,minWidth:8,align:right" columnTags:"param:latency"`
 }
 
 func GetColumns() *columns.Columns[Event] {

--- a/pkg/gadgets/trace/tcpdrop/types/types.go
+++ b/pkg/gadgets/trace/tcpdrop/types/types.go
@@ -77,42 +77,40 @@ func GetColumns() *columns.Columns[Event] {
 	cols := columns.MustCreateColumns[Event]()
 
 	// Virtual column for the source and destination endpoints
-	err := cols.AddColumn(columns.Column[Event]{
-		Name: "src",
-		Extractor: func(e *Event) string {
-			switch e.SrcKind {
-			case eventtypes.RemoteKindPod:
-				return "p/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
-			case eventtypes.RemoteKindService:
-				return "s/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
-			case eventtypes.RemoteKindOther:
-				return "o/" + e.Saddr + ":" + fmt.Sprint(e.Sport)
-			}
-			return e.Saddr + ":" + fmt.Sprint(e.Sport)
-		},
+	err := cols.AddColumn(columns.Attributes{
+		Name:    "src",
 		Visible: true,
 		Width:   30,
 		Order:   2000,
+	}, func(e *Event) string {
+		switch e.SrcKind {
+		case eventtypes.RemoteKindPod:
+			return "p/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
+		case eventtypes.RemoteKindService:
+			return "s/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
+		case eventtypes.RemoteKindOther:
+			return "o/" + e.Saddr + ":" + fmt.Sprint(e.Sport)
+		}
+		return e.Saddr + ":" + fmt.Sprint(e.Sport)
 	})
 	if err != nil {
 		panic(err)
 	}
-	err = cols.AddColumn(columns.Column[Event]{
-		Name: "dst",
-		Extractor: func(e *Event) string {
-			switch e.DstKind {
-			case eventtypes.RemoteKindPod:
-				return "p/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
-			case eventtypes.RemoteKindService:
-				return "s/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
-			case eventtypes.RemoteKindOther:
-				return "o/" + e.Daddr + ":" + fmt.Sprint(e.Dport)
-			}
-			return e.Daddr + ":" + fmt.Sprint(e.Dport)
-		},
+	err = cols.AddColumn(columns.Attributes{
+		Name:    "dst",
 		Visible: true,
 		Width:   30,
 		Order:   3000,
+	}, func(e *Event) string {
+		switch e.DstKind {
+		case eventtypes.RemoteKindPod:
+			return "p/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
+		case eventtypes.RemoteKindService:
+			return "s/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
+		case eventtypes.RemoteKindOther:
+			return "o/" + e.Daddr + ":" + fmt.Sprint(e.Dport)
+		}
+		return e.Daddr + ":" + fmt.Sprint(e.Dport)
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/gadgets/trace/tcpretrans/types/types.go
+++ b/pkg/gadgets/trace/tcpretrans/types/types.go
@@ -76,42 +76,40 @@ func GetColumns() *columns.Columns[Event] {
 	cols := columns.MustCreateColumns[Event]()
 
 	// Virtual column for the source and destination endpoints
-	err := cols.AddColumn(columns.Column[Event]{
-		Name: "src",
-		Extractor: func(e *Event) string {
-			switch e.SrcKind {
-			case eventtypes.RemoteKindPod:
-				return "p/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
-			case eventtypes.RemoteKindService:
-				return "s/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
-			case eventtypes.RemoteKindOther:
-				return "o/" + e.Saddr + ":" + fmt.Sprint(e.Sport)
-			}
-			return e.Saddr + ":" + fmt.Sprint(e.Sport)
-		},
+	err := cols.AddColumn(columns.Attributes{
+		Name:    "src",
 		Visible: true,
 		Width:   30,
 		Order:   2000,
+	}, func(e *Event) string {
+		switch e.SrcKind {
+		case eventtypes.RemoteKindPod:
+			return "p/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
+		case eventtypes.RemoteKindService:
+			return "s/" + e.SrcNamespace + "/" + e.SrcName + ":" + fmt.Sprint(e.Sport)
+		case eventtypes.RemoteKindOther:
+			return "o/" + e.Saddr + ":" + fmt.Sprint(e.Sport)
+		}
+		return e.Saddr + ":" + fmt.Sprint(e.Sport)
 	})
 	if err != nil {
 		panic(err)
 	}
-	err = cols.AddColumn(columns.Column[Event]{
-		Name: "dst",
-		Extractor: func(e *Event) string {
-			switch e.DstKind {
-			case eventtypes.RemoteKindPod:
-				return "p/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
-			case eventtypes.RemoteKindService:
-				return "s/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
-			case eventtypes.RemoteKindOther:
-				return "o/" + e.Daddr + ":" + fmt.Sprint(e.Dport)
-			}
-			return e.Daddr + ":" + fmt.Sprint(e.Dport)
-		},
+	err = cols.AddColumn(columns.Attributes{
+		Name:    "dst",
 		Visible: true,
 		Width:   30,
 		Order:   3000,
+	}, func(e *Event) string {
+		switch e.DstKind {
+		case eventtypes.RemoteKindPod:
+			return "p/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
+		case eventtypes.RemoteKindService:
+			return "s/" + e.DstNamespace + "/" + e.DstName + ":" + fmt.Sprint(e.Dport)
+		case eventtypes.RemoteKindOther:
+			return "o/" + e.Daddr + ":" + fmt.Sprint(e.Dport)
+		}
+		return e.Daddr + ":" + fmt.Sprint(e.Dport)
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -42,8 +42,8 @@ type Parser interface {
 	// GetTextColumnsFormatter returns the default formatter for this columns instance
 	GetTextColumnsFormatter(options ...textcolumns.Option) TextColumnsFormatter
 
-	// GetColumnNamesAndDescription returns a map of column names to their respective descriptions
-	GetColumnNamesAndDescription() map[string]string
+	// GetColumnAttributes returns a map of column names to their respective attributes
+	GetColumnAttributes() []columns.Attributes
 
 	// GetDefaultColumns returns a list of columns that are visible by default; optionally, hiddenTags will
 	// hide columns that contain any of the given tags
@@ -301,10 +301,10 @@ func (p *parser[T]) GetTextColumnsFormatter(options ...textcolumns.Option) TextC
 	}
 }
 
-func (p *parser[T]) GetColumnNamesAndDescription() map[string]string {
-	out := make(map[string]string)
+func (p *parser[T]) GetColumnAttributes() []columns.Attributes {
+	out := make([]columns.Attributes, 0)
 	for _, column := range p.columns.GetOrderedColumns(p.columnFilters...) {
-		out[column.Name] = column.Description
+		out = append(out, column.Attributes)
 	}
 	return out
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -45,8 +45,9 @@ type Parser interface {
 	// GetColumnNamesAndDescription returns a map of column names to their respective descriptions
 	GetColumnNamesAndDescription() map[string]string
 
-	// GetDefaultColumns returns a list of columns that are visible by default
-	GetDefaultColumns() []string
+	// GetDefaultColumns returns a list of columns that are visible by default; optionally, hiddenTags will
+	// hide columns that contain any of the given tags
+	GetDefaultColumns(hiddenTags ...string) []string
 
 	// GetColumns returns the underlying columns definition (mainly used for serialization)
 	GetColumns() any
@@ -312,11 +313,17 @@ func (p *parser[T]) GetColumns() any {
 	return p.columns.GetColumnMap(p.columnFilters...)
 }
 
-func (p *parser[T]) GetDefaultColumns() []string {
+func (p *parser[T]) GetDefaultColumns(hiddenTags ...string) []string {
 	cols := make([]string, 0)
+columnLoop:
 	for _, column := range p.columns.GetOrderedColumns(p.columnFilters...) {
 		if !column.Visible {
 			continue
+		}
+		for _, tag := range hiddenTags {
+			if column.HasTag(tag) {
+				continue columnLoop
+			}
 		}
 		cols = append(cols, column.Name)
 	}


### PR DESCRIPTION
Right now, the `snapshot/process` gadget has the parameter `--threads`, which, if enabled, would allow displaying a new column showing `TID`. This column however doesn't get shown automatically right now, if said parameter is `true`. Instead, the user would have to specify the column explicitly by using `-o columns=...,tid`.

This PR allows adding `columnTags` in the form of `param:threads` to columns. These tags then will be compared to boolean parameters available for a gadget (like said `--threads`) - and if those parameters are falsy, columns with corresponding tags will be hidden.

To improve UX, required parameters will now also be shown in the `--help` for the columns:

```
  -o, --output string          Output format (jsonpretty, yaml, tree, json, columns).

                               Columns (columns)
                                 The output of the gadget is formatted in human readable columns.
                                 You can optionally specify the columns to output using '-o columns=col1,col2,col3' etc.
                                   Available columns:
                                     ...
                                     ppid
                                     tid (enabled when using --threads)
                                     ...
```

To be able to access the tag information in a generic way (NOT using generics), I've moved out all column attributes to a separate non-generic struct that can easily be passed around.

Solves #1578