### PR TITLE
ci: Ignore unfixed CVEs

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -368,7 +368,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           # uncomment to ignore vulnerabilities
-          # ignore-unfixed: true
+          ignore-unfixed: true
           # ignore-policy: .github/trivy/ignore-policy.yaml
 
   publish-gadget-images-manifest:


### PR DESCRIPTION
Ignore unfixed CVEs to avoid the CI failing in those cases.

