### PR TITLE
pkg/prometheus: Move config to independent package

### DIFF
--- a/pkg/gadgets/prometheus/tracer/gadget.go
+++ b/pkg/gadgets/prometheus/tracer/gadget.go
@@ -19,7 +19,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
-	igprometheus "github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus/config"
 )
 
 const (
@@ -55,7 +55,7 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			IsMandatory: true,
 			TypeHint:    params.TypeBytes,
 			Validator: func(value string) error {
-				_, err := igprometheus.ParseConfig([]byte(value))
+				_, err := config.ParseConfig([]byte(value))
 				return err
 			},
 		},

--- a/pkg/gadgets/prometheus/tracer/tracer.go
+++ b/pkg/gadgets/prometheus/tracer/tracer.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	igprometheus "github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus/config"
 )
 
 type Tracer struct {
@@ -33,7 +34,7 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
 	metricsConfig := params.Get(ParamConfig).AsBytes()
 
-	config, err := igprometheus.ParseConfig(metricsConfig)
+	config, err := config.ParseConfig(metricsConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package prometheus
+package config
 
 import (
 	"errors"

--- a/pkg/prometheus/config/config_test.go
+++ b/pkg/prometheus/config/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package prometheus
+package config
 
 import (
 	"testing"

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -28,6 +28,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 )
@@ -42,11 +43,11 @@ const (
 )
 
 type Counter struct {
-	Metric
+	config.Metric
 }
 
 type Gauge struct {
-	Metric
+	config.Metric
 
 	registration otelmetric.Registration
 }
@@ -56,7 +57,7 @@ type Instruments struct {
 	Gauges   []*Gauge
 }
 
-func CreateMetrics(ctx context.Context, config *Config, meterProvider otelmetric.MeterProvider) (func(), error) {
+func CreateMetrics(ctx context.Context, config *config.Config, meterProvider otelmetric.MeterProvider) (func(), error) {
 	runtime := &local.Runtime{}
 	instruments := &Instruments{}
 
@@ -92,7 +93,7 @@ func CreateMetrics(ctx context.Context, config *Config, meterProvider otelmetric
 
 func handleMetric(
 	ctx context.Context,
-	metricCommon *Metric,
+	metricCommon *config.Metric,
 	runtime runtime.Runtime,
 ) (*gadgetcontext.GadgetContext, parser.Parser, error) {
 	runtimeParams := runtime.ParamDescs().ToParams()
@@ -177,7 +178,7 @@ func handleMetric(
 func createCounter(
 	ctx context.Context,
 	runtime runtime.Runtime,
-	metric *Metric,
+	metric *config.Metric,
 	meter otelmetric.Meter,
 ) (*Counter, error) {
 	counter := &Counter{Metric: *metric}
@@ -280,7 +281,7 @@ func createCounter(
 func createGauge(
 	ctx context.Context,
 	runtime runtime.Runtime,
-	metric *Metric,
+	metric *config.Metric,
 	meter otelmetric.Meter,
 ) (*Gauge, error) {
 	gauge := &Gauge{Metric: *metric}

--- a/pkg/prometheus/prometheus_test.go
+++ b/pkg/prometheus/prometheus_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/prometheus/config"
 )
 
 // events that are generated in the test. Counters are incremented based on them and the metric
@@ -37,7 +39,7 @@ var testEvents = []*stubEvent{
 func TestMetrics(t *testing.T) {
 	type testDefinition struct {
 		name        string
-		config      *Config
+		config      *config.Config
 		expectedErr bool
 
 		// outer key: metric name, inner key: attributes hash
@@ -51,9 +53,9 @@ func TestMetrics(t *testing.T) {
 		// Generic checks before
 		{
 			name: "wrong_metric_type",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "wrong_metric_type",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "wrong_metric_type",
 						Type:     "nonvalidtype",
@@ -67,9 +69,9 @@ func TestMetrics(t *testing.T) {
 		// Wrong configurations
 		{
 			name: "counter_wrong_gadget_name",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_gadget_name",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_gadget_name",
 						Type:     "counter",
@@ -82,9 +84,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_wrong_gadget_category",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_gadget_category",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_gadget_category",
 						Type:     "counter",
@@ -97,9 +99,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_wrong_gadget_type",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_gadget_type",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_gadget_type",
 						Type:     "counter",
@@ -112,9 +114,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_wrong_type_field",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_type_field",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_type_field",
 						Type:     "counter",
@@ -128,9 +130,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_wrong_selector",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_selector",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_selector",
 						Type:     "counter",
@@ -145,9 +147,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_wrong_labels",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_wrong_labels",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_labels",
 						Type:     "counter",
@@ -162,9 +164,9 @@ func TestMetrics(t *testing.T) {
 		// Check that counters are updated correctly
 		{
 			name: "counter_no_labels_nor_filtering",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_no_labels_nor_filtering",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_no_labels_nor_filtering",
 						Type:     "counter",
@@ -179,9 +181,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_filter_only_root_events",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_filter_only_root_events",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_filter_only_root_events",
 						Type:     "counter",
@@ -197,9 +199,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_filter_only_root_cat_events",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_filter_only_root_cat_events",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_filter_only_root_cat_events",
 						Type:     "counter",
@@ -215,9 +217,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_filter_uid_greater_than_0",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_filter_uid_greater_than_0",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_filter_uid_greater_than_0",
 						Type:     "counter",
@@ -233,9 +235,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_aggregate_by_comm",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_aggregate_by_comm",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_aggregate_by_comm",
 						Type:     "counter",
@@ -251,9 +253,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_aggregate_by_uid",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_aggregate_by_uid",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_aggregate_by_uid",
 						Type:     "counter",
@@ -269,9 +271,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_aggregate_by_uid_and_comm",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_aggregate_by_uid_and_comm",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_aggregate_by_uid_and_comm",
 						Type:     "counter",
@@ -292,9 +294,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_aggregate_by_uid_and_filter_by_comm",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_aggregate_by_uid_and_filter_by_comm",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_aggregate_by_uid_and_filter_by_comm",
 						Type:     "counter",
@@ -311,9 +313,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_with_int_field",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_with_int_field",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_with_int_field",
 						Type:     "counter",
@@ -329,9 +331,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_with_float_field",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_with_float_field",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_with_float_field",
 						Type:     "counter",
@@ -347,9 +349,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "counter_with_float_field_aggregate_by_uid_and_filter_by_comm",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_with_float_field_aggregate_by_uid_and_filter_by_comm",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_with_float_field_aggregate_by_uid_and_filter_by_comm",
 						Type:     "counter",
@@ -368,9 +370,9 @@ func TestMetrics(t *testing.T) {
 		// Multiple counters
 		{
 			name: "counter_multiple_mixed",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "counter_multiple_mixed",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_multiple1",
 						Type:     "counter",
@@ -396,9 +398,9 @@ func TestMetrics(t *testing.T) {
 		// Gauges
 		{
 			name: "gauge_wrong_gadget_name",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_wrong_gadget_name",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_wrong_gadget_name",
 						Type:     "gauge",
@@ -411,9 +413,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_wrong_gadget_category",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_wrong_gadget_category",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_wrong_gadget_category",
 						Type:     "gauge",
@@ -426,9 +428,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_wrong_gadget_type",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_wrong_gadget_type",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "counter_wrong_gadget_type",
 						Type:     "gauge",
@@ -441,9 +443,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_no_labels_nor_filtering",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_no_labels_nor_filtering",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_no_labels_nor_filtering",
 						Type:     "gauge",
@@ -458,9 +460,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_filter_only_root_events",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_filter_only_root_events",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_filter_only_root_events",
 						Type:     "gauge",
@@ -476,9 +478,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_filter_only_root_cat_events",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_filter_only_root_cat_events",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_filter_only_root_cat_events",
 						Type:     "gauge",
@@ -494,9 +496,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_with_int_field",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_with_int_field",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_with_int_field",
 						Type:     "gauge",
@@ -512,9 +514,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_with_float_field",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_with_float_field",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_with_float_field",
 						Type:     "gauge",
@@ -530,9 +532,9 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			name: "gauge_multiple",
-			config: &Config{
+			config: &config.Config{
 				MetricsName: "gauge_multiple",
-				Metrics: []Metric{
+				Metrics: []config.Metric{
 					{
 						Name:     "gauge_no_labels_nor_filtering",
 						Type:     "gauge",


### PR DESCRIPTION
Avoid packages that only need the config having to pull all dependencies. For instance, this avoid kubectl-gadget importing
"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local".

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1830

### Testing

Introduce any linux specific code, for instance:

```diff
$ git diff
diff --git pkg/runtime/local/local.go pkg/runtime/local/local.go
index ab39ee02..3e12262b 100644
--- pkg/runtime/local/local.go
+++ pkg/runtime/local/local.go
@@ -34,6 +34,8 @@ type Runtime struct {
 }
 
 func New() *Runtime {
+       fmt.Printf("%s\n", Foo)
+
        return &Runtime{
                catalog: prepareCatalog(),
        }
```

```bash 
$ cat pkg/runtime/local/foo_linux.go 
package local

const Foo = "foo"
```

Compiling kubectl-gadget for Windows works fine with this commit

```
$ make kubectl-gadget-windows-amd64
...

```

but it fails without it
```
$ make kubectl-gadget-windows-amd64
...
# github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local
pkg/runtime/local/local.go:37:21: undefined: Foo
make: *** [Makefile:121: kubectl-gadget-windows-amd64] Error 1
```

