### PR TITLE
gha: Run AKS and ARO integration tests for `citest/` branches too.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -793,7 +793,13 @@ jobs:
   test-integration-aks:
     name: Integration tests on AKS
     # level: 2
-    needs: [check-secrets, test-unit, build-kubectl-gadget, build-ig, build-gadget-container-images, publish-gadget-images-manifest]
+    needs:
+      - check-secrets
+      - test-unit
+      - build-kubectl-gadget
+      - build-ig
+      - build-gadget-container-images
+      - publish-gadget-images-manifest
     if: needs.check-secrets.outputs.aks == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -869,7 +875,13 @@ jobs:
   test-integration-aro:
     name: Integration tests on ARO
     # level: 2
-    needs: [check-secrets, test-unit, build-kubectl-gadget, build-ig, build-gadget-container-images, publish-gadget-images-manifest]
+    needs:
+      - check-secrets
+      - test-unit
+      - build-kubectl-gadget
+      - build-ig
+      - build-gadget-container-images
+      - publish-gadget-images-manifest
     # Run this job only if an ARO cluster is available on repo secrets. See
     # docs/ci.md for further details.
     if: needs.check-secrets.outputs.aro == 'true'
@@ -912,7 +924,12 @@ jobs:
   test-integration-minikube:
     name: Integr. tests
     # level: 1
-    needs: [test-unit, build-kubectl-gadget, build-ig, build-gadget-container-images, build-helper-images ]
+    needs:
+      - test-unit
+      - build-kubectl-gadget
+      - build-ig
+      - build-gadget-container-images
+      - build-helper-images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
     - main
+    - 'citest/**'
     tags:
     - 'v*'
 

--- a/docs/devel/CONTRIBUTING.md
+++ b/docs/devel/CONTRIBUTING.md
@@ -111,7 +111,7 @@ registry.
 
 #### Requirements
 
-For running unit tests, the following additional requirements need to be installed and configured on your system: 
+For running unit tests, the following additional requirements need to be installed and configured on your system:
 - gcc compiler
 - `pkg-config` and `libseccomp-dev` libraries
 
@@ -297,7 +297,13 @@ $ go tool pprof -top mem.prof
 ### Continuous Integration
 
 Inspektor Gadget uses GitHub Actions as CI. Please check dedicated [CI
-documentation](../ci.md) for details.
+documentation](../ci.md) for more details.
+
+Some integration tests (like AKS and ARO) are only run when a commit is pushed to the main branch or
+a new tag is pushed. It's also possible to run those by pusing a branch named `citest/...`. Please
+notice that the container images will be pushed to
+https://github.com/inspektor-gadget/inspektor-gadget/pkgs/container/inspektor-gadget and those
+should be manually cleaned up.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
 
    It's useful for debugging purposes to avoid having to setup all of this
    in a personal fork or pushing to main.
    
    Signed-off-by: Mauricio Vásquez <mauriciov@microsoft.com>

---

I tried to implement a solution to automatically remove the image in the container repository but I'm too afraid that I can get this wrong and remove important images, hence I prefer to leave this as a manual step. 

---

Tested in https://github.com/mauriciovasquezbernal/inspektor-gadget/actions/runs/5212558595, I don't have AKS secrets configured but the image was pushed to https://github.com/mauriciovasquezbernal/inspektor-gadget/pkgs/container/inspektor-gadget, so it should work all fine :tm: .