### PR TITLE
Registry/Columns: Read from file + new `bytes` type

### DIFF
--- a/cmd/common/params.go
+++ b/cmd/common/params.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const FilePrefix = "@"
+
+// Param is a wrapper around params.Param. It's used to implement the logic that reads parameters from files.
+type Param struct {
+	*params.Param
+}
+
+func (p *Param) Set(val string) error {
+	if strings.HasPrefix(val, FilePrefix) {
+		filepath := strings.TrimPrefix(val, FilePrefix)
+		data, err := os.ReadFile(filepath)
+		if err != nil {
+			return fmt.Errorf("reading file %q for parameter %q: %w", filepath, p.Key, err)
+		}
+		return p.Param.Set(string(data))
+	}
+	return p.Param.Set(val)
+}

--- a/cmd/common/params_test.go
+++ b/cmd/common/params_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+func TestHandleFileArguments(t *testing.T) {
+	t.Parallel()
+
+	pd := &params.ParamDesc{
+		Key:      "test",
+		TypeHint: "string",
+	}
+	p := Param{
+		Param: pd.ToParam(),
+	}
+
+	const fileContent = "This is a magic String. 123$$##@!"
+	const filename = "./file_param_testfile"
+	require.Nil(t, os.WriteFile(filename, []byte(fileContent), 0o600))
+	defer os.Remove(filename)
+
+	err := p.Set(FilePrefix + filename)
+	require.Nil(t, err, "Error while handling file argument")
+	require.Equal(t, p.AsString(), fileContent)
+}

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -589,7 +589,7 @@ func addFlags(cmd *cobra.Command, params *params.Params, skipParams []params.Val
 			desc += " [" + strings.Join(p.PossibleValues, ", ") + "]"
 		}
 
-		flag := cmd.PersistentFlags().VarPF(p, p.Key, p.Alias, desc)
+		flag := cmd.PersistentFlags().VarPF(&Param{p}, p.Key, p.Alias, desc)
 		if p.IsMandatory {
 			cmd.MarkPersistentFlagRequired(p.Key)
 		}

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -363,6 +363,10 @@ func (p *Param) AsString() string {
 	return p.value
 }
 
+func (p *Param) AsBytes() []byte {
+	return []byte(p.value)
+}
+
 func (p *Param) AsStringSlice() []string {
 	if p.value == "" {
 		return []string{}

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -380,3 +380,28 @@ func TestParamDefaultValue(t *testing.T) {
 	param.Set("bar")
 	require.Equal(t, "bar", param.String())
 }
+
+func TestBytesHandling(t *testing.T) {
+	// Test if a param of type Bytes gets compressed and decompressed correctly
+	const testString = "test123"
+	const testStringCompressed = "eJwqSS0uMTQyBgQAAP//CsoCVw=="
+	params := Params{
+		&Param{
+			ParamDesc: &ParamDesc{
+				Key:      "bytes",
+				TypeHint: TypeBytes,
+			},
+		},
+	}
+
+	// Compress
+	params[0].Set(testString)
+	testMap := map[string]string{}
+	params.CopyToMap(testMap, "")
+	require.Equal(t, testStringCompressed, testMap["bytes"], "compression + B64 encoding failed")
+
+	// Decompress
+	params[0].Set("")
+	params.CopyFromMap(testMap, "")
+	require.Equal(t, testString, string(params[0].AsBytes()), "decompression + B64 decoding failed")
+}

--- a/pkg/params/validators.go
+++ b/pkg/params/validators.go
@@ -26,6 +26,7 @@ type TypeHint string
 const (
 	TypeBool     TypeHint = "bool"
 	TypeString   TypeHint = "string"
+	TypeBytes    TypeHint = "bytes"
 	TypeInt      TypeHint = "int"
 	TypeInt8     TypeHint = "int8"
 	TypeInt16    TypeHint = "int16"


### PR DESCRIPTION
Sometimes a parameter can become long or one wants to set the whole content of a file as the parameter. For this use case one can now specify the filepath if a `@` is used as a prefix 

Example: `echo docker > test.txt && sudo ./ig -r @./test.txt snapshot process`


Furthermore the `bytes` type was introduced. For best transportation it is compressed and then b64 encoded (because of CR)