### PR TITLE
cmd/common/registry: fix `--help` for gadgets without parser, fix `--verbose`

### DIFF
--- a/cmd/common/verbose.go
+++ b/cmd/common/verbose.go
@@ -19,8 +19,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var verbose bool
+
+func checkVerboseFlag() {
+	if verbose {
+		log.SetLevel(log.DebugLevel)
+	}
+}
+
 func AddVerboseFlag(rootCmd *cobra.Command) {
-	var verbose bool
 	rootCmd.PersistentFlags().BoolVarP(
 		&verbose,
 		"verbose", "v",
@@ -28,8 +35,6 @@ func AddVerboseFlag(rootCmd *cobra.Command) {
 		"Print debug information",
 	)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		if verbose {
-			log.SetLevel(log.DebugLevel)
-		}
+		checkVerboseFlag()
 	}
 }


### PR DESCRIPTION
There was a bug, that prevented gadgets that don't use a parser, from outputting help when requested. This fixes that. This also fixes `--verbose` not working properly on gadgets anymore by manually checking the flag at a later stage.

Reason for the changed behavior is that we delayed flag parsing, so that we can handle them more dynamically and still have proper `--help` output.