### PR TITLE
gadgets: fix ipv6 printing

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -251,3 +251,15 @@ func IsDockerRuntime(t *testing.T) bool {
 
 	return strings.Contains(ret, "docker")
 }
+
+// GetIPVersion returns the version of the IP, 4 or 6. It makes the test fail in case of error.
+// Based on https://stackoverflow.com/a/48519490
+func GetIPVersion(t *testing.T, address string) uint8 {
+	if strings.Count(address, ":") < 2 {
+		return 4
+	} else if strings.Count(address, ":") >= 2 {
+		return 6
+	}
+	t.Fatalf("Failed to determine IP version for address %s", address)
+	return 0
+}

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -37,12 +37,14 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 			IPVersion: syscall.AF_INET,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: "127.0.0.1",
+					Addr:    "127.0.0.1",
+					Version: 4,
 				},
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: "127.0.0.1",
+					Addr:    "127.0.0.1",
+					Version: 4,
 				},
 				Port: 80,
 			},

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -36,6 +36,7 @@ func TestTraceNetwork(t *testing.T) {
 
 	RunTestSteps(commandsPreTest, t)
 	nginxIP := GetTestPodIP(t, ns, "nginx-pod")
+	nginxIPVersion := GetIPVersion(t, nginxIP)
 
 	traceNetworkCmd := &Command{
 		Name:         "TraceNetwork",
@@ -43,6 +44,7 @@ func TestTraceNetwork(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			testPodIP := GetTestPodIP(t, ns, "test-pod")
+			testPodIPVersion := GetIPVersion(t, testPodIP)
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
 			expectedEntries := []*networkTypes.Event{
 				{
@@ -57,7 +59,8 @@ func TestTraceNetwork(t *testing.T) {
 					Proto:   "TCP",
 					Port:    80,
 					DstEndpoint: eventtypes.L3Endpoint{
-						Addr: nginxIP,
+						Addr:    nginxIP,
+						Version: nginxIPVersion,
 					},
 				},
 				{
@@ -85,7 +88,8 @@ func TestTraceNetwork(t *testing.T) {
 					Proto:   "TCP",
 					Port:    80,
 					DstEndpoint: eventtypes.L3Endpoint{
-						Addr: testPodIP,
+						Addr:    testPodIP,
+						Version: testPodIPVersion,
 					},
 				},
 			}

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -43,12 +43,14 @@ func TestTraceTCP(t *testing.T) {
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 					Port: 80,
 				},

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -43,12 +43,14 @@ func TestTraceTcpconnect(t *testing.T) {
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 					Port: 80,
 				},
@@ -112,12 +114,14 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 					Port: 80,
 				},

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -50,7 +50,8 @@ func TestTraceNetwork(t *testing.T) {
 					Proto:   "TCP",
 					Port:    80,
 					DstEndpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 				},
 				{
@@ -70,7 +71,8 @@ func TestTraceNetwork(t *testing.T) {
 					Proto:   "TCP",
 					Port:    80,
 					DstEndpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
+						Addr:    "127.0.0.1",
+						Version: 4,
 					},
 				},
 			}

--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -82,6 +82,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 					e.Tid = 0
 					e.PodIP = ""
 					e.DstEndpoint.Addr = ""
+					e.DstEndpoint.Version = 0
 					e.PodHostIP = ""
 					e.NetNsID = 0
 					e.MountNsID = 0
@@ -134,6 +135,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 					e.Tid = 0
 					e.PodIP = ""
 					e.DstEndpoint.Addr = ""
+					e.DstEndpoint.Version = 0
 					e.PodHostIP = ""
 					e.NetNsID = 0
 					e.MountNsID = 0

--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -61,15 +61,17 @@ func TestSnapshotSocket(t *testing.T) {
 					Protocol: "TCP",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "0.0.0.0",
-							Kind: eventtypes.EndpointKindRaw,
+							Addr:    "0.0.0.0",
+							Version: 4,
+							Kind:    eventtypes.EndpointKindRaw,
 						},
 						Port: 9090,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "0.0.0.0",
-							Kind: eventtypes.EndpointKindRaw,
+							Addr:    "0.0.0.0",
+							Version: 4,
+							Kind:    eventtypes.EndpointKindRaw,
 						},
 						Port: 0,
 					},

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -32,14 +32,16 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool
 			IPVersion:  syscall.AF_INET,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: "127.0.0.1",
-					Kind: eventtypes.EndpointKindRaw,
+					Addr:    "127.0.0.1",
+					Version: 4,
+					Kind:    eventtypes.EndpointKindRaw,
 				},
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: "127.0.0.1",
-					Kind: eventtypes.EndpointKindRaw,
+					Addr:    "127.0.0.1",
+					Version: 4,
+					Kind:    eventtypes.EndpointKindRaw,
 				},
 				Port: 80,
 			},

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -40,6 +40,7 @@ func TestTraceNetwork(t *testing.T) {
 
 	RunTestSteps(commandsPreTest, t)
 	nginxIP := GetTestPodIP(t, ns, "nginx-pod")
+	nginxIPVersion := GetIPVersion(t, nginxIP)
 
 	traceNetworkCmd := &Command{
 		Name:         "StartTraceNetworkGadget",
@@ -47,6 +48,7 @@ func TestTraceNetwork(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			testPodIP := GetTestPodIP(t, ns, "test-pod")
+			testPodIPVersion := GetIPVersion(t, testPodIP)
 
 			expectedEntries := []*tracenetworkTypes.Event{
 				{
@@ -61,6 +63,7 @@ func TestTraceNetwork(t *testing.T) {
 					Port:      80,
 					DstEndpoint: eventtypes.L3Endpoint{
 						Addr:      nginxIP,
+						Version:   nginxIPVersion,
 						Namespace: ns,
 						Name:      "nginx-pod",
 						Kind:      eventtypes.EndpointKindPod,
@@ -93,6 +96,7 @@ func TestTraceNetwork(t *testing.T) {
 					Port:      80,
 					DstEndpoint: eventtypes.L3Endpoint{
 						Addr:      testPodIP,
+						Version:   testPodIPVersion,
 						Namespace: ns,
 						Name:      "test-pod",
 						Kind:      eventtypes.EndpointKindPod,

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -44,14 +44,16 @@ func TestTraceTcp(t *testing.T) {
 				Operation: "connect",
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 					Port: 80,
 				},

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -42,14 +42,16 @@ func TestTraceTcpconnect(t *testing.T) {
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 					Port: 80,
 				},
@@ -102,14 +104,16 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 				},
 				DstEndpoint: eventtypes.L4Endpoint{
 					L3Endpoint: eventtypes.L3Endpoint{
-						Addr: "127.0.0.1",
-						Kind: eventtypes.EndpointKindRaw,
+						Addr:    "127.0.0.1",
+						Version: 4,
+						Kind:    eventtypes.EndpointKindRaw,
 					},
 					Port: 80,
 				},

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -100,6 +100,8 @@ func (t *Tracer) runCollector(pid uint32, netns uint64) ([]*socketcollectortypes
 					return err
 				}
 
+				ipversion := gadgets.IPVerFromAF(entry.Family)
+
 				event := &socketcollectortypes.Event{
 					Event: eventtypes.Event{
 						Type: eventtypes.NORMAL,
@@ -107,13 +109,15 @@ func (t *Tracer) runCollector(pid uint32, netns uint64) ([]*socketcollectortypes
 					Protocol: proto,
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: gadgets.IPStringFromBytes(entry.Saddr, gadgets.IPVerFromAF(entry.Family)),
+							Addr:    gadgets.IPStringFromBytes(entry.Saddr, ipversion),
+							Version: uint8(ipversion),
 						},
 						Port: entry.Sport,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: gadgets.IPStringFromBytes(entry.Daddr, gadgets.IPVerFromAF(entry.Family)),
+							Addr:    gadgets.IPStringFromBytes(entry.Daddr, ipversion),
+							Version: uint8(ipversion),
 						},
 						Port: entry.Dport,
 					},

--- a/pkg/gadgets/snapshot/socket/tracer/tracer_test.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer_test.go
@@ -67,14 +67,16 @@ func TestSnapshotSocket(t *testing.T) {
 					Status:      "LISTEN",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "127.0.0.1",
+							Addr:    "127.0.0.1",
+							Version: 4,
 						},
 						Port: 8082,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
 							// There is no connection in this test, so there remote address is null.
-							Addr: "0.0.0.0",
+							Addr:    "0.0.0.0",
+							Version: 4,
 						},
 					},
 				}
@@ -102,14 +104,16 @@ func TestSnapshotSocket(t *testing.T) {
 					Status:      "LISTEN",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "::1",
+							Addr:    "::1",
+							Version: 6,
 						},
 						Port: 8082,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
 							// There is no connection in this test, so the remote address is null.
-							Addr: "::",
+							Addr:    "::",
+							Version: 6,
 						},
 					},
 				}
@@ -137,14 +141,16 @@ func TestSnapshotSocket(t *testing.T) {
 					Status:      "INACTIVE",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "127.0.0.1",
+							Addr:    "127.0.0.1",
+							Version: 4,
 						},
 						Port: 8082,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
 							// There is no connection in this test, so there remote address is null.
-							Addr: "0.0.0.0",
+							Addr:    "0.0.0.0",
+							Version: 4,
 						},
 					},
 				}
