### PR TITLE
dependencies: Remove replace for protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,12 +141,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-// avoid reports on CVE-2021-3121
-replace (
-	github.com/gogo/protobuf v1.1.1 => github.com/gogo/protobuf v1.3.2
-	github.com/gogo/protobuf v1.2.1 => github.com/gogo/protobuf v1.3.2
-	github.com/gogo/protobuf v1.3.0 => github.com/gogo/protobuf v1.3.2
-	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
-)
-
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.13.1-0.20230315234915-a26de2d610c3


### PR DESCRIPTION
It's not needed anymore. Trivy doesn't report CVE-2021-3121 anymore:

```
$ ./trivy image  --format table --exit-code  1 --vuln-type  os,library --severity  CRITICAL,HIGH mauriciovasquezbernal/gadget:latest --ignore-unfixed 2023-05-18T10:18:30.907-0500	INFO	Vulnerability scanning is enabled 2023-05-18T10:18:30.907-0500	INFO	Secret scanning is enabled 2023-05-18T10:18:30.907-0500	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning 2023-05-18T10:18:30.907-0500	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection 2023-05-18T10:18:30.923-0500	INFO	Detected OS: ubuntu 2023-05-18T10:18:30.923-0500	INFO	Detecting Ubuntu vulnerabilities... 2023-05-18T10:18:30.929-0500	INFO	Number of language-specific files: 4 2023-05-18T10:18:30.929-0500	INFO	Detecting gobinary vulnerabilities... 2023-05-18T10:18:30.932-0500	INFO	Detecting python-pkg vulnerabilities...

mauriciovasquezbernal/gadget:latest (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
