### PR TITLE
Docker-ig: Enrich containers with container image name

### DIFF
--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -18,8 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/moby/moby/pkg/stringid"
 	"github.com/spf13/cobra"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
@@ -84,6 +86,12 @@ func NewListContainersCmd() *cobra.Command {
 			col.Visible = true
 			col, _ = cols.GetColumn("runtime.containerImageName")
 			col.Visible = true
+			cols.MustSetExtractor("runtime.containerImageName", func(event *containercollection.PubSubEvent) string {
+				if strings.Contains(event.Container.Runtime.ContainerImageName, "sha256") {
+					return stringid.TruncateID(event.Container.Runtime.ContainerImageName)
+				}
+				return event.Container.Runtime.ContainerImageName
+			})
 
 			parser, err := commonutils.NewGadgetParserWithRuntimeInfo(&commonFlags.OutputConfig, cols)
 			if err != nil {

--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -50,7 +50,7 @@ func newListContainerTestStep(
 				},
 			}
 
-			// TODO: Handle once we support getting ContainerImageName from docker
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			if isDockerRuntime {
 				expectedContainer.Runtime.ContainerImageName = ""
@@ -69,6 +69,11 @@ func newListContainerTestStep(
 
 				c.K8s.PodLabels = nil
 				c.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					c.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return verifyOutput(output, normalize, expectedContainer)
@@ -171,7 +176,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 				},
 			}
 
-			// TODO: Handle it once we support getting container image name for docker.
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -201,6 +206,11 @@ func TestWatchCreatedContainers(t *testing.T) {
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker ||
 					e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO {
 					e.Container.Runtime.ContainerName = cn
+				}
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
+					e.Container.Runtime.ContainerImageName = ""
 				}
 			}
 
@@ -254,7 +264,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 				},
 			}
 
-			// TODO: Handle once we support getting containerImageName from Docker
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
@@ -285,6 +295,11 @@ func TestWatchDeletedContainers(t *testing.T) {
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker ||
 					e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO {
 					e.Container.Runtime.ContainerName = cn
+				}
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
+					e.Container.Runtime.ContainerImageName = ""
 				}
 			}
 
@@ -342,7 +357,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 				},
 			}
 
-			// TODO: Handle it once we support getting container image name for docker.
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -372,6 +387,11 @@ func TestPodWithSecurityContext(t *testing.T) {
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker ||
 					e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO {
 					e.Container.Runtime.ContainerName = cn
+				}
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
+					e.Container.Runtime.ContainerImageName = ""
 				}
 			}
 

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -56,6 +56,11 @@ func TestProfileCpu(t *testing.T) {
 				e.Count = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -57,6 +57,11 @@ func TestSnapshotProcess(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesInArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -54,6 +54,11 @@ func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Operations = 0
 
 			e.Runtime.ContainerID = ""
+
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			if isDockerRuntime {
+				e.Runtime.ContainerImageName = ""
+			}
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -55,6 +55,11 @@ func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.WriteBytes = 0
 
 			e.Runtime.ContainerID = ""
+
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			if isDockerRuntime {
+				e.Runtime.ContainerImageName = ""
+			}
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -65,6 +65,11 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Received = 0
 
 			e.Runtime.ContainerID = ""
+
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			if isDockerRuntime {
+				e.Runtime.ContainerImageName = ""
+			}
 		}
 
 		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -60,6 +60,11 @@ func TestTraceBind(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			// Since we aren't doing any filtering in traceBindCmd we avoid using ExpectAllToMatch

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -81,6 +81,11 @@ func TestTraceCapabilities(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -167,6 +167,11 @@ func TestTraceDns(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -93,6 +93,11 @@ func TestTraceExec(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -64,6 +64,11 @@ func TestTraceFsslower(t *testing.T) {
 				e.Latency = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -66,6 +66,11 @@ func TestTraceMount(t *testing.T) {
 				e.Fs = ""
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -120,6 +120,11 @@ func TestTraceNetwork(t *testing.T) {
 				e.Tid = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntries...)

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -61,6 +61,11 @@ func TestTraceOOMKill(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectAllToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -65,6 +65,11 @@ func TestTraceOpen(t *testing.T) {
 				e.Pid = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -59,6 +59,11 @@ func TestTraceSignal(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -59,6 +59,11 @@ func TestTraceSni(t *testing.T) {
 				e.Tid = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -71,6 +71,11 @@ func TestTraceTCP(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -70,6 +70,11 @@ func TestTraceTcpconnect(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)
@@ -139,6 +144,11 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Runtime.ContainerImageName = ""
+				}
 			}
 
 			return ExpectEntriesToMatch(output, normalize, expectedEntry)

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/moby/pkg/stringid"
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -209,6 +210,13 @@ func GetColumns() *columns.Columns[Container] {
 
 	col, _ = cols.GetColumn("runtime.containerImageName")
 	col.Visible = true
+
+	cols.MustSetExtractor("runtime.containerImageName", func(container *Container) string {
+		if strings.Contains(container.Runtime.ContainerImageName, "sha256") {
+			return stringid.TruncateID(container.Runtime.ContainerImageName)
+		}
+		return container.Runtime.ContainerImageName
+	})
 
 	return cols
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -120,6 +120,11 @@ type BasicRuntimeMetadata struct {
 
 	// ContainerImageName is the name of the container image where the event comes from
 	// i.e. docker.io/library/busybox:latest
+	// Sometimes the image name is not provided by the runtime (i.e. Docker), then ContainerImageName
+	// is the imageID
+	// i.e. sha256:6e38f40d628db3002f5617342c8872c935de530d867d0f709a2fbda1a302a562
+	// OR
+	// i.e. 6e38f40d628d, when truncated
 	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName,hide"`
 }
 


### PR DESCRIPTION
# Docker-ig: Enrich containers with container image name

Partly implements: #1310

`ContainerImageName` is retrieved from the Docker API. When image name is not provided, then `ContainerImageName` will contain the imageID. 
In json output the image ID is displayed in long form, while for listing containers it is truncated.

Image filed provided by Docker API may looks like e.g.
1. gcr.io/k8s-minikube/kicbase:v0.0.37@sha256:8bf7a0e8a062bc5e2b71d28b35bfa9cc862d9220e234e86176b3785f685d8b15

OR

2. busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79

These two provide both image name and digest separated by '@'.
	
3. docker.io/library/busybox:latest or simply busybox

Just image name is provided.
	
4. sha256:aebe758cef4cd05b9f8cee39758227714d02f42ef3088023c1e3cd454f927a2b

This fourth option provides the imageID and, following Docker example, we'll use the imageID.

## Tests examples

`ig list-containers` on host (Docker version 23.0.4):

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/2181c515-0ec2-4225-96b3-bce138769e2e)


`ig list-containers` in minikube-docker (Docker version 20.10.23):

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/01f39ae3-2bbb-45b1-992a-77ccad7d30e1)


`ig list-containers -o json` in minikube-docker (Docker version 20.10.23):

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/a153c3ef-59b5-494a-8c27-228575a379f8)


`ig list-containers -w` in minikube-docker (Docker version 20.10.23):

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/bd7c2825-08aa-43a1-9642-9387d693de8b)


`ig trace exec -o json` in minikube-docker (Docker version 20.10.23):

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/26235020/bca068d8-03f5-4590-8906-92abc95dfd1e)






