### PR TITLE
integration: Add tests for prometheus gadget

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -203,6 +203,17 @@ func GetTestPodIP(ns string, podname string) (string, error) {
 	return string(r), nil
 }
 
+func GetPodIPsFromLabel(ns string, label string) ([]string, error) {
+	cmd := exec.Command("kubectl", "-n", ns, "get", "pod", "-l", label, "-o", "jsonpath={.items[*].status.podIP}")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	r, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return strings.Split(string(r), " "), nil
+}
+
 func GetPodNode(ns string, podname string) (string, error) {
 	cmd := exec.Command("kubectl", "-n", ns, "get", "pod", podname, "-o", "jsonpath={.spec.nodeName}")
 	var stderr bytes.Buffer

--- a/integration/inspektor-gadget/prometheus_test.go
+++ b/integration/inspektor-gadget/prometheus_test.go
@@ -1,0 +1,158 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestPrometheus(t *testing.T) {
+	ns := GenerateTestNamespaceName("test-prometheus")
+
+	// prepare prometheus scrape targets
+	gadgetPodIps, err := GetPodIPsFromLabel("gadget", "k8s-app=gadget")
+	if err != nil {
+		t.Fatalf("failed to get gadget pod ip: %v", err)
+	}
+	targets := make([]string, 0, len(gadgetPodIps))
+	for _, ip := range gadgetPodIps {
+		targets = append(targets, fmt.Sprintf("%s:2223", ip))
+	}
+	scrapeTargets, err := json.Marshal(targets)
+	if err != nil {
+		t.Fatalf("failed to marshal scrape targets: %v", err)
+	}
+
+	// set up prometheus pod
+	prometheusCmd := &Command{
+		Name: "RunPrometheus",
+		Cmd: fmt.Sprintf(`
+				kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: %s
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 3s
+      evaluation_interval: 3s
+
+    scrape_configs:
+     - job_name: "gadget"
+
+       static_configs:
+         - targets: %s
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prometheus
+  namespace: %s
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: prometheus
+      image: prom/prometheus:v2.44.0
+      args:
+        - "--config.file=/etc/prometheus/prometheus.yml"
+      ports:
+        - containerPort: 9090
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/prometheus
+          readOnly: true
+  volumes:
+    - name: config-volume
+      configMap:
+        name: prometheus-config
+EOF
+`, ns, scrapeTargets, ns),
+	}
+
+	RunTestSteps([]*Command{
+		CreateTestNamespaceCommand(ns),
+		prometheusCmd,
+		WaitUntilPodReadyCommand(ns, "prometheus"),
+	}, t)
+
+	t.Cleanup(func() {
+		cleanupCommands := []*Command{
+			DeleteTestNamespaceCommand(ns),
+		}
+		RunTestSteps(cleanupCommands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("CounterMetrics", func(t *testing.T) {
+		counterMetricsCommand := []*Command{
+			{
+				Name:         "RunPrometheusGadget",
+				Cmd:          "$KUBECTL_GADGET prometheus --config @testdata/prometheus/counter.yaml",
+				StartAndStop: true,
+			},
+			SleepForSecondsCommand(2),
+			BusyboxPodCommand(ns, "for i in $(seq 1 100); do cat /dev/null; done"),
+			SleepForSecondsCommand(10), // wait for prometheus to scrape
+			{
+				Name: "ValidatePrometheusMetrics",
+				Cmd:  fmt.Sprintf("kubectl exec -n %s prometheus -- wget -qO- http://localhost:9090/api/v1/query?query=executed_processes_total", ns),
+				ExpectedOutputFn: func(output string) error {
+					var prometheusResponse struct {
+						Data struct {
+							Result json.RawMessage `json:"result"`
+						} `json:"data"`
+					}
+					err = json.Unmarshal([]byte(output), &prometheusResponse)
+					if err != nil {
+						return fmt.Errorf("marshaling prometheus response: %w", err)
+					}
+
+					type Result struct {
+						Metric map[string]string `json:"metric"`
+						Value  []interface{}     `json:"value"`
+					}
+
+					expectedEntry := &Result{
+						Metric: map[string]string{
+							"__name__":        "executed_processes_total",
+							"container":       "test-pod",
+							"job":             "gadget",
+							"namespace":       ns,
+							"pod":             "test-pod",
+							"instance":        "",
+							"otel_scope_name": "",
+						},
+						Value: []interface{}{nil, "100"},
+					}
+
+					normalize := func(r *Result) {
+						r.Value = []interface{}{nil, r.Value[1]}
+						r.Metric["instance"] = ""
+						r.Metric["otel_scope_name"] = ""
+					}
+
+					return ExpectEntriesInArrayToMatch(string(prometheusResponse.Data.Result), normalize, expectedEntry)
+				},
+			},
+		}
+
+		RunTestSteps(counterMetricsCommand, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+}

--- a/integration/inspektor-gadget/testdata/prometheus/counter.yaml
+++ b/integration/inspektor-gadget/testdata/prometheus/counter.yaml
@@ -1,0 +1,11 @@
+metrics:
+  - name: executed_processes
+    type: counter
+    category: trace
+    gadget: exec
+    labels:
+      - namespace
+      - pod
+      - container
+    selector:
+      - "comm:cat"


### PR DESCRIPTION
This is the initial idea of integration tests for Prometheus gadget. It need polishing to be ready for merge but I wanted to get early feedback on the approach in general. 

## Implementation

-  Start a prometheus server  with scrape_config for gadget pod.
- Start prometheus gadget to start collecting metrics.
- Generate test events.
- Validate metrics against prometheus API. 

## Testing Done

```bash
$ make minikube-deploy
$ INTEGRATION_TESTS_PARAMS="-run TestPrometheus/CounterMetrics -no-deploy-ig -no-deploy-spo" make integration-tests
...
...
--- PASS: TestPrometheus (34.22s)
    --- PASS: TestPrometheus/CounterMetrics (32.37s)
PASS
Cleaning up...
Start command(DeleteRemainingTestNamespace): kubectl delete ns -l scope=ig-integration-tests
Wait for command(DeleteRemainingTestNamespace)
Command returned(DeleteRemainingTestNamespace):

namespace "test-prometheus-2292209043224655007" deleted

ok  	github.com/inspektor-gadget/inspektor-gadget/integration/inspektor-gadget	39.678s
```