### PR TITLE
cmd/ig: Fix order and visible columns in list-containers command

### DIFF
--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -77,6 +77,11 @@ func NewListContainersCmd() *cobra.Command {
 			cols.SetExtractor("event", func(event *containercollection.PubSubEvent) string {
 				return event.Type.String()
 			})
+			// Display the runtime name and container ID when watching containers
+			col, _ := cols.GetColumn("runtime.containerId")
+			col.Visible = true
+			col, _ = cols.GetColumn("runtime.runtimeName")
+			col.Visible = true
 
 			parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, cols)
 			if err != nil {

--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -66,7 +66,7 @@ func NewListContainersCmd() *cobra.Command {
 				}
 				containers := igmanager.GetContainersBySelector(&selector)
 
-				parser.Sort(containers, []string{"runtime", "name"})
+				parser.Sort(containers, []string{"runtime.runtimeName", "runtime.containerName"})
 				if err = printContainers(parser, commonFlags, containers); err != nil {
 					return err
 				}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -107,7 +107,7 @@ type BasicRuntimeMetadata struct {
 	// RuntimeName is the name of the container runtime. It is useful to distinguish
 	// who is the "owner" of each container in a list of containers collected
 	// from multiple runtimes.
-	RuntimeName RuntimeName `json:"runtimeName,omitempty" column:"runtimeName,minWidth:5,maxWidth:12,hide"`
+	RuntimeName RuntimeName `json:"runtimeName,omitempty" column:"runtimeName,width:19,fixed,hide"`
 
 	// ContainerID is the container ContainerID without the container runtime prefix. For
 	// instance, without the "cri-o://" for CRI-O.


### PR DESCRIPTION
# cmd/ig: Fix order and visible columns in list-containers command

### Before this PR

Wrong order:
```bash
$ sudo ./ig list-containers
RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID                                              RUNTIME.CONTAINERNAME
docker              50a302ad9b0462831f023f3715b9936f09985c0ce59290d577a0e1eee0f82d3f foo
containerd          6791084becce901dd1da36eaad312c6cb58ffb8e308ce491e45b62f30e3f51fe etcd
containerd          b2463090f4483b0bb30e4e37d9fbb0e6149b786b112d1f1173d11e0275e0e4f1 kube-scheduler
containerd          b74c71741d99bc3b6a6d8fd5ef2af0cfbe2b8cd6bd4902bcc5fc81ad2a796514 kube-controller-manager
```

Missing columns:
```bash
$ sudo ./ig list-containers -w
TIMESTAMP                      EVENT      RUNTIME.CONTAINERNAME
2023-07-14T11:37:47Z           CREATED    etcd
2023-07-14T11:37:47Z           CREATED    kube-scheduler
2023-07-14T11:37:47Z           CREATED    kube-controller-manager
2023-07-14T11:37:49Z           CREATED    foo
2023-07-14T11:37:51Z           DELETED    foo
```

### After this PR

Correct order:
```bash
$ sudo ./ig list-containers
RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID                                              RUNTIME.CONTAINERNAME
containerd          6791084becce901dd1da36eaad312c6cb58ffb8e308ce491e45b62f30e3f51fe etcd
containerd          0b564605dc5bf34c11b05ff10a906cc88b1f559683d4d2468e0e13894e9d69ad kube-apiserver
containerd          b74c71741d99bc3b6a6d8fd5ef2af0cfbe2b8cd6bd4902bcc5fc81ad2a796514 kube-controller-manager
containerd          b2463090f4483b0bb30e4e37d9fbb0e6149b786b112d1f1173d11e0275e0e4f1 kube-scheduler
docker              a24ee4a9f2e5aece9012c4950134f7d65f614eb34eb40a102cbc7ea60bb3f108 foo
```

No missing columns:
```bash
$ sudo ./ig list-containers -w
TIMESTAMP                      EVENT      RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID                     RUNTIME.CONTAINERNAME
2023-07-14T11:35:48Z           CREATED    containerd          415699a6e75bfac6e3c9fddbeb914e9fe932c9… kube-apiserver
2023-07-14T11:35:48Z           CREATED    containerd          6791084becce901dd1da36eaad312c6cb58ffb… etcd
2023-07-14T11:35:48Z           CREATED    containerd          b2463090f4483b0bb30e4e37d9fbb0e6149b78… kube-scheduler
2023-07-14T11:35:48Z           CREATED    containerd          b74c71741d99bc3b6a6d8fd5ef2af0cfbe2b8c… kube-controller-manager
2023-07-14T11:35:50Z           CREATED    docker              14766fcf0215f72792e76120139efdb4e862f7… foo
2023-07-14T11:35:52Z           DELETED    docker              14766fcf0215f72792e76120139efdb4e862f7… foo
```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/pull/1702
