### PR TITLE
deploy: Add 'seLinuxOptions' for gadget container

### DIFF
--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -178,6 +178,14 @@ spec:
           - name: IG_EXPERIMENTAL
             value: "false"
         securityContext:
+          # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate
+          # SELinux context [2] to be able to mount host directories with correct permissions.
+          # This option is ignored if hostPID/hostNetwork/privileged is set to true or SELinux isn't enabled.
+          # See:
+          # 1 - https://github.com/cri-o/cri-o/blob/v1.27.0/server/sandbox_run_linux.go#L537
+          # 2 - https://github.com/cri-o/cri-o/blob/v1.27.0/server/container_create_linux.go#L310
+          seLinuxOptions:
+            type: "spc_t"
           capabilities:
             add:
               # We need CAP_NET_ADMIN to be able to create BPF link.


### PR DESCRIPTION
It seems the pods with hostNetwork/hostPid [1] aren't confined by SELinux. But recently we disabled both hostNetwork/hostPid for gadget pod hence we need to set appropiate SELinux context allowing us to mount host paths with correct persmission. This change also introduces a flag 'skip-selinux-opts' to allow user to skip this option if needed. Please see the [comments](https://github.com/inspektor-gadget/inspektor-gadget/pull/1709#issuecomment-1599080208) for details.

1 - https://github.com/cri-o/cri-o/blob/v1.27.0/server/sandbox_run_linux.go#L537

