### PR TITLE
cmd: Check --help was given in RunE.

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -216,6 +216,10 @@ func buildCommandFromGadget(
 			return cmd.ParseFlags(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if showHelp, _ := cmd.Flags().GetBool("help"); showHelp {
+				return cmd.Help()
+			}
+
 			if c, ok := gadgetDesc.(gadgets.GadgetDescCustomParser); ok {
 				var err error
 				parser, err = c.CustomParser(gadgetParams, cmd.Flags().Args())


### PR DESCRIPTION
Setting DisableFlagParsing caused issues where --help would not be taken into
    account:
    $ sudo ./ig profile block-io --help
    INFO[0000] Running. Press Ctrl + C to finish
    
    To fix this, we need to check that --help was given in RunE and call the
    corresponding Help().
    
    Fixes: 8511d3b25dd7 ("gadgets: Add custom formatting options")