### PR TITLE
pkg/gadgets: add helpers to copy from/to param maps

### DIFF
--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -110,25 +110,17 @@ func (s *Service) RunGadget(runGadget pb.GadgetManager_RunGadgetServer) error {
 	ops := operators.GetOperatorsForGadget(gadgetDesc)
 
 	operatorParams := ops.ParamCollection()
-	err = operatorParams.CopyFromMap(request.Params, "operator.")
-	if err != nil {
-		return fmt.Errorf("setting operator parameters: %w", err)
-	}
 
 	parser := gadgetDesc.Parser()
 
 	runtimeParams := runtime.ParamDescs().ToParams()
-	err = runtimeParams.CopyFromMap(request.Params, "runtime.")
-	if err != nil {
-		return fmt.Errorf("setting runtime parameters: %w", err)
-	}
 
 	gadgetParamDescs := gadgetDesc.ParamDescs()
 	gadgetParamDescs.Add(gadgets.GadgetParams(gadgetDesc, parser)...)
 	gadgetParams := gadgetParamDescs.ToParams()
-	err = gadgetParams.CopyFromMap(request.Params, "")
+	err = gadgets.ParamsFromMap(request.Params, gadgetParams, runtimeParams, operatorParams)
 	if err != nil {
-		return fmt.Errorf("setting gadget parameters: %w", err)
+		return fmt.Errorf("setting parameters: %w", err)
 	}
 
 	// Create payload buffer

--- a/pkg/gadgets/params.go
+++ b/pkg/gadgets/params.go
@@ -15,6 +15,7 @@
 package gadgets
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
@@ -94,4 +95,41 @@ func SortableParams(gadget GadgetDesc, parser parser.Parser) params.ParamDescs {
 			Description:  "Sort by columns. Join multiple columns with ','. Prefix a column with '-' to sort in descending order.",
 		},
 	}
+}
+
+// ParamsFromMap fills the given params (gadget, runtime and operator) using values from `paramMap`. It looks up
+// values using prefixes (see also `ParamsToMap`) and applies verification. If verification for a field fails, an
+// error will be returned.
+func ParamsFromMap(
+	paramMap map[string]string,
+	gadgetParams *params.Params,
+	runtimeParams *params.Params,
+	operatorParams params.Collection,
+) error {
+	err := gadgetParams.CopyFromMap(paramMap, "")
+	if err != nil {
+		return fmt.Errorf("setting gadget parameters: %w", err)
+	}
+	err = runtimeParams.CopyFromMap(paramMap, "runtime.")
+	if err != nil {
+		return fmt.Errorf("setting runtime parameters: %w", err)
+	}
+	err = operatorParams.CopyFromMap(paramMap, "operator.")
+	if err != nil {
+		return fmt.Errorf("setting operator parameters: %w", err)
+	}
+	return nil
+}
+
+// ParamsToMap adds the given params (gadget, runtime and operator) to the paramMap. It uses prefixes to ensure
+// the keys remain unique.
+func ParamsToMap(
+	paramMap map[string]string,
+	gadgetParams *params.Params,
+	runtimeParams *params.Params,
+	operatorParams params.Collection,
+) {
+	gadgetParams.CopyToMap(paramMap, "")
+	runtimeParams.CopyToMap(paramMap, "runtime.")
+	operatorParams.CopyToMap(paramMap, "operator.")
 }

--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -211,8 +211,12 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext) (runtime.CombinedGa
 	var resultsLock sync.Mutex
 
 	allParams := make(map[string]string)
-	gadgetCtx.GadgetParams().CopyToMap(allParams, "")
-	gadgetCtx.OperatorsParamCollection().CopyToMap(allParams, "operator.")
+	gadgets.ParamsToMap(
+		allParams,
+		gadgetCtx.GadgetParams(),
+		gadgetCtx.RuntimeParams(),
+		gadgetCtx.OperatorsParamCollection(),
+	)
 
 	gadgetCtx.Logger().Debugf("Params")
 	for k, v := range allParams {


### PR DESCRIPTION
This PR moves the serialization / deserialization of params (gadget, runtime and operator params) from and into `map[string]string` for our gadgets to a central location that can easily be reused. One such upcoming reuse will happen when serializing to and from custom resources.