### PR TITLE
localmanager: Reintroduce custom socket paths for container runtimes

### DIFF
--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -37,6 +37,9 @@ const (
 	OperatorInstanceName = "LocalManagerTrace"
 	Runtimes             = "runtimes"
 	ContainerName        = "containername"
+	DockerSocketPath     = "docker-socketpath"
+	ContainerdSocketPath = "containerd-socketpath"
+	CrioSocketPath       = "crio-socketpath"
 )
 
 type MountNsMapSetter interface {
@@ -74,6 +77,21 @@ func (l *LocalManager) GlobalParamDescs() params.ParamDescs {
 			Description: fmt.Sprintf("Container runtimes to be used separated by comma. Supported values are: %s",
 				strings.Join(containerutils.AvailableRuntimes, ", ")),
 			// PossibleValues: containerutils.AvailableRuntimes, // TODO
+		},
+		{
+			Key:          DockerSocketPath,
+			DefaultValue: runtimeclient.DockerDefaultSocketPath,
+			Description:  "Docker Engine API Unix socket path",
+		},
+		{
+			Key:          ContainerdSocketPath,
+			DefaultValue: runtimeclient.ContainerdDefaultSocketPath,
+			Description:  "Containerd CRI Unix socket path",
+		},
+		{
+			Key:          CrioSocketPath,
+			DefaultValue: runtimeclient.CrioDefaultSocketPath,
+			Description:  "CRI-O CRI Unix socket path",
 		},
 	}
 }
@@ -130,11 +148,11 @@ partsLoop:
 
 		switch runtimeName {
 		case runtimeclient.DockerName:
-			// socketPath = commonFlags.RuntimesSocketPathConfig.Docker
+			socketPath = operatorParams.Get(DockerSocketPath).AsString()
 		case runtimeclient.ContainerdName:
-			// socketPath = commonFlags.RuntimesSocketPathConfig.Containerd
+			socketPath = operatorParams.Get(ContainerdSocketPath).AsString()
 		case runtimeclient.CrioName:
-			// socketPath = commonFlags.RuntimesSocketPathConfig.Crio
+			socketPath = operatorParams.Get(CrioSocketPath).AsString()
 		default:
 			return commonutils.WrapInErrInvalidArg("--runtime / -r",
 				fmt.Errorf("runtime %q is not supported", p))


### PR DESCRIPTION
This PR reintroduces the flags related to custom socket paths for container runtimes:

## Before the PR

```
→ ig -h
Collection of gadgets for containers
...
...
Flags:
  -h, --help              help for ig
  -r, --runtimes string   Container runtimes to be used separated by comma. Supported values are: docker, containerd, cri-o (default "docker,containerd,cri-o")
...
```

## After the PR
```
→ ./ig -h
Collection of gadgets for containers
...
...
Flags:
      --containerd-socketpath string   Containerd CRI Unix socket path (default "/run/containerd/containerd.sock")
      --crio-socketpath string         CRI-O CRI Unix socket path (default "/var/run/crio/crio.sock")
      --docker-socketpath string       Docker Engine API Unix socket path (default "/var/run/docker.sock")
  -h, --help                           help for ig
  -r, --runtimes string                Container runtimes to be used separated by comma. Supported values are: docker, containerd, cri-o (default "docker,containerd,cri-o")
...
```

## Testing done

```
→ sudo ./ig snapshot process -r docker
CONTAINER                                                                                                                                                                COMM             PID                  UID        GID       
loving_chatelet                                                                                                                                                          sleep            125182               0          0         
quizzical_galois 

→ sudo ./ig snapshot process -r docker --docker-socketpath /run/docker.sock
CONTAINER                                                                                                                                                                COMM             PID                  UID        GID       
loving_chatelet                                                                                                                                                          sleep            125182               0          0         
quizzical_galois 
```
