### PR TITLE
Dockerfiles: Update alpine image and change CO-RE image to debian:bullseye-slim

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -6,7 +6,7 @@
 # (CONFIG_DEBUG_INFO_BTF).
 
 ARG BUILDER_IMAGE=golang:1.19-bullseye
-ARG BASE_IMAGE=alpine:3.14
+ARG BASE_IMAGE=debian:bullseye-slim
 
 # Prepare and build gadget artifacts in a container
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
@@ -47,7 +47,9 @@ RUN set -ex; \
 		yum install -y libseccomp wget util-linux socat; \
 	elif command -v apt-get; then \
 		apt-get update && \
-		apt-get install -y seccomp wget util-linux socat; \
+		apt-get install -y seccomp wget util-linux socat && \
+		apt-get clean && \
+		rm -rf /var/lib/apt/lists/*; \
 	elif command -v apk; then \
 		apk add gcompat libseccomp wget util-linux socat; \
 	fi && \

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -7,7 +7,7 @@
 # between size and tools available in the image.
 
 ARG BUILDER_IMAGE=golang:1.19-bullseye
-ARG BASE_IMAGE=alpine:3.14
+ARG BASE_IMAGE=alpine:3.18
 
 FROM ${BUILDER_IMAGE} as builder
 

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -7,7 +7,7 @@ COPY go.mod go.sum dnstester.go /go/src/github.com/inspektor-gadget/inspektor-ga
 RUN GOARCH=${TARGETARCH} go build -o /dnstester /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
 
 # Final image
-FROM alpine:3.14
+FROM alpine:3.18
 COPY --from=builder /dnstester /dnstester
 
 CMD ["/dnstester"]


### PR DESCRIPTION
Since alpine 3.14 has reached end of support (https://www.alpinelinux.org/releases/), Update to latest (stable) release for all builder images. Also, change the CO-RE base image to `debian:bullseye-slim` till #801 is fixed and we are able to move to distroless. The change in the size of the final image is from  `67 MB (192 MB)` compressed to `90 MB (260 MB)`. 


