### PR TITLE
charts: allow overriding gadget pod capabilities

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -104,6 +104,7 @@ spec:
             seLinuxOptions:
               type: "spc_t"
             capabilities:
+              {{- if not .Values.capabilities }}
               add:
                 # We need CAP_NET_ADMIN to be able to create BPF link.
                 # Indeed, link_create is called with prog->type which equals
@@ -172,6 +173,9 @@ spec:
 
                 # Needed by gadgets that open a raw sock like dns and snisnoop
                 - NET_RAW
+              {{- else }}
+              {{- toYaml .Values.capabilities | nindent 14 }}
+              {{- end }}
           volumeMounts:
             - mountPath: /host
               name: host

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -34,6 +34,9 @@ nodeSelector:
 # -- Affinity used by `gadget` container
 affinity: {}
 
+# -- Capabilities used by `gadget` container
+capabilities: {}
+
 # -- Tolerations used by `gadget` container
 tolerations:
   - effect: NoSchedule


### PR DESCRIPTION
Allow overriding gadget pod capabilities using `values.yaml`. 

Related:  #1934 

## Testing Done

### values.yaml

```
image:
    tag: latest-core
capabilities:
    add:
    - NET_ADMIN
    - SYS_ADMIN
    - SYSLOG
    - SYS_PTRACE
    - IPC_LOCK
    - SYS_MODULE
    - NET_RAW
```
```
$ make -C charts APP_VERSION=latest  install
$ kubectl get daemonsets.apps -n gadget gadget --template='{{range .spec.template.spec.containers}}{{.securityContext.capabilities}}{{println}}{{end}}'
map[add:[NET_ADMIN SYS_ADMIN SYSLOG SYS_PTRACE SYS_RESOURCE IPC_LOCK SYS_MODULE NET_RAW]]
$ helm upgrade gadget -n gadget charts/bin/gadget --values values.yaml
$ kubectl get daemonsets.apps -n gadget gadget --template='{{range .spec.template.spec.containers}}{{.securityContext.capabilities}}{{println}}{{end}}'
 map[add:[NET_ADMIN SYS_ADMIN SYSLOG SYS_PTRACE IPC_LOCK SYS_MODULE NET_RAW]]
$ make -C charts uninstall
```
