### PR TITLE
containerd and cri-o: Enrich initial containers with container image name

### DIFF
--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -43,10 +43,17 @@ func newListContainerTestStep(
 				},
 				Runtime: containercollection.RuntimeMetadata{
 					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-						RuntimeName:   types.String2RuntimeName(runtime),
-						ContainerName: runtimeContainerName,
+						RuntimeName:        types.String2RuntimeName(runtime),
+						ContainerName:      runtimeContainerName,
+						ContainerImageName: "docker.io/library/busybox:latest",
 					},
 				},
+			}
+
+			// TODO: Handle once we support getting ContainerImageName from docker
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			if isDockerRuntime {
+				expectedContainer.Runtime.ContainerImageName = ""
 			}
 
 			normalize := func(c *containercollection.Container) {
@@ -239,11 +246,18 @@ func TestWatchDeletedContainers(t *testing.T) {
 					},
 					Runtime: containercollection.RuntimeMetadata{
 						BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-							RuntimeName:   types.String2RuntimeName(*containerRuntime),
-							ContainerName: cn,
+							RuntimeName:        types.String2RuntimeName(*containerRuntime),
+							ContainerName:      cn,
+							ContainerImageName: "docker.io/library/busybox:latest",
 						},
 					},
 				},
+			}
+
+			// TODO: Handle once we support getting containerImageName from Docker
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			if isDockerRuntime {
+				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -31,9 +31,13 @@ func TestProfileCpu(t *testing.T) {
 		Name: "ProfileCpu",
 		Cmd:  fmt.Sprintf("ig profile cpu -K -o json --runtimes=%s --timeout 10", *containerRuntime),
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &cpuprofileTypes.Report{
-				CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime)),
-				Comm:       "sh",
+				CommonData: BuildCommonData(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
+				Comm: "sh",
 			}
 
 			normalize := func(e *cpuprofileTypes.Report) {

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -32,8 +32,12 @@ func TestSnapshotProcess(t *testing.T) {
 		Cmd:          fmt.Sprintf("ig snapshot process -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
 		ExpectedOutputFn: func(output string) error {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &types.Event{
-				Event:   BuildBaseEvent(ns, WithRuntimeMetadata(*containerRuntime)),
+				Event: BuildBaseEvent(ns,
+					WithRuntimeMetadata(*containerRuntime),
+					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				),
 				Command: "nc",
 			}
 

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -25,10 +25,14 @@ import (
 
 func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
 	expectedOutputFn := func(output string) error {
+		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
-			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime)),
-			Comm:       "dd",
-			Write:      true,
+			CommonData: BuildCommonData(ns,
+				WithRuntimeMetadata(*containerRuntime),
+				WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+			),
+			Comm:  "dd",
+			Write: true,
 		}
 
 		normalize := func(e *types.Stats) {

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -25,8 +25,11 @@ import (
 
 func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
 	expectedOutputFn := func(output string) error {
+		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
-			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime)),
+			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime),
+				WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+			),
 			// echo is built-in
 			Comm:     "sh",
 			Filename: "bar",

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -27,10 +27,14 @@ import (
 
 func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 	expectedOutputFn := func(output string) error {
+		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
-			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime)),
-			Comm:       "curl",
-			IPVersion:  syscall.AF_INET,
+			CommonData: BuildCommonData(ns,
+				WithRuntimeMetadata(*containerRuntime),
+				WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+			),
+			Comm:      "curl",
+			IPVersion: syscall.AF_INET,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
 					Addr: "127.0.0.1",

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -79,10 +79,9 @@ func TestTraceNetwork(t *testing.T) {
 								},
 							},
 							Runtime: eventtypes.BasicRuntimeMetadata{
-								ContainerName: "nginx-pod",
-								RuntimeName:   eventtypes.String2RuntimeName(*containerRuntime),
-								// TODO: once ig supports initial containers images enrichment, ContainerImageName should be added
-								// ContainerImageName: "docker.io/library/nginx:latest",
+								ContainerName:      "nginx-pod",
+								RuntimeName:        eventtypes.String2RuntimeName(*containerRuntime),
+								ContainerImageName: "docker.io/library/nginx:latest",
 							},
 						},
 					},
