### PR TITLE
docs: Switch udp/tcp to upper case.

### DIFF
--- a/docs/gadgets/trace/network.md
+++ b/docs/gadgets/trace/network.md
@@ -21,8 +21,8 @@ $ kubectl run -ti -n demo --image=busybox --restart=Never shell -- wget 1.1.1.1.
 * Observe the results:
 ```
 NODE             NAMESPACE        POD                            TYPE      PROTO  PORT    REMOTE
-minikube         demo             shell                          OUTGOING  udp    53      svc kube-system/kube-dns
-minikube         demo             shell                          OUTGOING  tcp    80      endpoint 1.1.1.1
+minikube         demo             shell                          OUTGOING  UDP    53      svc kube-system/kube-dns
+minikube         demo             shell                          OUTGOING  TCP    80      endpoint 1.1.1.1
 ```
 
 ### With `ig`
@@ -45,6 +45,6 @@ The tools will show the network activity:
 ```bash
 $ sudo ig trace network -c test-container
 CONTAINER                       TYPE      PROTO PORT  REMOTE
-demo                            OUTGOING  udp   53    192.168.67.1
-demo                            OUTGOING  tcp   80    1.1.1.1
+demo                            OUTGOING  UDP   53    192.168.67.1
+demo                            OUTGOING  TCP   80    1.1.1.1
 ```


### PR DESCRIPTION
ProtoString() was modified to return the prototype as upper case. This commit reflects this change on the documentation.

Fixes: b9e7897e78cb ("feat(DNS-gadget): Add more fields to DNS gadget")