### PR TITLE
parser: Sort events after combining for top/snapshot gadgets

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -161,6 +161,9 @@ func (p *parser[T]) EnableSnapshots(ctx context.Context, interval time.Duration,
 			select {
 			case <-ticker.C:
 				out, _ := p.snapshotCombiner.GetSnapshots()
+				if p.sortSpec != nil {
+					p.sortSpec.Sort(out)
+				}
 				p.eventCallbackArray(out)
 			case <-ctx.Done():
 				return
@@ -179,6 +182,9 @@ func (p *parser[T]) EnableCombiner() {
 }
 
 func (p *parser[T]) Flush() {
+	if p.sortSpec != nil {
+		p.sortSpec.Sort(p.combinedEvents)
+	}
 	p.eventCallbackArray(p.combinedEvents)
 }
 


### PR DESCRIPTION
Currently we don't do any sorting after combining events related to top gadgets from different node. I believe this isn't an expected behavior so I sort events after combining from all the nodes. 

Fixes: #1733 

## Testing done

```bash
# create multi node cluster with ig-k8s
$ MINIKUBE_PARAMS="-n 3" make minikube-deploy
# run the gadget to ensure events are sorted correctly
# if same command is ran w/o the fix you should see output only sorted per node.
$ make kubectl-gadget 
$ ./kubectl-gadget top tcp --all-namespaces --interval 5 --max-rows 20 --sort -sent
```