### PR TITLE
pkg/types: Create ip version column template

### DIFF
--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -31,11 +31,11 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 				Namespace: ns,
 				Pod:       "test-pod",
 			},
-			Comm:   "curl",
-			Family: syscall.AF_INET,
-			Dport:  80,
-			Saddr:  "127.0.0.1",
-			Daddr:  "127.0.0.1",
+			Comm:      "curl",
+			IPVersion: syscall.AF_INET,
+			Dport:     80,
+			Saddr:     "127.0.0.1",
+			Daddr:     "127.0.0.1",
 		}
 
 		normalize := func(e *types.Stats) {

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -38,7 +38,7 @@ func TestTopTcp(t *testing.T) {
 				CommonData: BuildCommonData(ns),
 				Comm:       "curl",
 				Dport:      80,
-				Family:     syscall.AF_INET,
+				IPVersion:  syscall.AF_INET,
 				Saddr:      "127.0.0.1",
 				Daddr:      "127.0.0.1",
 			}

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -174,7 +174,7 @@ func (t *Tracer) nextStats() ([]*types.Stats, error) {
 			Comm:          gadgets.FromCString(key.Name[:]),
 			Sport:         key.Lport,
 			Dport:         key.Dport,
-			Family:        key.Family,
+			IPVersion:     key.Family,
 			Sent:          val.Sent,
 			Received:      val.Received,
 		}

--- a/pkg/gadgets/top/tcp/types/types.go
+++ b/pkg/gadgets/top/tcp/types/types.go
@@ -49,7 +49,7 @@ type Stats struct {
 
 	Pid       int32  `json:"pid,omitempty" column:"pid,template:pid"`
 	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
-	IPVersion uint16 `json:"ipversion,omitempty" column:"ip,maxWidth:2"`
+	IPVersion uint16 `json:"ipversion,omitempty" column:"ip,template:ipversion"`
 	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr,hide"`
 	Daddr     string `json:"daddr,omitempty" column:"daddr,template:ipaddr,hide"`
 	Sport     uint16 `json:"sport,omitempty" column:"sport,template:ipport,hide"`

--- a/pkg/gadgets/top/tcp/types/types.go
+++ b/pkg/gadgets/top/tcp/types/types.go
@@ -47,22 +47,22 @@ type Stats struct {
 	eventtypes.CommonData
 	eventtypes.WithMountNsID
 
-	Pid      int32  `json:"pid,omitempty" column:"pid,template:pid"`
-	Comm     string `json:"comm,omitempty" column:"comm,template:comm"`
-	Family   uint16 `json:"family,omitempty" column:"ip,maxWidth:2"`
-	Saddr    string `json:"saddr,omitempty" column:"saddr,template:ipaddr,hide"`
-	Daddr    string `json:"daddr,omitempty" column:"daddr,template:ipaddr,hide"`
-	Sport    uint16 `json:"sport,omitempty" column:"sport,template:ipport,hide"`
-	Dport    uint16 `json:"dport,omitempty" column:"dport,template:ipport,hide"`
-	Sent     uint64 `json:"sent,omitempty" column:"sent,order:1002"`
-	Received uint64 `json:"received,omitempty" column:"recv,order:1003"`
+	Pid       int32  `json:"pid,omitempty" column:"pid,template:pid"`
+	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
+	IPVersion uint16 `json:"ipversion,omitempty" column:"ip,maxWidth:2"`
+	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr,hide"`
+	Daddr     string `json:"daddr,omitempty" column:"daddr,template:ipaddr,hide"`
+	Sport     uint16 `json:"sport,omitempty" column:"sport,template:ipport,hide"`
+	Dport     uint16 `json:"dport,omitempty" column:"dport,template:ipport,hide"`
+	Sent      uint64 `json:"sent,omitempty" column:"sent,order:1002"`
+	Received  uint64 `json:"received,omitempty" column:"recv,order:1003"`
 }
 
 func GetColumns() *columns.Columns[Stats] {
 	cols := columns.MustCreateColumns[Stats]()
 
 	cols.MustSetExtractor("ip", func(stats *Stats) (ret string) {
-		if stats.Family == syscall.AF_INET {
+		if stats.IPVersion == syscall.AF_INET {
 			return "4"
 		}
 		return "6"

--- a/pkg/gadgets/trace/tcp/types/types.go
+++ b/pkg/gadgets/trace/tcp/types/types.go
@@ -26,7 +26,7 @@ type Event struct {
 	Operation string `json:"operation,omitempty" column:"t,width:1,fixed"`
 	Pid       uint32 `json:"pid,omitempty" column:"pid,template:pid"`
 	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
-	IPVersion int    `json:"ipversion,omitempty" column:"ip,width:2,fixed"`
+	IPVersion int    `json:"ipversion,omitempty" column:"ip,template:ipversion"`
 	Saddr     string `json:"saddr,omitempty" column:"saddr,template:ipaddr"`
 	Daddr     string `json:"daddr,omitempty" column:"daddr,template:ipaddr"`
 	Sport     uint16 `json:"sport,omitempty" column:"sport,template:ipport"`

--- a/pkg/gadgets/trace/tcpconnect/types/types.go
+++ b/pkg/gadgets/trace/tcpconnect/types/types.go
@@ -28,7 +28,7 @@ type Event struct {
 	Pid       uint32        `json:"pid,omitempty" column:"pid,template:pid"`
 	Uid       uint32        `json:"uid,omitempty" column:"uid,minWidth:6,hide"`
 	Comm      string        `json:"comm,omitempty" column:"comm,template:comm"`
-	IPVersion int           `json:"ipversion,omitempty" column:"ip,width:2,fixed"`
+	IPVersion int           `json:"ipversion,omitempty" column:"ip,template:ipversion"`
 	Saddr     string        `json:"saddr,omitempty" column:"saddr,template:ipaddr"`
 	Daddr     string        `json:"daddr,omitempty" column:"daddr,template:ipaddr"`
 	Sport     uint16        `json:"sport,omitempty" column:"sport,template:ipport"`

--- a/pkg/gadgets/trace/tcpdrop/types/types.go
+++ b/pkg/gadgets/trace/tcpdrop/types/types.go
@@ -29,7 +29,7 @@ type Event struct {
 	Pid  uint32 `json:"pid,omitempty" column:"pid,template:pid,order:1000"`
 	Comm string `json:"comm,omitempty" column:"comm,template:comm,order:1001"`
 
-	IPVersion int `json:"ipversion,omitempty" column:"ip,width:2,fixed,order:1005"`
+	IPVersion int `json:"ipversion,omitempty" column:"ip,template:ipversion,order:1005"`
 
 	Saddr string `json:"saddr,omitempty" column:"saddr,template:ipaddr,hide,order:2001"`
 	Sport uint16 `json:"sport,omitempty" column:"sport,template:ipport,hide,order:2002"`

--- a/pkg/gadgets/trace/tcpretrans/types/types.go
+++ b/pkg/gadgets/trace/tcpretrans/types/types.go
@@ -29,7 +29,7 @@ type Event struct {
 	Pid  uint32 `json:"pid,omitempty" column:"pid,template:pid,order:1000"`
 	Comm string `json:"comm,omitempty" column:"comm,template:comm,order:1001"`
 
-	IPVersion int `json:"ipversion,omitempty" column:"ip,width:2,fixed,order:1005"`
+	IPVersion int `json:"ipversion,omitempty" column:"ip,template:ipversion,order:1005"`
 
 	Saddr string `json:"saddr,omitempty" column:"saddr,template:ipaddr,hide,order:2001"`
 	Sport uint16 `json:"sport,omitempty" column:"sport,template:ipport,hide,order:2002"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -44,6 +44,7 @@ func init() {
 	// Max: 0000:0000:0000:0000:0000:ffff:XXX.XXX.XXX.XXX (IPv4-mapped IPv6 address) = 45
 	columns.MustRegisterTemplate("ipaddr", "minWidth:15,maxWidth:45")
 	columns.MustRegisterTemplate("ipport", "minWidth:type")
+	columns.MustRegisterTemplate("ipversion", "width:2,fixed")
 
 	// For system calls as the longest is sched_rr_get_interval_time64 with 28
 	// characters:


### PR DESCRIPTION
This PR creates a template for the ip version column and applies it to all gadgets with such a column. In particular, notice that the top tcp gadget was using `maxWidth` instead of `width:2,fixed`, thus this PR uniforms it with other gadgets.