### PR TITLE
entrypoint: Do not fail if os-release info is not available.

### DIFF
--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -16,12 +16,18 @@
 
 set -e
 
-if [ ! -r /host/etc/os-release ] ; then
+if [ ! -d /host/bin ] ; then
   echo "$0 must be executed in a pod with access to the host via /host" >&2
   exit 1
 fi
 
-. /host/etc/os-release
+# In some distributions /host/etc/os-release is a symlink that can't be read from the container. For
+# instance, NixOS -> https://github.com/NixOS/nixpkgs/issues/28833.
+if [ ! -r /host/etc/os-release ] ; then
+  echo "os-release information not available. Some features could not work" >&2
+else
+  . /host/etc/os-release
+fi
 
 echo -n "OS detected: "
 echo $PRETTY_NAME


### PR DESCRIPTION
The entry point script reads the os-release information from /host/etc/os-release. This is used to print some debug messages and to gather the BTF files from btfhub.  In some cases, this file is not available at that location, for instance in NixOS. This makes the installation fail and hence IG is unusable there.

This commit modifies the logic not to return a hard error in that case, as this information is not fundmental and Inspektor Gadget can work without it.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1697. 

--- 

# How to test

I followed the instructions in https://nixos.wiki/wiki/K3s to get a k3s cluster running on NixOS. I used kubectl-gadget v0.17 for this.

```bash
# deploy pointing to custom image
# pass also the containerd socket path is it's not in a standard location
$./kubectl-gadget deploy --image=docker.io/mauriciovasquezbernal/gadget:mauricio-ignore-os-release-error --containerd-socketpath=/run/k3s/containerd/containerd.sock
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Retrieving Gadget Catalog...
Inspektor Gadget successfully deployed

# it works now
$ ./kubectl-gadget trace open -A
NODE                      NAMESPACE                 POD                      CONTAINER                PID        COMM         FD ERR PATH                     
nixos                     kube-system               coredns-59b4f5bbd5-24v6r coredns                  11058      coredns      13 0   /etc/coredns/NodeHosts   
```



