### PR TITLE
Don't use hostNetwork=true

### DIFF
--- a/examples/kube-container-collection/deploy.yaml
+++ b/examples/kube-container-collection/deploy.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       serviceAccount: gadget-container-collection
       hostPID: true
-      hostNetwork: true
+      hostNetwork: false
       containers:
       - name: gadget
         terminationMessagePolicy: FallbackToLogsOnError

--- a/examples/runc-hook/deploy.yaml
+++ b/examples/runc-hook/deploy.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       serviceAccount: runc-hook
       hostPID: true
-      hostNetwork: true
+      hostNetwork: false
       containers:
       - name: gadget
         terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -105,7 +105,7 @@ spec:
     spec:
       serviceAccount: gadget
       hostPID: true
-      hostNetwork: true
+      hostNetwork: false
       nodeSelector:
         kubernetes.io/os: "linux"
       containers:


### PR DESCRIPTION
hostNetwork=true was initially necessary for the traceloop gadget. But since it was refactored, it is not necessary anymore.

This patch changes the gadget DaemonSet to use hostNetwork=false.

Since the gadget pod is no longer running in the host network namespace, changes the code to get the inode of the host network namespace with `$HOST_ROOT/proc/1/ns/net`.

We cannot use `$HOST_ROOT/proc/$(os.Getpid)/ns/net` anymore because:
- gadgettracermanager might not be in the host network namespace
- os.Getpid() will not return a valid pid in the host pid namespace.

Reading `$HOST_ROOT/proc/1/ns/net` requires `CAP_SYS_PTRACE` if pid 1 runs as a different uid than Inspektor Gadget. We should avoid that from an init() function because it makes 'make generate-documentation' fail.

Part of https://github.com/inspektor-gadget/inspektor-gadget/issues/1658