### PR TITLE
ci: Replace Mariner name by AzureLinux.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -806,7 +806,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-sku: [Ubuntu, Mariner]
+        os-sku: [Ubuntu, AzureLinux]
         arch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v3
@@ -839,8 +839,8 @@ jobs:
           node_size='Standard_D2ps_v5'
         fi
 
-        # Enable the aks-preview extension to use Mariner as --os-sku.
-        # This should lead to AKS being deployed on top of Mariner 2.0.
+        # Enable the aks-preview extension to use AzureLinux as --os-sku.
+        # This should lead to AKS being deployed on top of AzureLinux.
         # We do not upgrade az because there is a problem doing so in the
         # GitHub Action.
         az extension add --name aks-preview

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 const (
-	K8sDistroAKSMariner = "aks-Mariner"
-	K8sDistroAKSUbuntu  = "aks-Ubuntu"
-	K8sDistroARO        = "aro"
-	K8sDistroMinikubeGH = "minikube-github"
+	K8sDistroAKSAzureLinux = "aks-AzureLinux"
+	K8sDistroAKSUbuntu     = "aks-Ubuntu"
+	K8sDistroARO           = "aro"
+	K8sDistroMinikubeGH    = "minikube-github"
 )
 
 const (
@@ -46,7 +46,7 @@ const securityProfileOperatorNamespace = "security-profiles-operator"
 const topTimeoutInSeconds = 10
 
 var (
-	supportedK8sDistros = []string{K8sDistroAKSMariner, K8sDistroAKSUbuntu, K8sDistroARO, K8sDistroMinikubeGH}
+	supportedK8sDistros = []string{K8sDistroAKSAzureLinux, K8sDistroAKSUbuntu, K8sDistroARO, K8sDistroMinikubeGH}
 	cleaningUp          = uint32(0)
 )
 


### PR DESCRIPTION
AzureLinux is the new name of Mariner, as the latter will soon be deprecated [1].