### PR TITLE
cmd/kubectl-gadget: add support to dynamically deploy multiple embedded CRD

### DIFF
--- a/pkg/resources/embed.go
+++ b/pkg/resources/embed.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Inspektor Gadget authors
+// Copyright 2019-2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
 package resources
 
 import (
-	_ "embed"
+	"embed"
 )
 
-//go:embed crd/bases/gadget.kinvolk.io_traces.yaml
-var TracesCustomResource string
+//go:embed crd/bases/*.yaml
+var CustomResources embed.FS
 
 //go:embed rbac/role.yaml
 var RbacRole string

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -45,10 +45,6 @@ rules:
   resources: ["services"]
   # list services is needed by network-policy gadget.
   verbs: ["list"]
-- apiGroups: ["gadget.kinvolk.io"]
-  resources: ["traces", "traces/status"]
-  # For traces, we need all rights on them as we define this resource.
-  verbs: ["delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"]
 - apiGroups: ["*"]
   resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "replicationcontrollers"]
   # Required to retrieve the owner references used by the seccomp gadget.


### PR DESCRIPTION
This change will import multiple CRD yaml definitions stored in `resources/crd/bases` (which are generated using `crd.mk`/kubebuilder). Additionally, rules will be added to our ClusterRole to allow permissions for all verbs on our custom resources.
On undeploy, it will retrieve a list the installed CRD and remove those belonging to Inspektor Gadget.

## Why?

For now, this is a prerequisite to add back the persistent gadget behavior using custom resources (a new CRD is being used for that). As we might in the future implement more custom resources for "external gadgets" as well, this hopefully helps adding them more easily to our deploy/undeploy routines.

## Other notes

Additionally to our current API group `gadget.kinvolk.io`, this PR adds support for the API group `inspektor-gadget.io`, which IMHO we should use in the future.