### PR TITLE
Dockerfiles: Ensure we use 'bullseye' for golang builder image

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -5,7 +5,7 @@
 # and is designed to be used on systems that support BTF
 # (CONFIG_DEBUG_INFO_BTF).
 
-ARG BUILDER_IMAGE=golang:1.19
+ARG BUILDER_IMAGE=golang:1.19-bullseye
 ARG BASE_IMAGE=alpine:3.14
 
 # Prepare and build gadget artifacts in a container

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -2,7 +2,7 @@
 # This image contains CO-RE and BCC-based gadgets. Its base image is the
 # BCC image. It's the default image that is deployed in Inspektor Gadget.
 
-ARG BUILDER_IMAGE=golang:1.19
+ARG BUILDER_IMAGE=golang:1.19-bullseye
 
 # BCC built from the gadget branch in the kinvolk/bcc fork.
 # See BCC section in docs/devel/CONTRIBUTING.md for further details.


### PR DESCRIPTION
golang1.19 switched to using [debian bookworm](https://github.com/docker-library/golang/commit/cd607138e461368506a6ba50be2163a09b93dab5) by default. This results in [couple of issues](https://kubernetes.slack.com/archives/CSYL75LF6/p1686815178297799) related to libseccomp for arm64 and missing GLIBC version for BCC image. We use 'bullseye' image to unblock, till we have a proper way to handle debian bookworm.

Related :
- #1749 
- https://github.com/docker-library/golang/issues/466
