### PR TITLE
gha: Remove uneeded steps for CVE scanning

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -347,14 +347,6 @@ jobs:
         os: [ linux ]
         platform: [ amd64 ]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set container repository and determine image tag
-        id: set-repo-determine-image-tag
-        uses: ./.github/actions/set-container-repo-and-determine-image-tag
-        with:
-          registry: ${{ env.REGISTRY }}
-          container-image: ${{ env.CONTAINER_REPO }}
-          co-re: ${{ matrix.type == 'core' }}
       - name: Download gadget ${{ matrix.type }} ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The scanning only uses the container image, it doesn't need the code nor the image tag.

Suggested-by: Qasim Sarfraz <qasimsarfraz@microsoft.com>

ref https://github.com/inspektor-gadget/inspektor-gadget/pull/1641#discussion_r1198715827

/cc @mqasimsarfraz 