### PR TITLE
container-collection: Keep net ns inode id reference

### DIFF
--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -778,10 +778,7 @@ func WithTracerCollection(tc TracerCollection) ContainerCollectionOption {
 						c := value.(*Container)
 
 						if now.Sub(c.deletionTimestamp) > cc.cacheDelay {
-							if c.mntNsFd != 0 {
-								unix.Close(c.mntNsFd)
-								c.mntNsFd = 0
-							}
+							c.close()
 							cc.cachedContainers.Delete(c.ID)
 						}
 
@@ -796,15 +793,23 @@ func WithTracerCollection(tc TracerCollection) ContainerCollectionOption {
 		}()
 
 		cc.containerEnrichers = append(cc.containerEnrichers, func(container *Container) bool {
-			path := filepath.Join(host.HostProcFs, fmt.Sprint(container.Pid), "ns", "mnt")
-			fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+			mntNsPath := filepath.Join(host.HostProcFs, fmt.Sprint(container.Pid), "ns", "mnt")
+			mntNsFd, err := unix.Open(mntNsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 			if err != nil {
 				log.Warnf("WithTracerCollection: failed to open mntns reference for container %s: %s",
 					container.ID, err)
 				return false
 			}
+			container.mntNsFd = mntNsFd
 
-			container.mntNsFd = fd
+			netNsPath := filepath.Join(host.HostProcFs, fmt.Sprint(container.Pid), "ns", "net")
+			netNsFd, err := unix.Open(netNsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+			if err != nil {
+				log.Warnf("WithTracerCollection: failed to open netns reference for container %s: %s",
+					container.ID, err)
+				return false
+			}
+			container.netNsFd = netNsFd
 			return true
 		})
 
@@ -812,10 +817,7 @@ func WithTracerCollection(tc TracerCollection) ContainerCollectionOption {
 			// clean up functions are called with the mutex held
 			cc.cachedContainers.Range(func(key, value interface{}) bool {
 				c := value.(*Container)
-				if c.mntNsFd != 0 {
-					unix.Close(c.mntNsFd)
-					c.mntNsFd = 0
-				}
+				c.close()
 				cc.cachedContainers.Delete(key)
 				return true
 			})


### PR DESCRIPTION
We're hitting, again, the issue where the events are enriched with the wrong container data, this time in networking gadgets. This is happenning because in some situations the container collection can keep the reference to a container that is not present anymore in the kernel (yes, I know containers aren't a kernel concept but you get the point). In this case, the kernel can reuse the net ns inode in a new container, making the enrichment process to use the wrong container.

The solution proposed here is the same as 4dedafc8565d ("Fix race condition on enrichers") but this time for the net ns.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1001

TODO
- [ ] Implement a test like `TestEventEnrichmentRaceCondition` for this case. 