@@ -175,14 +181,16 @@ func TestSnapshotSocket(t *testing.T) {
 					Status:      "INACTIVE",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
-							Addr: "::1",
+							Addr:    "::1",
+							Version: 6,
 						},
 						Port: 8082,
 					},
 					DstEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{
 							// There is no connection in this test, so there remote address is null.
-							Addr: "::",
+							Addr:    "::",
+							Version: 6,
 						},
 					},
 				}

--- a/pkg/gadgets/trace/network/tracer/tracer.go
+++ b/pkg/gadgets/trace/network/tracer/tracer.go
@@ -97,7 +97,8 @@ func parseNetEvent(sample []byte, netns uint64) (*types.Event, error) {
 		Proto:   gadgets.ProtoString(int(bpfEvent.Proto)),
 		Port:    gadgets.Htons(bpfEvent.Port),
 		DstEndpoint: eventtypes.L3Endpoint{
-			Addr: ip.String(),
+			Addr:    ip.String(),
+			Version: 4,
 		},
 
 		Pid:           bpfEvent.Pid,

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -188,13 +188,15 @@ func (t *Tracer) run() {
 			Comm:          gadgets.FromCString(bpfEvent.Task[:]),
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Sport),
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Dport),
 			},

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -185,13 +185,15 @@ func (t *Tracer) run() {
 			Comm:          gadgets.FromCString(bpfEvent.Task[:]),
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.SaddrV6, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.SaddrV6, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Sport),
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.DaddrV6, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.DaddrV6, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Dport),
 			},

