### PR TITLE
container-utils: Generalize testutils pkg and test runtime-client interface

### DIFF
--- a/integration/container_interface.go
+++ b/integration/container_interface.go
@@ -47,11 +47,13 @@ func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 }
 
 type containerSpec struct {
-	name         string
-	cmd          string
+	// Options
 	options      []testutils.Option
 	cleanup      bool
 	startAndStop bool
+
+	// Internal
+	started bool
 }
 
 // containerOption is a function that modifies a ContainerSpec and exposes only

--- a/integration/container_interface.go
+++ b/integration/container_interface.go
@@ -46,40 +46,36 @@ func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 	}
 }
 
-type containerSpec struct {
-	// Options
+type cOptions struct {
 	options      []testutils.Option
 	cleanup      bool
 	startAndStop bool
-
-	// Internal
-	started bool
 }
 
 // containerOption is a function that modifies a ContainerSpec and exposes only
 // few options from testutils.Option to the user.
-type containerOption func(specs *containerSpec)
+type containerOption func(opts *cOptions)
 
 func WithContainerImage(image string) containerOption {
-	return func(specs *containerSpec) {
-		specs.options = append(specs.options, testutils.WithImage(image))
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithImage(image))
 	}
 }
 
 func WithContainerSeccompProfile(profile string) containerOption {
-	return func(specs *containerSpec) {
-		specs.options = append(specs.options, testutils.WithSeccompProfile(profile))
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithSeccompProfile(profile))
 	}
 }
 
 func WithCleanup() containerOption {
-	return func(specs *containerSpec) {
-		specs.cleanup = true
+	return func(opts *cOptions) {
+		opts.cleanup = true
 	}
 }
 
 func WithStartAndStop() containerOption {
-	return func(specs *containerSpec) {
-		specs.startAndStop = true
+	return func(opts *cOptions) {
+		opts.startAndStop = true
 	}
 }

--- a/integration/container_interface.go
+++ b/integration/container_interface.go
@@ -23,10 +23,10 @@ import (
 )
 
 type ContainerFactory interface {
-	NewContainer(name, cmd string, opts ...containerOption) ContainerInterface
+	NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer
 }
 
-type ContainerInterface interface {
+type IntegrationTestsContainer interface {
 	Run(t *testing.T)
 	Start(t *testing.T)
 	Stop(t *testing.T)

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -22,7 +22,7 @@ import (
 
 type ContainerdManager struct{}
 
-func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) ContainerInterface {
+func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer {
 	c := &ContainerdContainer{}
 
 	for _, o := range opts {

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -58,7 +58,7 @@ func (c *ContainerdContainer) Start(t *testing.T) {
 }
 
 func (c *ContainerdContainer) Stop(t *testing.T) {
-	testutils.RemoveContainerdContainer(context.Background(), t, c.name)
+	testutils.StopContainerdContainer(context.Background(), t, c.name)
 	c.started = false
 }
 

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -43,8 +43,7 @@ type ContainerdContainer struct {
 }
 
 func (c *ContainerdContainer) Run(t *testing.T) {
-	opts := append(c.options, testutils.WithName(c.name))
-	testutils.RunContainerdContainer(context.Background(), t, c.cmd, opts...)
+	testutils.RunContainerdContainer(context.Background(), t, c.name, c.cmd, c.options...)
 }
 
 func (c *ContainerdContainer) Start(t *testing.T) {
@@ -52,8 +51,7 @@ func (c *ContainerdContainer) Start(t *testing.T) {
 		t.Logf("Warn(%s): trying to start already running container\n", c.name)
 		return
 	}
-	opts := append(c.options, testutils.WithName(c.name), testutils.WithoutRemoval(), testutils.WithoutWait())
-	testutils.RunContainerdContainer(context.Background(), t, c.cmd, opts...)
+	testutils.StartContainerdContainer(context.Background(), t, c.name, c.cmd, c.options...)
 	c.started = true
 }
 

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"context"
-	"testing"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
@@ -27,7 +26,7 @@ func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOpt
 	c := &ContainerdContainer{}
 
 	for _, o := range opts {
-		o(&c.containerSpec)
+		o(&c.cOptions)
 	}
 	c.options = append(c.options, testutils.WithContext(context.Background()))
 
@@ -38,25 +37,7 @@ func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOpt
 // ContainerdContainer implements TestStep for containerd containers
 type ContainerdContainer struct {
 	testutils.Container
-	containerSpec
-}
-
-func (c *ContainerdContainer) Run(t *testing.T) {
-	c.Container.Run(t)
-}
-
-func (c *ContainerdContainer) Start(t *testing.T) {
-	if c.started {
-		t.Logf("Warn(%s): trying to start already running container\n", c.Container.Name())
-		return
-	}
-	c.Container.Start(t)
-	c.started = true
-}
-
-func (c *ContainerdContainer) Stop(t *testing.T) {
-	c.Container.Stop(t)
-	c.started = false
+	cOptions
 }
 
 func (c *ContainerdContainer) IsCleanup() bool {
@@ -65,8 +46,4 @@ func (c *ContainerdContainer) IsCleanup() bool {
 
 func (c *ContainerdContainer) IsStartAndStop() bool {
 	return c.startAndStop
-}
-
-func (c *ContainerdContainer) Running() bool {
-	return c.started
 }

--- a/integration/docker.go
+++ b/integration/docker.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"context"
-	"testing"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
@@ -27,7 +26,7 @@ func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption)
 	c := &DockerContainer{}
 
 	for _, o := range opts {
-		o(&c.containerSpec)
+		o(&c.cOptions)
 	}
 	c.options = append(c.options, testutils.WithContext(context.Background()))
 
@@ -38,25 +37,7 @@ func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption)
 // DockerContainer implements TestStep for docker containers
 type DockerContainer struct {
 	testutils.Container
-	containerSpec
-}
-
-func (d *DockerContainer) Run(t *testing.T) {
-	d.Container.Run(t)
-}
-
-func (d *DockerContainer) Start(t *testing.T) {
-	if d.started {
-		t.Logf("Warn(%s): trying to start already running container\n", d.Container.Name())
-		return
-	}
-	d.Container.Start(t)
-	d.started = true
-}
-
-func (d *DockerContainer) Stop(t *testing.T) {
-	d.Container.Stop(t)
-	d.started = false
+	cOptions
 }
 
 func (d *DockerContainer) IsCleanup() bool {
@@ -65,8 +46,4 @@ func (d *DockerContainer) IsCleanup() bool {
 
 func (d *DockerContainer) IsStartAndStop() bool {
 	return d.startAndStop
-}
-
-func (d *DockerContainer) Running() bool {
-	return d.started
 }

--- a/integration/docker.go
+++ b/integration/docker.go
@@ -22,7 +22,7 @@ import (
 
 type DockerManager struct{}
 
-func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) ContainerInterface {
+func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer {
 	c := &DockerContainer{}
 
 	for _, o := range opts {

--- a/integration/docker.go
+++ b/integration/docker.go
@@ -59,7 +59,7 @@ func (d *DockerContainer) Start(t *testing.T) {
 }
 
 func (d *DockerContainer) Stop(t *testing.T) {
-	testutils.RemoveDockerContainer(context.Background(), t, d.name)
+	testutils.StopDockerContainer(context.Background(), t, d.name)
 	d.started = false
 }
 

--- a/integration/docker.go
+++ b/integration/docker.go
@@ -44,8 +44,7 @@ type DockerContainer struct {
 }
 
 func (d *DockerContainer) Run(t *testing.T) {
-	opts := append(d.options, testutils.WithName(d.name))
-	testutils.RunDockerContainer(context.Background(), t, d.cmd, opts...)
+	testutils.RunDockerContainer(context.Background(), t, d.name, d.cmd, d.options...)
 }
 
 func (d *DockerContainer) Start(t *testing.T) {
@@ -53,8 +52,7 @@ func (d *DockerContainer) Start(t *testing.T) {
 		t.Logf("Warn(%s): trying to start already running container\n", d.name)
 		return
 	}
-	opts := append(d.options, testutils.WithName(d.name), testutils.WithoutRemoval(), testutils.WithoutWait())
-	testutils.RunDockerContainer(context.Background(), t, d.cmd, opts...)
+	testutils.StartDockerContainer(context.Background(), t, d.name, d.cmd, d.options...)
 	d.started = true
 }
 

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -63,11 +63,7 @@ func TestFilterByContainerName(t *testing.T) {
 	}
 
 	testSteps := []TestStep{
-		containerFactory.NewContainer(ContainerSpec{
-			Name:         cn,
-			Cmd:          "sleep inf",
-			StartAndStop: true,
-		}),
+		containerFactory.NewContainer(cn, "sleep inf", WithStartAndStop()),
 		SleepForSecondsCommand(2),
 		listContainersCmd,
 	}
@@ -135,10 +131,7 @@ func TestWatchContainers(t *testing.T) {
 	testSteps := []TestStep{
 		watchContainersCommand,
 		SleepForSecondsCommand(2),
-		containerFactory.NewContainer(ContainerSpec{
-			Name: cn,
-			Cmd:  "echo I am short lived container",
-		}),
+		containerFactory.NewContainer(cn, "echo I am short lived container"),
 	}
 
 	RunTestSteps(testSteps, t)

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -60,11 +60,7 @@ func TestSnapshotProcess(t *testing.T) {
 	}
 
 	testSteps := []TestStep{
-		containerFactory.NewContainer(ContainerSpec{
-			Name:         cn,
-			Cmd:          "nc -l -p 9090",
-			StartAndStop: true,
-		}),
+		containerFactory.NewContainer(cn, "nc -l -p 9090", WithStartAndStop()),
 		snapshotProcessCmd,
 	}
 

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -144,11 +144,7 @@ func TestTraceDns(t *testing.T) {
 	testSteps := []TestStep{
 		traceDNSCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		containerFactory.NewContainer(ContainerSpec{
-			Name:    cn,
-			Cmd:     strings.Join(dnsCmds, " ; "),
-			Options: NewContainerOptions(WithContainerImage(*dnsTesterImage)),
-		}),
+		containerFactory.NewContainer(cn, strings.Join(dnsCmds, " ; "), WithContainerImage(*dnsTesterImage)),
 	}
 
 	RunTestSteps(testSteps, t)

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -94,11 +94,7 @@ func TestTraceNetwork(t *testing.T) {
 	testSteps := []TestStep{
 		traceNetworkCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		containerFactory.NewContainer(ContainerSpec{
-			Name:    cn,
-			Cmd:     "nginx && curl 127.0.0.1",
-			Options: NewContainerOptions(WithContainerImage("docker.io/library/nginx")),
-		}),
+		containerFactory.NewContainer(cn, "nginx && curl 127.0.0.1", WithContainerImage("docker.io/library/nginx")),
 	}
 
 	RunTestSteps(testSteps, t)

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -131,7 +131,7 @@ func (c *ContainerdClient) GetContainer(containerID string) (*runtimeclient.Cont
 		return nil, fmt.Errorf("getting image details %q: %w", container.ID(), err)
 	}
 
-	// State is getting set to `Created` here for the following reasons:
+	// State is getting set to `Running` here for the following reasons:
 	// 1. GetContainer is only getting called on new created containers
 	// 2. We would need to get the Task for the Container. containerd needs to aquire a mutex
 	//    that is currently hold by the creating process, which we interrupted -> deadlock
@@ -143,7 +143,7 @@ func (c *ContainerdClient) GetContainer(containerID string) (*runtimeclient.Cont
 				RuntimeName:        types.RuntimeNameContainerd,
 				ContainerImageName: image.Name(),
 			},
-			State: runtimeclient.StateCreated,
+			State: runtimeclient.StateRunning,
 		},
 	}
 	runtimeclient.EnrichWithK8sMetadata(containerData, labels)

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -1,0 +1,173 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimeclient_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+const (
+	containerNamePrefix = "test-container"
+	containerImageName  = "docker.io/library/alpine:latest"
+	numContainers       = 2
+)
+
+func TestRuntimeClientInterface(t *testing.T) {
+	t.Parallel()
+	utilstest.RequireRoot(t)
+
+	for _, runtime := range testutils.SupportedContainerRuntimes {
+		t.Run(runtime.String(), func(t *testing.T) {
+			runtime := runtime
+			t.Parallel()
+
+			// Create test containers and their expected data
+			var expectedData []*runtimeclient.ContainerDetailsData
+			for i := 0; i < numContainers; i++ {
+				cn := fmt.Sprintf("%s-%s-%d", containerNamePrefix, runtime, i)
+				c, err := testutils.NewContainer(
+					runtime,
+					cn,
+					"sleep inf", // We simply want to keep the container running
+					testutils.WithImage(containerImageName),
+				)
+				require.Nil(t, err)
+				require.NotNil(t, c)
+
+				c.Start(t)
+				t.Cleanup(func() {
+					c.Stop(t)
+				})
+
+				expectedData = append(expectedData,
+					&runtimeclient.ContainerDetailsData{
+						ContainerData: runtimeclient.ContainerData{
+							Runtime: runtimeclient.RuntimeContainerData{
+								BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+									RuntimeName:        runtime,
+									ContainerName:      cn,
+									ContainerID:        c.ID(),
+									ContainerImageName: containerImageName,
+								},
+								State: runtimeclient.StateRunning,
+							},
+							K8s: runtimeclient.K8sContainerData{},
+						},
+						Pid: c.Pid(),
+						// TODO: Is it worth to compare the cgroups path and mounts?
+					},
+				)
+			}
+
+			// Initialize runtime client
+			config := &containerutils.RuntimeConfig{
+				Name: runtime,
+			}
+			rc, err := containerutils.NewContainerRuntimeClient(config)
+			t.Cleanup(func() {
+				if rc != nil {
+					rc.Close()
+				}
+			})
+			require.Nil(t, err)
+			require.NotNil(t, rc)
+
+			// Test runtime client methods
+			t.Run("GetContainers", func(t *testing.T) {
+				t.Parallel()
+
+				containers, err := rc.GetContainers()
+				require.Nil(t, err)
+				require.NotNil(t, containers)
+
+				for _, eData := range expectedData {
+					found := false
+					for _, cData := range containers {
+						if cmp.Equal(*cData, eData.ContainerData) {
+							found = true
+							break
+						}
+					}
+					require.True(t, found, "couldn't find container:\n%s\nin:\n%s",
+						spew.Sdump(eData.ContainerData), spew.Sdump(containers))
+				}
+			})
+
+			t.Run("GetContainer", func(t *testing.T) {
+				t.Parallel()
+
+				for _, eData := range expectedData {
+					cData, err := rc.GetContainer(eData.Runtime.ContainerID)
+					require.Nil(t, err)
+					require.NotNil(t, cData)
+					require.True(t, cmp.Equal(*cData, eData.ContainerData),
+						"unexpected container data:\n%s", cmp.Diff(*cData, eData.ContainerData))
+				}
+			})
+
+			t.Run("GetContainerDetails", func(t *testing.T) {
+				t.Parallel()
+
+				for _, eData := range expectedData {
+					cData, err := rc.GetContainerDetails(eData.Runtime.ContainerID)
+					require.Nil(t, err)
+					require.NotNil(t, cData)
+
+					// TODO: Is it worth to compare the cgroups path and mounts?
+					require.NotEmpty(t, cData.CgroupsPath)
+					cData.CgroupsPath = eData.CgroupsPath
+					cData.Mounts = eData.Mounts
+
+					require.True(t, cmp.Equal(cData, eData),
+						"unexpected container data:\n%s", cmp.Diff(cData, eData))
+				}
+			})
+		})
+	}
+}
+
+// TestDeleteContainers is useful to delete containers from
+// TestRuntimeClientInterface that were not properly deleted because of a bug.
+// func TestDeleteContainers(t *testing.T) {
+// 	t.Parallel()
+// 	utilstest.RequireRoot(t)
+
+// 	for _, runtime := range testutils.SupportedContainerRuntimes {
+// 		t.Run(runtime.String(), func(t *testing.T) {
+// 			runtime := runtime
+// 			t.Parallel()
+
+// 			// Delete test containers from previous runs
+// 			for i := 0; i < numContainers; i++ {
+// 				cn := fmt.Sprintf("%s-%s-%d", containerNamePrefix, runtime, i)
+// 				c, err := testutils.NewContainer(runtime, cn, "sleep inf", testutils.WithForceDelete())
+// 				require.Nil(t, err)
+// 				require.NotNil(t, c)
+// 				c.Stop(t)
+// 			}
+// 		})
+// 	}
+// }

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -27,17 +27,18 @@ type containerSpec struct {
 	options *containerOptions
 
 	// Internal state
-	id  string
-	pid int
+	id      string
+	pid     int
+	started bool
 }
 
 type Container interface {
-	Name() string
 	Run(t *testing.T)
 	Start(t *testing.T)
 	Stop(t *testing.T)
 	ID() string
 	Pid() int
+	Running() bool
 }
 
 var SupportedContainerRuntimes = []types.RuntimeName{

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -1,0 +1,57 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type containerSpec struct {
+	name    string
+	cmd     string
+	options *containerOptions
+
+	// Internal state
+	id  string
+	pid int
+}
+
+type Container interface {
+	Name() string
+	Run(t *testing.T)
+	Start(t *testing.T)
+	Stop(t *testing.T)
+	ID() string
+	Pid() int
+}
+
+var SupportedContainerRuntimes = []types.RuntimeName{
+	types.RuntimeNameDocker,
+	types.RuntimeNameContainerd,
+}
+
+func NewContainer(runtime types.RuntimeName, name, cmd string, options ...Option) (Container, error) {
+	switch runtime {
+	case types.RuntimeNameDocker:
+		return NewDockerContainer(name, cmd, options...), nil
+	case types.RuntimeNameContainerd:
+		return NewContainerdContainer(name, cmd, options...), nil
+	default:
+		return nil, fmt.Errorf("unknown container runtime %q", runtime)
+	}
+}

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -147,7 +147,7 @@ func RunContainerdFailedContainer(ctx context.Context, t *testing.T) {
 	)
 }
 
-func RemoveContainerdContainer(ctx context.Context, t *testing.T, name string) {
+func StopContainerdContainer(ctx context.Context, t *testing.T, name string) {
 	client, err := containerd.New("/run/containerd/containerd.sock",
 		containerd.WithTimeout(3*time.Second),
 	)

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -52,8 +52,8 @@ type ContainerdContainer struct {
 	containerSpec
 }
 
-func (c *ContainerdContainer) Name() string {
-	return c.name
+func (c *ContainerdContainer) Running() bool {
+	return c.started
 }
 
 func (c *ContainerdContainer) ID() string {
@@ -166,6 +166,15 @@ func (c *ContainerdContainer) Run(t *testing.T) {
 }
 
 func (c *ContainerdContainer) Start(t *testing.T) {
+	if c.started {
+		t.Logf("Warn(%s): trying to start already running container\n", c.name)
+		return
+	}
+	c.start(t)
+	c.started = true
+}
+
+func (c *ContainerdContainer) start(t *testing.T) {
 	for _, o := range []Option{WithoutWait(), WithoutRemoval()} {
 		o(c.options)
 	}
@@ -173,6 +182,11 @@ func (c *ContainerdContainer) Start(t *testing.T) {
 }
 
 func (c *ContainerdContainer) Stop(t *testing.T) {
+	c.stop(t)
+	c.started = false
+}
+
+func (c *ContainerdContainer) stop(t *testing.T) {
 	client, err := containerd.New("/run/containerd/containerd.sock",
 		containerd.WithTimeout(3*time.Second),
 	)

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -185,7 +185,7 @@ func (c *ContainerdContainer) Start(t *testing.T) {
 }
 
 func (c *ContainerdContainer) start(t *testing.T) {
-	for _, o := range []Option{WithoutWait(), WithoutRemoval()} {
+	for _, o := range []Option{WithoutWait(), withoutRemoval()} {
 		o(c.options)
 	}
 	c.Run(t)

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -44,8 +44,8 @@ type DockerContainer struct {
 	containerSpec
 }
 
-func (d *DockerContainer) Name() string {
-	return d.name
+func (d *DockerContainer) Running() bool {
+	return d.started
 }
 
 func (d *DockerContainer) ID() string {
@@ -124,6 +124,15 @@ func (d *DockerContainer) Run(t *testing.T) {
 }
 
 func (d *DockerContainer) Start(t *testing.T) {
+	if d.started {
+		t.Logf("Warn(%s): trying to start already running container\n", d.name)
+		return
+	}
+	d.start(t)
+	d.started = true
+}
+
+func (d *DockerContainer) start(t *testing.T) {
 	for _, o := range []Option{WithoutWait(), WithoutRemoval()} {
 		o(d.options)
 	}
@@ -131,6 +140,11 @@ func (d *DockerContainer) Start(t *testing.T) {
 }
 
 func (d *DockerContainer) Stop(t *testing.T) {
+	d.stop(t)
+	d.started = false
+}
+
+func (d *DockerContainer) stop(t *testing.T) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("Failed to connect to Docker: %s", err)

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -142,7 +142,7 @@ func (d *DockerContainer) Start(t *testing.T) {
 }
 
 func (d *DockerContainer) start(t *testing.T) {
-	for _, o := range []Option{WithoutWait(), WithoutRemoval()} {
+	for _, o := range []Option{WithoutWait(), withoutRemoval()} {
 		o(d.options)
 	}
 	d.Run(t)

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -101,7 +101,7 @@ func RunDockerFailedContainer(ctx context.Context, t *testing.T) {
 	)
 }
 
-func RemoveDockerContainer(ctx context.Context, t *testing.T, name string) {
+func StopDockerContainer(ctx context.Context, t *testing.T, name string) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("Failed to connect to Docker: %s", err)

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -78,15 +78,18 @@ func WithoutWait() Option {
 	}
 }
 
-func WithoutRemoval() Option {
-	return func(opts *containerOptions) {
-		opts.removal = false
-	}
-}
-
 func WithoutLogs() Option {
 	return func(opts *containerOptions) {
 		opts.logs = false
+	}
+}
+
+// withoutRemoval is only used internally. If an external caller wants to run a
+// container without removal, they should use the Start() method instead of
+// Run().
+func withoutRemoval() Option {
+	return func(opts *containerOptions) {
+		opts.removal = false
 	}
 }
 

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -15,7 +15,6 @@
 package testutils
 
 const (
-	DefaultContainerName     = "test-container"
 	DefaultContainerImage    = "docker.io/library/busybox"
 	DefaultContainerImageTag = "latest"
 )
@@ -23,7 +22,6 @@ const (
 type Option func(*containerOptions)
 
 type containerOptions struct {
-	name           string
 	image          string
 	imageTag       string
 	seccompProfile string
@@ -34,18 +32,11 @@ type containerOptions struct {
 
 func defaultContainerOptions() *containerOptions {
 	return &containerOptions{
-		name:     DefaultContainerName,
 		image:    DefaultContainerImage,
 		imageTag: DefaultContainerImageTag,
 		logs:     true,
 		wait:     true,
 		removal:  true,
-	}
-}
-
-func WithName(name string) Option {
-	return func(opts *containerOptions) {
-		opts.name = name
 	}
 }
 

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -14,6 +14,8 @@
 
 package testutils
 
+import "context"
+
 const (
 	DefaultContainerImage    = "docker.io/library/busybox"
 	DefaultContainerImageTag = "latest"
@@ -22,6 +24,7 @@ const (
 type Option func(*containerOptions)
 
 type containerOptions struct {
+	ctx            context.Context
 	image          string
 	imageTag       string
 	seccompProfile string
@@ -32,11 +35,18 @@ type containerOptions struct {
 
 func defaultContainerOptions() *containerOptions {
 	return &containerOptions{
+		ctx:      context.TODO(),
 		image:    DefaultContainerImage,
 		imageTag: DefaultContainerImageTag,
 		logs:     true,
 		wait:     true,
 		removal:  true,
+	}
+}
+
+func WithContext(ctx context.Context) Option {
+	return func(opts *containerOptions) {
+		opts.ctx = ctx
 	}
 }
 

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -31,6 +31,10 @@ type containerOptions struct {
 	wait           bool
 	logs           bool
 	removal        bool
+
+	// forceDelete is mostly used for debugging purposes, when a container
+	// fails to be deleted and we want to force it.
+	forceDelete bool
 }
 
 func defaultContainerOptions() *containerOptions {
@@ -83,5 +87,13 @@ func WithoutRemoval() Option {
 func WithoutLogs() Option {
 	return func(opts *containerOptions) {
 		opts.logs = false
+	}
+}
+
+// WithForceDelete is mostly used for debugging purposes, when a container
+// fails to be deleted and we want to force it.
+func WithForceDelete() Option {
+	return func(opts *containerOptions) {
+		opts.forceDelete = true
 	}
 }

--- a/pkg/container-utils/testutils/options_test.go
+++ b/pkg/container-utils/testutils/options_test.go
@@ -7,9 +7,6 @@ import (
 func TestContainerOptions(t *testing.T) {
 	opts := defaultContainerOptions()
 
-	if opts.name != DefaultContainerName {
-		t.Errorf("Expected default container name to be %q", DefaultContainerName)
-	}
 	if opts.image != DefaultContainerImage {
 		t.Errorf("Expected default container image to be %q", DefaultContainerImage)
 	}

--- a/pkg/ig-manager/ig-manager_test.go
+++ b/pkg/ig-manager/ig-manager_test.go
@@ -127,15 +127,10 @@ func checkFdList(t *testing.T, initialFdList string, attempts int, sleep time.Du
 func TestClose(t *testing.T) {
 	utilstest.RequireRoot(t)
 
-	opts := []testutils.Option{
-		testutils.WithName("test-ig-close"),
-		testutils.WithoutRemoval(),
-		testutils.WithoutWait(),
-		testutils.WithoutLogs(),
-	}
-	testutils.RunDockerContainer(context.Background(), t, "sleep inf", opts...)
+	c := testutils.NewDockerContainer("test-ig-close", "sleep inf", testutils.WithoutLogs())
+	c.Start(t)
 	t.Cleanup(func() {
-		testutils.RemoveDockerContainer(context.Background(), t, "test-ig-close")
+		c.Stop(t)
 	})
 
 	initialFdList := currentFdList(t)


### PR DESCRIPTION
# container-utils: Generalize testutils pkg and test runtime-client interface

The container-utils/testutils package was generalized (new `Container` interface defined) to be easily used directly for any tests involving the creation of containers using Docker or Containerd (Both use the API).

The new `Container` interface was used to create tests to verify the runtime-client interface methods:

```bash
sudo go test -v -run TestRuntimeClientInterface ./pkg/container-utils/runtime-client...
```

NOTE: The same `Container` interface could be used to test other modules like the container-hook (some experiments [here](https://github.com/inspektor-gadget/inspektor-gadget/commit/43692ae9e69240d3dea663a67131b18c2cb04944)). cc @alban 
