### PR TITLE
container-collection: fix fd leak for initial containers

### DIFF
--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -109,21 +109,8 @@ func (cc *ContainerCollection) Initialize(options ...ContainerCollectionOption) 
 	// Consume initial containers that might have been fetched by
 	// functional options. This is done after all functional options have
 	// been called, so that cc.containerEnrichers is fully set up.
-initialContainersLoop:
 	for _, container := range cc.initialContainers {
-		for _, enricher := range cc.containerEnrichers {
-			ok := enricher(container)
-			if !ok {
-				// Enrichers can decide to drop a container
-				container.close()
-				continue initialContainersLoop
-			}
-		}
-
 		cc.AddContainer(container)
-		if cc.pubsub != nil {
-			cc.pubsub.Publish(EventTypeAddContainer, container)
-		}
 	}
 	cc.initialContainers = nil
 

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -819,6 +819,9 @@ func WithTracerCollection(tc TracerCollection) ContainerCollectionOption {
 					container.Runtime.ContainerID, err)
 				return false
 			}
+			if container.mntNsFd != 0 {
+				log.Warnf("WithTracerCollection: mntns reference already set for container %s", container.Runtime.ContainerID)
+			}
 			container.mntNsFd = mntNsFd
 
 			netNsPath := filepath.Join(host.HostProcFs, fmt.Sprint(container.Pid), "ns", "net")
@@ -827,6 +830,9 @@ func WithTracerCollection(tc TracerCollection) ContainerCollectionOption {
 				log.Warnf("WithTracerCollection: failed to open netns reference for container %s: %s",
 					container.Runtime.ContainerID, err)
 				return false
+			}
+			if container.netNsFd != 0 {
+				log.Warnf("WithTracerCollection: netns reference already set for container %s", container.Runtime.ContainerID)
 			}
 			container.netNsFd = netNsFd
 			return true

--- a/pkg/ig-manager/ig-manager_test.go
+++ b/pkg/ig-manager/ig-manager_test.go
@@ -127,6 +127,17 @@ func checkFdList(t *testing.T, initialFdList string, attempts int, sleep time.Du
 func TestClose(t *testing.T) {
 	utilstest.RequireRoot(t)
 
+	opts := []testutils.Option{
+		testutils.WithName("test-ig-close"),
+		testutils.WithoutRemoval(),
+		testutils.WithoutWait(),
+		testutils.WithoutLogs(),
+	}
+	testutils.RunDockerContainer(context.Background(), t, "sleep inf", opts...)
+	t.Cleanup(func() {
+		testutils.RemoveDockerContainer(context.Background(), t, "test-ig-close")
+	})
+
 	initialFdList := currentFdList(t)
 
 	for i := 0; i < 4; i++ {


### PR DESCRIPTION
The enrichers were called twice for initial containers.

This was especially problematic for the WithTracerCollection enricher because it opens file descriptors and they were never closed.

This patch ensures the enricher were called only one time.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/1832

## Testing done

```
go test -test.v -exec sudo -run TestClose ./pkg/ig-manager/...
```