### PR TITLE
container-utils/containerd: Add support for custom namespace

### DIFF
--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -20,6 +20,7 @@ import (
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
 	log "github.com/sirupsen/logrus"
@@ -46,7 +47,7 @@ type CommonFlags struct {
 
 	// RuntimeConfigs contains the list of the container runtimes to be used
 	// with their specific socket path.
-	RuntimeConfigs []*containerutils.RuntimeConfig
+	RuntimeConfigs []*containerutilsTypes.RuntimeConfig
 
 	// Number of seconds that the gadget will run for
 	Timeout int
@@ -84,7 +85,7 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 				}
 			}
 
-			commonFlags.RuntimeConfigs = append(commonFlags.RuntimeConfigs, &containerutils.RuntimeConfig{
+			commonFlags.RuntimeConfigs = append(commonFlags.RuntimeConfigs, &containerutilsTypes.RuntimeConfig{
 				Name:       runtimeName,
 				SocketPath: socketPath,
 			})

--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -21,7 +21,7 @@ import (
 	"syscall"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -53,7 +53,7 @@ func main() {
 		// runtime. docker and containerd in this case.
 		// (It's needed to have the name of the container in this example).
 		containercollection.WithMultipleContainerRuntimesEnrichment(
-			[]*containerutils.RuntimeConfig{
+			[]*containerutilsTypes.RuntimeConfig{
 				{Name: types.RuntimeNameDocker},
 				{Name: types.RuntimeNameContainerd},
 			}),

--- a/examples/gadgets/formatter/trace/exec/exec.go
+++ b/examples/gadgets/formatter/trace/exec/exec.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/formatter/textcolumns"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	execTracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
 	execTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
@@ -76,7 +76,7 @@ func main() {
 		// Enrich those containers with data from the container
 		// runtime. docker and containerd in this case.
 		containercollection.WithMultipleContainerRuntimesEnrichment(
-			[]*containerutils.RuntimeConfig{
+			[]*containerutilsTypes.RuntimeConfig{
 				{Name: types.RuntimeNameDocker},
 				{Name: types.RuntimeNameContainerd},
 			}),

--- a/examples/gadgets/withfilter/trace/exec/exec.go
+++ b/examples/gadgets/withfilter/trace/exec/exec.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	execTracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer"
 	execTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/types"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
@@ -75,7 +75,7 @@ func main() {
 		// Enrich those containers with data from the container
 		// runtime. docker and containerd in this case.
 		containercollection.WithMultipleContainerRuntimesEnrichment(
-			[]*containerutils.RuntimeConfig{
+			[]*containerutilsTypes.RuntimeConfig{
 				{Name: types.RuntimeNameDocker},
 				{Name: types.RuntimeNameContainerd},
 			}),

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -30,6 +30,7 @@ import (
 
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -61,7 +62,7 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 	// this node.
 	list := strings.SplitN(node.Status.NodeInfo.ContainerRuntimeVersion, "://", 2)
 	runtimeClient, err := containerutils.NewContainerRuntimeClient(
-		&containerutils.RuntimeConfig{
+		&containerutilsTypes.RuntimeConfig{
 			Name: types.String2RuntimeName(list[0]),
 		})
 	if err != nil {

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -39,6 +39,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cgroups"
 	ociannotations "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/oci-annotations"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runcfanotify"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
@@ -102,7 +103,7 @@ func WithDisableContainerRuntimeWarnings() ContainerCollectionOption {
 // one single call.
 //
 // ContainerCollection.Initialize(WithMultipleContainerRuntimesEnrichment([]*RuntimeConfig)...)
-func WithMultipleContainerRuntimesEnrichment(runtimes []*containerutils.RuntimeConfig) ContainerCollectionOption {
+func WithMultipleContainerRuntimesEnrichment(runtimes []*containerutilsTypes.RuntimeConfig) ContainerCollectionOption {
 	var opts []ContainerCollectionOption
 
 	for _, r := range runtimes {
@@ -130,7 +131,7 @@ func WithMultipleContainerRuntimesEnrichment(runtimes []*containerutils.RuntimeC
 // name because some gadgets need those two values to be set.
 //
 // ContainerCollection.Initialize(WithContainerRuntimeEnrichment(*RuntimeConfig))
-func WithContainerRuntimeEnrichment(runtime *containerutils.RuntimeConfig) ContainerCollectionOption {
+func WithContainerRuntimeEnrichment(runtime *containerutilsTypes.RuntimeConfig) ContainerCollectionOption {
 	return func(cc *ContainerCollection) error {
 		runtimeClient, err := containerutils.NewContainerRuntimeClient(runtime)
 		if err != nil {

--- a/pkg/container-utils/containerd/containerd_test.go
+++ b/pkg/container-utils/containerd/containerd_test.go
@@ -1,0 +1,72 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
+)
+
+func TestNamespace(t *testing.T) {
+	test.RequireRoot(t)
+
+	// validate the container in k8s.io (default for ig) namespace
+	c1 := testutils.NewContainerdContainer("test-k8s-io", "sleep inf")
+	c1.Start(t)
+	k8sClient, err := NewContainerdClient("", nil)
+	t.Cleanup(func() {
+		k8sClient.Close()
+		c1.Stop(t)
+	})
+	require.Nil(t, err)
+	require.NotNil(t, k8sClient)
+
+	container, err := k8sClient.GetContainer("test-k8s-io")
+	require.Nil(t, err)
+	require.NotNil(t, container)
+	require.Equal(t, "test-k8s-io", container.Runtime.ContainerID)
+	require.Equal(t, "test-k8s-io", container.Runtime.ContainerName)
+
+	// validate the container in default (default for containerd) namespace
+	c2 := testutils.NewContainerdContainer("test-default", "sleep inf", testutils.WithNamespace("default"))
+	c2.Start(t)
+	defaultClient, err := NewContainerdClient("", &containerutilsTypes.ExtraConfig{Namespace: "default"})
+	t.Cleanup(func() {
+		defaultClient.Close()
+		c2.Stop(t)
+	})
+	require.Nil(t, err)
+	require.NotNil(t, defaultClient)
+
+	container, err = defaultClient.GetContainer("test-default")
+	require.Nil(t, err)
+	require.NotNil(t, container)
+	require.Equal(t, "test-default", container.Runtime.ContainerID)
+	require.Equal(t, "test-default", container.Runtime.ContainerName)
+
+	// validate we can't see the container in empty-ns namespace
+	emptyClient, err := NewContainerdClient("", &containerutilsTypes.ExtraConfig{Namespace: "empty-ns"})
+	t.Cleanup(func() {
+		emptyClient.Close()
+	})
+	require.Nil(t, err)
+	require.NotNil(t, emptyClient)
+
+	containers, err := k8sClient.GetContainers()
+	require.Nil(t, err)
+	require.NotNil(t, containers)
+	require.GreaterOrEqual(t, len(containers), 1)
+
+	containers, err = defaultClient.GetContainers()
+	require.Nil(t, err)
+	require.NotNil(t, containers)
+	require.GreaterOrEqual(t, len(containers), 1)
+
+	containers, err = emptyClient.GetContainers()
+	require.Nil(t, err)
+	require.NotNil(t, containers)
+	require.Len(t, containers, 0)
+}

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/docker"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/podman"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
@@ -42,12 +43,7 @@ var AvailableRuntimes = []string{
 	types.RuntimeNamePodman.String(),
 }
 
-type RuntimeConfig struct {
-	Name       types.RuntimeName
-	SocketPath string
-}
-
-func NewContainerRuntimeClient(runtime *RuntimeConfig) (runtimeclient.ContainerRuntimeClient, error) {
+func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runtimeclient.ContainerRuntimeClient, error) {
 	switch runtime.Name {
 	case types.RuntimeNameDocker:
 		socketPath := runtime.SocketPath
@@ -75,7 +71,7 @@ func NewContainerRuntimeClient(runtime *RuntimeConfig) (runtimeclient.ContainerR
 		return podman.NewPodmanClient(socketPath), nil
 	default:
 		return nil, fmt.Errorf("unknown container runtime: %s (available %s)",
-			runtime, strings.Join(AvailableRuntimes, ", "))
+			runtime.Name, strings.Join(AvailableRuntimes, ", "))
 	}
 }
 

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -56,7 +56,7 @@ func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runt
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"); envsp != "" && socketPath == "" {
 			socketPath = envsp
 		}
-		return containerd.NewContainerdClient(socketPath)
+		return containerd.NewContainerdClient(socketPath, runtime.Extra)
 	case types.RuntimeNameCrio:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CRIO_SOCKETPATH"); envsp != "" && socketPath == "" {

--- a/pkg/container-utils/containerutils_test.go
+++ b/pkg/container-utils/containerutils_test.go
@@ -19,13 +19,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/stretchr/testify/require"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 func newRuntimeClient(t *testing.T, runtime types.RuntimeName, sPath string) (runtimeclient.ContainerRuntimeClient, error) {
-	config := &RuntimeConfig{
+	config := &containerutilsTypes.RuntimeConfig{
 		Name:       runtime,
 		SocketPath: sPath,
 	}

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -26,6 +26,7 @@ import (
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -83,7 +84,7 @@ func TestRuntimeClientInterface(t *testing.T) {
 			}
 
 			// Initialize runtime client
-			config := &containerutils.RuntimeConfig{
+			config := &containerutilsTypes.RuntimeConfig{
 				Name: runtime,
 			}
 			rc, err := containerutils.NewContainerRuntimeClient(config)

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -26,14 +26,13 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (
-	// TODO containerd currently only works on k8s.io namespace
-	defaultNamespace = "k8s.io"
-	taskKillTimeout  = 3 * time.Second
+	taskKillTimeout = 3 * time.Second
 )
 
 func NewContainerdContainer(name, cmd string, options ...Option) Container {
@@ -79,7 +78,11 @@ func (c *ContainerdContainer) initClientAndCtx() error {
 		return fmt.Errorf("creating a client: %w", err)
 	}
 
-	c.nsCtx = namespaces.WithNamespace(c.options.ctx, defaultNamespace)
+	namespace := constants.K8sContainerdNamespace
+	if c.options.namespace != "" {
+		namespace = c.options.namespace
+	}
+	c.nsCtx = namespaces.WithNamespace(c.options.ctx, namespace)
 	return nil
 }
 

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -28,6 +28,7 @@ type containerOptions struct {
 	image          string
 	imageTag       string
 	seccompProfile string
+	namespace      string
 	wait           bool
 	logs           bool
 	removal        bool
@@ -69,6 +70,13 @@ func WithImageTag(tag string) Option {
 func WithSeccompProfile(profile string) Option {
 	return func(opts *containerOptions) {
 		opts.seccompProfile = profile
+	}
+}
+
+// WithNamespace sets the namespace of the container runtime
+func WithNamespace(namespace string) Option {
+	return func(opts *containerOptions) {
+		opts.namespace = namespace
 	}
 }
 

--- a/pkg/container-utils/types/types.go
+++ b/pkg/container-utils/types/types.go
@@ -16,7 +16,12 @@ package types
 
 import "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
+type ExtraConfig struct {
+	Namespace string
+}
+
 type RuntimeConfig struct {
 	Name       types.RuntimeName
 	SocketPath string
+	Extra      *ExtraConfig
 }

--- a/pkg/container-utils/types/types.go
+++ b/pkg/container-utils/types/types.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+
+type RuntimeConfig struct {
+	Name       types.RuntimeName
+	SocketPath string
+}

--- a/pkg/ig-manager/ig-manager.go
+++ b/pkg/ig-manager/ig-manager.go
@@ -24,6 +24,7 @@ import (
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	containersmap "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgettracermanager/containers-map"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -73,7 +74,7 @@ func (l *IGManager) RemoveMountNsMap(id string) error {
 	return l.tracerCollection.RemoveTracer(id)
 }
 
-func NewManager(runtimes []*containerutils.RuntimeConfig) (*IGManager, error) {
+func NewManager(runtimes []*containerutilsTypes.RuntimeConfig) (*IGManager, error) {
 	l := &IGManager{}
 
 	var err error
@@ -124,7 +125,7 @@ func (l *IGManager) Close() {
 	}
 }
 
-func isDefaultContainerRuntimeConfig(runtimes []*containerutils.RuntimeConfig) bool {
+func isDefaultContainerRuntimeConfig(runtimes []*containerutilsTypes.RuntimeConfig) bool {
 	if len(runtimes) != len(containerutils.AvailableRuntimes) {
 		return false
 	}

--- a/pkg/ig-manager/ig-manager_test.go
+++ b/pkg/ig-manager/ig-manager_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
-	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 
 	// Yes, not the better naming for these two.
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
@@ -136,7 +136,7 @@ func TestClose(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	for i := 0; i < 4; i++ {
-		igManager, err := NewManager([]*containerutils.RuntimeConfig{{Name: "docker"}})
+		igManager, err := NewManager([]*containerutilsTypes.RuntimeConfig{{Name: "docker"}})
 		if err != nil {
 			t.Fatalf("Failed to start ig manager: %s", err)
 		}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -27,6 +27,7 @@ import (
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	igmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
@@ -57,7 +58,7 @@ type Attacher interface {
 
 type LocalManager struct {
 	igManager *igmanager.IGManager
-	rc        []*containerutils.RuntimeConfig
+	rc        []*containerutilsTypes.RuntimeConfig
 }
 
 func (l *LocalManager) Name() string {
@@ -153,7 +154,7 @@ func (l *LocalManager) CanOperateOn(gadget gadgets.GadgetDesc) bool {
 }
 
 func (l *LocalManager) Init(operatorParams *params.Params) error {
-	rc := make([]*containerutils.RuntimeConfig, 0)
+	rc := make([]*containerutilsTypes.RuntimeConfig, 0)
 	parts := operatorParams.Get(Runtimes).AsStringSlice()
 
 partsLoop:
@@ -183,7 +184,7 @@ partsLoop:
 			}
 		}
 
-		rc = append(rc, &containerutils.RuntimeConfig{
+		rc = append(rc, &containerutilsTypes.RuntimeConfig{
 			Name:       runtimeName,
 			SocketPath: socketPath,
 		})


### PR DESCRIPTION
Currently we only support initial containers in `k8s.io` namespace for containerd. This change add supports for a `--containerd-namespace` flag to allow selecting custom namespace. The main use case of this change is to allow selecting "default" namespace, used by containers created using `nerdctl/ctr`.

Fixes: #1849 

### Testing Done

```
$ sudo ctr image pull docker.io/library/nginx:latest
$ sudo ctr c create docker.io/library/nginx:latest test-container
$ sudo ctr t start test-container -d
$ sudo ./ig list-containers --containerd-namespace default
RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID RUNTIME.CONTAINERNAME RUNTIME.CONTAINERIMAGENAME    
containerd          test-container      test-container        docker.io/library/nginx:latest
$ sudo ./ig snapshot process --containerd-namespace default
RUNTIME.CONTAINE… COMM      PID       UID       GID      
test-container    nginx     791186    0         0        
test-container    nginx     791252    101       101      
test-container    nginx     791253    101       101      
test-container    nginx     791254    101       101      
test-container    nginx     791255    101       101      
test-container    nginx     791256    101       101      
test-container    nginx     791257    101       101      
test-container    nginx     791258    101       101      
test-container    nginx     791259    101       101
```