### PR TITLE
Dockerfiles: Set PKG_CONFIG_PATH for arm64.

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -32,6 +32,7 @@ COPY ./ /gadget
 RUN cd /gadget/gadget-container && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		export CC=aarch64-linux-gnu-gcc; \
+		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/; \
 	fi; \
 	make -j$(nproc) TARGET_ARCH=${TARGETARCH} gadget-container-deps
 

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -36,6 +36,7 @@ COPY ./ /gadget
 RUN cd /gadget/gadget-container && \
 	if [ ${TARGETARCH} = 'arm64' ]; then \
 		export CC=aarch64-linux-gnu-gcc; \
+		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/; \
 	fi; \
 	make -j$(nproc) TARGET_ARCH=${TARGETARCH} gadget-container-deps
 


### PR DESCRIPTION
```
On newer version of golang:1.19 which are based on debian bookworm, the build will fail without this variable as pkg-config will try to find libseccomp for amd64 using the default personality.

By setting this variable, it will search it for the corresponding architecture.
```