### PR TITLE
integration: Pass testing.T object to helper functions

### DIFF
--- a/integration/ig/k8s/profile_bio_test.go
+++ b/integration/ig/k8s/profile_bio_test.go
@@ -28,14 +28,14 @@ func TestProfileBio(t *testing.T) {
 	profileBioCmd := &Command{
 		Name: "ProfileBio",
 		Cmd:  "ig profile block-io -o json --timeout 10",
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := bioprofileTypes.NewReport(histogram.UnitMicroseconds, nil)
 
 			normalize := func(e *bioprofileTypes.Report) {
 				e.Intervals = nil
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -30,7 +30,7 @@ func TestProfileCpu(t *testing.T) {
 	profileCPUCmd := &Command{
 		Name: "ProfileCpu",
 		Cmd:  fmt.Sprintf("ig profile cpu -K -o json --runtimes=%s --timeout 10", *containerRuntime),
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &cpuprofileTypes.Report{
 				CommonData: BuildCommonData(ns,
@@ -58,7 +58,7 @@ func TestProfileCpu(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -31,7 +31,7 @@ func TestSnapshotProcess(t *testing.T) {
 		Name:         "SnapshotProcess",
 		Cmd:          fmt.Sprintf("ig snapshot process -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &types.Event{
 				Event: BuildBaseEvent(ns,
@@ -59,7 +59,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesInArrayToMatch(output, normalize, expectedEntry)
+			ExpectEntriesInArrayToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns,
@@ -56,14 +56,14 @@ func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 
 	return &Command{
-		Name:             "TopBlockIO",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopBlockIO",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 

--- a/integration/ig/k8s/top_ebpf_test.go
+++ b/integration/ig/k8s/top_ebpf_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &types.Stats{
 			Type: ebpf.Tracing.String(),
 			Name: "ig_top_ebpf_it",
@@ -46,14 +46,14 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 			e.PerCpuUsage = 0
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 
 	return &Command{
-		Name:             "TopEbpf",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopEbpf",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime),
@@ -57,14 +57,14 @@ func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 
 	return &Command{
-		Name:             "TopFile",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopFile",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns,
@@ -67,14 +67,14 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 
 	return &Command{
-		Name:             "TopTCP",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopTCP",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -31,7 +31,7 @@ func TestTraceBind(t *testing.T) {
 		Name:         "TraceBind",
 		Cmd:          fmt.Sprintf("ig trace bind -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &bindTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -64,7 +64,7 @@ func TestTraceBind(t *testing.T) {
 
 			// Since we aren't doing any filtering in traceBindCmd we avoid using ExpectAllToMatch
 			// Issue: https://github.com/inspektor-gadget/inspektor-gadget/issues/644
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -31,7 +31,7 @@ func TestTraceCapabilities(t *testing.T) {
 		Name:         "TraceCapabilities",
 		Cmd:          fmt.Sprintf("ig trace capabilities -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &capabilitiesTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -83,7 +83,7 @@ func TestTraceCapabilities(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -35,16 +35,13 @@ func TestTraceDns(t *testing.T) {
 	}
 
 	RunTestSteps(commandsPreTest, t)
-	dnsServer, err := GetTestPodIP(ns, "dnstester")
-	if err != nil {
-		t.Fatalf("failed to get pod ip: %v", err)
-	}
+	dnsServer := GetTestPodIP(t, ns, "dnstester")
 
 	traceDNSCmd := &Command{
 		Name:         "TraceDns",
 		Cmd:          fmt.Sprintf("ig trace dns -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*dnsTypes.Event{
 				{
@@ -169,7 +166,7 @@ func TestTraceDns(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 
@@ -202,16 +199,13 @@ func TestTraceDnsHost(t *testing.T) {
 	}
 
 	RunTestSteps(commandsPreTest, t)
-	dnsServer, err := GetTestPodIP(ns, "dnstester")
-	if err != nil {
-		t.Fatalf("failed to get pod ip: %v", err)
-	}
+	dnsServer := GetTestPodIP(t, ns, "dnstester")
 
 	traceDNSCmd := &Command{
 		Name:         "TraceDnsHost",
 		Cmd:          "ig trace dns -o json --host",
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*dnsTypes.Event{
 				{
 					Event: eventtypes.Event{
@@ -264,7 +258,7 @@ func TestTraceDnsHost(t *testing.T) {
 				}
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -38,7 +38,7 @@ func TestTraceExec(t *testing.T) {
 		Name:         "TraceExec",
 		Cmd:          fmt.Sprintf("ig trace exec -o json --runtimes=%s --cwd", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*execTypes.Event{
 				{
@@ -95,7 +95,7 @@ func TestTraceExec(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 
@@ -122,7 +122,7 @@ func TestTraceExecHost(t *testing.T) {
 		Name:         "TraceExecHost",
 		Cmd:          "ig trace exec -o json --host",
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*execTypes.Event{
 				{
 					Event: eventtypes.Event{
@@ -150,7 +150,7 @@ func TestTraceExecHost(t *testing.T) {
 				e.MountNsID = 0
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -34,7 +34,7 @@ func TestTraceFsslower(t *testing.T) {
 		Name:         "TraceFsslower",
 		Cmd:          fmt.Sprintf("ig trace fsslower -f %s --runtimes=%s -m 0 -o json", fsType, *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &fsslowerTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -66,7 +66,7 @@ func TestTraceFsslower(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -33,7 +33,7 @@ func TestTraceMount(t *testing.T) {
 		Name:         "TraceMount",
 		Cmd:          fmt.Sprintf("ig trace mount -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &mountTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -68,7 +68,7 @@ func TestTraceMount(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -35,21 +35,14 @@ func TestTraceNetwork(t *testing.T) {
 	}
 
 	RunTestSteps(commandsPreTest, t)
-	nginxIP, err := GetTestPodIP(ns, "nginx-pod")
-	if err != nil {
-		t.Fatalf("failed to get pod ip %s", err)
-	}
+	nginxIP := GetTestPodIP(t, ns, "nginx-pod")
 
 	traceNetworkCmd := &Command{
 		Name:         "TraceNetwork",
 		Cmd:          fmt.Sprintf("ig trace network -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
-			testPodIP, err := GetTestPodIP(ns, "test-pod")
-			if err != nil {
-				return fmt.Errorf("getting pod ip: %w", err)
-			}
-
+		ValidateOutput: func(t *testing.T, output string) {
+			testPodIP := GetTestPodIP(t, ns, "test-pod")
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*networkTypes.Event{
 				{
@@ -122,7 +115,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -31,7 +31,7 @@ func TestTraceOOMKill(t *testing.T) {
 		Name:         "TraceOomkill",
 		Cmd:          fmt.Sprintf("ig trace oomkill -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &oomkillTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -63,7 +63,7 @@ func TestTraceOOMKill(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedEntry)
+			ExpectAllToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -31,7 +31,7 @@ func TestTraceOpen(t *testing.T) {
 		Name:         "TraceOpen",
 		Cmd:          fmt.Sprintf("ig trace open -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &openTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -67,7 +67,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -31,7 +31,7 @@ func TestTraceSignal(t *testing.T) {
 		Name:         "TraceSignal",
 		Cmd:          fmt.Sprintf("ig trace signal -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &signalTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -61,7 +61,7 @@ func TestTraceSignal(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -31,7 +31,7 @@ func TestTraceSni(t *testing.T) {
 		Name:         "TraceSNI",
 		Cmd:          fmt.Sprintf("ig trace sni -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &sniTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -61,7 +61,7 @@ func TestTraceSni(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -32,7 +32,7 @@ func TestTraceTCP(t *testing.T) {
 		Name:         "TraceTCP",
 		Cmd:          fmt.Sprintf("ig trace tcp -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -73,7 +73,7 @@ func TestTraceTCP(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -32,7 +32,7 @@ func TestTraceTcpconnect(t *testing.T) {
 		Name:         "StartTcpconnectGadget",
 		Cmd:          fmt.Sprintf("ig trace tcpconnect -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpconnectTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -72,7 +72,7 @@ func TestTraceTcpconnect(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 
@@ -96,7 +96,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		Name:         "StartTcpconnectGadget",
 		Cmd:          fmt.Sprintf("ig trace tcpconnect --latency -o json --runtimes=%s", *containerRuntime),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntry := &tcpconnectTypes.Event{
 				Event: BuildBaseEvent(ns,
@@ -141,7 +141,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -30,7 +30,7 @@ func TestFilterByContainerName(t *testing.T) {
 	listContainersCmd := &Command{
 		Name: "RunFilterByContainerName",
 		Cmd:  fmt.Sprintf("./ig list-containers -o json --runtimes=%s --containername=%s", *runtime, cn),
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedContainer := &containercollection.Container{
 				Runtime: containercollection.RuntimeMetadata{
 					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
@@ -58,7 +58,7 @@ func TestFilterByContainerName(t *testing.T) {
 				c.Runtime.ContainerImageName = ""
 			}
 
-			return ExpectAllInArrayToMatch(output, normalize, expectedContainer)
+			ExpectAllInArrayToMatch(t, output, normalize, expectedContainer)
 		},
 	}
 
@@ -83,7 +83,7 @@ func TestWatchContainers(t *testing.T) {
 		Name:         "RunWatchContainers",
 		Cmd:          fmt.Sprintf("./ig list-containers -o json --watch --runtimes=%s -c %s", *runtime, cn),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEvents := []*containercollection.PubSubEvent{
 				{
 					Type: containercollection.EventTypeAddContainer,
@@ -128,7 +128,7 @@ func TestWatchContainers(t *testing.T) {
 				e.Container.Runtime.ContainerImageName = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEvents...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEvents...)
 		},
 	}
 

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -30,7 +30,7 @@ func TestSnapshotProcess(t *testing.T) {
 	snapshotProcessCmd := &Command{
 		Name: "SnapshotProcess",
 		Cmd:  fmt.Sprintf("./ig snapshot process -o json --runtimes=%s -c %s", *runtime, cn),
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &snapshotprocessTypes.Event{
 				Event: eventtypes.Event{
 					Type: eventtypes.NORMAL,
@@ -55,7 +55,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.Runtime.ContainerImageName = ""
 			}
 
-			return ExpectEntriesInArrayToMatch(output, normalize, expectedEntry)
+			ExpectEntriesInArrayToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/non-k8s/top_ebpf_test.go
+++ b/integration/ig/non-k8s/top_ebpf_test.go
@@ -30,7 +30,7 @@ func TestTopEbpf(t *testing.T) {
 		Name:         "TopEbpf",
 		Cmd:          "./ig top ebpf -o json -m 100 --runtimes=docker",
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &topebpfTypes.Stats{
 				Type: ebpf.Tracing.String(),
 				Name: "ig_top_ebpf_it",
@@ -51,7 +51,7 @@ func TestTopEbpf(t *testing.T) {
 				e.PerCpuUsage = 0
 			}
 
-			return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+			ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -32,7 +32,7 @@ func TestTraceDns(t *testing.T) {
 		Name:         "TraceDns",
 		Cmd:          fmt.Sprintf("./ig trace dns -o json --runtimes=%s -c %s", *runtime, cn),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*dnsTypes.Event{
 				{
 					Event: eventtypes.Event{
@@ -130,7 +130,7 @@ func TestTraceDns(t *testing.T) {
 				e.Runtime.ContainerImageName = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -31,7 +31,7 @@ func TestTraceNetwork(t *testing.T) {
 		Name:         "TraceNetwork",
 		Cmd:          fmt.Sprintf("./ig trace network -o json --runtimes=%s -c %s", *runtime, cn),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*networkTypes.Event{
 				{
 					Event: eventtypes.Event{
@@ -87,7 +87,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Runtime.ContainerImageName = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/inspektor-gadget/profile_blockio_test.go
+++ b/integration/inspektor-gadget/profile_blockio_test.go
@@ -30,14 +30,14 @@ func TestProfileBlockIO(t *testing.T) {
 		{
 			Name: "RunProfileBlockIOGadget",
 			Cmd:  "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15 -o json",
-			ExpectedOutputFn: func(output string) error {
+			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := bioprofileTypes.NewReport(histogram.UnitMicroseconds, nil)
 
 				normalize := func(e *bioprofileTypes.Report) {
 					e.Intervals = nil
 				}
 
-				return ExpectEntriesToMatch(output, normalize, expectedEntry)
+				ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 			},
 		},
 	}

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -29,10 +29,7 @@ func TestProfileCpu(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	commands := []*Command{
 		CreateTestNamespaceCommand(ns),
@@ -41,7 +38,7 @@ func TestProfileCpu(t *testing.T) {
 		{
 			Name: "RunProfileCpuGadget",
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -K --timeout 15 -o json", ns),
-			ExpectedOutputFn: func(output string) error {
+			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &profilecpuTypes.Report{
 					CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "sh",
@@ -60,7 +57,7 @@ func TestProfileCpu(t *testing.T) {
 					e.Runtime.ContainerID = ""
 				}
 
-				return ExpectEntriesToMatch(output, normalize, expectedEntry)
+				ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 			},
 		},
 		DeleteTestNamespaceCommand(ns),

--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -31,10 +31,7 @@ func TestRunTraceOpen(t *testing.T) {
 	prog := "../../gadgets/trace_open_x86.bpf.o"
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	if *k8sArch == "arm64" {
 		prog = "../../gadgets/trace_open_arm64.bpf.o"
@@ -48,7 +45,7 @@ func TestRunTraceOpen(t *testing.T) {
 		Name:         "StartRunTraceOpenGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET run --prog @%s --definition @%s -n %s -o json", prog, def, ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
 				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
@@ -81,7 +78,7 @@ func TestRunTraceOpen(t *testing.T) {
 				m["mntns_id"] = uint64(0)
 			}
 
-			return ExpectEntriesToMatchObj(t, output, normalize, expectedJsonObj)
+			ExpectEntriesToMatchObj(t, output, normalize, expectedJsonObj)
 		},
 	}
 

--- a/integration/inspektor-gadget/script_test.go
+++ b/integration/inspektor-gadget/script_test.go
@@ -16,8 +16,9 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
 )
@@ -37,12 +38,8 @@ func TestScript(t *testing.T) {
 		Name:         "StartScriptGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET script -o json -e '%s'", prog),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
-			if strings.Contains(output, "fofofofof nc") {
-				return nil
-			}
-
-			return fmt.Errorf("output doesn't contain 'fofofofof nc': %s", output)
+		ValidateOutput: func(t *testing.T, output string) {
+			require.Contains(t, output, "fofofofof nc")
 		},
 	}
 

--- a/integration/inspektor-gadget/top_blockio_test.go
+++ b/integration/inspektor-gadget/top_blockio_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func newTopBlockIOCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &topblockioTypes.Stats{
 			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			Write:      true,
@@ -46,13 +46,13 @@ func newTopBlockIOCmd(ns string, cmd string, startAndStop bool, isDockerRuntime 
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 	return &Command{
-		Name:             "TopBlockIO",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopBlockIO",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 
@@ -65,10 +65,7 @@ func TestTopBlockIO(t *testing.T) {
 	ns := GenerateTestNamespaceName("test-top-block-io")
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &topebpfTypes.Stats{
 			Type: ebpf.Tracing.String(),
 			Name: "ig_top_ebpf_it",
@@ -53,13 +53,13 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 	return &Command{
-		Name:             "TopEbpf",
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
-		ExpectedOutputFn: expectedOutputFn,
+		Name:           "TopEbpf",
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
+		ValidateOutput: validateOutputFn,
 	}
 }
 

--- a/integration/inspektor-gadget/top_file_test.go
+++ b/integration/inspektor-gadget/top_file_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func newTopFileCmd(ns, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &topfileTypes.Stats{
 			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			Reads:      0,
@@ -47,13 +47,13 @@ func newTopFileCmd(ns, cmd string, startAndStop bool, isDockerRuntime bool) *Com
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 	return &Command{
-		Name:             "TopFile",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopFile",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 
@@ -62,10 +62,7 @@ func TestTopFile(t *testing.T) {
 	ns := GenerateTestNamespaceName("test-top-file")
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
-	expectedOutputFn := func(output string) error {
+	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &toptcpTypes.Stats{
 			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 			Comm:       "curl",
@@ -59,14 +59,14 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool
 			e.Runtime.ContainerID = ""
 		}
 
-		return ExpectEntriesInMultipleArrayToMatch(output, normalize, expectedEntry)
+		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)
 	}
 
 	return &Command{
-		Name:             "TopTCP",
-		ExpectedOutputFn: expectedOutputFn,
-		Cmd:              cmd,
-		StartAndStop:     startAndStop,
+		Name:           "TopTCP",
+		ValidateOutput: validateOutputFn,
+		Cmd:            cmd,
+		StartAndStop:   startAndStop,
 	}
 }
 
@@ -75,10 +75,7 @@ func TestTopTcp(t *testing.T) {
 	ns := GenerateTestNamespaceName("test-top-tcp")
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),

--- a/integration/inspektor-gadget/trace_bind_test.go
+++ b/integration/inspektor-gadget/trace_bind_test.go
@@ -29,16 +29,13 @@ func TestTraceBind(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceBindCmd := &Command{
 		Name:         "StartBindsnoopGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace bind -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracebindTypes.Event{
 				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:      "nc",
@@ -63,7 +60,7 @@ func TestTraceBind(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedEntry)
+			ExpectAllToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -33,16 +33,13 @@ func TestTraceCapabilities(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceCapabilitiesCmd := &Command{
 		Name:         "StartTraceCapabilitiesGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace capabilities -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracecapabilitiesTypes.Event{
 				Event:         BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:          "nice",
@@ -85,7 +82,7 @@ func TestTraceCapabilities(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -29,10 +29,7 @@ func TestTraceExec(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	cmd := "setuidgid 1000:1111 sh -c 'while true; do date ; /bin/sleep 0.1; done'"
 	shArgs := []string{"/bin/sh", "-c", cmd}
@@ -43,7 +40,7 @@ func TestTraceExec(t *testing.T) {
 		Name:         "StartTraceExecGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace exec -n %s -o json --cwd", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*traceexecTypes.Event{
 				{
 					Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
@@ -85,7 +82,7 @@ func TestTraceExec(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntries...)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -34,16 +34,13 @@ func TestTraceFsslower(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	fsslowerCmd := &Command{
 		Name:         "StartTraceFsslowerGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace fsslower -n %s -f %s -m 0 -o json", ns, fsType),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracefsslowerType.Event{
 				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:  "cat",
@@ -66,7 +63,7 @@ func TestTraceFsslower(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_mount_test.go
+++ b/integration/inspektor-gadget/trace_mount_test.go
@@ -29,16 +29,13 @@ func TestTraceMount(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceMountCmd := &Command{
 		Name:         "StartTraceMountGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace mount -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracemountTypes.Event{
 				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:      "mount",
@@ -66,7 +63,7 @@ func TestTraceMount(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -29,16 +29,13 @@ func TestTraceOOMKill(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceOomkillCmd := &Command{
 		Name:         "StartOomkilGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace oomkill -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &traceoomkillTypes.Event{
 				Event:        BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				KilledComm:   "tail",
@@ -62,7 +59,7 @@ func TestTraceOOMKill(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedEntry)
+			ExpectAllToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -29,16 +29,13 @@ func TestTraceOpen(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceOpenCmd := &Command{
 		Name:         "StartTraceOpenGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace open -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &traceopenTypes.Event{
 				Event:    BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:     "cat",
@@ -65,7 +62,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_signal_test.go
+++ b/integration/inspektor-gadget/trace_signal_test.go
@@ -29,16 +29,13 @@ func TestTraceSignal(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceSignalCmd := &Command{
 		Name:         "StartSigsnoopGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace signal -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracesignalTypes.Event{
 				Event:  BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:   "sh",
@@ -59,7 +56,7 @@ func TestTraceSignal(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -29,16 +29,13 @@ func TestTraceSni(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceSniCmd := &Command{
 		Name:         "StartTraceSniGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace sni -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracesniTypes.Event{
 				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:  "wget",
@@ -61,7 +58,7 @@ func TestTraceSni(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectAllToMatch(output, normalize, expectedEntry)
+			ExpectAllToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -30,16 +30,13 @@ func TestTraceTcp(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceTCPCmd := &Command{
 		Name:         "StartTraceTcpGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcp -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpTypes.Event{
 				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
@@ -75,7 +72,7 @@ func TestTraceTcp(t *testing.T) {
 
 			fmt.Printf("output: %s\n", output)
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -29,16 +29,13 @@ func TestTraceTcpconnect(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceTcpconnectCmd := &Command{
 		Name:         "StartTraceTcpconnectGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpconnectTypes.Event{
 				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
@@ -71,7 +68,7 @@ func TestTraceTcpconnect(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 
@@ -92,16 +89,13 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 	t.Parallel()
 
 	// TODO: Handle it once we support getting container image name from docker
-	errIsDocker, isDockerRuntime := IsDockerRuntime()
-	if errIsDocker != nil {
-		t.Fatalf("checking if docker is current runtime: %v", errIsDocker)
-	}
+	isDockerRuntime := IsDockerRuntime(t)
 
 	traceTcpconnectCmd := &Command{
 		Name:         "StartTraceTcpconnectGadget",
 		Cmd:          fmt.Sprintf("$KUBECTL_GADGET trace tcpconnect -n %s -o json --latency", ns),
 		StartAndStop: true,
-		ExpectedOutputFn: func(output string) error {
+		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpconnectTypes.Event{
 				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
@@ -139,7 +133,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				e.Runtime.ContainerID = ""
 			}
 
-			return ExpectEntriesToMatch(output, normalize, expectedEntry)
+			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 		},
 	}
 


### PR DESCRIPTION
Pass the testing object directly to the helper functions to allow them to fail the tests. This avoids all the error check logic on the callers.

ref https://github.com/inspektor-gadget/inspektor-gadget/pull/1866#discussion_r1281952242