### PR TITLE
pkg/gadgets/top/ebpf: introduce cpu usage

### DIFF
--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (node,namespace,pod,container,hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (node,namespace,pod,container,hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/gadgets/top/ebpf.md
+++ b/docs/gadgets/top/ebpf.md
@@ -104,3 +104,11 @@ be used by more than one program and would account towards the MapMemory of all 
 Also note:
 * BPF_MAP_TYPE_PERF_EVENT_ARRAY: value_size is not counting the ring buffers, but only their file descriptors (i.e. sizeof(int) = 4 bytes)
 * BPF_MAP_TYPE_{HASH,ARRAY}_OF_MAPS: value_size is not counting the inner maps, but only their file descriptors (i.e. sizeof(int) = 4 bytes)
+
+### A note about CPU usage
+
+There are two types of cpu usage metrics available in top ebpf gadget:
+* TotalCPUUsage: It means all ebpf progs' share of the elapsed CPU time since the last update, expressed as a percentage of total CPU time. This value can be >100% because it summed up cpu time in all cpu cores, similar to linux `top`.
+* PerCPUUsage: This value is `TotalCPUUsage / CPUCores` and `CPUCores` is the number of cpu cores in a node. PerCPUUsage will be always be <=100%. When using ebpf top gadget to check cpu usage for many nodes, it's suggested to use PerCPUUsage.
+
+To show them, you can run the gadget with `percpu` and `totalcpu` specified in `-o columns` option.

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+	github.com/tklauser/numcpus v0.6.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.0
 	go.opentelemetry.io/otel/metric v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
+github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/integration/ig/k8s/top_ebpf_test.go
+++ b/integration/ig/k8s/top_ebpf_test.go
@@ -42,6 +42,8 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 			e.TotalRunCount = 0
 			e.MapMemory = 0
 			e.MapCount = 0
+			e.TotalCpuUsage = 0
+			e.PerCpuUsage = 0
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/non-k8s/top_ebpf_test.go
+++ b/integration/ig/non-k8s/top_ebpf_test.go
@@ -47,6 +47,8 @@ func TestTopEbpf(t *testing.T) {
 				e.TotalRunCount = 0
 				e.MapMemory = 0
 				e.MapCount = 0
+				e.TotalCpuUsage = 0
+				e.PerCpuUsage = 0
 			}
 
 			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -47,6 +47,8 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 			e.TotalRunCount = 0
 			e.MapMemory = 0
 			e.MapCount = 0
+			e.TotalCpuUsage = 0
+			e.PerCpuUsage = 0
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -47,6 +47,8 @@ type Stats struct {
 	TotalRunCount      uint64     `json:"totalRunCount,omitempty" column:"totalRunCount,order:1006,align:right,hide"`
 	MapMemory          uint64     `json:"mapMemory,omitempty" column:"mapmemory,order:1007,align:right"`
 	MapCount           uint32     `json:"mapCount,omitempty" column:"mapcount,order:1008"`
+	TotalCpuUsage      float64    `json:"totalCpuUsage,omitempty" column:"totalcpu,order:1009,align:right,hide"`
+	PerCpuUsage        float64    `json:"perCpuUsage,omitempty" column:"percpu,order:1010,align:right,hide"`
 }
 
 func GetColumns() *columns.Columns[Stats] {
@@ -101,6 +103,12 @@ func GetColumns() *columns.Columns[Stats] {
 	})
 	cols.MustSetExtractor("mapmemory", func(stats *Stats) (ret string) {
 		return fmt.Sprint(units.BytesSize(float64(stats.MapMemory)))
+	})
+	cols.MustSetExtractor("totalcpu", func(stats *Stats) (ret string) {
+		return fmt.Sprintf("%.4f%%", stats.TotalCpuUsage)
+	})
+	cols.MustSetExtractor("percpu", func(stats *Stats) (ret string) {
+		return fmt.Sprintf("%.4f%%", stats.PerCpuUsage)
 	})
 
 	return cols


### PR DESCRIPTION
# pkg/gadgets/top/ebpf: introduce cpu usage

This PR introduces cpu usage column in top ebpf gadget. Related issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/1757

For those who want to compare ebpf prog overheads with other processes, runtime is not intuitive. Thus, It would be better if we have a column `CPU` to show sth like what we see in top.

The definition for cpuusage here is similar to that in `top`. It is defined as: The ebpf prog's share of the elapsed CPU time since the last update, expressed as a percentage of total CPU time. Because the ebpf prog's runtime is adding up runtime on each core in kernel, it's possible that the cpuusage here is over 100%.

## How to use

1. build ig: `make ig`
2. run ig ebpf top: `sudo ./ig top ebpf -o columns=progid,type,name,pid,comm,runtime,cpu`
3. check test case: `make test`

## Testing done

1. make test
4. run ig to check the output. (The column is disabled by default.)
```
$ sudo ./ig top ebpf -o columns=progid,type,name,pid,comm,runtime,cpu
PROGID     TYPE                 NAME                 PID                  COMM                              RUNTIME CPU
4035       Tracing              ig_top_ebpf_it       242591               ig                               269.82µs 0.0270%
4026       SchedCLS             cil_from_contai                                                            229.87µs 0.0230%
3988       SchedCLS             cil_from_contai                                                           139.297µs 0.0139%
3941       SchedCLS             cil_to_containe                                                            120.62µs 0.0121%
```

PTAL, feel free to let me know if you have any comments or concerns on this PR.
