### PR TITLE
Remove duplicated function

### DIFF
--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -107,7 +107,7 @@ func (t *Tracer) runCollector(pid uint32, netns uint64) ([]*socketcollectortypes
 			for i := 0; i < len(buf)/entrySize; i++ {
 				entry := (*socketEntry)(unsafe.Pointer(&buf[i*entrySize]))
 
-				proto := eventtypes.ProtoToString(entry.Proto)
+				proto := gadgets.ProtoString(int(entry.Proto))
 				status, err := parseStatus(proto, entry.State)
 				if err != nil {
 					return err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -228,20 +228,6 @@ func (e *L3Endpoint) String() string {
 	}
 }
 
-// ProtoToString converts an IP protocol number to its name.
-// https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-// TODO: Support other protos
-func ProtoToString(proto uint16) string {
-	switch proto {
-	case 6:
-		return "TCP"
-	case 17:
-		return "UDP"
-	default:
-		return fmt.Sprintf("unknown(%d)", proto)
-	}
-}
-
 type L4Endpoint struct {
 	L3Endpoint
 	// Port is filled by the gadget


### PR DESCRIPTION
We got two functions that do the same (ProtoString and ProtoToString), use only one of them.


