### PR TITLE
logs: Print ig warnings only with custom config

### DIFF
--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -70,6 +70,9 @@ type ContainerCollection struct {
 
 	// functions to be called on Close()
 	cleanUpFuncs []func()
+
+	// disableContainerRuntimeWarnings is used to disable warnings about container runtimes.
+	disableContainerRuntimeWarnings bool
 }
 
 // ContainerCollectionOption are options to pass to

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -75,7 +75,7 @@ func NewCRIClient(name, socketPath string, timeout time.Duration) (CRIClient, er
 		cc.client = nil
 		cc.clientV1alpha2 = runtimeV1alpha2.NewRuntimeServiceClient(conn)
 	} else {
-		log.Warnf("Failed to determine CRI API version: %v using v1", err)
+		log.Debugf("Failed to determine CRI API version: %v using v1", err)
 	}
 
 	return cc, nil


### PR DESCRIPTION
We want to disable container runtime warnings in case user is running with default container runtime configuration to improve the user experience. Also, I don't want to disable warnings by default and allow it to be configured via an option e.g we should keep these warnings for `gadgettracermanager` 

Fixes #1537 

## Testing done

### before the PR
```bash
→ sudo ./ig trace open
WARN[0000] Failed to determine CRI API version: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /run/crio/crio.sock: connect: no such file or directory" using v1 
WARN[0000] Runtime enricher (cri-o): couldn't get current containers: listing containers with request &ListContainersRequest{Filter:nil,}: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /run/crio/crio.sock: connect: no such file or directory" 
```
### after the PR

```
# default config
→ sudo ./ig trace open 
CONTAINER                                                                                  PID        COMM             FD        ERR PATH                                                                                          

# custom runtime name
→ sudo ./ig trace open -r cri-o
WARN[0000] Runtime enricher (cri-o): couldn't get current containers: listing containers with request &ListContainersRequest{Filter:nil,}: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /run/crio/crio.sock: connect: no such file or directory" 
CONTAINER                                                                                  PID        COMM             FD        ERR PATH   

# custom socket path
→ sudo ./ig trace open  --crio-socketpath foo.sock
WARN[0000] Runtime enricher (cri-o): couldn't get current containers: listing containers with request &ListContainersRequest{Filter:nil,}: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix foo.sock: connect: no such file or directory" 
CONTAINER                                                                                  PID        COMM             FD        ERR PATH  
```