### PR TITLE
Don't use hostNetwork=true or hostPID=true

### DIFF
--- a/examples/kube-container-collection/deploy.yaml
+++ b/examples/kube-container-collection/deploy.yaml
@@ -59,7 +59,7 @@ spec:
         k8s-app: gadget-container-collection
     spec:
       serviceAccount: gadget-container-collection
-      hostPID: true
+      hostPID: false
       hostNetwork: false
       containers:
       - name: gadget

--- a/examples/runc-hook/deploy.yaml
+++ b/examples/runc-hook/deploy.yaml
@@ -56,7 +56,7 @@ spec:
         k8s-app: runc-hook
     spec:
       serviceAccount: runc-hook
-      hostPID: true
+      hostPID: false
       hostNetwork: false
       containers:
       - name: gadget

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -30,6 +30,21 @@ KERNEL=$(uname -r)
 echo -n "Kernel detected: "
 echo $KERNEL
 
+echo "/proc/self/cgroup"
+cat /proc/self/cgroup
+
+echo "/host/proc/self/cgroup"
+cat /host/proc/self/cgroup
+
+echo "/host/proc/1/cgroup"
+cat /host/proc/1/cgroup
+
+echo /host/proc/self/ns
+ls -l /host/proc/self/ns
+
+echo /proc/self/ns
+ls -l /proc/self/ns
+
 # The gadget-core image does not provide bcc.
 if [ "$GADGET_IMAGE_FLAVOUR" = "default" ] ; then
 	echo -n "bcc detected: "

--- a/go.mod
+++ b/go.mod
@@ -150,3 +150,5 @@ replace (
 )
 
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.13.1-0.20230315234915-a26de2d610c3
+
+replace github.com/vishvananda/netns => github.com/alban/netns v0.0.5-0.20230524182144-71bb9f1bb18d

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFP
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alban/netns v0.0.5-0.20230524182144-71bb9f1bb18d h1:RGdRDlaEjJE2TcYe54/KeUZN+Rm7JrdAtjRxnhKxFE0=
+github.com/alban/netns v0.0.5-0.20230524182144-71bb9f1bb18d/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -274,9 +276,6 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtse
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
-github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
@@ -352,7 +351,6 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -364,6 +362,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -72,6 +72,9 @@ type Container struct {
 	// events from it.
 	// This is only used when cachedContainers are enabled through WithTracerCollection().
 	mntNsFd int
+
+	// functions to be called when Container is released
+	cleanUpFuncs []func()
 }
 
 type ContainerSelector struct {

--- a/pkg/netnsenter/netnsenter.go
+++ b/pkg/netnsenter/netnsenter.go
@@ -18,6 +18,8 @@ import (
 	"runtime"
 
 	"github.com/vishvananda/netns"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 func NetnsEnter(pid int, f func() error) error {
@@ -33,7 +35,7 @@ func NetnsEnter(pid int, f func() error) error {
 	origns, _ := netns.Get()
 	defer origns.Close()
 
-	netnsHandle, err := netns.GetFromPid(pid)
+	netnsHandle, err := netns.GetFromPidWithAltProcfs(pid, host.HostProcFs)
 	if err != nil {
 		return err
 	}

--- a/pkg/rawsock/rawsock.go
+++ b/pkg/rawsock/rawsock.go
@@ -21,6 +21,8 @@ import (
 	"unsafe"
 
 	"github.com/vishvananda/netns"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 // Both openRawSock and htons are from github.com/cilium/ebpf:
@@ -47,7 +49,7 @@ func OpenRawSock(pid uint32) (int, error) {
 		origns, _ := netns.Get()
 		defer origns.Close()
 
-		netnsHandle, err := netns.GetFromPid(int(pid))
+		netnsHandle, err := netns.GetFromPidWithAltProcfs(int(pid), host.HostProcFs)
 		if err != nil {
 			return -1, err
 		}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -104,7 +104,7 @@ spec:
         inspektor-gadget.kinvolk.io/option-hook-mode: "auto"
     spec:
       serviceAccount: gadget
-      hostPID: true
+      hostPID: false
       hostNetwork: false
       nodeSelector:
         kubernetes.io/os: "linux"

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -229,7 +229,7 @@ func (n *RuncNotifier) watchContainersTermination() {
 				return
 			}
 
-			dirEntries, err := os.ReadDir(hostRoot + "/proc")
+			dirEntries, err := os.ReadDir(host.HostProcFs)
 			if err != nil {
 				log.Errorf("reading /proc: %s", err)
 				return


### PR DESCRIPTION
# Don't use hostNetwork=true or hostPID=true

Deploy Inspektor Gadget as regular containers without using the host network/pid namespaces.

This PRs includes different PRs to make it work. They should be merged first.
- [x] https://github.com/inspektor-gadget/inspektor-gadget/pull/1648
- [x] https://github.com/inspektor-gadget/inspektor-gadget/pull/1659
- [x] https://github.com/inspektor-gadget/inspektor-gadget/pull/1662

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1658

This uses https://github.com/vishvananda/netns/pull/76

## How to use

No changes.

## Testing done

In progress.