### PR TITLE
dependabot: Run the scans at 05:00 CET/CEST.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,24 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      # Il est cinq heures, Paris s'éveille !
+      time: "05:00"
+      timezone: "Europe/Paris"
     commit-message:
       prefix: "ci:"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
   - package-ecosystem: "docker"
     directory: "/Dockerfiles"
     schedule:
       interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Paris"
     commit-message:
       prefix: "Dockerfiles:"


### PR DESCRIPTION
```
It is possible to set scan time and timezone using specific YAML keys [1].
[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletimezone
```