### PR TITLE
Dockerfiles: Remove clang and llvm libraries.

### DIFF
--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \
 	apt-get install -y --no-install-recommends \
-		ca-certificates jq wget xz-utils binutils socat libclang-11-dev libelf-dev llvm-11-dev && \
+		ca-certificates jq wget xz-utils binutils socat && \
 	rmdir /usr/src && ln -sf /host/usr/src /usr/src && \
 	rm -f /etc/localtime && ln -sf /host/etc/localtime /etc/localtime
 
@@ -73,11 +73,6 @@ COPY gadget-container/hooks/nri/conf.json /opt/hooks/nri/
 # BTF files
 COPY hack/btfs /btfs/
 
-# bpftrace binary
-# TODO: this work because both bcc and bpftrace are based on the same ubuntu version:
-# https://github.com/kinvolk/bcc/blob/72b4247d7333df499a727987fde4e7903fc344d0/.github/workflows/publish.yml#L28
-# https://github.com/iovisor/bpftrace/blob/cd8c1b188df149277c09ebfb208de623a1aeaebb/docker/Dockerfile.focal#L1
-# We should consider building bpftrace ourselves to avoid this issue.
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
 
 # Mitigate https://github.com/kubernetes/kubernetes/issues/106962.


### PR DESCRIPTION
Hi.


In this PR, I removed `clang` and `llvm` libraries as I was able to statically compile `bpftrace` in iovisor/bpftrace#2568:

```bash
$ docker run --privileged --rm -ti ghcr.io/inspektor-gadget/inspektor-gadget:francis-bpftrace-no-libs
root@cd024768dacb:/# file $(which bpftrace)
/usr/bin/bpftrace: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=b5e57afdedd869836ec214e9021c273640916c6d, for GNU/Linux 3.2.0, with debug_info, not stripped
root@cd024768dacb:/# ldd $(which bpftrace)
        linux-vdso.so.1 (0x00007ffe81599000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f67669fc000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f67669f6000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f67668a7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f67666b5000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6769746000)
root@cd024768dacb:/# bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }' | head
stdin:1:1-20: WARNING: do_nanosleep is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }
~~~~~~~~~~~~~~~~~~~
Attaching 1 probe...
PID 2024 sleeping...
PID 2024 sleeping...
PID 36464 sleeping...
PID 2024 sleeping...
PID 36464 sleeping...
PID 36413 sleeping...
PID 2024 sleeping...
PID 36464 sleeping...
PID 2024 sleeping...
```


Best regards.