--- a/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
@@ -197,13 +197,15 @@ func (t *Tracer) run() {
 
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Sport),
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Dport),
 			},

--- a/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
@@ -160,13 +160,15 @@ func (t *Tracer) run() {
 			IPVersion:     ipversion,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Saddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Sport),
 			},
 			DstEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
-					Addr: gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Addr:    gadgets.IPStringFromBytes(bpfEvent.Daddr, ipversion),
+					Version: uint8(ipversion),
 				},
 				Port: gadgets.Htons(bpfEvent.Dport),
 			},

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -225,6 +225,9 @@ func (e *L3Endpoint) String() string {
 	case EndpointKindRaw:
 		return "r/" + e.Addr
 	default:
+		if e.Version == 6 {
+			return "[" + e.Addr + "]"
+		}
 		return e.Addr
 	}
 }


### PR DESCRIPTION
Use [] around IPv6 addresses to make it more clear:

### before

```bash
$ go run -exec "sudo -E" ./cmd/ig/. trace tcpconnect
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME               PID        COMM             IP SRC                                           DST                                          
mycontainer                         218949     wget             4  172.18.0.2:52926                              142.250.78.110:80                            
mycontainer                         218949     wget             4  172.18.0.2:47832                              142.250.78.132:80                            
mycontainer                         218950     wget             6  2001:db8::2:54444                             2800:3f0:4005:40a::200e:80                   
mycontainer                         218950     wget             6  2001:db8::2:28894                             2800:3f0:4005:409::2004:80 

$ go run -exec "sudo -E" ./cmd/ig/. snapshot socket
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                 PROTOCOL SRC                                               DST                                              STATUS      
local-registry                        TCP      :::5000                                           :::0                                             LISTEN 
```

### now 

```bash
$ go run -exec "sudo -E" ./cmd/ig/. trace tcpconnect
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME               PID        COMM             IP SRC                                           DST                                          
mycontainer                         218354     wget             4  172.18.0.2:13542                              142.250.78.110:80                            
mycontainer                         218354     wget             4  172.18.0.2:41660                              172.217.28.100:80                            
mycontainer                         218355     wget             6  [2001:db8::2]:50841                           [2800:3f0:4005:40a::200e]:80                 
mycontainer                         218355     wget             6  [2001:db8::2]:63721                           [2800:3f0:4005:409::2004]:80 


$ go run -exec "sudo -E" ./cmd/ig/. snapshot socket
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                 PROTOCOL SRC                                               DST                                              STATUS      
local-registry                        TCP      [::]:5000                                         [::]:0                                           LISTEN 
```