### PR TITLE
add extra path for runc on talos

### DIFF
--- a/pkg/container-hook/tracer.go
+++ b/pkg/container-hook/tracer.go
@@ -139,6 +139,7 @@ type ContainerNotifier struct {
 // When this package is executed in a container, it prepends the
 // HOST_ROOT env variable to the path.
 var runtimePaths = []string{
+	"/bin/runc",
 	"/usr/bin/runc",
 	"/usr/sbin/runc",
 	"/usr/local/sbin/runc",

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -114,6 +114,7 @@ type RuncNotifier struct {
 // When this package is executed in a container, it prepends the
 // HOST_ROOT env variable to the path.
 var runcPaths = []string{
+	"/bin/runc",
 	"/usr/bin/runc",
 	"/usr/sbin/runc",
 	"/usr/local/sbin/runc",


### PR DESCRIPTION
# add extra path for runc on talos

Talos Linux (https://www.talos.dev/) has `runc` installed to a different location. Adding this path to the `runcPaths` slice.

## How to use

I would suggest you try one of the virtualized [local platforms](https://www.talos.dev/v1.3/talos-guides/install/local-platforms/) to validate this PR.

## Testing done

I have used my fork in my project instead of the main repo in my `go.mod`:
```
replace github.com/inspektor-gadget/inspektor-gadget v0.18.0 => github.com/matthyx/inspektor-gadget v0.0.0-20230705092830-3f5f553ecd9c
```
