### PR TITLE
gadget/top: Print first header columns only when frontend is a terminal

### DIFF
--- a/cmd/common/frontends/console/console.go
+++ b/cmd/common/frontends/console/console.go
@@ -67,6 +67,10 @@ func (f *frontend) Clear() {
 	}
 }
 
+func (f *frontend) IsTerminal() bool {
+	return f.isTerminal
+}
+
 func (f *frontend) Output(payload string) {
 	fmt.Fprintln(os.Stdout, payload)
 }

--- a/cmd/common/frontends/frontends.go
+++ b/cmd/common/frontends/frontends.go
@@ -23,6 +23,7 @@ import (
 type Frontend interface {
 	Output(payload string)
 	Logf(severity logger.Level, fmt string, params ...any)
+	IsTerminal() bool
 	Clear()
 	Close()
 	GetContext() context.Context

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -388,8 +388,10 @@ func buildCommandFromGadget(
 					))
 
 					// Print first header while we wait for input
-					fe.Clear()
-					fe.Output(formatter.FormatHeader())
+					if fe.IsTerminal() {
+						fe.Clear()
+						fe.Output(formatter.FormatHeader())
+					}
 					break
 				}
 				fe.Output(formatter.FormatHeader())


### PR DESCRIPTION
When frontend is not a terminal:

### Before this PR
```bash
CONTAINER                      PID              COMM             IP               REMOTE           LOCAL            SENT             RECV
CONTAINER                      PID              COMM             IP               REMOTE           LOCAL            SENT             RECV
konnectivity-agent             6270             proxy-agent      4                52.224.21.37:443 10.224.0.138:438 43.56KiB         2.077KiB
konnectivity-agent             6270             proxy-agent      4                52.224.21.37:443 10.224.0.138:339 3.518KiB         1.624KiB
ama-logs                       1856536          in_cadvisor_pe*  4                10.224.0.113:102 10.224.0.125:394 1.969KiB         37.08KiB
ama-logs                       1856536          in_cadvisor_pe*  4                10.224.0.113:102 10.224.0.125:394 1.969KiB         37.08KiB
ama-logs                       1856536          in_cadvisor_pe*  4                10.224.0.113:102 10.224.0.125:394 1.96KiB          89.58KiB
ama-logs                       1856536          in_containerin*  4                10.224.0.113:102 10.224.0.125:394 1.96KiB          89.58KiB
ama-logs                       1856536          in_cadvisor_pe*  4                10.224.0.113:102 10.224.0.125:394 1.96KiB          89.58KiB
konnectivity-agent             6270             proxy-agent      4                52.224.21.37:443 10.224.0.138:405 957B             368B
konnectivity-agent             6270             proxy-agent      4                52.224.21.37:443 10.224.0.138:340 501B             350B
konnectivity-agent             6270             proxy-agent      4                10.224.0.113:102 10.224.0.138:333 455B             28.59KiB
konnectivity-agent             6270             proxy-agent      4                10.224.0.4:19100 10.224.0.138:497 449B             13.18KiB
```
### After this PR
```bash
CONTAINER                      PID              COMM             IP LOCAL            REMOTE           SENT             RECV
nsenter                        2396             kubelet          6  ::ffff:10.224.0. ::ffff:10.224.1. 15.98KiB         112B
nsenter                        2396             kubelet          6  ::ffff:10.224.0. ::ffff:10.224.0. 15.94KiB         73B
ama-logs                       2240395          flush_thread_3   4  10.224.0.28:5884 20.49.109.85:443 6.316KiB         4.68KiB
nsenter                        2396             kubelet          4  10.224.0.4:39296 52.224.21.37:443 3.032KiB         17.22KiB
metrics-server                 3104494          metrics-server   6  ::ffff:10.224.0. ::ffff:10.224.0. 2.785KiB         592B
metrics-server                 3104494          metrics-server   6  ::ffff:10.224.0. ::ffff:10.224.0. 2.501KiB         569B
metrics-server                 3104494          metrics-server   6  ::ffff:10.224.0. ::ffff:10.224.0. 2.479KiB         568B
metrics-server                 3104494          metrics-server   6  ::ffff:10.224.0. ::ffff:10.224.0. 719B             148B
nsenter                        2396             kubelet          4  10.224.0.4:37572 10.224.0.30:4443 569B             2.478KiB
nsenter                        2396             kubelet          4  10.224.0.4:37568 10.224.0.30:4443 568B             2.456KiB
metrics-server                 3104494          metrics-server   6  ::ffff:10.224.0. ::ffff:10.224.0. 382B             74B
cloud-node-manager             1773298          cloud-node-mana  4  10.224.0.4:48998 52.224.21.37:443 199B             588B
```

There are not changes when frontend is a terminal.