### PR TITLE
Fix Inspektor Gadget environment variables for container runtime

### DIFF
--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -39,4 +39,8 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 COPY --from=builder /go/src/github.com/inspektor-gadget/inspektor-gadget/ig-${TARGETOS}-${TARGETARCH} /usr/bin/ig
 ENV HOST_ROOT=/host
+ENV INSPEKTOR_GADGET_DOCKER_SOCKETPATH=/host/run/docker.sock
+ENV INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH=/host/run/containerd/containerd.sock
+ENV INSPEKTOR_GADGET_CRIO_SOCKETPATH=/host/run/crio/crio.sock
+ENV INSPEKTOR_GADGET_PODMAN_SOCKETPATH=/host/run/podman/podman.sock
 ENTRYPOINT ["/usr/bin/ig"]

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -31,6 +31,11 @@ import (
 const (
 	OutputModeJSON          = "json"
 	OutputModeCustomColumns = "custom-columns"
+
+	DockerSocketPathFlag     = "docker-socketpath"
+	ContainerdSocketPathFlag = "containerd-socketpath"
+	CrioSocketPathFlag       = "crio-socketpath"
+	PodmanSocketPathFlag     = "podman-socketpath"
 )
 
 var SupportedOutputModes = []string{OutputModeJSON, OutputModeCustomColumns}
@@ -108,28 +113,28 @@ type RuntimesSocketPathConfig struct {
 func AddRuntimesSocketPathFlags(command *cobra.Command, config *RuntimesSocketPathConfig) {
 	command.PersistentFlags().StringVarP(
 		&config.Docker,
-		"docker-socketpath", "",
+		DockerSocketPathFlag, "",
 		runtimeclient.DockerDefaultSocketPath,
 		"Docker Engine API Unix socket path",
 	)
 
 	command.PersistentFlags().StringVarP(
 		&config.Containerd,
-		"containerd-socketpath", "",
+		ContainerdSocketPathFlag, "",
 		runtimeclient.ContainerdDefaultSocketPath,
 		"containerd CRI Unix socket path",
 	)
 
 	command.PersistentFlags().StringVarP(
 		&config.Crio,
-		"crio-socketpath", "",
+		CrioSocketPathFlag, "",
 		runtimeclient.CrioDefaultSocketPath,
 		"CRI-O CRI Unix socket path",
 	)
 
 	command.PersistentFlags().StringVarP(
 		&config.Podman,
-		"podman-socketpath", "",
+		PodmanSocketPathFlag, "",
 		runtimeclient.PodmanDefaultSocketPath,
 		"Podman Unix socket path",
 	)

--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -77,22 +77,36 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 
 		parts := strings.Split(commonFlags.Runtimes, ",")
 
+		flagSet := cmd.Flags()
+		if flagSet == nil {
+			return fmt.Errorf("nil flag set")
+		}
+
 	partsLoop:
 		for _, p := range parts {
+			var socketPath *string
+
 			runtimeName := types.String2RuntimeName(strings.TrimSpace(p))
-			socketPath := ""
 			namespace := ""
 
 			switch runtimeName {
 			case types.RuntimeNameDocker:
-				socketPath = commonFlags.RuntimesSocketPathConfig.Docker
+				if flagSet.Changed(commonutils.DockerSocketPathFlag) {
+					socketPath = &commonFlags.RuntimesSocketPathConfig.Docker
+				}
 			case types.RuntimeNameContainerd:
-				socketPath = commonFlags.RuntimesSocketPathConfig.Containerd
 				namespace = commonFlags.ContainerdNamespace
+				if flagSet.Changed(commonutils.ContainerdSocketPathFlag) {
+					socketPath = &commonFlags.RuntimesSocketPathConfig.Containerd
+				}
 			case types.RuntimeNameCrio:
-				socketPath = commonFlags.RuntimesSocketPathConfig.Crio
+				if flagSet.Changed(commonutils.CrioSocketPathFlag) {
+					socketPath = &commonFlags.RuntimesSocketPathConfig.Crio
+				}
 			case types.RuntimeNamePodman:
-				socketPath = commonFlags.RuntimesSocketPathConfig.Podman
+				if flagSet.Changed(commonutils.PodmanSocketPathFlag) {
+					socketPath = &commonFlags.RuntimesSocketPathConfig.Podman
+				}
 			default:
 				return commonutils.WrapInErrInvalidArg("--runtime / -r",
 					fmt.Errorf("runtime %q is not supported", p))

--- a/pkg/container-utils/containerutils_test.go
+++ b/pkg/container-utils/containerutils_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 func newRuntimeClient(t *testing.T, runtime types.RuntimeName, sPath string) (runtimeclient.ContainerRuntimeClient, error) {
+	path := sPath
 	config := &containerutilsTypes.RuntimeConfig{
 		Name:       runtime,
-		SocketPath: sPath,
+		SocketPath: &path,
 	}
 	rc, err := NewContainerRuntimeClient(config)
 	t.Cleanup(func() {

--- a/pkg/container-utils/types/types.go
+++ b/pkg/container-utils/types/types.go
@@ -27,7 +27,7 @@ type ExtraConfig struct {
 
 type RuntimeConfig struct {
 	Name            types.RuntimeName
-	SocketPath      string
+	SocketPath      *string
 	RuntimeProtocol string
 	Extra           ExtraConfig
 }

--- a/pkg/ig-manager/ig-manager.go
+++ b/pkg/ig-manager/ig-manager.go
@@ -134,13 +134,13 @@ func isDefaultContainerRuntimeConfig(runtimes []*containerutilsTypes.RuntimeConf
 	for _, runtime := range runtimes {
 		switch runtime.Name {
 		case types.RuntimeNameDocker:
-			customSocketPath = runtime.SocketPath != runtimeclient.DockerDefaultSocketPath
+			customSocketPath = *runtime.SocketPath != runtimeclient.DockerDefaultSocketPath
 		case types.RuntimeNameContainerd:
-			customSocketPath = runtime.SocketPath != runtimeclient.ContainerdDefaultSocketPath
+			customSocketPath = *runtime.SocketPath != runtimeclient.ContainerdDefaultSocketPath
 		case types.RuntimeNameCrio:
-			customSocketPath = runtime.SocketPath != runtimeclient.CrioDefaultSocketPath
+			customSocketPath = *runtime.SocketPath != runtimeclient.CrioDefaultSocketPath
 		case types.RuntimeNamePodman:
-			customSocketPath = runtime.SocketPath != runtimeclient.PodmanDefaultSocketPath
+			customSocketPath = *runtime.SocketPath != runtimeclient.PodmanDefaultSocketPath
 		default:
 			customSocketPath = true
 		}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -17,6 +17,7 @@ package localmanager
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/cilium/ebpf"
@@ -178,14 +179,38 @@ partsLoop:
 
 		switch runtimeName {
 		case types.RuntimeNameDocker:
-			socketPath = operatorParams.Get(DockerSocketPath).AsString()
+			param := operatorParams.Get(DockerSocketPath)
+
+			if envsp := os.Getenv("INSPEKTOR_GADGET_DOCKER_SOCKETPATH"); envsp != "" && !param.IsSet() {
+				socketPath = envsp
+			} else {
+				socketPath = param.AsString()
+			}
 		case types.RuntimeNameContainerd:
-			socketPath = operatorParams.Get(ContainerdSocketPath).AsString()
 			namespace = operatorParams.Get(ContainerdNamespace).AsString()
+			param := operatorParams.Get(ContainerdSocketPath)
+
+			if envsp := os.Getenv("INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"); envsp != "" && !param.IsSet() {
+				socketPath = envsp
+			} else {
+				socketPath = param.AsString()
+			}
 		case types.RuntimeNameCrio:
-			socketPath = operatorParams.Get(CrioSocketPath).AsString()
+			param := operatorParams.Get(CrioSocketPath)
+
+			if envsp := os.Getenv("INSPEKTOR_GADGET_CRIO_SOCKETPATH"); envsp != "" && !param.IsSet() {
+				socketPath = envsp
+			} else {
+				socketPath = param.AsString()
+			}
 		case types.RuntimeNamePodman:
-			socketPath = operatorParams.Get(PodmanSocketPath).AsString()
+			param := operatorParams.Get(PodmanSocketPath)
+
+			if envsp := os.Getenv("INSPEKTOR_GADGET_PODMAN_SOCKETPATH"); envsp != "" && !param.IsSet() {
+				socketPath = envsp
+			} else {
+				socketPath = param.AsString()
+			}
 		default:
 			return commonutils.WrapInErrInvalidArg("--runtime / -r",
 				fmt.Errorf("runtime %q is not supported", p))

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -201,7 +201,7 @@ partsLoop:
 
 		r := &containerutilsTypes.RuntimeConfig{
 			Name:            runtimeName,
-			SocketPath:      socketPath,
+			SocketPath:      &socketPath,
 			RuntimeProtocol: operatorParams.Get(RuntimeProtocol).AsString(),
 			Extra: containerutilsTypes.ExtraConfig{
 				Namespace: namespace,


### PR DESCRIPTION
Hi.


This PR fixes the `INSPEKTOR_GADGET_*SOCKETPATH`.


Best regards.