### PR TITLE
integration: Increase wait duration in TestPrometheus

### DIFF
--- a/integration/inspektor-gadget/prometheus_test.go
+++ b/integration/inspektor-gadget/prometheus_test.go
@@ -73,6 +73,7 @@ spec:
       image: prom/prometheus:v2.44.0
       args:
         - "--config.file=/etc/prometheus/prometheus.yml"
+        - "--log.level=debug"
       ports:
         - containerPort: 9090
       volumeMounts:
@@ -109,7 +110,7 @@ EOF
 			},
 			SleepForSecondsCommand(2),
 			BusyboxPodCommand(ns, "for i in $(seq 1 100); do cat /dev/null; done; sleep 2"),
-			SleepForSecondsCommand(5), // wait for prometheus to scrape
+			SleepForSecondsCommand(10), // wait for prometheus to scrape
 			{
 				Name: "ValidatePrometheusMetrics",
 				Cmd:  fmt.Sprintf("kubectl exec -n %s prometheus -- wget -qO- http://localhost:9090/api/v1/query?query=executed_processes_total", ns),


### PR DESCRIPTION
TestPrometheus failed few times in the CI without [expected counter value](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/5177112743/attempts/1#summary-14008659335). We believe it might be related to wait duration after we generate the events. The idea of this change is to increase the sleep interval to ensure we get enough time to capture all the events. Also, it enables debug logging for prometheus pod.