### PR TITLE
Adding "/usr/local/bin/runc" to the list of potential runc paths

### DIFF
--- a/pkg/container-hook/tracer.go
+++ b/pkg/container-hook/tracer.go
@@ -142,6 +142,7 @@ var runtimePaths = []string{
 	"/bin/runc",
 	"/usr/bin/runc",
 	"/usr/sbin/runc",
+	"/usr/local/bin/runc",
 	"/usr/local/sbin/runc",
 	"/usr/lib/cri-o-runc/sbin/runc",
 	"/run/torcx/unpack/docker/bin/runc",

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -119,6 +119,7 @@ var runcPaths = []string{
 	"/bin/runc",
 	"/usr/bin/runc",
 	"/usr/sbin/runc",
+	"/usr/local/bin/runc",
 	"/usr/local/sbin/runc",
 	"/usr/lib/cri-o-runc/sbin/runc",
 	"/run/torcx/unpack/docker/bin/runc",


### PR DESCRIPTION
# Adding /usr/local/bin/runc to the list of potential installation paths of runc

We have found an installation with contrainerd where runc was installed into the /usr/local/bin directory. This was not included in the paths where IG is looking for the runc binary though it looks like it should.

## Testing done

Verified the change on the given setup.
