### PR TITLE
gadgets/run: Fix handling of --host parameter

### DIFF
--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -156,16 +156,18 @@ func (t *Tracer) installTracer() error {
 		printMap.ValueSize = 4
 	}
 
-	for _, m := range t.spec.Maps {
-		// Replace filter mount ns map
-		if m.Name == gadgets.MntNsFilterMapName {
-			mapReplacements[gadgets.MntNsFilterMapName] = t.config.MountnsMap
-			consts[gadgets.FilterByMntNsName] = true
+	if t.config.MountnsMap != nil {
+		for _, m := range t.spec.Maps {
+			// Replace filter mount ns map
+			if m.Name == gadgets.MntNsFilterMapName {
+				mapReplacements[gadgets.MntNsFilterMapName] = t.config.MountnsMap
+				consts[gadgets.FilterByMntNsName] = true
+			}
 		}
-	}
 
-	if err := t.spec.RewriteConstants(consts); err != nil {
-		return fmt.Errorf("rewriting constants: %w", err)
+		if err := t.spec.RewriteConstants(consts); err != nil {
+			return fmt.Errorf("rewriting constants: %w", err)
+		}
 	}
 
 	// Load the ebpf objects


### PR DESCRIPTION
Avoid crashing when the --host parameter is passed as in that case the mount ns filter map is not created.

Fixes: 07ca0fb4e97a ("Initial support for containerized gadgets")


