### PR TITLE
bpf-iter-ns: fix bpf pin path again

### DIFF
--- a/pkg/utils/bpf-iter-ns/bpf-iter-ns.go
+++ b/pkg/utils/bpf-iter-ns/bpf-iter-ns.go
@@ -96,19 +96,19 @@ func ReadOnHostPidNs(iter *link.Iter) ([]byte, error) {
 		return nil, fmt.Errorf("empty /proc/self symlink")
 	}
 
-	// Create a temporary directory in the host bpffs
+	// Create a temporary directory in bpffs
 	bpfFS := "/sys/fs/bpf"
-	tmpPinDir, err := os.MkdirTemp(host.HostRoot+bpfFS, "ig-iter-")
+	tmpPinDir, err := os.MkdirTemp(bpfFS, "ig-iter-")
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary directory in bpffs: %w", err)
 	}
 	defer os.RemoveAll(tmpPinDir)
 
 	// Prepare the pin path from the container and host point of view
-	pinPath := filepath.Join(tmpPinDir, "iter")
-	pinPathHost := filepath.Join(bpfFS, filepath.Base(tmpPinDir), "iter")
+	pinPathFromContainer := filepath.Join(tmpPinDir, "iter")
+	pinPathFromHost := filepath.Join("/proc", selfPidOnHost, "root", pinPathFromContainer)
 
-	err = iter.Pin(pinPath)
+	err = iter.Pin(pinPathFromContainer)
 	if err != nil {
 		return nil, fmt.Errorf("pinning iterator: %w", err)
 	}
@@ -149,7 +149,7 @@ func ReadOnHostPidNs(iter *link.Iter) ([]byte, error) {
 		systemdDbus.PropExecStart([]string{
 			"/bin/sh",
 			"-c",
-			fmt.Sprintf("cat %s > %s", pinPathHost, writerPath),
+			fmt.Sprintf("cat %s > %s", pinPathFromHost, writerPath),
 		}, true),
 	}
 


### PR DESCRIPTION
The host might not have bpffs mounted in some setups. See:
- [IG's entrypoint.sh#L50-L59](https://github.com/inspektor-gadget/inspektor-gadget/blob/v0.17.0/gadget-container/entrypoint.sh#L50-L59)
-  [minikube's entrypoint#L76-L81](https://github.com/kubernetes/minikube/blob/99a0c91459f17ad8c83c80fc37a9ded41e34370c/deploy/kicbase/entrypoint#L76-L81)

So use the bpffs mountpoint in the container mount namespace.

Symptoms before the fix:
> creating socket enricher: read BPF iterator: creating temporary
> directory in bpffs: mkdir /host/sys/fs/bpf/ig-iter-3218307710: no such
> file or directory

Fixes: 55f58bbe8dcf ("bpf-iter-ns: fix bpf pin path"), #1719
Fixes: e91a93bb2c0a ("Read bpf iterators from host pid ns"), https://github.com/inspektor-gadget/inspektor-gadget/pull/1708#discussion_r1220175307