### PR TITLE
gadgets/run: Add JSON output

### DIFF
--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -49,50 +49,39 @@ func TestRunTraceOpen(t *testing.T) {
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET run --prog @%s --definition @%s -n %s -o json", prog, def, ns),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
-			expectedEntry := &types.Event{
+			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
 				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
-				Data: map[string]interface{}{
-					"comm":      "cat",
-					"fname":     "/dev/null",
-					"uid":       uint32(1000),
-					"gid":       uint32(1111),
-					"ret":       3,
-					"flags":     0,
-					"mode":      uint16(0),
-					"mntns_id":  uint64(0),
-					"pid":       uint32(0),
-					"timestamp": uint64(0),
-				},
+			})
+
+			expectedTraceOpenJsonObj := map[string]interface{}{
+				"comm":     "cat",
+				"fname":    "/dev/null",
+				"uid":      1000,
+				"gid":      1111,
+				"ret":      3,
+				"flags":    0,
+				"mntns_id": 0,
+				"pid":      0,
 			}
 
-			normalize := func(e *types.Event) {
-				e.Timestamp = 0
-				e.MountNsID = 0
-				e.RawData = nil
-				data := e.Data.(map[string]interface{})
-				if data == nil {
-					return
-				}
-				data["pid"] = uint32(0)
-				data["mntns_id"] = uint64(0)
-				data["timestamp"] = uint64(0)
+			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceOpenJsonObj)
 
-				// TODO: find better way
-				// json unmarshalling always uses float64 for numbers
-				data["ret"] = int(data["ret"].(float64))
-				data["flags"] = int(data["flags"].(float64))
-				data["mode"] = uint16(data["mode"].(float64))
-				data["uid"] = uint32(data["uid"].(float64))
-				data["gid"] = uint32(data["gid"].(float64))
+			normalize := func(m map[string]interface{}) {
+				SetEventTimestamp(m, 0)
+				SetEventMountNsID(m, 0)
 
-				e.K8s.Node = ""
+				SetEventK8sNode(m, "")
+
 				// TODO: Verify container runtime and container name
-				e.Runtime.RuntimeName = ""
-				e.Runtime.ContainerName = ""
-				e.Runtime.ContainerID = ""
+				SetEventRuntimeName(m, "")
+				SetEventRuntimeContainerID(m, "")
+				SetEventRuntimeContainerName(m, "")
+
+				m["pid"] = uint32(0)
+				m["mntns_id"] = uint64(0)
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			return ExpectEntriesToMatchObj(t, output, normalize, expectedJsonObj)
 		},
 	}
 

