### PR TITLE
feat: Add namespace overrides to Helm chart

### DIFF
--- a/charts/gadget/templates/_helpers.tpl
+++ b/charts/gadget/templates/_helpers.tpl
@@ -34,7 +34,11 @@ Create chart name and version as used by the chart label.
 Namespace used by all resources.
 */}}
 {{- define "gadget.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 gadget
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
# Add namespace overrides to Helm chart

Allows setting a `namespaceOverride` on the helm chart

## How to use

- Generate helm chart from this
- Deploy helm chart with `namespaceOverride` set in the values file
- Observe namespaces are overridden

## Testing done

- Followed the abovementioned steps