### PR TITLE
runcfanotify/container-hook: Ignore events from 'passwd' in pidfile directory

### DIFF
--- a/pkg/container-hook/tracer.go
+++ b/pkg/container-hook/tracer.go
@@ -560,6 +560,16 @@ func (n *ContainerNotifier) monitorRuntimeInstance(bundleDir string, pidFile str
 		return fmt.Errorf("marking %s: %w", configJSONPath, err)
 	}
 
+	// similar to config.json, we ignore passwd file if it exists
+	passwdPath := filepath.Join(bundleDir, "passwd")
+	if _, err := os.Stat(passwdPath); !errors.Is(err, os.ErrNotExist) {
+		err = pidFileDirNotify.Mark(unix.FAN_MARK_ADD|unix.FAN_MARK_IGNORED_MASK, unix.FAN_ACCESS_PERM, unix.AT_FDCWD, passwdPath)
+		if err != nil {
+			pidFileDirNotify.File.Close()
+			return fmt.Errorf("marking %s: %w", passwdPath, err)
+		}
+	}
+
 	n.wg.Add(1)
 	go func() {
 		defer n.wg.Done()

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -429,6 +429,16 @@ func (n *RuncNotifier) monitorRuncInstance(bundleDir string, pidFile string) err
 		return fmt.Errorf("ignoring %s: %w", configJSONPath, err)
 	}
 
+	// similar to config.json, we ignore passwd file if it exists
+	passwdPath := filepath.Join(bundleDir, "passwd")
+	if _, err := os.Stat(passwdPath); !errors.Is(err, os.ErrNotExist) {
+		err = pidFileDirNotify.Mark(unix.FAN_MARK_ADD|unix.FAN_MARK_IGNORED_MASK, unix.FAN_ACCESS_PERM, unix.AT_FDCWD, passwdPath)
+		if err != nil {
+			pidFileDirNotify.File.Close()
+			return fmt.Errorf("marking %s: %w", passwdPath, err)
+		}
+	}
+
 	n.wg.Add(1)
 	go func() {
 		defer n.wg.Done()


### PR DESCRIPTION
As mentioned in the comment [here](https://github.com/inspektor-gadget/inspektor-gadget/issues/1692#issuecomment-1591486516) we need to handle `passwd` file in case of non root crio containers. The idea is to ignore events from `passwd` similar to `config.json`.

Fixes: #1692 

## Testing done
Added an integration test: [TestPodWithSecurityContext](https://github.com/inspektor-gadget/inspektor-gadget/blob/69f61a3df1bbecbcad775a708c66ea74b6f4634a/integration/ig/k8s/list_containers_test.go#L247). Also, can be tested manually as:

```bash
$ make CONTAINER_RUNTIME=cri-o minikube-start
$ make ig && docker cp ig minikube-cri-o:/bin/ig
$ docker exec -it minikube-cri-o ig list-containers -w
# start a container with security context in other terminal
$ kubectl run test-pod --image=busybox --overrides='{ "apiVersion": "v1", "spec": { "securityContext": { "runAsUser": 1000 } } }' sleep inf
...
2023-06-16T10:57:59Z           CREATED    cri-o      ff389d1241831c24c25ea845307d039a3aaa218cec98b0d… test-pod
...

