### PR TITLE
kubectl-gadget/top: Ensure timeout=interval prints event before exiting

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -43,6 +43,8 @@ const (
 
 const securityProfileOperatorNamespace = "security-profiles-operator"
 
+const topTimeoutInSeconds = 10
+
 var (
 	supportedK8sDistros = []string{K8sDistroAKSMariner, K8sDistroAKSUbuntu, K8sDistroARO, K8sDistroMinikubeGH}
 	cleaningUp          = uint32(0)

--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -200,6 +200,7 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext) (runtime.CombinedGa
 			time.Duration(gadgetCtx.GadgetParams().Get(gadgets.ParamInterval).AsInt32())*time.Second,
 			2,
 		)
+		defer gadgetCtx.Parser().Flush()
 	}
 
 	if gadgetCtx.GadgetDesc().Type() == gadgets.TypeOneShot {


### PR DESCRIPTION
As mentioned in the comment [here](https://github.com/inspektor-gadget/inspektor-gadget/issues/716#issuecomment-1581315275) the [snapshot ticker](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/parser/parser.go#L159) can go off bit early compared to when we [receive](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/runtime/grpc/grpc-runtime.go#L310) events. Which should be fine in case user is running gadget for multiple intervals since the missed events will be printed in following interval. But this is problematic when gadget is only ran for single interval (`timeout==interval`). 

The idea with this change it to introduce a flush mechanism to ensure all the outstanding events are sent downstream for handling before exiting. Timeout timer is running on the server side, ensuring we receive all the events from server before calling `Flush()`. Following diagram (courtesy: @flyth) shows the flow with the fix.

```mermaid
sequenceDiagram
    participant Local as Local (kubectl gadget)
    participant Remote as Remote (gadget pods)
    Local->>Local: Start Snapshot Timer
    Local->>Remote: Start Gadget
    Remote->>Remote: Start Gadget Timer
    loop every interval
        Local->>Local: SnapshotCombiner Timer fires
        Local->>Local: Get Events from SnapshotCombiner
        Remote->>Local: New Event
        Local->>Local: Add Events to SnapshotCombiner
    end
    alt end
        Remote->>Remote: Timer done
        Remote->>Local: Send last results
    end
    Local->>Local: Wait for all connections to be done
    Local->>Local: Flush "last results"
```

Fixes #716 

## Testing done

Integration test adapted to test `timeout==interval`, Also failure results before the fix:

- [Failing CI w/o fix](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/5220885409) - [Summary](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/5220885409/attempts/1#summary-14133592143)
