### PR TITLE
ci: Add missing semgrep file

### DIFF
--- a/.semgrep_rules.yaml
+++ b/.semgrep_rules.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: bad-error-wrap-wording
+    patterns:
+      - pattern-regex: fmt\.Errorf\(".?([Ff]ailed|[]Uu]nable|[Cc]ould|([Ee]rror)|([Cc]an[ ]?not))
+    message: Phrases "fail", "failed", "unable", "could not", "cannot", "can not" should not be used when wrapping errors. Use verb in continuous form instead!
+    languages: [go]
+    severity: ERROR


### PR DESCRIPTION
I forgot to git add the file in previous commit. It's not clear to me why the CI didn't fail, but the semgrep container returns 0 if the config file doesn't exist:

```bash
$ docker run -v $(pwd):/host returntocorp/semgrep sh -c "cd /host && semgrep ci --config /doesnotexist.yaml"

┌────────────────┐
│ Debugging Info │
└────────────────┘

  SCAN ENVIRONMENT
  versions    - semgrep 1.22.0 on python 3.11.3
  environment - running in environment git, triggering event is unknown
[ERROR] WARNING: unable to find a config; path `/doesnotexist.yaml` does not exist (since you are running in docker, you cannot specify arbitrary paths on the host; they must be mounted into the container)
[ERROR] invalid configuration file found (1 configs were invalid)
$ echo $?
0
```
Fixes: f825ff80e29d ("ci: Add semgrep rules")
Ref: https://github.com/inspektor-gadget/inspektor-gadget/pull/1657

### Testing

semgrep only checks files modified by the PR, I introduced an issued and tested that it was caught in https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/5083481635/jobs/9134539831. 

--- 


![](https://i.redd.it/oibivuestzi91.png)


