### PR TITLE
integration: Add a delay before terminating container for TestPrometheus

### DIFF
--- a/integration/inspektor-gadget/prometheus_test.go
+++ b/integration/inspektor-gadget/prometheus_test.go
@@ -52,8 +52,8 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 10s
-      evaluation_interval: 10s
+      scrape_interval: 1s
+      evaluation_interval: 1s
 
     scrape_configs:
      - job_name: "gadget"
@@ -108,8 +108,8 @@ EOF
 				StartAndStop: true,
 			},
 			SleepForSecondsCommand(2),
-			BusyboxPodCommand(ns, "for i in $(seq 1 100); do cat /dev/null; done"),
-			SleepForSecondsCommand(30), // wait for prometheus to scrape
+			BusyboxPodCommand(ns, "for i in $(seq 1 100); do cat /dev/null; done; sleep 2"),
+			SleepForSecondsCommand(5), // wait for prometheus to scrape
 			{
 				Name: "ValidatePrometheusMetrics",
 				Cmd:  fmt.Sprintf("kubectl exec -n %s prometheus -- wget -qO- http://localhost:9090/api/v1/query?query=executed_processes_total", ns),


### PR DESCRIPTION
We are currently seeing [failures](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/5135691143/attempts/1#summary-13901056688) in integration tests because of TestPrometheus. It seems we are generating bit too much events and tracer needs time to process before container is removed. The idea here is to introduce a delay to ensure we get enough time to process the events. 

Also, we reduce the scrape interval because I initially thought it might be cause of small interval but that seems to be unrelated. 

# Testing Done

- [Failing after running test 50 times without delay.](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/5143706433)
- [Passing after running test 50 times with delay.](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/5144010912)