### PR TITLE
Enrich new containers with ContainerImageName

### DIFF
--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,node,namespace,pod,container,hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,node,namespace,pod,container,hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,node,namespace,pod,container,hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,node,namespace,pod,container,hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -155,8 +155,9 @@ func TestWatchCreatedContainers(t *testing.T) {
 					},
 					Runtime: containercollection.RuntimeMetadata{
 						BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-							RuntimeName:   types.String2RuntimeName(*containerRuntime),
-							ContainerName: cn,
+							RuntimeName:        types.String2RuntimeName(*containerRuntime),
+							ContainerName:      cn,
+							ContainerImageName: "docker.io/library/busybox:latest",
 						},
 					},
 				},

--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -143,6 +143,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig list-containers -o json --runtimes=%s --watch", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEvent := &containercollection.PubSubEvent{
 				Type: containercollection.EventTypeAddContainer,
 				Container: &containercollection.Container{
@@ -161,6 +162,11 @@ func TestWatchCreatedContainers(t *testing.T) {
 						},
 					},
 				},
+			}
+
+			// TODO: Handle it once we support getting container image name for docker.
+			if isDockerRuntime {
+				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
@@ -301,6 +307,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig list-containers -o json --runtimes=%s --watch", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEvent := &containercollection.PubSubEvent{
 				Type: containercollection.EventTypeAddContainer,
 				Container: &containercollection.Container{
@@ -313,11 +320,17 @@ func TestPodWithSecurityContext(t *testing.T) {
 					},
 					Runtime: containercollection.RuntimeMetadata{
 						BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-							RuntimeName:   types.String2RuntimeName(*containerRuntime),
-							ContainerName: cn,
+							RuntimeName:        types.String2RuntimeName(*containerRuntime),
+							ContainerName:      cn,
+							ContainerImageName: "docker.io/library/busybox:latest",
 						},
 					},
 				},