--- a/integration/run_helpers.go
+++ b/integration/run_helpers.go
@@ -1,0 +1,176 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	columns_json "github.com/inspektor-gadget/inspektor-gadget/pkg/columns/formatter/json"
+	runtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/run/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func SetEventTimestamp(jsonObj map[string]interface{}, timestamp eventtypes.Time) {
+	jsonObj["timestamp"] = timestamp.String()
+}
+
+func SetEventMountNsID(jsonObj map[string]interface{}, mountNsID uint64) {
+	jsonObj["mntns"] = mountNsID
+}
+
+func SetEventRuntimeName(jsonObj map[string]interface{}, runtimeName eventtypes.RuntimeName) {
+	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
+	if runtimeMetadata != nil {
+		runtimeMetadata["runtimeName"] = runtimeName
+	}
+}
+
+func SetEventRuntimeContainerID(jsonObj map[string]interface{}, s string) {
+	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
+	if runtimeMetadata != nil {
+		runtimeMetadata["containerId"] = s
+	}
+}
+
+func SetEventRuntimeContainerName(jsonObj map[string]interface{}, s string) {
+	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
+	if runtimeMetadata != nil {
+		runtimeMetadata["containerName"] = s
+	}
+}
+
+func SetEventK8sNode(jsonObj map[string]interface{}, s string) {
+	jsonObj["node"] = s
+}
+
+func SetEventK8sNamespace(jsonObj map[string]interface{}, s string) {
+	jsonObj["namespace"] = s
+}
+
+func SetEventK8sPod(jsonObj map[string]interface{}, s string) {
+	jsonObj["pod"] = s
+}
+
+func SetEventK8sContainer(jsonObj map[string]interface{}, s string) {
+	jsonObj["container"] = s
+}
+
+func SetEventK8sHostNetwork(jsonObj map[string]interface{}, b bool) {
+	jsonObj["hostnetwork"] = b
+}
+
+func RunEventToObj(t *testing.T, ev *runtypes.Event) map[string]interface{} {
+	cols := columns.MustCreateColumns[runtypes.Event]()
+	jsonFormatter := columns_json.NewFormatter[runtypes.Event](cols.GetColumnMap())
+
+	jsonStr := jsonFormatter.FormatEntry(ev)
+
+	var jsonObj map[string]interface{}
+	err := json.Unmarshal([]byte(jsonStr), &jsonObj)
+	require.NoError(t, err, "unmarshalling event json")
+
+	delete(jsonObj, "raw_data")
+	delete(jsonObj, "data")
+
+	return jsonObj
+}
+
+// MergeJsonObjs merges two JSON objects (map[string]interface{}) and returns a copy.
+// The original objects are not modified in order to use the base for multiple merges.
+// If a key exists in both objects, the function fails.
+func MergeJsonObjs(t *testing.T, base map[string]interface{}, additionalFields map[string]interface{}) map[string]interface{} {
+	// First copy the base map
+	target := map[string]interface{}{}
+	for k, v := range base {
+		target[k] = v
+	}
+	// Then merge the additional fields and fail if a field already exists
+	for k, v := range additionalFields {
+		_, ok := target[k]
+		require.False(t, ok, fmt.Sprintf("key %s already exists in target map", k))
+		target[k] = v
+	}
+	return target
+}
+
+// parseMultiJSONOutputToObj parses a string containing multiple JSON objects
+// (one per line) into a slice of maps.
+func parseMultiJSONOutputToObj(output string, normalize func(map[string]interface{})) ([]map[string]interface{}, error) {
+	ret := []map[string]interface{}{}
+
+	decoder := json.NewDecoder(strings.NewReader(output))
+	for decoder.More() {
+		var entry map[string]interface{}
+		if err := decoder.Decode(&entry); err != nil {
+			return nil, fmt.Errorf("decoding json: %w", err)
+		}
+		if normalize != nil {
+			normalize(entry)
+		}
+
+		// Marshal & Unmarshal to have the right types in the map
+		bytes, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling json: %w", err)
+		}
+		err = json.Unmarshal(bytes, &entry)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling json: %w", err)
+		}
+		ret = append(ret, entry)
+	}
+	return ret, nil
+}
+
+// expectEntriesToMatchObj verifies that all the entries in expectedEntries are
+// matched by at least one entry in the output
+func expectEntriesToMatchObj(t *testing.T, entries []map[string]interface{}, expectedEntries ...map[string]interface{}) error {
+out:
+	for _, expectedEntry := range expectedEntries { // Marshal & Unmarshal to have the right types in the map
+		bytes, err := json.Marshal(expectedEntry)
+		require.NoError(t, err, "marshalling expectedEntry")
+		err = json.Unmarshal(bytes, &expectedEntry)
+		require.NoError(t, err, "unmarshalling expectedEntry")
+
+		for _, entry := range entries {
+			if entry["fname"] == "/dev/null" {
+				fmt.Println("actual entry:", entry)
+			}
+			if reflect.DeepEqual(expectedEntry, entry) {
+				continue out
+			}
+		}
+		expectedJsonEntry, _ := json.Marshal(expectedEntry)
+		return fmt.Errorf("output doesn't contain the expected entry: %+v", string(expectedJsonEntry))
+	}
+	return nil
+}
+
+// ExpectEntriesToMatchObj verifies that all the entries in expectedEntries are
+// matched by at least one entry in the output (Lines of independent JSON objects).
+func ExpectEntriesToMatchObj(t *testing.T, output string, normalize func(map[string]interface{}), expectedEntries ...map[string]interface{}) error {
+	entries, err := parseMultiJSONOutputToObj(output, normalize)
+	if err != nil {
+		return err
+	}
+	return expectEntriesToMatchObj(t, entries, expectedEntries...)
+}

