### PR TITLE
docs: Remove post release task for minikube.

### DIFF
--- a/docs/devel/release-process.md
+++ b/docs/devel/release-process.md
@@ -69,8 +69,6 @@ $ git push origin v0.x.0
 
 - Update other projects using Inspektor Gadget:
 
-  - Update the [Inspektor Gadget Addon in Minikube](https://github.com/kubernetes/minikube/pull/15869). This includes the
-    yaml files and the container image version.
   - Update the [Azure Kubernetes Service (AKS) Extension for Visual Studio Code](https://github.com/Azure/vscode-aks-tools/pull/191).
 
 ## Troubleshooting a failed release


### PR DESCRIPTION
```
Minikube developers added a script to automate this in their repository [1].

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1]: https://github.com/kubernetes/minikube/commit/984dc6d4bba4
```