### PR TITLE
Refactoring Kubernetes labels

### DIFF
--- a/charts/gadget/templates/_helpers.tpl
+++ b/charts/gadget/templates/_helpers.tpl
@@ -38,6 +38,33 @@ gadget
 {{- end }}
 
 {{/*
+Common labels
+*/}}
+{{- define "gadget.labels" -}}
+helm.sh/chart: {{ include "gadget.chart" . }}
+{{ include "gadget.selectorLabels" . }}
+app.kubernetes.io/component: controller
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels.enabled }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gadget.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gadget.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
 Image tag
 */}}
 {{- define "gadget.image.tag" -}}

--- a/charts/gadget/templates/clusterrole.yaml
+++ b/charts/gadget/templates/clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "gadget.fullname" . }}-cluster-role
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["namespaces", "nodes", "pods"]

--- a/charts/gadget/templates/clusterrolebinding.yaml
+++ b/charts/gadget/templates/clusterrolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "gadget.fullname" . }}-cluster-role-binding
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -2,16 +2,25 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
+    {{- if not .Values.skipLabels }}
+    {{- include "gadget.labels" . | nindent 4 }}
+    {{- end }}
     k8s-app: {{ include "gadget.fullname" . }}
   name: {{ include "gadget.fullname" . }}
   namespace: {{ include "gadget.namespace" . }}
 spec:
   selector:
     matchLabels:
+      {{- if not .Values.skipLabels }}
+      {{- include "gadget.selectorLabels" . | nindent 6 }}
+      {{- end }}
       k8s-app: {{ include "gadget.fullname" . }}
   template:
     metadata:
       labels:
+        {{- if not .Values.skipLabels }}
+        {{- include "gadget.labels" . | nindent 8 }}
+        {{- end }}
         k8s-app: {{ include "gadget.fullname" . }}
       annotations:
         # We need to set gadget container as unconfined so it is able to write

--- a/charts/gadget/templates/role.yaml
+++ b/charts/gadget/templates/role.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
   name: {{ include "gadget.fullname" . }}-role
   namespace: {{ include "gadget.namespace" . }}
 rules:

--- a/charts/gadget/templates/rolebinding.yaml
+++ b/charts/gadget/templates/rolebinding.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
   name: {{ include "gadget.fullname" . }}-role-binding
   namespace: {{ include "gadget.namespace" . }}
 roleRef:

--- a/charts/gadget/templates/serviceaccount.yaml
+++ b/charts/gadget/templates/serviceaccount.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
   name: {{ include "gadget.fullname" . }}
   namespace: {{ include "gadget.namespace" . }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Skip Helm labels
+skipLabels: true
+
+# -- Labels to be added to all other resources.
+additionalLabels:
+  labels: {}
+
 config:
   # -- How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify, fanotify+ebpf")
   hookMode: auto


### PR DESCRIPTION
# [Support Kubernetes recommended labels and additional labels]

- Use [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
- Support to additional labels

## How to use

```
helm template .
```

## Testing done

Manifests seems valid. Ex:

```yaml
---
# Source: gadget/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    helm.sh/chart: gadget-1.0.0
    app.kubernetes.io/name: gadget
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: controller
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
  name: release-name-gadget
  namespace: gadget
```
