### PR TITLE
podinformer: Fix removing non-running containers

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -88,7 +88,7 @@ if [ "$HOOK_MODE" = "crio" ] ; then
   for HOOK_PATH in "/host/etc/containers/oci/hooks.d" \
                    "/host/usr/share/containers/oci/hooks.d/"
   do
-    echo "Installing OCI hooks configuration in /etc/containers/oci/hooks.d"
+    echo "Installing OCI hooks configuration in $HOOK_PATH"
     mkdir -p $HOOK_PATH
     cp /opt/hooks/crio/gadget-prestart.json $HOOK_PATH 2>/dev/null || true
     cp /opt/hooks/crio/gadget-poststop.json $HOOK_PATH 2>/dev/null || true

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -111,9 +111,8 @@ func (k *K8sClient) GetNonRunningContainers(pod *v1.Pod) []string {
 	return ret
 }
 
-// PodToContainers returns a list of the containers of a given Pod.
-// Containers that are not running or don't have an ID are not considered.
-func (k *K8sClient) PodToContainers(pod *v1.Pod) []Container {
+// GetRunningContainers returns a list of the containers of a given Pod that are running.
+func (k *K8sClient) GetRunningContainers(pod *v1.Pod) []Container {
 	containers := []Container{}
 
 	labels := map[string]string{}
@@ -174,7 +173,7 @@ func (k *K8sClient) ListContainers() (arr []Container, err error) {
 	}
 
 	for _, pod := range pods.Items {
-		containers := k.PodToContainers(&pod)
+		containers := k.GetRunningContainers(&pod)
 		arr = append(arr, containers...)
 	}
 	return arr, nil

--- a/pkg/container-collection/podinformer.go
+++ b/pkg/container-collection/podinformer.go
@@ -44,7 +44,7 @@ type PodInformer struct {
 	informer cache.Controller
 
 	stop           chan struct{}
-	createdPodChan chan *v1.Pod
+	updatedPodChan chan *v1.Pod
 	deletedPodChan chan string
 	wg             sync.WaitGroup
 }
@@ -92,7 +92,7 @@ func NewPodInformer(node string) (*PodInformer, error) {
 		queue:          queue,
 		informer:       informer,
 		stop:           make(chan struct{}),
-		createdPodChan: make(chan *v1.Pod),
+		updatedPodChan: make(chan *v1.Pod),
 		deletedPodChan: make(chan string),
 	}
 
@@ -110,12 +110,12 @@ func (p *PodInformer) Stop() {
 	// writing to closed channels
 	p.wg.Wait()
 
-	close(p.createdPodChan)
+	close(p.updatedPodChan)
 	close(p.deletedPodChan)
 }
 
-func (p *PodInformer) CreatedChan() <-chan *v1.Pod {
-	return p.createdPodChan
+func (p *PodInformer) UpdatedChan() <-chan *v1.Pod {
+	return p.updatedPodChan
 }
 
 func (p *PodInformer) DeletedChan() <-chan string {
@@ -149,7 +149,7 @@ func (p *PodInformer) notifyChans(key string) error {
 		return nil
 	}
 
-	p.createdPodChan <- obj.(*v1.Pod)
+	p.updatedPodChan <- obj.(*v1.Pod)
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes few issues with the logic to remove non-runinng
containers:
1. Remove container that weren't added by the pod informer: it can happen
   that a container is added by a different hook but such hooks fails to
   remove it. In this case the podinformer can act as a backup mechanism
   to remove such container.
   This cause the enrichment to fail in some cases as the cotainer
   collection keep a container with a mount or net ns reference that
   doesn't exist anymore, then it can be reused by a new container making
   the enrichment to enrich with the wrong data.
2. Remove runtime prefix from id: The container's ID in the container
   collection is stored without a container runtime prefix. Remove this
   before calling cc.RemoveContainer().
3. Remove elements from containerIDsByKey map when pod is removed.

---

This PR is a mitigation for https://github.com/inspektor-gadget/inspektor-gadget/issues/1001 (I wasn't able to reproduce the issue anymore with this), but the real solution is in https://github.com/inspektor-gadget/inspektor-gadget/pull/1779.

---

## Testing

0. Deploy Inspektor Gadget in a cluster running cri-o:

```bash
$ minikube start --container-runtime=cri-o -n 1
$ ./kubectl-gadget deploy
```

The following commands assume the cluster only has a single node, update
them in case it isn't true.

### Before this commit

1. Create pod that finishes and it's restarted

```bash
$ kubectl run --restart=Never --image busybox mypod -- sh -c "sleep 5 && echo foo"
```

2. Container is present for a while

```bash
$ PODNAME=$(kubectl -n gadget get pod -o jsonpath='{.items[*].metadata.name}' | awk '{print $1;}')
$ kubectl -n gadget exec -it $PODNAME -- bash -c "gadgettracermanager -dump containers | grep mypod | wc -l"
1
```

3. After the pod is done, the container is still present:
```bash
$ kubectl -n gadget exec -it $PODNAME -- bash -c "gadgettracermanager -dump containers | grep mypod | wc -l"
1
```

The container is marked as `Exited` by cri-o:

```bash
$ minikube ssh "sudo crictl ps -a | grep mypod"
de22f2a3d8414       docker.io/library/busybox@sha256:1b0a26bd07a3d17473d8d8468bea84015e27f87124b283b91d781bce13f61370                45 seconds ago      Exited              mypod                     0                   0492288eb0fcf
```

After some minutes the container is removed from cri-o and then
from Inspektor Gadget too (by using the post-stop hook):

```bash
$ minikube ssh "sudo crictl ps -a | grep mypod"
ssh: Process exited with status 1
$ kubectl -n gadget exec -it $PODNAME -- bash -c "gadgettracermanager -dump containers | grep mypod | wc -l"
0
```

### After this commit

1. Create pod that finishes and it's restarted

```bash
$ kubectl run --restart=Never --image busybox mypod -- sh -c "sleep 5 && echo foo"
```

2. Container is present for a while

```bash
$ PODNAME=$(kubectl -n gadget get pod -o jsonpath='{.items[*].metadata.name}' | awk '{print $1;}')
$ kubectl -n gadget exec -it $PODNAME -- bash -c "gadgettracermanager -dump containers | grep mypod | wc -l"
1
```

3. After the pod is done, the container is removed:
```bash
$ kubectl -n gadget exec -it $PODNAME -- bash -c "gadgettracermanager -dump containers | grep mypod | wc -l"
0
```

