### PR TITLE
integration: Use cmpopts.IgnoreUnexported for cmp.Diff

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -24,9 +24,13 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
+
+var cmpIgnoreUnexported = cmpopts.IgnoreUnexported(containercollection.Container{})
 
 func parseMultiJSONOutput[T any](output string, normalize func(*T)) ([]*T, error) {
 	ret := []*T{}
@@ -96,7 +100,7 @@ func expectAllToMatch[T any](entries []*T, expectedEntry *T) error {
 	for _, entry := range entries {
 		if !reflect.DeepEqual(expectedEntry, entry) {
 			return fmt.Errorf("unexpected output entry:\n%s",
-				cmp.Diff(expectedEntry, entry))
+				cmp.Diff(expectedEntry, entry, cmpIgnoreUnexported))
 		}
 	}
 	return nil


### PR DESCRIPTION
Ignore unexported fields when doing `cmp.Diff` to avoid panic during test runs. Currently, I see only `containercollection.Container{}` has unexported events. 

## Testing done

Break the test with:

<details><summary>Patch</summary>
<p>

```
diff --git a/integration/ig/non-k8s/list_containers_test.go b/integration/ig/non-k8s/list_containers_test.go
index fb68774a..10d56f8b 100644
--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -37,7 +37,7 @@ func TestFilterByContainerName(t *testing.T) {
 
                        normalize := func(c *containercollection.Container) {
                                c.ID = ""
-                               c.Pid = 0
+                               //c.Pid = 0
                                c.OciConfig = nil
                                c.Bundle = ""
                                c.Mntns = 0

```


</p>
</details> 

### before the PR

<details><summary>Diff</summary>
<p>

```
...
--- FAIL: TestFilterByContainerName (14.89s)
panic: cannot handle unexported field at {*containercollection.Container}.ownerReference:
        "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection".Container
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported [recovered]
        panic: cannot handle unexported field at {*containercollection.Container}.ownerReference:
        "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection".Container
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported

goroutine 8 [running]:
testing.tRunner.func1.2({0x16cf0e0, 0xc0003059d0})
        /home/qasim/go/go1.19.4/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
        /home/qasim/go/go1.19.4/src/testing/testing.go:1399 +0x39f
panic({0x16cf0e0, 0xc0003059d0})
        /home/qasim/go/go1.19.4/src/runtime/panic.go:884 +0x212
github.com/google/go-cmp/cmp.validator.apply({{}}, 0xc000282000, {0x189e300?, 0xc00028e0d8?, 0xc000305900?}, {0x189e300?, 0xc00028e1c8?, 0xc00028e0d8?})
        /home/qasim/go/pkg/mod/github.com/google/go-cmp@v0.5.9/cmp/options.go:246 +0x3bd
github.com/google/go-cmp/cmp.(*state).tryOptions(0xc000282000, {0x1bda748, 0x189e300}, {0x189e300?, 0xc00028e0d8?, 0x7f0af0450a38?}, {0x189e300?, 0xc00028e1c8?, 0x40f69f?})
        /home/qasim/go/pkg/mod/github.com/google/go-cmp@v0.5.9/cmp/compare.go:304 +0x11a
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000282000, {0x1bca7c8, 0xc0000b6000?})
        /home/qasim/go/pkg/mod/github.com/google/go-cmp@v0.5.9/cmp/compare.go:259 +0x451
...
...

```


</p>
</details> 

### after the PR

<details><summary>Diff</summary>
<p>

```
...
          &containercollection.Container{
                Runtime:   "docker",
                ID:        "",
        -       Pid:       0,
        +       Pid:       369045,
                OciConfig: nil,
                Bundle:    "",
                ... // 2 ignored and 12 identical fields
          }
        
--- FAIL: TestFilterByContainerName (15.93s)
FAIL
...
```

</p>
</details> 