@@ -96,6 +95,11 @@ func TestTraceNetwork(t *testing.T) {
 						Addr: testPodIP,
 					},
 				},
+			}
+
+			// TODO: Handle once we can get ContainerImageName from docker
+			if isDockerRuntime {
+				expectedEntries[1].Event.Runtime.ContainerImageName = ""
 			}
 
 			normalize := func(e *networkTypes.Event) {

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -54,6 +54,8 @@ func TestFilterByContainerName(t *testing.T) {
 				c.K8s.PodLabels = nil
 				c.K8s.PodUID = ""
 				c.Runtime.ContainerID = ""
+				// TODO: Handle once we support getting ContainerImageName from Docker
+				c.Runtime.ContainerImageName = ""
 			}
 
 			return ExpectAllInArrayToMatch(output, normalize, expectedContainer)
@@ -122,6 +124,8 @@ func TestWatchContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				// TODO: Handle once we support getting ContainerImageName from Docker
+				e.Container.Runtime.ContainerImageName = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEvents...)

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -51,6 +51,8 @@ func TestSnapshotProcess(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				// TODO: Handle once we support getting ContainerImageName from Docker
+				e.Runtime.ContainerImageName = ""
 			}
 
 			return ExpectEntriesInArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -126,6 +126,8 @@ func TestTraceDns(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+				// TODO: Handle once we support getting ContainerImageName from Docker
+				e.Runtime.ContainerImageName = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -83,6 +83,8 @@ func TestTraceNetwork(t *testing.T) {
 				e.Tid = 0
 
 				e.Runtime.ContainerID = ""
+				// TODO: Handle once we support getting ContainerImageName from Docker
+				e.Runtime.ContainerImageName = ""
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -49,6 +49,7 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	container.Runtime.ContainerID = containerData.Runtime.ContainerID
 	container.Runtime.RuntimeName = containerData.Runtime.RuntimeName
 	container.Runtime.ContainerName = containerData.Runtime.ContainerName
+	container.Runtime.ContainerImageName = containerData.Runtime.ContainerImageName
 
 	// Kubernetes
 	container.K8s.Namespace = containerData.K8s.Namespace

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -331,17 +331,20 @@ type CRIContainer interface {
 	GetState() runtime.ContainerState
 	GetMetadata() *runtime.ContainerMetadata
 	GetLabels() map[string]string
+	GetImage() *runtime.ImageSpec
 }
 
 func CRIContainerToContainerData(runtimeName types.RuntimeName, container CRIContainer) *runtimeclient.ContainerData {
 	containerMetadata := container.GetMetadata()
+	image := container.GetImage()
 
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
 			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:   container.GetId(),
-				ContainerName: strings.TrimPrefix(containerMetadata.GetName(), "/"),
-				RuntimeName:   runtimeName,
+				ContainerID:        container.GetId(),
+				ContainerName:      strings.TrimPrefix(containerMetadata.GetName(), "/"),
+				RuntimeName:        runtimeName,
+				ContainerImageName: image.GetImage(),
 			},
 			State: containerStatusStateToRuntimeClientState(container.GetState()),
 		},


### PR DESCRIPTION
# containerd and cri-o: Enrich initial containers with container image name

This PR adds initial containers enrichment with ContainerImageName for containerd and cri-o runtimes.
Implements:  #1310  

## Testing done
### containerd
![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/f0e34669-1329-418e-a796-a21ee679068f)

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/c8bd592a-cf8f-49d8-ae9f-e4db2b1ca972)


### cri-o
![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/9e011cd2-3efb-4d2b-8c86-b5b5da759e8e)

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/be995940-9aff-405a-a6dd-10abf3480b46)



