### PR TITLE
cmd: move verbose flag to top level

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -132,7 +132,6 @@ func buildCommandFromGadget(
 	operatorsParamsCollection params.Collection,
 ) *cobra.Command {
 	var outputMode string
-	var verbose bool
 	var filters []string
 	var timeout int
 
@@ -166,12 +165,6 @@ func buildCommandFromGadget(
 		Use:          gadgetDesc.Name(),
 		Short:        gadgetDesc.Description(),
 		SilenceUsage: true, // do not print usage when there is an error
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if verbose {
-				log.SetLevel(log.DebugLevel)
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := runtime.Init(runtimeGlobalParams)
 			if err != nil {
@@ -430,13 +423,6 @@ func buildCommandFromGadget(
 			"Number of seconds that the gadget will run for, 0 to disable",
 		)
 	}
-
-	cmd.PersistentFlags().BoolVarP(
-		&verbose,
-		"verbose", "v",
-		false,
-		"Print debug information",
-	)
 
 	outputFormats.Append(gadgets.OutputFormats{
 		"json": {

--- a/cmd/common/verbose.go
+++ b/cmd/common/verbose.go
@@ -1,0 +1,35 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func AddVerboseFlag(rootCmd *cobra.Command) {
+	var verbose bool
+	rootCmd.PersistentFlags().BoolVarP(
+		&verbose,
+		"verbose", "v",
+		false,
+		"Print debug information",
+	)
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if verbose {
+			log.SetLevel(log.DebugLevel)
+		}
+	}
+}

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -40,6 +40,7 @@ func main() {
 		Use:   "ig",
 		Short: "Collection of gadgets for containers",
 	}
+	common.AddVerboseFlag(rootCmd)
 
 	rootCmd.AddCommand(
 		containers.NewListContainersCmd(),

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -48,6 +48,8 @@ func init() {
 }
 
 func main() {
+	common.AddVerboseFlag(rootCmd)
+
 	// grpcruntime.New() will try to fetch a catalog from the cluster by
 	// default. Make sure we don't do this when certain commands are run
 	// (as they just don't need it or imply that there are no nodes to


### PR DESCRIPTION
This change adds a global verbose flag that affects all logging operations using logrus instead of implementing it per command.