--- a/pkg/columns/formatter/json/buffer.go
+++ b/pkg/columns/formatter/json/buffer.go
@@ -1,0 +1,32 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bufpool = sync.Pool{
+	New: func() interface{} {
+		return &encodeState{}
+	},
+}
+
+type encodeState struct {
+	bytes.Buffer
+	scratch [64]byte
+	err     error
+}

--- a/pkg/columns/formatter/json/json.go
+++ b/pkg/columns/formatter/json/json.go
@@ -1,0 +1,264 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"unicode/utf8"
+	_ "unsafe"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+)
+
+type column[T any] struct {
+	name      string
+	nameb     []byte
+	column    *columns.Column[T]
+	formatter func(*encodeState, *T)
+}
+
+type Formatter[T any] struct {
+	options *Options
+	columns []*column[T]
+}
+
+// NewFormatter returns a Formatter that will turn entries of type T into JSON representation
+func NewFormatter[T any](cols columns.ColumnMap[T], options ...Option) *Formatter[T] {
+	opts := DefaultOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	ncols := make([]*column[T], 0)
+	for _, col := range cols.GetOrderedColumns() {
+		name, _ := json.Marshal(col.Name)
+		key := append(name, []byte(": ")...)
+
+		var formatter func(*encodeState, *T)
+		switch col.Kind() {
+		default:
+			continue
+		case reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64:
+			ff := columns.GetFieldAsNumberFunc[int64, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				b := strconv.AppendInt(e.scratch[:0], ff(t), 10)
+				e.Write(b)
+			}
+		case reflect.Uint,
+			reflect.Uint8,
+			reflect.Uint16,
+			reflect.Uint32,
+			reflect.Uint64:
+			ff := columns.GetFieldAsNumberFunc[uint64, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				b := strconv.AppendUint(e.scratch[:0], ff(t), 10)
+				e.Write(b)
+			}
+		case reflect.Bool:
+			ff := columns.GetFieldFunc[bool, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				if ff(t) {
+					e.WriteString("true")
+					return
+				}
+				e.WriteString("false")
+			}
+		case reflect.Float32:
+			ff := columns.GetFieldAsNumberFunc[float64, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				floatEncoder(32).writeFloat(e, ff(t))
+			}
+		case reflect.Float64:
+			ff := columns.GetFieldAsNumberFunc[float64, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				floatEncoder(64).writeFloat(e, ff(t))
+			}
+		case reflect.Array:
+			ff := columns.GetFieldAsString[T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				writeString(e, ff(t))
+			}
+		case reflect.String:
+			ff := columns.GetFieldFunc[string, T](col)
+			formatter = func(e *encodeState, t *T) {
+				e.Write(key)
+				writeString(e, ff(t))
+			}
+		}
+
+		ncols = append(ncols, &column[T]{
+			column:    col,
+			name:      string(name) + ": ",
+			nameb:     []byte(string(name) + ": "),
+			formatter: formatter,
+		})
+	}
+
+	tf := &Formatter[T]{
+		options: opts,
+		columns: ncols,
+	}
+	return tf
+}
+
+// FormatEntry returns an entry as a formatted string, respecting the given formatting settings
+func (f *Formatter[T]) FormatEntry(entry *T) string {
+	if entry == nil {
+		return ""
+	}
+
+	buf := bufpool.Get().(*encodeState)
+	buf.Reset()
+	defer bufpool.Put(buf)
+
+	buf.WriteByte('{')
+	for i, col := range f.columns {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		col.formatter(buf, entry)
+	}
+	buf.WriteByte('}')
+	return buf.String()
+}
+
+type floatEncoder int // number of bits
+
+// from encoding/json/encode.go
+func (bits floatEncoder) writeFloat(e *encodeState, f float64) {
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		e.err = fmt.Errorf("invalid float value")
+		return
+	}
+
+	// Convert as if by ES6 number to string conversion.
+	// This matches most other JSON generators.
+	// See golang.org/issue/6384 and golang.org/issue/14135.
+	// Like fmt %g, but the exponent cutoffs are different
+	// and exponents themselves are not padded to two digits.
+	b := e.scratch[:0]
+	abs := math.Abs(f)
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if bits == 64 && (abs < 1e-6 || abs >= 1e21) || bits == 32 && (float32(abs) < 1e-6 || float32(abs) >= 1e21) {
+			fmt = 'e'
+		}
+	}
+	b = strconv.AppendFloat(b, f, fmt, -1, int(bits))
+	if fmt == 'e' {
+		// clean up e-09 to e-9
+		n := len(b)
+		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+
+	e.Write(b)
+}
+
+// from encoding/json/encode.go
+func writeString(e *encodeState, s string) {
+	e.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			e.WriteByte('\\')
+			switch b {
+			case '\\', '"':
+				e.WriteByte(b)
+			case '\n':
+				e.WriteByte('n')
+			case '\r':
+				e.WriteByte('r')
+			case '\t':
+				e.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				e.WriteString(`u00`)
+				e.WriteByte(hex[b>>4])
+				e.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			e.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			e.WriteString(`\u202`)
+			e.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		e.WriteString(s[start:])
+	}
+	e.WriteByte('"')
+}
+
+var hex = "0123456789abcdef"
+
+// use safeSet from encoding/json directly
+//
+//go:linkname safeSet encoding/json.safeSet
+var safeSet = [utf8.RuneSelf]bool{}

