### PR TITLE
pkg/container-utils: Prepend host path when using custom socket path.

### DIFF
--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -48,25 +48,25 @@ func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runt
 	case types.RuntimeNameDocker:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_DOCKER_SOCKETPATH"); envsp != "" && socketPath == "" {
-			socketPath = envsp
+			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
 		return docker.NewDockerClient(socketPath)
 	case types.RuntimeNameContainerd:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"); envsp != "" && socketPath == "" {
-			socketPath = envsp
+			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
 		return containerd.NewContainerdClient(socketPath, runtime.Extra)
 	case types.RuntimeNameCrio:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CRIO_SOCKETPATH"); envsp != "" && socketPath == "" {
-			socketPath = envsp
+			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
 		return crio.NewCrioClient(socketPath)
 	case types.RuntimeNamePodman:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_PODMAN_SOCKETPATH"); envsp != "" && socketPath == "" {
-			socketPath = envsp
+			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
 		return podman.NewPodmanClient(socketPath), nil
 	default:


### PR DESCRIPTION
Hi.

In this PR, I preprend `/host` to socket paths.
This way, users just give the normal path towards socket path like `/run/docker.sock`:

```bash
$ ./kubectl-gadget deploy --docker-socketpath /foo/bar --image-pull-policy Never
...
$ kubectl logs -n gadget gadget-5jqbz
...
time="2023-09-08T12:23:15Z" level=warning msg="Skip pod gadget/gadget-5jqbz: cannot find container (ID: docker://11d5409dad1706adf185c12100a6b70039424e4431ec4a9190e8acc4e81b36d8): Cannot connect to the Docker daemon at unix:///host/foo/bar. Is the docker daemon running?"
...
$ ./kubectl-gadget undeploy
...
$ ./kubectl-gadget deploy --docker-socketpath /run/docker.sock --image-pull-policy Never
...
$ kubectl logs -n gadget gadget-cgtzh | grep 'daemon'
```

Best regards.