### PR TITLE
ci: Fix btfgen

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -311,7 +311,8 @@ jobs:
       if: ${{ steps.cache-btfgen.outputs.cache-hit != 'true' }}
       run: |
           ./tools/getbtfhub.sh
-          make btfgen BPFTOOL=$HOME/btfhub/tools/bin/bpftool.x86_64 \
+          ./tools/getbpftool.sh
+          make btfgen BPFTOOL=/tmp/bpftool \
               BTFHUB_ARCHIVE=$HOME/btfhub-archive/ OUTPUT=$GITHUB_WORKSPACE/hack/btfs -j$(nproc)
     # we are using cache-to mode=min (default) implying that only final image layers are cached, using cache
     # mode=max results in builder image layer of ~7GB because of btfhub files in a layer, which is too

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ cross-gadget-container-all: $(foreach container,$(GADGET_CONTAINERS),$(addprefix
 gadget-%-container:
 	if $(ENABLE_BTFGEN) == "true" ; then \
 		./tools/getbtfhub.sh && \
-		$(MAKE) -f Makefile.btfgen BPFTOOL=$(HOME)/btfhub/tools/bin/bpftool.$(uname -m) \
+		$(MAKE) -f Makefile.btfgen \
 			BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ OUTPUT=hack/btfs/ -j$(nproc); \
 	fi
 	docker buildx build --load -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) \
@@ -150,7 +150,7 @@ gadget-%-container:
 cross-gadget-%-container:
 	if $(ENABLE_BTFGEN) == "true" ; then \
 		./tools/getbtfhub.sh && \
-		$(MAKE) -f Makefile.btfgen BPFTOOL=$(HOME)/btfhub/tools/bin/bpftool.$(uname -m) \
+		$(MAKE) -f Makefile.btfgen \
 			BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ OUTPUT=hack/btfs/ -j$(nproc); \
 	fi
 	docker buildx build --platform=$(PLATFORMS) -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) \

--- a/tools/getbpftool.sh
+++ b/tools/getbpftool.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION=$(curl -s "https://api.github.com/repos/libbpf/bpftool/releases/latest" | jq -r '.tag_name')
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+        ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+        ARCH="arm64"
+fi
+
+curl -sL "https://github.com/libbpf/bpftool/releases/download/${VERSION}/bpftool-${VERSION}-${ARCH}.tar.gz" > /tmp/bpftool.tar.gz
+tar -xzf /tmp/bpftool.tar.gz -C /tmp/
+chmod +x /tmp/bpftool

--- a/tools/getbtfhub.sh
+++ b/tools/getbtfhub.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # Don't clone the repo to /tmp because on some systems it's mounted as tempfs and will require a lot
 # of RAM.
-
-if [ ! -d $HOME/btfhub ]; then
-	git clone --depth 1 https://github.com/aquasecurity/btfhub $HOME/btfhub
-fi
 
 if [ ! -d $HOME/btfhub-archive/ ]; then
 	git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ $HOME/btfhub-archive/


### PR DESCRIPTION
btfhub removed their binary from the repo in https://github.com/aquasecurity/btfhub/pull/96. Switch to download the binary from the bpftool repo instead.

Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/1896
    
