### PR TITLE
Fix make kubectl-gadget-container

### DIFF
--- a/Dockerfiles/kubectl-gadget.Dockerfile.dockerignore
+++ b/Dockerfiles/kubectl-gadget.Dockerfile.dockerignore
@@ -4,6 +4,7 @@
 !cmd
 !pkg
 !internal/thirdparty
+!internal/deployinfo
 !tools
 !Makefile
 !*.mk


### PR DESCRIPTION
When the --experimental flag was added, it added a internal/deployinfo package that is needed to build kubectl-gadget in a container.

Symptoms:
```
cmd/kubectl-gadget/undeploy.go:25:2: no required module provides package github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo; to add it:
  go get github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo
make: *** [Makefile:121: kubectl-gadget-linux-amd64] Error 1
```

xref https://github.com/inspektor-gadget/inspektor-gadget/pull/1728