### PR TITLE
ig container image: docs and fixes for kubectl-debug and Docker Desktop on Windows

### DIFF
--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	igmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 const igSubKey = "ig-key"
@@ -39,6 +40,13 @@ func NewListContainersCmd() *cobra.Command {
 		Use:   "list-containers",
 		Short: "List all containers",
 		RunE: func(*cobra.Command, []string) error {
+			// The list-containers command is not a gadget, so the local
+			// runtime won't call host.Init().
+			err := host.Init(host.Config{})
+			if err != nil {
+				return err
+			}
+
 			igmanager, err := igmanager.NewManager(commonFlags.RuntimeConfigs)
 			if err != nil {
 				return commonutils.WrapInErrManagerInit(err)

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 
 	// This is a blank include that actually imports all gadgets
 	// TODO: traceloop is imported separately because it is not in all-gadgets
@@ -47,6 +48,8 @@ func main() {
 		Short: "Collection of gadgets for containers",
 	}
 	common.AddVerboseFlag(rootCmd)
+
+	host.AddFlags(rootCmd)
 
 	rootCmd.AddCommand(
 		containers.NewListContainersCmd(),

--- a/gadget-container/entrypoint.sh
+++ b/gadget-container/entrypoint.sh
@@ -53,17 +53,6 @@ env | grep '^INSPEKTOR_GADGET_OPTION_.*='
 echo -n "Inspektor Gadget version: "
 echo $INSPEKTOR_GADGET_VERSION
 
-# Workaround for Minikube with the Docker driver:
-# Since it starts an outer docker container with a read-only /sys without bpf
-# mounted, passing /sys/fs/bpf from the pseudo-host does not work.
-# See also:
-# https://github.com/kubernetes/minikube/blob/99a0c91459f17ad8c83c80fc37a9ded41e34370c/deploy/kicbase/entrypoint#L76-L81
-BPF_MOUNTPOINT_TYPE="`stat -f -c %T /sys/fs/bpf`"
-if [ "$BPF_MOUNTPOINT_TYPE" != "bpf_fs" ] ; then
-  echo "/sys/fs/bpf is of type $BPF_MOUNTPOINT_TYPE. Remounting."
-  mount -t bpf bpf /sys/fs/bpf/
-fi
-
 CRIO=0
 if grep -q '^1:name=systemd:.*/crio-[0-9a-f]*\.scope$' /proc/self/cgroup > /dev/null ; then
     echo "CRI-O detected."

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -257,8 +256,24 @@ func main() {
 		if experimental.Enabled() {
 			log.Info("Experimental features enabled")
 		}
-		log.Infof("HostPID=%s", strconv.FormatBool(host.IsHostPidNs))
-		log.Infof("HostNetwork=%s", strconv.FormatBool(host.IsHostNetNs))
+		hostConfig := host.Config{
+			AutoMountFilesystems: true,
+		}
+		err := host.Init(hostConfig)
+		if err != nil {
+			log.Fatalf("host.Init() failed: %v", err)
+		}
+
+		hostPidNs, err := host.IsHostPidNs()
+		if err != nil {
+			log.Fatalf("Detecting pid namespace: %v", err)
+		}
+		log.Infof("HostPID=%t", hostPidNs)
+		hostNetNs, err := host.IsHostNetNs()
+		if err != nil {
+			log.Fatalf("Detecting net namespace: %v", err)
+		}
+		log.Infof("HostNetwork=%t", hostNetNs)
 
 		node := os.Getenv("NODE_NAME")
 		if node == "" {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -28,7 +28,17 @@ import (
 	"github.com/moby/moby/pkg/parsers/kernel"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
+
+// HostInit initializes the host package for testing without any automatic workarounds.
+func HostInit(t *testing.T) {
+	err := host.Init(host.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 // CreateMntNsFilterMap creates and fills an eBPF map that can be used
 // to filter by mount namespace in the different tracers.

--- a/pkg/gadgets/internal/socketenricher/tracer_test.go
+++ b/pkg/gadgets/internal/socketenricher/tracer_test.go
@@ -33,6 +33,7 @@ func TestSocketEnricherCreate(t *testing.T) {
 	t.Parallel()
 
 	utilstest.RequireRoot(t)
+	utilstest.HostInit(t)
 
 	tracer, err := NewSocketEnricher()
 	if err != nil {
@@ -47,6 +48,7 @@ func TestSocketEnricherStopIdempotent(t *testing.T) {
 	t.Parallel()
 
 	utilstest.RequireRoot(t)
+	utilstest.HostInit(t)
 
 	tracer, _ := NewSocketEnricher()
 
@@ -70,6 +72,7 @@ func TestSocketEnricherBind(t *testing.T) {
 	t.Parallel()
 
 	utilstest.RequireRoot(t)
+	utilstest.HostInit(t)
 
 	type testDefinition struct {
 		runnerConfig  *utilstest.RunnerConfig

--- a/pkg/gadgets/snapshot/process/tracer/tracer_test.go
+++ b/pkg/gadgets/snapshot/process/tracer/tracer_test.go
@@ -64,6 +64,7 @@ func testTracer(t *testing.T, runCollector collectorFunc) {
 	t.Parallel()
 
 	utilstest.RequireRoot(t)
+	utilstest.HostInit(t)
 
 	type testDefinition struct {
 		getTracerConfig func(info *utilstest.RunnerInfo) *Config

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -132,7 +132,12 @@ func initFanotify() (*fanotify.NotifyFD, error) {
 
 // Supported detects if RuncNotifier is supported in the current environment
 func Supported() bool {
-	if !host.IsHostPidNs {
+	hostPidNs, err := host.IsHostPidNs()
+	if err != nil {
+		log.Debugf("Runcfanotify: not supported: %s", err)
+		return false
+	}
+	if !hostPidNs {
 		log.Debugf("Runcfanotify: not supported: not in host pid namespace")
 		return false
 	}
@@ -141,7 +146,7 @@ func Supported() bool {
 		notifier.Close()
 	}
 	if err != nil {
-		log.Warnf("Runcfanotify: not supported: %s", err)
+		log.Warnf("checking if current pid namespace is host pid namespace %s", err)
 	}
 	return err == nil
 }

--- a/pkg/runtime/local/local.go
+++ b/pkg/runtime/local/local.go
@@ -27,6 +27,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 type Runtime struct {
@@ -57,6 +58,11 @@ func prepareCatalog() *runtime.Catalog {
 func (r *Runtime) Init(globalRuntimeParams *params.Params) error {
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
+	}
+
+	err := host.Init(host.Config{})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/utils/bpf-iter-ns/bpf-iter-ns.go
+++ b/pkg/utils/bpf-iter-ns/bpf-iter-ns.go
@@ -37,7 +37,11 @@ import (
 // Read reads the iterator in the host pid namespace.
 // It will test if the current pid namespace is the host pid namespace.
 func Read(iter *link.Iter) ([]byte, error) {
-	if host.IsHostPidNs {
+	hostPidNs, err := host.IsHostPidNs()
+	if err != nil {
+		return nil, fmt.Errorf("checking if current pid namespace is host pid namespace: %w", err)
+	}
+	if hostPidNs {
 		return ReadOnCurrentPidNs(iter)
 	} else {
 		return ReadOnHostPidNs(iter)

--- a/pkg/utils/host/host.go
+++ b/pkg/utils/host/host.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 // Copyright 2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,38 +27,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+
+	"github.com/spf13/cobra"
 )
 
 var (
 	HostRoot   string
 	HostProcFs string
-
-	IsHostPidNs bool
-	IsHostNetNs bool
 )
-
-func isHostNamespace(nsKind string) bool {
-	selfFileInfo, err := os.Stat("/proc/self/ns/" + nsKind)
-	if err != nil {
-		return false
-	}
-	selfStat, ok := selfFileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-
-	systemdFileInfo, err := os.Stat(fmt.Sprintf("%s/1/ns/%s", HostProcFs, nsKind))
-	if err != nil {
-		return false
-	}
-	systemdStat, ok := systemdFileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-
-	return selfStat.Ino == systemdStat.Ino
-}
 
 func init() {
 	// Initialize HostRoot and HostProcFs
@@ -64,10 +43,119 @@ func init() {
 		HostRoot = "/"
 	}
 	HostProcFs = filepath.Join(HostRoot, "/proc")
+}
 
-	// Initialize IsHost*Ns
-	IsHostPidNs = isHostNamespace("pid")
-	IsHostNetNs = isHostNamespace("net")
+type Config struct {
+	// AutoMountFilesystems will automatically mount bpffs, debugfs and
+	// tracefs if they are not already mounted.
+	//
+	// This is useful for some environments where those filesystems are not
+	// mounted by default on the host, such as:
+	// - minikube with the Docker driver
+	// - Docker Desktop with WSL2
+	// - Talos Linux
+	AutoMountFilesystems bool
+}
+
+var (
+	autoSdUnitRestartFlag    bool
+	autoMountFilesystemsFlag bool
+	autoWSLWorkaroundFlag    bool
+
+	initDone bool
+)
+
+func Init(config Config) error {
+	var err error
+
+	// Init() is called both from the local runtime and the local manager operator.
+	// Different gadgets (trace-exec and top-ebpf) have different code paths, and we need both to make both work.
+	// TODO: understand why we need to call Init() twice and fix it.
+	if initDone {
+		return nil
+	}
+
+	// Apply systemd workaround first because it might start a new process and
+	// exit before the other workarounds.
+	if autoSdUnitRestartFlag {
+		exit, err := autoSdUnitRestart()
+		if exit {
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := suggestSdUnitRestart(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// The mount workaround could either be applied unconditionally (in the
+	// gadget DaemonSet) or with the flag (in ig).
+	if config.AutoMountFilesystems || autoMountFilesystemsFlag {
+		_, err = autoMountFilesystems(false)
+		if err != nil {
+			return err
+		}
+	} else {
+		mountsSuggested, err := autoMountFilesystems(true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		if len(mountsSuggested) != 0 {
+			fmt.Fprintf(os.Stderr, "error: filesystems %s not mounted (did you try --auto-mount-filesystems?)\n", strings.Join(mountsSuggested, ", "))
+			os.Exit(1)
+		}
+	}
+
+	// The WSL workaround is applied with the flag (in ig).
+	if autoWSLWorkaroundFlag {
+		err = autoWSLWorkaround()
+		if err != nil {
+			return err
+		}
+	} else {
+		err = suggestWSLWorkaround()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	initDone = true
+	return nil
+}
+
+// AddFlags adds CLI flags for various workarounds
+func AddFlags(command *cobra.Command) {
+	command.PersistentFlags().BoolVarP(
+		&autoSdUnitRestartFlag,
+		"auto-sd-unit-restart",
+		"",
+		false,
+		"Automatically run in a privileged systemd unit if lacking enough capabilities",
+	)
+	command.PersistentFlags().BoolVarP(
+		&autoMountFilesystemsFlag,
+		"auto-mount-filesystems",
+		"",
+		false,
+		"Automatically mount bpffs, debugfs and tracefs if they are not already mounted",
+	)
+	command.PersistentFlags().BoolVarP(
+		&autoWSLWorkaroundFlag,
+		"auto-wsl-workaround",
+		"",
+		false,
+		"Automatically find the host procfs when running in WSL2",
+	)
 }
 
 func GetProcComm(pid int) string {

--- a/pkg/utils/host/namespaces.go
+++ b/pkg/utils/host/namespaces.go
@@ -1,0 +1,84 @@
+//go:build linux
+// +build linux
+
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package host provides ways to access the host filesystem.
+//
+// Inspektor Gadget can run either in the host or in a container. When running
+// in a container, the host filesystem must be available in a specific
+// directory.
+package host
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+)
+
+var (
+	onceHostPidNs sync.Once
+	isHostPidNs   bool
+	errHostPidNs  error
+
+	onceHostNetNs sync.Once
+	isHostNetNs   bool
+	errHostNetNs  error
+)
+
+// IsHostPidNs returns true if the current process is running in the host PID namespace
+func IsHostPidNs() (bool, error) {
+	onceHostPidNs.Do(func() {
+		isHostPidNs, errHostPidNs = isHostNamespace("pid")
+	})
+	return isHostPidNs, errHostPidNs
+}
+
+// IsHostNetNs returns true if the current process is running in the host network namespace
+func IsHostNetNs() (bool, error) {
+	onceHostNetNs.Do(func() {
+		isHostNetNs, errHostNetNs = isHostNamespace("net")
+	})
+	return isHostNetNs, errHostNetNs
+}
+
+// isHostNamespace checks if the current process is running in the specified host namespace
+func isHostNamespace(nsKind string) (bool, error) {
+	if !initDone {
+		// HostProcFs can be overwritten by workarounds, so Init() must be called first.
+		panic("host.Init() must be called before calling isHostNamespace()")
+	}
+
+	selfFileInfo, err := os.Stat("/proc/self/ns/" + nsKind)
+	if err != nil {
+		return false, err
+	}
+	selfStat, ok := selfFileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("reading inode of /proc/self/ns/%s", nsKind)
+	}
+
+	systemdFileInfo, err := os.Stat(fmt.Sprintf("%s/1/ns/%s", HostProcFs, nsKind))
+	if err != nil {
+		return false, err
+	}
+	systemdStat, ok := systemdFileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("reading inode of %s/1/ns/%s", HostProcFs, nsKind)
+	}
+
+	return selfStat.Ino == systemdStat.Ino, nil
+}

--- a/pkg/utils/host/workarounds.go
+++ b/pkg/utils/host/workarounds.go
@@ -1,0 +1,347 @@
+//go:build linux
+// +build linux
+
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package host provides ways to access the host filesystem.
+//
+// Inspektor Gadget can run either in the host or in a container. When running
+// in a container, the host filesystem must be available in a specific
+// directory.
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/syndtr/gocapability/capability"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func hasCapSysAdmin() (bool, error) {
+	c, err := capability.NewPid2(0)
+	if err != nil {
+		return false, err
+	}
+	err = c.Load()
+	if err != nil {
+		return false, err
+	}
+	return c.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN), nil
+}
+
+func suggestSdUnitRestart() error {
+	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if errors.Is(err, os.ErrNotExist) {
+		// Not running in a pod. Not suggesting --auto-sd-unit-restart
+		return nil
+	}
+
+	hasCap, err := hasCapSysAdmin()
+	if err != nil {
+		return err
+	}
+	if !hasCap {
+		return errors.New("need CAP_SYS_ADMIN (did you try --auto-sd-unit-restart?)")
+	}
+	return nil
+}
+
+// autoSdUnitRestart will automatically restart the process in a privileged
+// systemd unit if the current process does not have enough capabilities.
+func autoSdUnitRestart() (exit bool, err error) {
+	const IgInSystemdUnitEnv = "IG_IN_SYSTEMD_UNIT"
+
+	// No recursive restarts
+	if os.Getenv(IgInSystemdUnitEnv) == "1" {
+		return false, nil
+	}
+
+	// If we already have CAP_SYS_ADMIN, we don't need a workaround
+	hasCap, err := hasCapSysAdmin()
+	if err != nil {
+		return false, err
+	}
+	if hasCap {
+		return false, nil
+	}
+
+	// From here, we decided to use the workaround. This function will return
+	// exit=true.
+
+	if HostRoot == "/" {
+		return true, errors.New("host rootfs not found")
+	}
+
+	// if the host does not use systemd, we cannot use this workaround
+	_, err = os.Stat(filepath.Join(HostRoot, "/run/systemd/private"))
+	if err != nil {
+		return true, errors.New("systemd private socket not found")
+	}
+
+	// Only root can talk to the systemd socket
+	if os.Geteuid() != 0 {
+		return true, errors.New("need root user")
+	}
+
+	runID := uuid.New().String()[:8]
+	unitName := fmt.Sprintf("kubectl-debug-ig-%s.service", runID)
+	log.Debugf("Missing capability. Starting systemd unit %q", unitName)
+
+	// systemdDbus.NewSystemdConnectionContext() hard codes the path to the
+	// systemd socket to /run/systemd/private. We need to make sure that this
+	// path exists (if the /run:/run mount was set up correctly). If it doesn't
+	// exist, we create the symlink to /host/run/systemd/private.
+	_, err = os.Stat("/run/systemd/private")
+	if errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll("/run/systemd", 0o755)
+		if err != nil {
+			return true, err
+		}
+
+		err = os.Symlink("/host/run/systemd/private", "/run/systemd/private")
+		if err != nil {
+			return true, fmt.Errorf("linking /run/systemd/private: %w", err)
+		}
+	} else if err != nil {
+		return true, fmt.Errorf("statting /run/systemd/private: %w", err)
+	}
+
+	conn, err := systemdDbus.NewSystemdConnectionContext(context.TODO())
+	if err != nil {
+		return true, fmt.Errorf("connecting to systemd: %w", err)
+	}
+	defer conn.Close()
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	statusChan := make(chan string, 1)
+	cmd := []string{
+		fmt.Sprintf("/proc/%d/root/usr/bin/ig", os.Getpid()),
+	}
+	cmd = append(cmd, os.Args[1:]...)
+	envs := []string{IgInSystemdUnitEnv + "=1"}
+	isTerminal := term.IsTerminal(int(os.Stdin.Fd())) || term.IsTerminal(int(os.Stdout.Fd())) || term.IsTerminal(int(os.Stderr.Fd()))
+	if isTerminal && os.Getenv("TERM") != "" {
+		envs = append(envs, "TERM="+os.Getenv("TERM"))
+	}
+
+	properties := []systemdDbus.Property{
+		systemdDbus.PropDescription("Inspektor Gadget via kubectl debug"),
+		// Type=oneshot ensures that StartTransientUnitContext will only return "done" when the job is done
+		systemdDbus.PropType("oneshot"),
+		// Pass stdio to the systemd unit
+		{
+			Name:  "StandardInputFileDescriptor",
+			Value: dbus.MakeVariant(dbus.UnixFD(unix.Stdin)),
+		},
+		{
+			Name:  "StandardOutputFileDescriptor",
+			Value: dbus.MakeVariant(dbus.UnixFD(unix.Stdout)),
+		},
+		{
+			Name:  "StandardErrorFileDescriptor",
+			Value: dbus.MakeVariant(dbus.UnixFD(unix.Stderr)),
+		},
+		{
+			Name:  "Environment",
+			Value: dbus.MakeVariant(envs),
+		},
+		systemdDbus.PropExecStart(cmd, true),
+	}
+
+	_, err = conn.StartTransientUnitContext(context.TODO(),
+		unitName, "fail", properties, statusChan)
+	if err != nil {
+		return true, fmt.Errorf("starting transient unit %q: %w", unitName, err)
+	}
+
+	select {
+	case s := <-statusChan:
+		log.Debugf("systemd unit %q returned %q", unitName, s)
+		// "done" indicates successful execution of a job
+		// See https://pkg.go.dev/github.com/coreos/go-systemd/v22/dbus#Conn.StartUnit
+		if s != "done" {
+			conn.ResetFailedUnitContext(context.TODO(), unitName)
+
+			return true, fmt.Errorf("creating systemd unit `%s`: got `%s`", unitName, s)
+		}
+	case sig := <-signalChan:
+		log.Debugf("%s: interrupt systemd unit %q", sig, unitName)
+		statusStopChan := make(chan string, 1)
+		_, err := conn.StopUnitContext(context.TODO(), unitName, "replace", statusStopChan)
+		if err != nil {
+			return true, fmt.Errorf("stopping transient unit %q: %w", unitName, err)
+		}
+		s := <-statusChan
+		if s != "done" && s != "canceled" {
+			return true, fmt.Errorf("stopping transient unit %q: got `%s`", unitName, s)
+		}
+	}
+
+	return true, nil
+}
+
+// autoMount ensures that filesystems are mounted correctly.
+// Some environments (e.g. minikube) runs with a read-only /sys without bpf
+// https://github.com/kubernetes/minikube/blob/99a0c91459f17ad8c83c80fc37a9ded41e34370c/deploy/kicbase/entrypoint#L76-L81
+// Docker Desktop with WSL2 also has filesystems unmounted.
+//
+// If dryRun is true, autoMount will only check if the filesystems need to be
+// mounted.
+// Returns the list of filesystems that need to be mounted.
+func autoMountFilesystems(dryRun bool) (mountsSuggested []string, err error) {
+	fs := []struct {
+		name    string
+		path    string
+		magic   int64
+		suggest bool // suggest mounting this filesystem
+	}{
+		{
+			"bpf",
+			"/sys/fs/bpf",
+			unix.BPF_FS_MAGIC,
+			false, // do not make 'ig --auto-mount-filesystems=false' fail if bpffs is not mounted
+		},
+		{
+			"debugfs",
+			"/sys/kernel/debug",
+			unix.DEBUGFS_MAGIC,
+			true,
+		},
+		{
+			"tracefs",
+			"/sys/kernel/tracing",
+			unix.TRACEFS_MAGIC,
+			true,
+		},
+	}
+	for _, f := range fs {
+		var statfs unix.Statfs_t
+		err = unix.Statfs(f.path, &statfs)
+		if err != nil {
+			return mountsSuggested, fmt.Errorf("statfs %s: %w", f.path, err)
+		}
+		if statfs.Type == f.magic {
+			log.Debugf("%s already mounted", f.name)
+			continue
+		}
+		if f.suggest {
+			mountsSuggested = append(mountsSuggested, f.name)
+		}
+		if dryRun {
+			continue
+		}
+
+		err = unix.Mount("none", f.path, f.name, 0, "")
+		if err != nil {
+			return mountsSuggested, fmt.Errorf("mounting %s: %w", f.path, err)
+		}
+		log.Debugf("%s mounted (%s)", f.name, f.path)
+	}
+	return
+}
+
+func suggestWSLWorkaround() error {
+	var utsname unix.Utsname
+	err := unix.Uname(&utsname)
+	if err != nil {
+		return err
+	}
+	release := unix.ByteSliceToString(utsname.Release[:])
+	if !strings.HasSuffix(release, "-WSL2") {
+		return nil
+	}
+
+	// If /host/proc is correctly set up, we don't need this workaround
+	target, err := os.Readlink(HostProcFs + "/self")
+	if target != "" && err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%s/self not found on WSL2 (did you try --auto-wsl-workaround?)", HostProcFs)
+}
+
+// autoWSLWorkaround overrides HostRoot and HostProcFs if necessary.
+// Docker Desktop with WSL2 sets up host volumes with weird pidns.
+func autoWSLWorkaround() error {
+	// If we're not in a container, we can't use this workaround
+	if HostRoot == "/" {
+		return nil
+	}
+
+	// If /host/proc is correctly set up, we don't need this workaround
+	target, err := os.Readlink(HostProcFs + "/self")
+	if target != "" && err == nil {
+		return nil
+	}
+
+	log.Warnf("%s's pidns is neither the current pidns or a parent of the current pidns. Remounting.", HostProcFs)
+	err = unix.Mount("/proc", HostProcFs, "", unix.MS_BIND, "")
+	if err != nil {
+		return fmt.Errorf("remounting %s: %w", HostProcFs, err)
+	}
+	// Find lifecycle-server process and set HOST_PID to its root
+	processes, err := os.ReadDir(HostProcFs)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", HostProcFs, err)
+	}
+	for _, p := range processes {
+		if !p.IsDir() {
+			continue
+		}
+
+		pid, err := strconv.Atoi(p.Name())
+		if err != nil {
+			continue
+		}
+
+		cmdLine := GetProcCmdline(pid)
+		if cmdLine[0] != "/usr/bin/lifecycle-server" {
+			continue
+		}
+		log.Debugf("Found lifecycle-server process %s", p.Name())
+
+		buf, err := os.ReadFile(fmt.Sprintf("/proc/%s/cgroup", p.Name()))
+		if err != nil {
+			continue
+		}
+		if !strings.Contains(string(buf), "/podruntime/docker") {
+			continue
+		}
+		log.Debugf("Found lifecycle-server process %s in cgroup /podruntime/docker", p.Name())
+
+		HostRoot = fmt.Sprintf("/proc/%s/root/", p.Name())
+		HostProcFs = filepath.Join(HostRoot, "/proc")
+		log.Warnf("Overriding HostRoot=%s HostProcFs=%s (lifecycle-server)", HostRoot, HostProcFs)
+
+		return nil
+	}
+
+	return errors.New("lifecycle-server process not found")
+}


### PR DESCRIPTION
Since #1787, ig is published as a container image. You can fetch it with:
```
docker pull ghcr.io/inspektor-gadget/ig
```

This PR adds documentation and fixes for kubectl-debug and Docker Desktop on Windows.

This is part of removing things from entrypoint.sh as suggested in #801. This picks up the changes in entrypoint.sh required by Docker Desktop (#1768). See also https://github.com/inspektor-gadget/inspektor-gadget/pull/1789#discussion_r1245693180.


## How to use

### Using ig with kubectl debug

Examples of commands:

```bash
$ kubectl debug node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig trace exec
$ kubectl debug node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig list-containers -o json
```

### Using ig in a container

Example of command:

```bash
$ docker run -ti --rm \
    --privileged \
    -v /sys/fs/bpf:/sys/fs/bpf \
    -v /sys/kernel/debug:/sys/kernel/debug \
    -v /run:/run \
    -v /:/host \
    -e HOST_ROOT=/host \
    ghcr.io/inspektor-gadget/ig \
    trace exec
CONTAINER    PID        PPID       COMM  RET ARGS
cool_wright  1163565    1154511    ls    0   /bin/ls
```

If you use Docker Desktop on Windows, please add `--pid=host` in the docker command.

## Testing done

I tested the commands above with `albantest.azurecr.io/ig:dev-pr1` on:
- minikube with docker driver
- Docker Desktop on Windows with WSL2

cc @mqasimsarfraz @eiffel-fl 

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1783