### PR TITLE
Dockerfiles: Improve cross building.

### DIFF
--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -16,6 +16,8 @@ FROM ${BPFTRACE} as bpftrace
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETARCH
+ARG BUILDARCH
+
 # We need a cross compiler and libraries for TARGETARCH due to CGO.
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
@@ -23,8 +25,15 @@ RUN set -ex; \
 	apt-get update && \
 	apt-get install -y gcc make ca-certificates git libelf-dev:${TARGETARCH} \
 		pkg-config:${TARGETARCH} libseccomp-dev:${TARGETARCH} && \
-	if [ ${TARGETARCH} = 'arm64' ]; then \
-		apt-get install -y gcc-aarch64-linux-gnu; \
+	if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+		if [ ${TARGETARCH} = 'arm64' ]; then \
+				apt-get install -y gcc-aarch64-linux-gnu; \
+			elif [ ${TARGETARCH} = 'amd64' ]; then \
+				apt-get install -y gcc-x86-64-linux-gnu; \
+			else \
+				>&2 echo "${TARGETARCH} is not supported"; \
+				exit 1; \
+			fi \
 	fi
 
 # Cache go modules so they won't be downloaded at each build
@@ -34,9 +43,17 @@ RUN cd /gadget && go mod download
 # This COPY is limited by .dockerignore
 COPY ./ /gadget
 RUN cd /gadget/gadget-container && \
-	if [ ${TARGETARCH} = 'arm64' ]; then \
-		export CC=aarch64-linux-gnu-gcc; \
-		export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/; \
+	if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+		if [ ${TARGETARCH} = 'arm64' ]; then \
+			export CC=aarch64-linux-gnu-gcc; \
+			export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/; \
+		elif [ ${TARGETARCH} = 'amd64' ]; then \
+			export CC=x86_64-linux-gnu-gcc; \
+			export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig; \
+		else \
+			>&2 echo "${TARGETARCH} is not supported"; \
+			exit 1; \
+		fi \
 	fi; \
 	make -j$(nproc) TARGET_ARCH=${TARGETARCH} gadget-container-deps
 

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -4,14 +4,22 @@ ARG BASE_IMAGE=gcr.io/distroless/static-debian11
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETARCH
+ARG BUILDARCH
 
 RUN set -ex; \
 	export DEBIAN_FRONTEND=noninteractive; \
 	dpkg --add-architecture ${TARGETARCH} && \
 	apt-get update && \
 	apt-get install -y gcc build-essential libseccomp-dev:${TARGETARCH} && \
-	if [ ${TARGETARCH} = 'arm64' ]; then \
-		apt-get install -y gcc-aarch64-linux-gnu crossbuild-essential-arm64 ; \
+	if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+		if [ ${TARGETARCH} = 'arm64' ]; then \
+			apt-get install -y gcc-aarch64-linux-gnu crossbuild-essential-arm64; \
+		elif [ ${TARGETARCH} = 'amd64' ]; then \
+			apt-get install -y gcc-x86-64-linux-gnu crossbuild-essential-amd64; \
+		else \
+			>&2 echo "${TARGETARCH} is not supported"; \
+			exit 1; \
+		fi \
 	fi
 
 COPY go.mod go.sum /cache/


### PR DESCRIPTION
Previously to this commit, it was possible to cross build the images from amd64 to arm64.
With this commit, cross building can now be done in any direction:
1. From amd64 to arm64.
2. From arm64 to amd64.