### PR TITLE
container images: Add description to image index via annotations

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -499,6 +499,11 @@ jobs:
         type: [ default, core ]
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          # TODO: Remove once buildx v0.12.0 is released with https://github.com/docker/buildx/pull/1965
+          version: https://github.com/docker/buildx.git#e5cee892ed4fa2e0af53c54c09131c96c68383ff
       - name: Login to Container Registry
         uses: docker/login-action@v2
         with:
@@ -514,19 +519,35 @@ jobs:
           co-re: ${{ matrix.type == 'core' }}
       - name: Publish the manifest list
         run: |
+          IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
+          IMAGE_DOCUMENTATION="https://inspektor-gadget.io/docs"
+          IMAGE_LICENSES="Apache-2.0"
+          IMAGE_TITLE_FMT="Inspektor Gadget k8s DaemonSet (%s flavor)"
+          IMAGE_DESCRIPTION_FMT="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image is used as a long-running DaemonSet in Kubernetes via the kubectl-gadget deploy command or via the Helm charts. This is the %s flavor (default flavor includes both bcc-based tools and CO-RE-based tools; core flavor includes only CO-RE-based tools)."
+
           if [[ "${{ matrix.type }}" == "core" ]]; then
-            docker buildx imagetools create \
-              -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
-              ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-core-amd64 }} \
-              ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-core-arm64 }}
+            IMAGE_TITLE=$(printf "$IMAGE_TITLE_FMT" "core")
+            IMAGE_DESCRIPTION=$(printf "$IMAGE_DESCRIPTION_FMT" "core")
+            IMAGE_DIGEST_AMD64=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-core-amd64 }}
+            IMAGE_DIGEST_ARM64=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-core-arm64 }}
           fi
 
           if [[ "${{ matrix.type }}" == "default" ]]; then
-            docker buildx imagetools create \
-              -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
-              ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-default-amd64 }} \
-              ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-default-arm64 }}
+            IMAGE_TITLE=$(printf "$IMAGE_TITLE_FMT" "default")
+            IMAGE_DESCRIPTION=$(printf "$IMAGE_DESCRIPTION_FMT" "default")
+            IMAGE_DIGEST_AMD64=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-default-amd64 }}
+            IMAGE_DIGEST_ARM64=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-gadget-container-images.outputs.digest-default-arm64 }}
           fi
+
+          docker buildx imagetools create \
+              -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
+              --annotation index:org.opencontainers.image.documentation="$IMAGE_DOCUMENTATION" \
+              --annotation index:org.opencontainers.image.description="$IMAGE_DESCRIPTION" \
+              --annotation index:org.opencontainers.image.licenses="$IMAGE_LICENSES" \
+              --annotation index:org.opencontainers.image.source="$IMAGE_SOURCE" \
+              --annotation index:org.opencontainers.image.title="$IMAGE_TITLE" \
+              $IMAGE_DIGEST_AMD64 \
+              $IMAGE_DIGEST_ARM64
 
   publish-ig-images-manifest:
     name: Publish ig img manifest
@@ -541,6 +562,11 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          # TODO: Remove once buildx v0.12.0 is released with https://github.com/docker/buildx/pull/1965
+          version: https://github.com/docker/buildx.git#e5cee892ed4fa2e0af53c54c09131c96c68383ff
       - name: Login to Container Registry
         uses: docker/login-action@v2
         with:
@@ -556,10 +582,21 @@ jobs:
           co-re: false
       - name: Publish the manifest list
         run: |
+          IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
+          IMAGE_DOCUMENTATION="https://inspektor-gadget.io/docs"
+          IMAGE_LICENSES="Apache-2.0"
+          IMAGE_TITLE="Inspektor Gadget ig tool"
+          IMAGE_DESCRIPTION="Inspektor Gadget is a collection of tools (or gadgets) to debug and inspect Kubernetes resources and applications. This image only includes the ig binary, a standalone tool to run the gadgets."
+
           docker buildx imagetools create \
             -t ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
             ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-amd64 }} \
-            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-arm64 }}
+            ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ needs.build-ig-container-images.outputs.digest-arm64 }} \
+            --annotation index:org.opencontainers.image.documentation="$IMAGE_DOCUMENTATION" \
+            --annotation index:org.opencontainers.image.description="$IMAGE_DESCRIPTION" \
+            --annotation index:org.opencontainers.image.licenses="$IMAGE_LICENSES" \
+            --annotation index:org.opencontainers.image.source="$IMAGE_SOURCE" \
+            --annotation index:org.opencontainers.image.title="$IMAGE_TITLE"
 
   build-helper-images:
     # level: 0


### PR DESCRIPTION
Since https://github.com/docker/buildx/pull/1965 is merged we can use it to add annotation to multi-arch image index. The added description is visible in the ["About the Version"](https://github.com/mqasimsarfraz/inspektor-gadget/pkgs/container/inspektor-gadget/116822838?tag=latest) section.