### PR TITLE
Fix panic with --host on non-networking gadgets

### DIFF
--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -339,15 +339,17 @@ func (l *localManagerTrace) PostGadgetRun() error {
 		log.Debugf("calling Unsubscribe()")
 		l.manager.igManager.Unsubscribe(l.subscriptionKey)
 
-		// emit detach for all remaining containers
-		for container := range l.attachedContainers {
-			l.attacher.DetachContainer(container)
-		}
+		if l.attacher != nil {
+			// emit detach for all remaining containers
+			for container := range l.attachedContainers {
+				l.attacher.DetachContainer(container)
+			}
 
-		if host {
-			// Reciprocal operation of attaching fake container with PID 1 which is
-			// needed by gadgets relying on the Attacher concept.
-			l.attacher.DetachContainer(&containercollection.Container{Pid: 1})
+			if host {
+				// Reciprocal operation of attaching fake container with PID 1 which is
+				// needed by gadgets relying on the Attacher concept.
+				l.attacher.DetachContainer(&containercollection.Container{Pid: 1})
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Don't call AttachContainer/DetachContainer on gadgets that don't implement that interface.

Symptoms: ig panics after ctrl-c with trace exec --host

```
^Cpanic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1d8f0eb]

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManagerTrace).PostGadgetRun(0xc0004ca700)
	/go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager/localmanager.go:350 +0x24b
github.com/inspektor-gadget/inspektor-gadget/pkg/operators.OperatorInstances.PostGadgetRun(...)
	/go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/operators/operators.go:255
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget.func2()
	/go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local/local.go:143 +0xbf
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget(0x0?, {0x2b3a8a0, 0xc0015617a0})
	/go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local/local.go:156 +0xd08
github.com/inspektor-gadget/inspektor-gadget/cmd/common.buildCommandFromGadget.func2(0xc00060fdc8?, {0xc00054ade0, 0x1, 0x1})
	/go/src/github.com/inspektor-gadget/inspektor-gadget/cmd/common/registry.go:492 +0x1b9a
github.com/spf13/cobra.(*Command).execute(0xc0000fa900, {0xc00054ade0, 0x1, 0x1})
	/go/src/github.com/inspektor-gadget/inspektor-gadget/vendor/github.com/spf13/cobra/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000476000)
	/go/src/github.com/inspektor-gadget/inspektor-gadget/vendor/github.com/spf13/cobra/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/inspektor-gadget/inspektor-gadget/vendor/github.com/spf13/cobra/command.go:992
main.main()
	/go/src/github.com/inspektor-gadget/inspektor-gadget/cmd/ig/main.go:61 +0x1a5
```

Fixes 740976d3ab0f ("pkg/operators: Enable tracing hosts events for attacher gadgets")

Introduced by #1786