### PR TITLE
ci: Publish a new flavor of ig container image based on busybox.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -367,14 +367,17 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest-amd64: ${{ steps.published-ig-container-images.outputs.amd64 }}
-      digest-arm64: ${{ steps.published-ig-container-images.outputs.arm64 }}
+      digest-default-amd64: ${{ steps.published-ig-container-images.outputs.default-amd64 }}
+      digest-default-arm64: ${{ steps.published-ig-container-images.outputs.default-arm64 }}
+      digest-busybox-amd64: ${{ steps.published-ig-container-images.outputs.busybox-amd64 }}
+      digest-busybox-arm64: ${{ steps.published-ig-container-images.outputs.busybox-arm64 }}
     strategy:
       fail-fast: false
       matrix:
         os: [ linux ]
         # For the moment, we only support these two platforms.
         platform: [ arm64, amd64 ]
+        flavor: [ default, busybox ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up QEMU
@@ -402,25 +405,26 @@ jobs:
         registry: ${{ env.REGISTRY }}
         container-image: ${{ github.repository_owner }}/ig
         co-re: false
-    - name: Build ig ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
+    - name: Build ig ${{ matrix.flavor }} ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
       uses: docker/build-push-action@v4
       with:
         context: /home/runner/work/inspektor-gadget/inspektor-gadget/
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/Dockerfiles/ig.Dockerfile
-        outputs: type=docker,dest=/tmp/ig-container-image--${{ matrix.os }}-${{ matrix.platform }}.tar
-        tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        outputs: type=docker,dest=/tmp/ig-container-image-${{ matrix.flavor }}-${{ matrix.os }}-${{ matrix.platform }}.tar
+        tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}${{ matrix.flavor == 'busybox' && '-busybox' || '' }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}
+        build-args: ${{ matrix.flavor == 'busybox' && 'BASE_IMAGE=busybox:glibc' || '' }}
     - name: Publish ig ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
       uses: actions/upload-artifact@master
       with:
-        name: ig-container-image-${{ matrix.os }}-${{ matrix.platform }}.tar
-        path: /tmp/ig-container-image-${{ matrix.os }}-${{ matrix.platform }}.tar
+        name: ig-container-image-${{ matrix.flavor }}-${{ matrix.os }}-${{ matrix.platform }}.tar
+        path: /tmp/ig-container-image-${{ matrix.flavor }}-${{ matrix.os }}-${{ matrix.platform }}.tar
         retention-days: 1
     # build time will not be increased with this workflow because of internal cache
     # buildx is used here since it allows push-by-digest to avoid platform specific tags
-    - name: Publish ig ${{ matrix.os }} ${{ matrix.platform }} container image to registry
+    - name: Publish ig ${{ matrix.flavor}} ${{ matrix.os }} ${{ matrix.platform }} container image to registry
       id: publish-ig-container-images
       if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v4
@@ -434,11 +438,11 @@ jobs:
       id: published-ig-container-images
       if: github.event_name != 'pull_request'
       run: |
-          echo "${{ matrix.platform }}=${{ steps.publish-ig-container-images.outputs.digest }}" >> $GITHUB_OUTPUT
+          echo "${{ matrix.flavor }}-${{ matrix.platform }}=${{ steps.publish-ig-container-images.outputs.digest }}" >> $GITHUB_OUTPUT
     # old cache entries aren’t deleted, so the cache size keeps growing
     # remove old cache and move new cache to cache path to workaround the issue
     # https://github.com/docker/build-push-action/issues/252
-    - name: Move ig ${{ matrix.os }} ${{ matrix.platform }} container image cache to correct location
+    - name: Move ig ${{ matrix.flavor }}${{ matrix.os }} ${{ matrix.platform }} container image cache to correct location
       run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
@@ -547,8 +551,13 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
-            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-amd64 }} \
-            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-arm64 }}
+            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-default-amd64 }} \
+            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-default-arm64 }}
+
+          docker buildx imagetools create \
+            -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}-busybox \
+            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-busybox-amd64 }} \
+            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-busybox-arm64 }}
 
   build-helper-images:
     # level: 0


### PR DESCRIPTION
The default flavor relies on distroless, so it does not have any shell or tools. This new image brings busybox shell and associated tools.