### PR TITLE
top/ebpf: Hide the runtime container name

### DIFF
--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -60,6 +60,8 @@ func GetColumns() *columns.Columns[Stats] {
 	col.Visible = false
 	col, _ = cols.GetColumn("container")
 	col.Visible = false
+	col, _ = cols.GetColumn("runtime.containerName")
+	col.Visible = false
 
 	cols.MustAddColumn(columns.Attributes{
 		Name:         "pid",


### PR DESCRIPTION
# top/ebpf: Hide the runtime container name

The container name doesn't make sense for the top/ebpf gadget. So, let's hide it.

Related with https://github.com/inspektor-gadget/inspektor-gadget/issues/1859
Issue introduced in https://github.com/inspektor-gadget/inspektor-gadget/pull/1702