### PR TITLE
container images: add descriptions and other labels

### DIFF
--- a/Dockerfiles/gadget-core.Dockerfile
+++ b/Dockerfiles/gadget-core.Dockerfile
@@ -39,6 +39,12 @@ RUN cd /gadget/gadget-container && \
 # Main gadget image
 FROM ${BASE_IMAGE}
 
+LABEL org.opencontainers.image.source=https://github.com/inspektor-gadget/inspektor-gadget
+LABEL org.opencontainers.image.title="Inspektor Gadget k8s DaemonSet (core flavor)"
+LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image is used as a long-running DaemonSet in Kubernetes via the kubectl-gadget deploy command or via the Helm charts. This is the core flavor (default flavor includes both bcc-based tools and CO-RE-based tools; core flavor includes only CO-RE-based tools)."
+LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 # install runtime dependencies  according to the package manager
 # available on the base image
 RUN set -ex; \

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -44,6 +44,12 @@ RUN cd /gadget/gadget-container && \
 
 FROM bcc
 
+LABEL org.opencontainers.image.source=https://github.com/inspektor-gadget/inspektor-gadget
+LABEL org.opencontainers.image.title="Inspektor Gadget k8s DaemonSet (default flavor)"
+LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image is used as a long-running DaemonSet in Kubernetes via the kubectl-gadget deploy command or via the Helm charts. This is the default flavor (default flavor includes both bcc-based tools and CO-RE-based tools; core flavor includes only CO-RE-based tools)."
+LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	apt-get update && \

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -23,6 +23,12 @@ RUN GOARCH=${TARGETARCH} go test -c -o ig-integration-${TARGETARCH}.test ./...
 
 FROM ${BASE_IMAGE}
 
+LABEL org.opencontainers.image.source=https://github.com/inspektor-gadget/inspektor-gadget
+LABEL org.opencontainers.image.title="Inspektor Gadget integration tests for ig"
+LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image is used to run integration tests for the ig binary."
+LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 ARG TARGETARCH
 
 COPY --from=builder /go/src/github.com/inspektor-gadget/inspektor-gadget/integration/ig/k8s/ig-integration-${TARGETARCH}.test /usr/bin/ig-integration.test

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -38,6 +38,12 @@ FROM ${BASE_IMAGE}
 ARG TARGETOS
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.source=https://github.com/inspektor-gadget/inspektor-gadget
+LABEL org.opencontainers.image.title="Inspektor Gadget ig tool"
+LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image only includes the ig binary, a standalone tool to run the gadgets."
+LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 COPY --from=builder /go/src/github.com/inspektor-gadget/inspektor-gadget/ig-${TARGETOS}-${TARGETARCH} /usr/bin/ig
 ENV HOST_ROOT=/host
 ENTRYPOINT ["/usr/bin/ig"]

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -27,4 +27,11 @@ COPY ./ /gadget
 RUN cd /gadget && make kubectl-gadget
 
 FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.source=https://github.com/inspektor-gadget/inspektor-gadget
+LABEL org.opencontainers.image.title="Inspektor Gadget kubectl-gadget tool"
+LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image only includes the kubectl-gadget binary, a kubectl plugin for Inspektor Gadget."
+LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 COPY --from=builder /gadget/kubectl-gadget /bin/kubectl-gadget


### PR DESCRIPTION
The list of standard labels and annotations are defined here: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

When visiting different tags on the following container image pages, [this](https://github.com/inspektor-gadget/inspektor-gadget/pkgs/container/ig/110223979?tag=latest) currently says:

> About this version: No description provided

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/27575/286e9a5f-5e02-4885-b437-50948d080ec7)


See:
* https://github.com/inspektor-gadget/inspektor-gadget/pkgs/container/ig
* https://github.com/orgs/inspektor-gadget/packages

According to the following documentation, it is recommended to use labels except for the description of multi-arch images where an annotation should be defined in the GitHub Action.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

