### PR TITLE
integration tests: ARO: update openshift label

### DIFF
--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -91,7 +91,7 @@ spec:
           kubernetes.io/metadata.name: (kube-system|openshift-dns)
       podSelector:
         matchLabels:
-          .*(kubernetes.io/name: CoreDNS|k8s-app: kube-dns|dns.operator.openshift.io/daemonset-dns: default).*
+          .*(kubernetes.io/name: CoreDNS|k8s-app: kube-dns|dns.operator.openshift.io/.*: default).*
   podSelector:
     matchLabels:
       run: test-pod


### PR DESCRIPTION
The integration tests started to fail on ARO since approximately June 7th, see:
https://github.com/inspektor-gadget/inspektor-gadget/actions?query=branch%3Amain

---

TestAdviseNetworkpolicy generated a network policy with this label:
```
  podSelector:
    matchLabels:
      dns.operator.openshift.io/owning-dns: default
```
But the test expected:
```
  dns.operator.openshift.io/daemonset-dns: default
```
I am not sure what cause the change between 'owning-dns' and 'daemonset-dns'. It could be a different version of OpenShift.

---

I use a branch with prefix `citest/` for this PR so the CI should run the full tests thanks to https://github.com/inspektor-gadget/inspektor-gadget/pull/1723/files
