### PR TITLE
Hide `ContainerImageName` column by default

### DIFF
--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -77,10 +77,12 @@ func NewListContainersCmd() *cobra.Command {
 			cols.SetExtractor("event", func(event *containercollection.PubSubEvent) string {
 				return event.Type.String()
 			})
-			// Display the runtime name and container ID when watching containers
+			// Display the runtime name, container ID and image name when watching containers
 			col, _ := cols.GetColumn("runtime.containerId")
 			col.Visible = true
 			col, _ = cols.GetColumn("runtime.runtimeName")
+			col.Visible = true
+			col, _ = cols.GetColumn("runtime.containerImageName")
 			col.Visible = true
 
 			parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, cols)

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -200,11 +200,14 @@ func ownerReferenceEnrichment(
 func GetColumns() *columns.Columns[Container] {
 	cols := columns.MustCreateColumns[Container]()
 
-	// Display the runtime name and container ID when listing containers
+	// Display the runtime name, container ID and image name when listing containers
 	col, _ := cols.GetColumn("runtime.containerId")
 	col.Visible = true
 
 	col, _ = cols.GetColumn("runtime.runtimeName")
+	col.Visible = true
+
+	col, _ = cols.GetColumn("runtime.containerImageName")
 	col.Visible = true
 
 	return cols

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -120,7 +120,7 @@ type BasicRuntimeMetadata struct {
 
 	// ContainerImageName is the name of the container image where the event comes from
 	// i.e. docker.io/library/busybox:latest
-	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName"`
+	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName,hide"`
 }
 
 func (b *BasicRuntimeMetadata) IsEnriched() bool {


### PR DESCRIPTION
# Hide `ContainerImageName` column by default

`ContainerImageName` column was displayed for most of the gadgets taking unnecessary space on the screen.

It is now hidden for all gadgets and only displayed for `ig list-containers` and `ig list-containers -w`.

Fixes: #1859


