### PR TITLE
ci: Fix uploading ig container image as artifact

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -434,7 +434,7 @@ jobs:
       with:
         context: /home/runner/work/inspektor-gadget/inspektor-gadget/
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/Dockerfiles/ig.Dockerfile
-        outputs: type=docker,dest=/tmp/ig-container-image--${{ matrix.os }}-${{ matrix.platform }}.tar
+        outputs: type=docker,dest=/tmp/ig-container-image-${{ matrix.os }}-${{ matrix.platform }}.tar
         tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
Fixes: 463f5a88fddd ("ci: Publish ig container images.")

It was causing this step to fail with `Warning: No files were found with the provided path: /tmp/ig-container-image-linux-amd64.tar. No artifacts will be uploaded.`

Ref https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/6184453746/job/16790129503

It wasn't causing any other issue as these artifacts are not being used anywhere. 