### PR TITLE
integration: Skip RunTraceOpen on arm64.

### DIFF
--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -28,6 +28,10 @@ func TestRunTraceOpen(t *testing.T) {
 
 	t.Parallel()
 
+	if *k8sArch == "arm64" {
+		t.Skip("Skip running run trace open on arm64 as run gadget does not filter out non existing tracepoints")
+	}
+
 	const (
 		prog = "../../gadgets/trace_open_x86.bpf.o"
 		def  = "../../gadgets/trace_open.yaml"


### PR DESCRIPTION
BYOB does not filter out unexisting trace points.
    Sadly, arm64 does not define open() syscall, only openat().
    Then, when we try to load the corresponding eBPF object file, it will fail due
    to this.
    
 Indeed, at the moment, we do not filter out unexisting tracepoints in BYOB like
    we do in trace open [1].
    
 Fixes: 34e6e36d3e0b ("integration: Add basic test for "run trace open"")