--- a/pkg/columns/formatter/json/json.go
+++ b/pkg/columns/formatter/json/json.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 	_ "unsafe"
 
@@ -45,7 +46,12 @@ func NewFormatter[T any](cols columns.ColumnMap[T], options ...Option) *Formatte
 
 	ncols := make([]*column[T], 0)
 	for _, col := range cols.GetOrderedColumns() {
-		name, _ := json.Marshal(col.Name)
+		colName := col.Name
+		if strings.Contains(colName, ".") {
+			hierarchy := strings.Split(colName, ".")
+			colName = hierarchy[len(hierarchy)-1]
+		}
+		name, _ := json.Marshal(colName)
 		key := append(name, []byte(": ")...)
 
 		var formatter func(*encodeState, *T)
@@ -123,6 +129,75 @@ func NewFormatter[T any](cols columns.ColumnMap[T], options ...Option) *Formatte
 	return tf
 }
 
+func (f *Formatter[T]) printCols(entry *T, buf *encodeState, cols []*column[T], level int) {
+	indent := strings.Repeat("  ", level+1)
+	colsWithParent := map[string][]*column[T]{}
+	colsWithoutParent := []*column[T]{}
+
+	for _, col := range cols {
+		// Save columns which have a parent in its name
+		if strings.Count(col.column.Name, ".") > level {
+			hierarchy := strings.Split(col.column.Name, ".")
+			parentName := hierarchy[level]
+			colsWithParent[parentName] = append(colsWithParent[parentName], col)
+			continue
+		}
+		// Don't print columns without a parent directly
+		// It is possible that their name is the same as a name of an object in the same level
+		// For example: {"a": {"bbb": 1}, "a": 2}
+		// We will filter them out after we gathered all object names
+		colsWithoutParent = append(colsWithoutParent, col)
+	}
+
+	first := true
+	// Better name?
+	handlePrefix := func() {
+		if !first {
+			buf.WriteByte(',')
+			if f.options.prettyPrint {
+				buf.WriteString("\n" + indent)
+			} else {
+				buf.WriteByte(' ')
+			}
+		} else {
+			if f.options.prettyPrint {
+				buf.WriteString("\n" + indent)
+			}
+			first = false
+		}
+	}
+
+	// Now print columns with their parents
+	for key, val := range colsWithParent {
+		handlePrefix()
+
+		parentName, _ := json.Marshal(strings.Split(key, ".")[0])
+		buf.Write(parentName)
+		buf.WriteString(": {")
+
+		f.printCols(entry, buf, val, level+1)
+
+		// End parent
+		if f.options.prettyPrint {
+			buf.WriteString("\n" + indent + "}")
+		} else {
+			buf.WriteByte('}')
+		}
+	}
+
+	// Now all cols without a parent
+	for _, col := range colsWithoutParent {
+		childName := strings.Split(col.column.Name, ".")[level]
+		_, found := colsWithParent[childName]
+		if found {
+			// We already have an object with this key, skip this column
+			continue
+		}
+		handlePrefix()
+		col.formatter(buf, entry)
+	}
+}
+
 // FormatEntry returns an entry as a formatted string, respecting the given formatting settings
 func (f *Formatter[T]) FormatEntry(entry *T) string {
 	if entry == nil {
@@ -134,28 +209,12 @@ func (f *Formatter[T]) FormatEntry(entry *T) string {
 	defer bufpool.Put(buf)
 
 	buf.WriteByte('{')
+	f.printCols(entry, buf, f.columns, 0)
 	if f.options.prettyPrint {
 		buf.WriteByte('\n')
 	}
-	for i, col := range f.columns {
-		if i > 0 {
-			buf.WriteByte(',')
-			if f.options.prettyPrint {
-				buf.WriteByte('\n')
-			} else {
-				buf.WriteByte(' ')
-			}
-		}
-		if f.options.prettyPrint {
-			buf.WriteString("  ")
-		}
-		col.formatter(buf, entry)
-	}
-	// Don't pretty-print a newline when there are no columns
-	if f.options.prettyPrint && len(f.columns) > 0 {
-		buf.WriteByte('\n')
-	}
 	buf.WriteByte('}')
+
 	return buf.String()
 }
 

--- a/pkg/columns/formatter/json/json_test.go
+++ b/pkg/columns/formatter/json/json_test.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	Name     string  `column:"name"`
+	Age      uint    `column:"age"`
+	Size     float32 `column:"size"`
+	Balance  int     `column:"balance"`
+	CanDance bool    `column:"canDance"`
+}
+
+var testEntries = []*testStruct{
+	{"Alice", 32, 1.74, 1000, true},
+	{"Bob", 26, 1.73, -200, true},
+	{"Eve", 99, 5.12, 1000000, false},
+	nil,
+}
+
+var testColumns = columns.MustCreateColumns[testStruct]().GetColumnMap()
+
+func TestJSONFormatter_FormatEntry(t *testing.T) {
+	expected := []string{
+		`{"name": "Alice", "age": 32, "size": 1.74, "balance": 1000, "canDance": true}`,
+		`{"name": "Bob", "age": 26, "size": 1.73, "balance": -200, "canDance": true}`,
+		`{"name": "Eve", "age": 99, "size": 5.12, "balance": 1000000, "canDance": false}`,
+		``,
+	}
+	formatter := NewFormatter(testColumns)
+	for i, entry := range testEntries {
+		assert.Equal(t, expected[i], formatter.FormatEntry(entry))
+	}
+}
+
+func BenchmarkFormatter(b *testing.B) {
+	b.StopTimer()
+	formatter := NewFormatter(testColumns)
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		formatter.FormatEntry(testEntries[n%len(testEntries)])
+	}
+}
+
+func BenchmarkNative(b *testing.B) {
+	b.StopTimer()
+	// do a dry-run to enable caching
+	json.Marshal(testEntries[0])
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		json.Marshal(testEntries[n%len(testEntries)])
+	}
+}
+
+func TestDynamicFields(t *testing.T) {
+	// Write the data in its binary representation to a buffer
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.LittleEndian, []uint8("foobar"))
+	require.NoError(t, err)
+	err = binary.Write(buf, binary.LittleEndian, int32(1234567890))
+	require.NoError(t, err)
+	err = binary.Write(buf, binary.LittleEndian, true)
+	require.NoError(t, err)
+
+	fields := []columns.DynamicField{{
+		Attributes: &columns.Attributes{
+			Name:    "str",
+			Width:   columns.GetDefault().DefaultWidth,
+			Visible: true,
+			Order:   0,
+		},
+		Type:   reflect.TypeOf([6]uint8{}),
+		Offset: 0,
+	}, {
+		Attributes: &columns.Attributes{
+			Name:    "int32",
+			Width:   columns.GetDefault().DefaultWidth,
+			Visible: true,
+			Order:   1,
+		},
+		Type:   reflect.TypeOf(int32(0)),
+		Offset: 6,
+	}, {
+		Attributes: &columns.Attributes{
+			Name:    "bool",
+			Width:   columns.GetDefault().DefaultWidth,
+			Visible: true,
+			Order:   2,
+		},
+		Type:   reflect.TypeOf(true),
+		Offset: 10,
+	}}
+
+	type empty struct{}
+	cols := columns.MustCreateColumns[empty]()
+	cols.AddFields(fields, func(ev *empty) unsafe.Pointer {
+		bytes := buf.Bytes()
+		return unsafe.Pointer(&bytes[0])
+	})
+	formatter := NewFormatter[empty](cols.GetColumnMap())
+	assert.Equal(t, `{"str": "foobar", "int32": 1234567890, "bool": true}`, formatter.FormatEntry(&empty{}))
+}

