### PR TITLE
integration/ig/k8s: Add --load to docker buildx build

### DIFF
--- a/integration/ig/k8s/Makefile
+++ b/integration/ig/k8s/Makefile
@@ -16,7 +16,7 @@ build:
 
 .PHONY: build-tests
 build-tests:
-	docker buildx build -t ig-tests -f ./../../../Dockerfiles/ig-tests.Dockerfile ../../../
+	docker buildx build --load -t ig-tests -f ./../../../Dockerfiles/ig-tests.Dockerfile ../../../
 	docker run --rm --entrypoint cat ig-tests ig-integration.test > ./ig-integration.test
 
 # test


### PR DESCRIPTION
Without that option it doesn't load the image in docker and hence the tests fails on the local machine:

```
docker buildx build -t ig-tests -f ./../../../Dockerfiles/ig-tests.Dockerfile ../../../
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 0.7s (10/10) FINISHED
 => [internal] load build definition from ig-tests.Dockerfile                                                                                            0.0s
 => => transferring dockerfile: 357B                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load metadata for ghcr.io/inspektor-gadget/ig-builder:latest                                                                              0.4s
 => [1/3] FROM ghcr.io/inspektor-gadget/ig-builder:latest@sha256:a8b090a57013898ed7c8d66330a8af72b03d5380043827d74d8766fe967ec966                        0.0s
 => => resolve ghcr.io/inspektor-gadget/ig-builder:latest@sha256:a8b090a57013898ed7c8d66330a8af72b03d5380043827d74d8766fe967ec966                        0.0s
 => [internal] load build context                                                                                                                        0.2s
 => => transferring context: 52.04kB                                                                                                                     0.2s
 => CACHED [2/3] COPY go.mod go.sum /cache/                                                                                                              0.0s
 => CACHED [3/3] RUN cd /cache && go mod download                                                                                                        0.0s
 => CACHED [4/3] ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget                                                                              0.0s
 => CACHED [5/3] WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget/integration/ig/k8s                                                         0.0s
 => CACHED [6/3] RUN go test -c -o ig-integration.test ./...                                                                                             0.0s
docker run --rm --entrypoint cat ig-tests ig-integration.test > ./ig-integration.test
Unable to find image 'ig-tests:latest' locally
docker: Error response from daemon: pull access denied for ig-tests, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```

---

I have no idea why it works on the CI. Probably the docker buildx version there doesn't need this parameter?