### PR TITLE
columns: Support prefix when using templates

### DIFF
--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -125,8 +125,13 @@ func (ci *Column[T]) getWidth(params []string) (int, error) {
 
 func (ci *Column[T]) fromTag(tag string) error {
 	tagInfo := strings.Split(tag, ",")
-	ci.Name = tagInfo[0]
-	ci.RawName = ci.Name
+	// Don't overwrite the name if it has been already set. This prevents an
+	// already computed name (for example, with a prefix) from being overwritten
+	// when applying a template.
+	if ci.Name == "" {
+		ci.Name = tagInfo[0]
+		ci.RawName = ci.Name
+	}
 	if len(ci.Name) > 0 {
 		ci.explicitName = true
 	}


### PR DESCRIPTION
# columns: Support prefix when using templates

Currently, in the following case, the prefix `runtime` is not applied to the `Container` field because it uses a template. While the prefix is correctly applied to the `ID` field:

```golang
type RuntimeMetadata struct {
	ID        string `column:"id"`
	Container string `column:"container,template:container"`
}

type GadgetData struct {
	RuntimeMetadata RuntimeMetadata `column:"runtime" columnTags:"runtime"`
	GadgetData      string          `column:"gadgetData"`
}
```

This PR makes the columns library to support applying prefixes also when templates are used.