### PR TITLE
experimental: Fix detection logic

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -20,10 +20,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	// Import this early to set the enrivonment variable before any other package is imported
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/local"
+
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/ig/containers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
@@ -64,8 +66,4 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-func init() {
-	environment.Environment = environment.Local
 }

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -21,11 +21,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	// Import this early to set the enrivonment variable before any other package is imported
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/k8s"
+
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -92,8 +94,4 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-func init() {
-	environment.Environment = environment.Kubernetes
 }

--- a/pkg/environment/k8s/k8s.go
+++ b/pkg/environment/k8s/k8s.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8s sets the environnment to Kubernetes. Imported by kubectl-gadget.
+package k8s
+
+import "github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
+
+func init() {
+	environment.Environment = environment.Kubernetes
+}

--- a/pkg/environment/local/local.go
+++ b/pkg/environment/local/local.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package local sets the environnment to Local. Imported by ig.
+package local
+
+import "github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
+
+func init() {
+	environment.Environment = environment.Local
+}

--- a/pkg/utils/experimental/experimental.go
+++ b/pkg/utils/experimental/experimental.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 )
 
 var (
@@ -36,12 +37,15 @@ func Enabled() bool {
 			return
 		}
 
-		info, err := deployinfo.Load()
-		if err != nil {
-			return
-		}
+		// Only check the deployinfo file if this is running in Kubernetes
+		if environment.Environment == environment.Kubernetes {
+			info, err := deployinfo.Load()
+			if err != nil {
+				return
+			}
 
-		experimental = info.Experimental
+			experimental = info.Experimental
+		}
 	})
 
 	return experimental


### PR DESCRIPTION
The information from the deploy info only has to be taken into consideration when running in kubectl-gadget. When running ig, only the env variable is relevant.

This was causing an issue of enabling experimental features in ig when running on the same host where kubectl gadget deploy --experimental was used before.

```bash
$ ./kubectl-gadget deploy --experimental

$ cat $HOME/.ig/info.json  | jq '.Experimental'
true

 # IG_EXPERIMENTAL is not defined
$ sudo -E echo $IG_EXPERIMENTAL
```

Before this commit:

```
 # experimental features are wrongly enabled
$ sudo -E ./ig trace exec
INFO[0000] Experimental features enabled
...
```

After this commit:

```
 # not experimental features enabled by ig
$ sudo -E ./ig trace exec
RUNTIME.CONTAINERNAME                    RUNTIME.CONTAINERIMA… PID
PPID       COMM             RET ARGS

 # but can be enabled with IG_EXPERIMENTAL=true
$ sudo -E IG_EXPERIMENTAL=true ./ig trace exec
INFO[0000] Experimental features enabled
...
```