--- a/pkg/columns/formatter/json/json_test.go
+++ b/pkg/columns/formatter/json/json_test.go
@@ -57,6 +57,37 @@ func TestJSONFormatter_FormatEntry(t *testing.T) {
 	}
 }
 
+func TestJSONFormatter_PrettyFormatEntry(t *testing.T) {
+	expected := []string{
+		`{
+  "name": "Alice",
+  "age": 32,
+  "size": 1.74,
+  "balance": 1000,
+  "canDance": true
+}`,
+		`{
+  "name": "Bob",
+  "age": 26,
+  "size": 1.73,
+  "balance": -200,
+  "canDance": true
+}`,
+		`{
+  "name": "Eve",
+  "age": 99,
+  "size": 5.12,
+  "balance": 1000000,
+  "canDance": false
+}`,
+		``,
+	}
+	formatter := NewFormatter(testColumns, WithPrettyPrint())
+	for i, entry := range testEntries {
+		assert.Equal(t, expected[i], formatter.FormatEntry(entry))
+	}
+}
+
 func BenchmarkFormatter(b *testing.B) {
 	b.StopTimer()
 	formatter := NewFormatter(testColumns)

--- a/pkg/columns/formatter/json/options.go
+++ b/pkg/columns/formatter/json/options.go
@@ -16,8 +16,17 @@ package json
 
 type Option func(*Options)
 
-type Options struct{}
+type Options struct {
+	// Pretty print the JSON output
+	prettyPrint bool
+}
 
 func DefaultOptions() *Options {
 	return &Options{}
+}
+
+func WithPrettyPrint() func(*Options) {
+	return func(o *Options) {
+		o.prettyPrint = true
+	}
 }

--- a/pkg/columns/formatter/json/options.go
+++ b/pkg/columns/formatter/json/options.go
@@ -1,0 +1,23 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+type Option func(*Options)
+
+type Options struct{}
+
+func DefaultOptions() *Options {
+	return &Options{}
+}

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -17,7 +17,6 @@ package tracer
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
@@ -31,6 +30,7 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	columns_json "github.com/inspektor-gadget/inspektor-gadget/pkg/columns/formatter/json"
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/run/types"
@@ -197,7 +197,7 @@ func getSimpleType(typ btf.Type) reflect.Type {
 	return nil
 }
 
-func (g *GadgetDesc) CustomParser(params *params.Params, args []string) (parser.Parser, error) {
+func (g *GadgetDesc) getColumns(params *params.Params, args []string) (*columns.Columns[types.Event], error) {
 	if len(args) != 0 {
 		return nil, fmt.Errorf("no arguments expected: received %d", len(args))
 	}
@@ -272,8 +272,47 @@ func (g *GadgetDesc) CustomParser(params *params.Params, args []string) (parser.
 	if err := cols.AddFields(fields, base); err != nil {
 		return nil, fmt.Errorf("adding fields: %w", err)
 	}
+	return cols, nil
+}
 
+func (g *GadgetDesc) CustomParser(params *params.Params, args []string) (parser.Parser, error) {
+	cols, err := g.getColumns(params, args)
+	if err != nil {
+		return nil, err
+	}
 	return parser.NewParser[types.Event](cols), nil
+}
+
+func (g *GadgetDesc) customJsonParser(params *params.Params, args []string, options ...columns_json.Option) (*columns_json.Formatter[types.Event], error) {
+	cols, err := g.getColumns(params, args)
+	if err != nil {
+		return nil, err
+	}
+	return columns_json.NewFormatter(cols.ColumnMap, options...), nil
+}
+
+func (g *GadgetDesc) JSONConverter(params *params.Params, printer gadgets.Printer) func(ev any) {
+	formatter, err := g.customJsonParser(params, []string{})
+	if err != nil {
+		printer.Logf(logger.WarnLevel, "creating json formatter: %s", err)
+		return nil
+	}
+	return func(ev any) {
+		event := ev.(*types.Event)
+		printer.Output(formatter.FormatEntry(event))
+	}
+}
+
+func (g *GadgetDesc) JSONPrettyConverter(params *params.Params, printer gadgets.Printer) func(ev any) {
+	formatter, err := g.customJsonParser(params, []string{}, columns_json.WithPrettyPrint())
+	if err != nil {
+		printer.Logf(logger.WarnLevel, "creating json formatter: %s", err)
+		return nil
+	}
+	return func(ev any) {
+		event := ev.(*types.Event)
+		printer.Output(formatter.FormatEntry(event))
+	}
 }
 
 func genericConverter(params *params.Params, printer gadgets.Printer, convert func(any) ([]byte, error)) func(ev any) {
@@ -309,17 +348,6 @@ func genericConverter(params *params.Params, printer gadgets.Printer, convert fu
 		}
 		printer.Output(string(d))
 	}
-}
-
-func (g *GadgetDesc) JSONConverter(params *params.Params, printer gadgets.Printer) func(ev any) {
-	return genericConverter(params, printer, json.Marshal)
-}
-
-func (g *GadgetDesc) JSONPrettyConverter(params *params.Params, printer gadgets.Printer) func(ev any) {
-	convert := func(ev any) ([]byte, error) {
-		return json.MarshalIndent(ev, "", "  ")
-	}
-	return genericConverter(params, printer, convert)
 }
 
 func (g *GadgetDesc) YAMLConverter(params *params.Params, printer gadgets.Printer) func(ev any) {


### PR DESCRIPTION
# gadgets/run: Add JSON output

This PR adds a new formatter which outputs json "through" the columns library.

This has the advantage that the columns and json output will always be aligned and the same. Additionally we won't need duplicate logic for the different output modes in the `run` gadget

## Last commit about testing 
**WIP and proposal. Ideas really welcome :)**

I just added another commit which adds some integration test helpers and modifies the test for `TestRunTraceOpen`.

We can't use the traditional functions for the containerized gadgets.
They were directly unmarshaling into the Event object which we don't have with containerized gadgets.

Most of the columns are dynamically created and therefore the output json is also mostly dynamic and depends solely on the BTF and config from the input.

So with this commit the expected entry is now a `map[string]interface{}` which gets constructed through `RunEventToJsonObj(...)` and `MergeJsonObjs(...)` where the actual payload of the eBPF program is merged into the json object returned by `RunEventToJsonObj(...)` 

The rational behind creating helper functions such as `SetEventTimestamp` is that we can control the json path in a single location. So when the field changes in the future we don't have to change every test, only that function.