### PR TITLE
container-utils: Add TestNewContainerRuntimeClient

### DIFF
--- a/pkg/container-utils/containerutils_test.go
+++ b/pkg/container-utils/containerutils_test.go
@@ -18,7 +18,22 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewContainerRuntimeClient(t *testing.T) {
+	nonExistingSocketPath := filepath.Join(t.TempDir(), "non-existing-socket")
+	for _, runtime := range AvailableRuntimes {
+		rc := RuntimeConfig{
+			Name:       runtime,
+			SocketPath: nonExistingSocketPath,
+		}
+		c, err := NewContainerRuntimeClient(&rc)
+		require.Nil(t, err)
+		require.NotNil(t, c)
+	}
+}
 
 func TestParseOCIState(t *testing.T) {
 	match, err := filepath.Glob("testdata/*.input")


### PR DESCRIPTION
We should be able to initialze runtimeclient.ContainerRuntimeClient even if the underlying runtime isn't available e.g socketPath not found etc. I added a test to ensure we can track this intention.
