### PR TITLE
Makefile: ig: stop on build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ig: ig-$(GOHOSTOS)-$(GOHOSTARCH)
 ig-%: phony_explicit
 	echo Building $@
 	docker buildx build --load --platform=$(subst -,/,$*) -t $@ -f Dockerfiles/ig.Dockerfile \
-		--build-arg VERSION=$(VERSION) . ;\
+		--build-arg VERSION=$(VERSION) .
 	docker create --name ig-$*-container $@
 	docker cp ig-$*-container:/usr/bin/ig $@
 	docker rm ig-$*-container


### PR DESCRIPTION
When the ig container image fails to build, don't ignore the error and fail immediately. Otherwise, it's picking up whatever container image was previously built with the same name.

Before this patch, it was continuing as follows:
```
$ make ig
echo Building ig-linux-amd64
Building ig-linux-amd64
docker buildx build --load --platform=linux/amd64 -t ig-linux-amd64 -f Dockerfiles/ig.Dockerfile \
	--build-arg VERSION=`git describe --tags --always`-dirty . ;\
docker create --name ig-linux-amd64-container ig-linux-amd64
[+] Building 10.4s (4/4) FINISHED                                                                                     
 => [internal] load .dockerignore                                                                                0.1s
 => => transferring context: 2B                                                                                  0.0s
 => [internal] load build definition from ig.Dockerfile                                                          0.2s
 => => transferring dockerfile: 1.33kB                                                                           0.0s
 => ERROR [internal] load metadata for gcr.io/distroless/static-debian11:latest                                 10.0s
 => CANCELED [internal] load metadata for docker.io/library/golang:1.19                                         10.1s
------
 > [internal] load metadata for gcr.io/distroless/static-debian11:latest:
------
ig.Dockerfile:36
--------------------
  34 |     		github.com/inspektor-gadget/inspektor-gadget/cmd/ig
  35 |     
  36 | >>> FROM ${BASE_IMAGE}
  37 |     
  38 |     ARG TARGETOS
--------------------
ERROR: failed to solve: gcr.io/distroless/static-debian11: failed to do request: Head "https://gcr.io/v2/distroless/static-debian11/manifests/latest": dial tcp: lookup gcr.io on 192.168.0.1:53: read udp 172.17.0.3:58963->192.168.0.1:53: i/o timeout
65cd3a122491eadb90520355fe586087a87b3adb794538e07d8e5e569d6fc6e8
docker cp ig-linux-amd64-container:/usr/bin/ig ig-linux-amd64
Preparing to copy...
Copying from container - 512B
Copying from container - 32.77kB
...
```

Fixes ad69bb410d0db204bd74c464bf30ca38d428a12a