### PR TITLE
pkg/container-collection: replace container iteration with lookup maps for hot paths

### DIFF
--- a/pkg/container-collection/operator.go
+++ b/pkg/container-collection/operator.go
@@ -21,7 +21,11 @@ import (
 func (cc *ContainerCollection) EnrichEventByMntNs(event operators.ContainerInfoFromMountNSID) {
 	event.SetNode(cc.nodeName)
 
-	container := cc.LookupContainerByMntns(event.GetMountNSID())
+	mountNsId := event.GetMountNSID()
+	container := cc.LookupContainerByMntns(mountNsId)
+	if container == nil && cc.cachedContainers != nil {
+		container = lookupContainerByMntns(cc.cachedContainers, mountNsId)
+	}
 	if container != nil {
 		event.SetContainerInfo(container.Podname, container.Namespace, container.Name)
 	}
@@ -30,7 +34,11 @@ func (cc *ContainerCollection) EnrichEventByMntNs(event operators.ContainerInfoF
 func (cc *ContainerCollection) EnrichEventByNetNs(event operators.ContainerInfoFromNetNSID) {
 	event.SetNode(cc.nodeName)
 
-	containers := cc.LookupContainersByNetns(event.GetNetNSID())
+	netNsId := event.GetNetNSID()
+	containers := cc.LookupContainersByNetns(netNsId)
+	if len(containers) == 0 {
+		containers = lookupContainersByNetns(cc.cachedContainers, netNsId)
+	}
 	if len(containers) == 0 || containers[0].HostNetwork {
 		return
 	}


### PR DESCRIPTION
When enriching container information on events using the container-collection (which is a hot path in our code), we usually look up containers by either mntnsid or netnsid. Previously, we returned matching containers after iterating over the main container map. With this patch, we instead use dedicated lookup maps for both mntns and netns to increase performance. Additionally, previously, when looking up containers using netnsid, a temporary array got created - this allocation has also been moved to the map maintenance and only is done when adding or removing containers instead of on each lookup operation.

Benchmarks:

```
$ benchstat main.bench update.bench
goos: linux
goarch: arm64
pkg: github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection
                         │   main.bench    │            update.bench             │
                         │     sec/op      │   sec/op     vs base                │
LookupContainerByMntns-4    52008.00n ± 1%   42.48n ± 0%  -99.92% (p=0.000 n=10)
LookupContainerByNetns-4   104945.00n ± 1%   41.47n ± 1%  -99.96% (p=0.000 n=10)
geomean                        73.88µ        41.98n       -99.94%
```