### PR TITLE
pkg/gadgets: Add ntfs3 to trace fsslower.

### DIFF
--- a/pkg/gadgets/trace/fsslower/tracer/gadget.go
+++ b/pkg/gadgets/trace/fsslower/tracer/gadget.go
@@ -63,7 +63,7 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			Title:          "Filesystem",
 			DefaultValue:   "ext4",
 			Description:    "Filesystem to trace",
-			PossibleValues: []string{"btrfs", "ext4", "nfs", "ntfs3", "xfs"},
+			PossibleValues: []string{"btrfs", "ext4", "fuse", "nfs", "ntfs3", "xfs"},
 		},
 	}
 }

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -78,6 +78,12 @@ var fsConfMap = map[string]fsConf{
 		open:  "ext4_file_open",
 		fsync: "ext4_sync_file",
 	},
+	"fuse": {
+		read:  "fuse_file_read_iter",
+		write: "fuse_file_write_iter",
+		open:  "fuse_open",
+		fsync: "fuse_fsync",
+	},
 	"nfs": {
 		read:  "nfs_file_read",
 		write: "nfs_file_write",


### PR DESCRIPTION
Hi.

This PR enables `trace fsslower` to trace `ntfs3`:

```bash
root@vm-amd64:~# ./share/kinvolk/inspektor-gadget/ig trace fsslower -m 0 -f ntfs3 --host > /tmp/foo &
[1] 225
root@vm-amd64:~# cd /mnt/
root@vm-amd64:~# dd if=./foo of=./bar count=3 oflag=sync
3+0 records in
3+0 records out
1536 bytes (1.5 kB, 1.5 KiB) copied, 0.0225191 s, 68.2 kB/s
root@vm-amd64:/mnt# dd if=./foo of=./bar count=3
3+0 records in
3+0 records out
1536 bytes (1.5 kB, 1.5 KiB) copied, 0.00380181 s, 404 kB/s
root@vm-amd64:/mnt# fg
./share/kinvolk/inspektor-gadget/ig trace fsslower -m 0 -f ntfs3 --host > /tmp/foo      (wd: ~)
^Croot@vm-amd64:/mnt# more /tmp/foo
RUNTIME.CONTAINERNAME          RUNTIME.CONTAIN… PID              COMM           
  T      BYTES     OFFSET        LAT FILE                    
                                                258              dd             
  O          0          0          9 foo                     
                                                258              dd             
  O          0          0          8 bar                     
                                                258              dd             
  R        512          0        105 foo                     
                                                258              dd             
  F        511          0       6190 bar                     
                                                258              dd             
  R        512        512        106 foo                     
                                                258              dd             
  F        511        512       5467 bar                     
                                                258              dd             
  R        512       1024         48 foo                     
                                                258              dd             
  F        511       1024       5669 bar                     
                                                260              dd             
  O          0          0          9 foo                     
                                                260              dd             
  O          0          0          7 bar                     
                                                260              dd             
  R        512          0         18 foo                     
                                                260              dd             
  W        512          0        158 bar                     
                                                260              dd             
  R        512        512         10 foo                     
                                                260              dd             
  W        512        512         13 bar                     
                                                260              dd             
  R        512       1024          9 foo                     
                                                260              dd             
  W        512       1024         14 bar
```

Best regards.