### PR TITLE
docs: add examples how to run ig in a custom pod

### DIFF
--- a/docs/examples/ds-ig.yaml
+++ b/docs/examples/ds-ig.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ig
+  labels:
+    k8s-app: example-ig
+spec:
+  selector:
+    matchLabels:
+      name: example-ig
+  template:
+    metadata:
+      labels:
+        name: example-ig
+    spec:
+      containers:
+      - name: ig
+        # CHANGEME: use your own image
+        image: mycontainerimage:latest
+        securityContext:
+          # CHANGEME: you can also use a more restrictive securityContext
+          # See example in
+          # https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/resources/manifests/deploy.yaml
+          privileged: true
+        # CHANGEME: replace this with your own commands
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "sleep inf"
+        env:
+        - name: HOST_ROOT
+          value: "/host"
+        volumeMounts:
+          - mountPath: /host
+            name: host
+          - mountPath: /run
+            name: run
+          - mountPath: /sys/kernel/debug
+            name: debugfs
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+        - name: run
+          hostPath:
+            path: /run
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug

--- a/docs/examples/pod-ig.yaml
+++ b/docs/examples/pod-ig.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ig
+  labels:
+    k8s-app: example-ig
+spec:
+  containers:
+    - name: ig
+      image: ghcr.io/inspektor-gadget/ig:latest
+      securityContext:
+        # CHANGEME: you can also use a more restrictive securityContext
+        # See example in
+        # https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/resources/manifests/deploy.yaml
+        privileged: true
+      command:
+        # CHANGEME: run the gadget of your choice
+        - "ig"
+        - "--auto-mount-filesystems"
+        - "trace"
+        - "exec"
+        - "--host"
+      env:
+        - name: HOST_ROOT
+          value: "/host"
+      volumeMounts:
+        - mountPath: /host
+          name: host
+        - mountPath: /run
+          name: run
+        - mountPath: /sys/kernel/debug
+          name: debugfs
+  # CHANGEME: where do you want to run this pod?
+  nodeName: minikube-containerd
+  volumes:
+    - name: host
+      hostPath:
+        path: /
+    - name: run
+      hostPath:
+        path: /run
+    - name: debugfs
+      hostPath:
+        path: /sys/kernel/debug


### PR DESCRIPTION
The ig documentation included explanations how to run it with Docker and how to run it with the "kubectl debug" command.

This patch adds another way to use ig in a custom pod. This shows an example of Dockerfile and a Kubernetes daemon set yaml. This is useful for third party software that wants to include ig.
