### PR TITLE
[PoC] dns: implement parseLabelSequence in wasm

### DIFF
--- a/gadgets/dns-label-sequence/main.go
+++ b/gadgets/dns-label-sequence/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"unsafe"
+)
+
+var bufIn [1024]byte
+var bufOut [1024]byte
+
+//go:export alloc
+func alloc(size uint32) *byte {
+	return &bufIn[0]
+}
+
+//go:export parseLabelSequence
+func parseLabelSequence(input *byte, inputLength int) uint64 {
+	inputSlice := make([]byte, inputLength)
+	for i := 0; i < inputLength; i++ {
+		inputSlice[i] = *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(input)) + uintptr(i)))
+	}
+	var str string
+	for i := 0; i < inputLength; i++ {
+		length := int(inputSlice[i])
+		if length == 0 {
+			break
+		}
+		if i+1+length < inputLength {
+			str += string(inputSlice[i+1:i+1+length]) + "."
+		}
+		i += length
+	}
+
+	copy(bufOut[:], str)
+
+	return (uint64(uintptr(unsafe.Pointer(&bufOut[0]))) << uint64(32)) | uint64(len(str))
+}
+
+// main is required for the `wasi` target, even if it isn't used.
+// See https://wazero.io/languages/tinygo/#why-do-i-have-to-define-main
+func main() {}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+	github.com/tetratelabs/wazero v1.5.0
 	github.com/tklauser/numcpus v0.6.1
 	go.opentelemetry.io/otel v1.17.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=


### PR DESCRIPTION
This patch removes the implementation of parseLabelSequence from the dns tracer package and instead implements it in an external wasm module. In this PoC, the wasm module was compiled from Golang with tinygo but it could be from other languages.

The wasm module could be moved to the containerized gadget.

Compile the wasm module:
```
sudo dnf install tinygo binaryen
make -C gadgets/dns-label-sequence/
```

```
$ go run -exec sudo ./cmd/ig/... trace dns
RUNTIME.CONTAINERNAME    PID    TID    COMM  QR TYPE      QTYPE NAME              RCODE  NUMANSW…
keen_stonebraker         32910  32910  wget  Q  OUTGOING  A     wikipedia.org.           0
```

Event generated with:
```
docker run -ti --rm busybox wget wikipedia.org
```

xref https://github.com/inspektor-gadget/inspektor-gadget/issues/1929

cc @mauriciovasquezbernal 