### PR TITLE
pkg: Unwrap verifier error.

### DIFF
--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -15,6 +15,7 @@
 package kubemanager
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -244,6 +245,11 @@ func (m *KubeManagerInstance) PreGadgetRun() error {
 			log.Debugf("calling gadget.AttachContainer()")
 			err := attacher.AttachContainer(container)
 			if err != nil {
+				var ve *ebpf.VerifierError
+				if errors.As(err, &ve) {
+					m.gadgetCtx.Logger().Debugf("start tracing container %q: verifier error: %+v\n", container.Name, ve)
+				}
+
 				log.Warnf("start tracing container %q: %s", container.Name, err)
 				return
 			}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -15,6 +15,7 @@
 package localmanager
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -259,6 +260,11 @@ func (l *localManagerTrace) PreGadgetRun() error {
 			log.Debugf("calling gadget.AttachContainer()")
 			err := attacher.AttachContainer(container)
 			if err != nil {
+				var ve *ebpf.VerifierError
+				if errors.As(err, &ve) {
+					l.gadgetCtx.Logger().Debugf("start tracing container %q: verifier error: %+v\n", container.Name, ve)
+				}
+
 				log.Warnf("start tracing container %q: %s", container.Name, err)
 				return
 			}

--- a/pkg/runtime/local/local.go
+++ b/pkg/runtime/local/local.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cilium/ebpf"
+
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
@@ -142,6 +144,10 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext) (runtime.CombinedGa
 		log.Debugf("calling gadget.Run()")
 		err := run.Run(gadgetCtx)
 		if err != nil {
+			var ve *ebpf.VerifierError
+			if errors.As(err, &ve) {
+				gadgetCtx.Logger().Debugf("running gadget: verifier error: %+v\n", ve)
+			}
 			return nil, fmt.Errorf("running gadget: %w", err)
 		}
 		return nil, nil


### PR DESCRIPTION
When gadgets failed to run and returns a verifier error, we unwrap it so get the whole verifier stack.

Suggested-by: Michael Friese <mfriese@microsoft.com>