### PR TITLE
Makefile: automatically push on cross-gadget-default-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ cross-gadget-%-container:
 			BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ OUTPUT=hack/btfs/ -j$(nproc); \
 	fi
 	docker buildx build --platform=$(PLATFORMS) -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) \
+		--push \
 		-f Dockerfiles/gadget-$*.Dockerfile .
 
 push-gadget-%-container:


### PR DESCRIPTION
When I want to test my changes on a multi-architecture (amd64 and arm64), I build the image with:
```
$ export CONTAINER_REPO=myrepo/gadget
$ make build install/kubectl-gadget cross-gadget-default-container
$ kubectl-gadget deploy
```

Unfortunately, the `cross-gadget-default-container` target does not push the image on the OCI registry. So the `deploy` command was unable to download the correct image.

The Makefile target `push-gadget-%-container` is not useful here because it does not use buildx images, so it is not pushing all the architectures.
