### PR TITLE
integration: Run snapshot socket test on AKS.

### DIFF
--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -28,10 +28,6 @@ func TestSnapshotSocket(t *testing.T) {
 		t.Skip("Skip running snapshot socket gadget on ARO: iterators are not supported on kernel 4.18.0-305.19.1.el8_4.x86_64")
 	}
 
-	if *k8sDistro == K8sDistroAKSUbuntu && *k8sArch == "amd64" {
-		t.Skip("Skip running snapshot socket gadget on AKS Ubuntu amd64: iterators are not supported on kernel 5.4.0-1089-azure")
-	}
-
 	ns := GenerateTestNamespaceName("test-socket-collector")
 
 	t.Parallel()


### PR DESCRIPTION
AKS now runs on Kubernetes 1.25 which comes with kernel 5.15.0-1040-azure: $ kubectl describe node
Name:               aks-nodepool1-38109605-vmss000000
...
System Info:
...
  Kernel Version:             5.15.0-1040-azure
  OS Image:                   Ubuntu 22.04.2 LTS
  Operating System:           linux
  Architecture:               amd64
  Container Runtime Version:  containerd://1.7.1+azure-1
  Kubelet Version:            v1.25.6
  Kube-Proxy Version:         v1.25.6