+			}
+
+			// TODO: Handle it once we support getting container image name for docker.
+			if isDockerRuntime {
+				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -32,8 +32,12 @@ func TestTraceBind(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace bind -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &bindTypes.Event{
-				Event:    BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Comm:     "nc",
 				Protocol: "TCP",
 				Addr:     "::",

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -32,8 +32,12 @@ func TestTraceCapabilities(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace capabilities -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &capabilitiesTypes.Event{
-				Event:         BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Comm:          "nice",
 				CapName:       "SYS_NICE",
 				Cap:           23,

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -45,9 +45,13 @@ func TestTraceDns(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace dns -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*dnsTypes.Event{
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -58,7 +62,10 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,
@@ -73,7 +80,10 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -84,7 +94,10 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,
@@ -99,7 +112,10 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -110,7 +126,10 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -39,25 +39,35 @@ func TestTraceExec(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace exec -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*execTypes.Event{
 				{
-					Event: BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
-					Comm:  "sh",
-					Args:  shArgs,
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
+					Comm: "sh",
+					Args: shArgs,
 				},
 				{
-					Event: BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
-					Comm:  "date",
-					Args:  dateArgs,
-					Uid:   1000,
-					Gid:   1111,
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
+					Comm: "date",
+					Args: dateArgs,
+					Uid:  1000,
+					Gid:  1111,
 				},
 				{
-					Event: BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
-					Comm:  "sleep",
-					Args:  sleepArgs,
-					Uid:   1000,
-					Gid:   1111,
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
+					Comm: "sleep",
+					Args: sleepArgs,
+					Uid:  1000,
+					Gid:  1111,
 				},
 			}
 

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -35,11 +35,15 @@ func TestTraceFsslower(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace fsslower -f %s --runtimes=%s -m 0 -o json", fsType, *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &fsslowerTypes.Event{
-				Event: BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
-				Comm:  "cat",
-				File:  "foo",
-				Op:    "R",
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
+				Comm: "cat",
+				File: "foo",
+				Op:   "R",
 			}
 
 			normalize := func(e *fsslowerTypes.Event) {

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -34,8 +34,12 @@ func TestTraceMount(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace mount -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &mountTypes.Event{
-				Event:     BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Comm:      "mount",
 				Operation: "mount",
 				Retval:    -int(unix.ENOENT),

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -50,9 +50,13 @@ func TestTraceNetwork(t *testing.T) {
 				return fmt.Errorf("getting pod ip: %w", err)
 			}
 
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*networkTypes.Event{
 				{
-					Event:   BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+					Event: BuildBaseEvent(ns,
+						WithRuntimeMetadata(*containerRuntime),
+						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					),
 					Comm:    "wget",
 					Uid:     0,
 					Gid:     0,
@@ -77,6 +81,8 @@ func TestTraceNetwork(t *testing.T) {
 							Runtime: eventtypes.BasicRuntimeMetadata{
 								ContainerName: "nginx-pod",
 								RuntimeName:   eventtypes.String2RuntimeName(*containerRuntime),
+								// TODO: once ig supports initial containers images enrichment, ContainerImageName should be added
+								// ContainerImageName: "docker.io/library/nginx:latest",
 							},
 						},
 					},

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -32,8 +32,12 @@ func TestTraceOOMKill(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace oomkill -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &oomkillTypes.Event{
-				Event:        BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				KilledComm:   "tail",
 				TriggeredUid: 1000,
 				TriggeredGid: 2000,

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -32,8 +32,12 @@ func TestTraceOpen(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace open -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &openTypes.Event{
-				Event:    BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Comm:     "cat",
 				Fd:       3,
 				Ret:      3,

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -32,8 +32,12 @@ func TestTraceSignal(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace signal -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &signalTypes.Event{
-				Event:  BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Comm:   "sh",
 				Signal: "SIGTERM",
 			}

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -32,10 +32,14 @@ func TestTraceSni(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace sni -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &sniTypes.Event{
-				Event: BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
-				Comm:  "wget",
-				Name:  "kubernetes.default.svc.cluster.local",
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
+				Comm: "wget",
+				Name: "kubernetes.default.svc.cluster.local",
 			}
 
 			normalize := func(e *sniTypes.Event) {

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -33,8 +33,12 @@ func TestTraceTCP(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace tcp -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpTypes.Event{
-				Event:     BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+				),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -33,8 +33,12 @@ func TestTraceTcpconnect(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace tcpconnect -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+				),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
@@ -93,8 +97,12 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig trace tcpconnect --latency -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+				),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -48,7 +48,9 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 
 			e.K8s = types.K8sMetadata{}
 			// TODO: Verify container runtime and container name
-			e.Runtime = types.BasicRuntimeMetadata{}
+			e.Runtime.RuntimeName = ""
+			e.Runtime.ContainerName = ""
+			e.Runtime.ContainerID = ""
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	tracednsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 )
@@ -29,6 +28,12 @@ func TestTraceDns(t *testing.T) {
 	ns := GenerateTestNamespaceName("test-trace-dns")
 
 	t.Parallel()
+
+	// TODO: Handle it once we support getting container image name from docker
+	errIsDocker, isDockerRuntime := IsDockerRuntime()
+	if errIsDocker != nil {
+		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
+	}
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),
@@ -49,7 +54,7 @@ func TestTraceDns(t *testing.T) {
 		ExpectedOutputFn: func(output string) error {
 			expectedEntries := []*tracednsTypes.Event{
 				{
-					Event:      BuildBaseEvent(ns),
+					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -60,7 +65,7 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns),
+					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,
@@ -75,7 +80,7 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns),
+					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -86,7 +91,7 @@ func TestTraceDns(t *testing.T) {
 					Gid:        1111,
 				},
 				{
-					Event:      BuildBaseEvent(ns),
+					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,
@@ -117,7 +122,9 @@ func TestTraceDns(t *testing.T) {
 
 				e.K8s.Node = ""
 				// TODO: Verify container runtime and container name
-				e.Runtime = types.BasicRuntimeMetadata{}
+				e.Runtime.RuntimeName = ""
+				e.Runtime.ContainerName = ""
+				e.Runtime.ContainerID = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -28,13 +28,19 @@ func TestTraceTcpconnect(t *testing.T) {
 
 	t.Parallel()
 
+	// TODO: Handle it once we support getting container image name from docker
+	errIsDocker, isDockerRuntime := IsDockerRuntime()
+	if errIsDocker != nil {
+		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
+	}
+
 	traceTcpconnectCmd := &Command{
 		Name:         "StartTraceTcpconnectGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntry := &tracetcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns),
+				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
@@ -60,7 +66,9 @@ func TestTraceTcpconnect(t *testing.T) {
 
 				e.K8s.Node = ""
 				// TODO: Verify container runtime and container name
-				e.Runtime = eventtypes.BasicRuntimeMetadata{}
+				e.Runtime.RuntimeName = ""
+				e.Runtime.ContainerName = ""
+				e.Runtime.ContainerID = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)
@@ -83,13 +91,19 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 
 	t.Parallel()
 
+	// TODO: Handle it once we support getting container image name from docker
+	errIsDocker, isDockerRuntime := IsDockerRuntime()
+	if errIsDocker != nil {
+		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
+	}
+
 	traceTcpconnectCmd := &Command{
 		Name:         "StartTraceTcpconnectGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json --latency", ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
 			expectedEntry := &tracetcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns),
+				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
@@ -120,7 +134,9 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 
 				e.K8s.Node = ""
 				// TODO: Verify container runtime and container name
-				e.Runtime = eventtypes.BasicRuntimeMetadata{}
+				e.Runtime.RuntimeName = ""
+				e.Runtime.ContainerName = ""
+				e.Runtime.ContainerID = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -442,6 +442,7 @@ func (cc *ContainerCollection) EnrichByMntNs(event *eventtypes.CommonData, mount
 		event.Runtime.RuntimeName = container.Runtime.RuntimeName
 		event.Runtime.ContainerName = container.Runtime.ContainerName
 		event.Runtime.ContainerID = container.Runtime.ContainerID
+		event.Runtime.ContainerImageName = container.Runtime.ContainerImageName
 	}
 }
 
@@ -468,6 +469,7 @@ func (cc *ContainerCollection) EnrichByNetNs(event *eventtypes.CommonData, netns
 		event.Runtime.RuntimeName = containers[0].Runtime.RuntimeName
 		event.Runtime.ContainerName = containers[0].Runtime.ContainerName
 		event.Runtime.ContainerID = containers[0].Runtime.ContainerID
+		event.Runtime.ContainerImageName = containers[0].Runtime.ContainerImageName
 		return
 	}
 	if containers[0].K8s.PodName != "" && containers[0].K8s.Namespace != "" {

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -702,6 +702,7 @@ func WithLinuxNamespaceEnrichment() ContainerCollectionOption {
 func isEnrichedWithOCIConfigInfo(container *Container) bool {
 	return container.OciConfig != nil &&
 		container.Runtime.RuntimeName != "" &&
+		container.Runtime.ContainerImageName != "" &&
 		container.K8s.ContainerName != "" &&
 		container.K8s.PodName != "" &&
 		container.K8s.Namespace != "" &&
@@ -746,6 +747,9 @@ func WithOCIConfigEnrichment() ContainerCollectionOption {
 			}
 			if podUID := resolver.PodUID(container.OciConfig.Annotations); podUID != "" {
 				container.K8s.PodUID = podUID
+			}
+			if imageName := resolver.ContainerImageName(container.OciConfig.Annotations); imageName != "" {
+				container.Runtime.ContainerImageName = imageName
 			}
 
 			return true

--- a/pkg/container-utils/oci-annotations/resolver_containerd.go
+++ b/pkg/container-utils/oci-annotations/resolver_containerd.go
@@ -28,6 +28,7 @@ const (
 	containerdPodUIDAnnotation        = "io.kubernetes.cri.sandbox-uid"
 	containerdContainerNameAnnotation = "io.kubernetes.cri.container-name"
 	containerdContainerTypeAnnotation = "io.kubernetes.cri.container-type"
+	containerdContainerImageName      = "io.kubernetes.cri.image-name"
 )
 
 type containerdResolver struct{}
@@ -38,6 +39,10 @@ func (containerdResolver) ContainerName(annotations map[string]string) string {
 
 func (containerdResolver) ContainerType(annotations map[string]string) string {
 	return annotations[containerdContainerTypeAnnotation]
+}
+
+func (containerdResolver) ContainerImageName(annotations map[string]string) string {
+	return annotations[containerdContainerImageName]
 }
 
 func (containerdResolver) PodName(annotations map[string]string) string {

--- a/pkg/container-utils/oci-annotations/resolver_containerd_test.go
+++ b/pkg/container-utils/oci-annotations/resolver_containerd_test.go
@@ -23,6 +23,7 @@ func Test_containerdResolver(t *testing.T) {
 		containerdPodUIDAnnotation:        "test-pod-uid",
 		containerdContainerNameAnnotation: "test-container-name",
 		containerdContainerTypeAnnotation: "test-container-type",
+		containerdContainerImageName:      "test-container-image-name",
 	}
 
 	resolver := containerdResolver{}
@@ -38,4 +39,5 @@ func Test_containerdResolver(t *testing.T) {
 	assert(resolver.PodUID(annotations), "test-pod-uid")
 	assert(resolver.ContainerName(annotations), "test-container-name")
 	assert(resolver.ContainerType(annotations), "test-container-type")
+	assert(resolver.ContainerImageName(annotations), "test-container-image-name")
 }

--- a/pkg/container-utils/oci-annotations/resolver_crio.go
+++ b/pkg/container-utils/oci-annotations/resolver_crio.go
@@ -26,6 +26,7 @@ const (
 	crioPodUIDAnnotation           = "io.kubernetes.pod.uid"
 	crioContainerNameAnnotation    = "io.kubernetes.container.name"
 	crioContainerTypeAnnotation    = "io.kubernetes.cri-o.ContainerType"
+	crioContainerImageName         = "io.kubernetes.cri-o.ImageName"
 )
 
 type crioResolver struct{}
@@ -36,6 +37,10 @@ func (crioResolver) ContainerName(annotations map[string]string) string {
 
 func (crioResolver) ContainerType(annotations map[string]string) string {
 	return annotations[crioContainerTypeAnnotation]
+}
+
+func (crioResolver) ContainerImageName(annotations map[string]string) string {
+	return annotations[crioContainerImageName]
 }
 
 func (crioResolver) PodName(annotations map[string]string) string {

--- a/pkg/container-utils/oci-annotations/resolver_crio_test.go
+++ b/pkg/container-utils/oci-annotations/resolver_crio_test.go
@@ -23,6 +23,7 @@ func Test_crioResolver(t *testing.T) {
 		crioPodUIDAnnotation:        "test-pod-uid",
 		crioContainerNameAnnotation: "test-container-name",
 		crioContainerTypeAnnotation: "test-container-type",
+		crioContainerImageName:      "test-container-image-name",
 	}
 
 	resolver := crioResolver{}
@@ -38,4 +39,5 @@ func Test_crioResolver(t *testing.T) {
 	assert(resolver.PodUID(annotations), "test-pod-uid")
 	assert(resolver.ContainerName(annotations), "test-container-name")
 	assert(resolver.ContainerType(annotations), "test-container-type")
+	assert(resolver.ContainerImageName(annotations), "test-container-image-name")
 }

--- a/pkg/container-utils/oci-annotations/types.go
+++ b/pkg/container-utils/oci-annotations/types.go
@@ -30,6 +30,8 @@ type Resolver interface {
 	ContainerName(annotations map[string]string) string
 	// ContainerType returns the type of the container i.e "container" or "sandbox"
 	ContainerType(annotations map[string]string) string
+	// ContainerImageName returns the image name of the container i.e. docker.io/library/busybox:latest
+	ContainerImageName(annotations map[string]string) string
 	// PodName returns the name of the pod to which the container belongs
 	PodName(annotations map[string]string) string
 	// PodUID returns the uid of pod to which the container belongs

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -114,6 +114,7 @@ type ContainerInfoGetters interface {
 	GetPod() string
 	GetNamespace() string
 	GetContainer() string
+	GetContainerImageName() string
 }
 
 var allOperators = map[string]Operator{}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,7 @@ func init() {
 	columns.MustRegisterTemplate("namespace", "width:30")
 	columns.MustRegisterTemplate("pod", "width:30,ellipsis:middle")
 	columns.MustRegisterTemplate("container", "width:30")
+	columns.MustRegisterTemplate("containerImageName", "width:30")
 	columns.MustRegisterTemplate("comm", "maxWidth:16")
 	columns.MustRegisterTemplate("pid", "minWidth:7")
 	columns.MustRegisterTemplate("uid", "minWidth:8")
@@ -116,10 +117,14 @@ type BasicRuntimeMetadata struct {
 	// ContainerName is the container name. In the case the container runtime
 	// response with multiple containers, ContainerName contains only the first element.
 	ContainerName string `json:"containerName,omitempty" column:"containerName,template:container"`
+
+	// ContainerImageName is the name of the container image where the event comes from
+	// i.e. docker.io/library/busybox:latest
+	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName"`
 }
 
 func (b *BasicRuntimeMetadata) IsEnriched() bool {
-	return b.RuntimeName != RuntimeNameUnknown && b.RuntimeName != "" && b.ContainerID != "" && b.ContainerName != ""
+	return b.RuntimeName != RuntimeNameUnknown && b.RuntimeName != "" && b.ContainerID != "" && b.ContainerName != "" && b.ContainerImageName != ""
 }
 
 type BasicK8sMetadata struct {
@@ -171,6 +176,7 @@ func (c *CommonData) SetContainerMetadata(k8s *BasicK8sMetadata, runtime *BasicR
 	c.Runtime.RuntimeName = runtime.RuntimeName
 	c.Runtime.ContainerName = runtime.ContainerName
 	c.Runtime.ContainerID = runtime.ContainerID
+	c.Runtime.ContainerImageName = runtime.ContainerImageName
 }
 
 func (c *CommonData) GetNode() string {
@@ -187,6 +193,10 @@ func (c *CommonData) GetNamespace() string {
 
 func (c *CommonData) GetContainer() string {
 	return c.K8s.ContainerName
+}
+
+func (c *CommonData) GetContainerImageName() string {
+	return c.Runtime.ContainerImageName
 }
 
 type L3Endpoint struct {


### PR DESCRIPTION
# Enrich events with container image (ImageName)
- Implements #1310 

This PR partially implements #1310. The current iteration addresses only **new containers enrichment** for **containerd and cri-o** and adds `ContainerImageName` attribute to events as per the following table:

|                               | Initial containers            | New containers              |
|-------------------------------|-------------------------------|-----------------------------|
| With k8s: containerd or cri-o | TODO  | OCI annotations             |
| With k8s: docker              | TODO   | *Blocker: No OCI annotations* |
| W/o k8s: containerd           | *Blocker: no k8s, but may be solved by  #737*   | OCI annotations             |
| W/o k8s: podman               | *Blocker: no k8s, but may be solved by  #737*                             | OCI annotations             |
| W/o k8s: docker                 | *Blocker: no k8s, but may be solved by  #737* | *Blocker: No OCI annotations* |


## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

`imageName` field in gadgets output is populated for new containers :
`$ kubect-gadget trace exec -A -o json`

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/64f15f92-55f8-4c2b-ac61-2f99fc46a869)

`IMAGENAME` column in `ig list-containers` output is populated for new containers:

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/d32b7792-9dc4-4d8b-be36-9d0dad967a9f)
