### PR TITLE
cmd: Introduce runtime and k8s columns

### DIFF
--- a/cmd/common/utils/parser-tableformatter.go
+++ b/cmd/common/utils/parser-tableformatter.go
@@ -30,14 +30,14 @@ const (
 
 type Option func(*GadgetParserOptions)
 
-func WithMetadataTag(metadataTag string) Option {
+func WithMetadataTags(metadataTags ...string) Option {
 	return func(opts *GadgetParserOptions) {
-		opts.metadataTag = metadataTag
+		opts.metadataTags = metadataTags
 	}
 }
 
 type GadgetParserOptions struct {
-	metadataTag string
+	metadataTags []string
 }
 
 // GadgetParser is a parser that helps printing the gadget output in columns
@@ -58,10 +58,10 @@ func NewGadgetParser[T any](outputConfig *OutputConfig, cols *columns.Columns[T]
 	// other words, the gadget-specific columns. Otherwise, we also include the
 	// columns with the requested tag.
 	var colsMap columns.ColumnMap[T]
-	if opts.metadataTag == "" {
+	if len(opts.metadataTags) == 0 {
 		colsMap = cols.GetColumnMap(columns.WithNoTags())
 	} else {
-		colsMap = cols.GetColumnMap(columns.Or(columns.WithTag(opts.metadataTag), columns.WithNoTags()))
+		colsMap = cols.GetColumnMap(columns.Or(columns.WithAnyTag(opts.metadataTags), columns.WithNoTags()))
 	}
 
 	var formatter *textcolumns.TextColumnsFormatter[T]
@@ -86,11 +86,15 @@ func NewGadgetParser[T any](outputConfig *OutputConfig, cols *columns.Columns[T]
 }
 
 func NewGadgetParserWithK8sInfo[T any](outputConfig *OutputConfig, columns *columns.Columns[T]) (*GadgetParser[T], error) {
-	return NewGadgetParser(outputConfig, columns, WithMetadataTag(KubernetesTag))
+	return NewGadgetParser(outputConfig, columns, WithMetadataTags(KubernetesTag))
 }
 
 func NewGadgetParserWithRuntimeInfo[T any](outputConfig *OutputConfig, columns *columns.Columns[T]) (*GadgetParser[T], error) {
-	return NewGadgetParser(outputConfig, columns, WithMetadataTag(ContainerRuntimeTag))
+	return NewGadgetParser(outputConfig, columns, WithMetadataTags(ContainerRuntimeTag))
+}
+
+func NewGadgetParserWithK8sAndRuntimeInfo[T any](outputConfig *OutputConfig, columns *columns.Columns[T]) (*GadgetParser[T], error) {
+	return NewGadgetParser(outputConfig, columns, WithMetadataTags(KubernetesTag, ContainerRuntimeTag))
 }
 
 func (p *GadgetParser[T]) BuildColumnsHeader() string {

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -121,10 +121,10 @@ func (p *BaseParser[E]) GetOutputConfig() *OutputConfig {
 
 func GetKubernetesColumns() []string {
 	return []string{
-		"node",
-		"namespace",
-		"pod",
-		"container",
+		"k8s.node",
+		"k8s.namespace",
+		"k8s.pod",
+		"k8s.container",
 	}
 }
 

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/ig/containers"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
@@ -60,9 +59,8 @@ func main() {
 	)
 
 	runtime := local.New()
-	// columnFilters for ig
-	columnFilters := []columns.ColumnFilter{columns.WithoutExceptTag("kubernetes", "runtime")}
-	common.AddCommandsFromRegistry(rootCmd, runtime, columnFilters)
+	hiddenColumnTags := []string{"kubernetes"}
+	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
 
 	if experimental.Enabled() {
 		rootCmd.AddCommand(image.NewImageCmd())

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -76,9 +75,8 @@ func main() {
 	namespace, _ := utils.GetNamespace()
 	runtime.SetDefaultValue(gadgets.K8SNamespace, namespace)
 
-	// columnFilters for kubectl-gadget
-	columnFilters := []columns.ColumnFilter{columns.WithoutExceptTag("runtime", "kubernetes")}
-	common.AddCommandsFromRegistry(rootCmd, runtime, columnFilters)
+	hiddenColumnTags := []string{"runtime"}
+	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
 
 	// Advise category is still being handled by CRs for now
 	rootCmd.AddCommand(advise.NewAdviseCmd())

--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,node,namespace,pod,container,hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,node,namespace,pod,container,hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/docs/gadgets/audit/seccomp.md
+++ b/docs/gadgets/audit/seccomp.md
@@ -62,8 +62,8 @@ spec:
 * Start the audit-seccomp gadget.
 
 ```bash
-$ kubectl gadget audit seccomp -o custom-columns=namespace,pod,syscall,code
-NAMESPACE        POD              SYSCALL          CODE
+$ kubectl gadget audit seccomp -o columns=k8s.namespace,k8s.pod,syscall,code
+K8S.NAMESPACE    K8S.POD          SYSCALL          CODE
 ```
 
 * In another terminal, execute the aforementioned syscalls in the pod.
@@ -77,7 +77,7 @@ Bad system call (core dumped)
 * Observe the syscalls logged by seccomp in the first terminal.
 
 ```
-NAMESPACE        POD              SYSCALL          CODE
+K8S.NAMESPACE    K8S.POD          SYSCALL          CODE
 default          mypod            mkdir            log
 default          mypod            unshare          kill_thread
 ```
@@ -104,7 +104,7 @@ default          mypod            unshare          kill_thread
 
 ```bash
 $ sudo ig audit seccomp -r docker
-CONTAINER                                          PID        COMM             SYSCALL     CODE
+RUNTIME.CONTAINERNAME                              PID        COMM             SYSCALL     CODE
 ```
 
 * In another terminal, start a container and run unshare:
@@ -119,6 +119,6 @@ Bad system call (core dumped)
 
 ```bash
 $ sudo ig audit seccomp -r docker
-CONTAINER                                          PID        COMM             SYSCALL     CODE
+RUNTIME.CONTAINERNAME                              PID        COMM             SYSCALL     CODE
 eager_mclean                                       231712     unshare          unshare     kill_thread
 ```

--- a/docs/gadgets/common-features.md
+++ b/docs/gadgets/common-features.md
@@ -115,14 +115,14 @@ namespace during a window of 5 seconds, like this:
 
 ```bash
 $ kubectl gadget trace open -n gadget --timeout 5
-NODE             NAMESPACE        POD              CONTAINER        PID    COMM             FD  ERR PATH
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /etc/ld.so.cache
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libpthread.so.0
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libseccomp.so.2
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /lib/x86_64-linux-gnu/libc.so.6
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0 /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0 /usr/bin/gadgettracermanager
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0 /etc/localtime
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             FD    ERR PATH
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /etc/ld.so.cache
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libpthread.so.0
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libseccomp.so.2
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libc.so.6
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0   /usr/bin/gadgettracermanager
+minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0   /etc/localtime
 ```
 
 ## Kubernetes CLI Runtime options

--- a/docs/gadgets/profile/cpu.md
+++ b/docs/gadgets/profile/cpu.md
@@ -29,7 +29,7 @@ Capturing stack traces... Hit Ctrl-C to end.^C
 After a while press with Ctrl-C to stop trace collection
 
 ```
-NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             COUNT
+K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
 minikube         default          random                         random           340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
@@ -60,7 +60,7 @@ Instead of waiting, you can use the `--timeout` argument:
 ```bash
 $ kubectl gadget profile cpu --timeout 5 --podname random -K
 Capturing stack traces...
-NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             COUNT
+K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
 minikube         default          random                         random           340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
@@ -86,9 +86,9 @@ minikube         default          random                         random         
 This gadget also supports custom column outputting, for example:
 
 ```bash
-$ kubectl gadget profile cpu --timeout 1 --podname random -o custom-columns=node,pod
+$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.pod
 Capturing stack traces...
-NODE             POD
+K8S.NODE         K8S.POD
 minikube         random
 ...
 minikube         random
@@ -97,9 +97,9 @@ minikube         random
 The following command is the same as default printing:
 
 ```bash
-$ kubectl gadget profile cpu --timeout 1 --podname random -o custom-columns=node,namespace,pod,container,pid,comm,count,stack
+$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.namespace,k8s.pod,k8s.container,pid,comm,count
 Capturing stack traces...
-NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             COUNT
+K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
 minikube         default          random                         random           340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
@@ -154,7 +154,7 @@ $ sudo ./ig profile cpu -K --containername random --runtimes docker
 ```bash
 sudo ./ig profile cpu -K --containername random --runtimes docker
 Capturing stack traces... Hit Ctrl-C to end.^C
-CONTAINER                                                                                    COMM             PID        COUNT
+RUNTIME.CONTAINERNAME                                                                        COMM             PID        COUNT
 random                                                                                       cat              641045     1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64

--- a/docs/gadgets/prometheus.md
+++ b/docs/gadgets/prometheus.md
@@ -56,7 +56,7 @@ Only metrics for default namespace
 
 ```yaml
 selector:
-  - namespace: default
+  - k8s.namespace: default
 ```
 
 Only events with retval != 0
@@ -93,9 +93,9 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
 ```
 
 By default, a counter is increased by one each time there is an event, however it's possible to
@@ -111,10 +111,10 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - pod
-      - container
+      - k8s.pod
+      - k8s.container
     selector:
-      - "namespace:default"
+      - "k8s.namespace:default"
 ```
 
 Or only count events for a given command:
@@ -129,9 +129,9 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
     selector:
       - "comm:cat"
 ```
@@ -146,8 +146,8 @@ metrics:
     category: trace
     gadget: dns
     labels:
-      - namespace
-      - pod
+      - k8s.namespace
+      - k8s.pod
     selector:
       - "qr:Q" # Only count query events
 ```
@@ -172,9 +172,9 @@ metrics:
     category: snapshot
     gadget: process
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
 ```
 
 Number of sockets in `CLOSE_WAIT` state
@@ -187,9 +187,9 @@ metrics:
     category: snapshot
     gadget: socket
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
     selector:
       - "status:CLOSE_WAIT"
 ```
@@ -295,9 +295,9 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
 ```
 
 Start the gadget
@@ -336,9 +336,9 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
     selector:
      - "comm:cat"
 ```

--- a/docs/gadgets/run.md
+++ b/docs/gadgets/run.md
@@ -19,13 +19,13 @@ The [gadgets](../../gadgets) folder include some sample gadgets to be used with 
 ```bash
 $ kubectl gadget run --prog @./gadgets/trace_tcpconnect_x86.bpf.o --definition @./gadgets/trace_tcpconnect.yaml
 INFO[0000] Experimental features enabled
-NODE                   NAMESPACE             POD                   CONTAINER             PID     TASK        SRC                      DST
+K8S.NODE               K8S.NAMESPACE         K8S.POD               K8S.CONTAINER         PID     TASK        SRC                      DST
 ubuntu-hirsute         default               mypod2                mypod2                174085  wget        p/default/mypod2:37848   r/1.1.1.1:80
 ubuntu-hirsute         default               mypod2                mypod2                174085  wget        p/default/mypod2:33150   r/1.1.1.1:443
 
 $ kubectl gadget run --prog @./gadgets/trace_open_x86.bpf.o --definition @./gadgets/trace_open.yaml
 INFO[0000] Experimental features enabled
-NODE                   NAMESPACE              POD                    CONTAINER              PID     COMM        UID      GID      RET FNAME
+K8S.NODE               K8S.NAMESPACE          K8S.POD                K8S.CONTAINER          PID     COMM        UID      GID      RET FNAME
 ubuntu-hirsute         default                mypod2                 mypod2                 225071  sh          0        0        3   /
 ubuntu-hirsute         default                mypod2                 mypod2                 225071  sh          0        0        3   /root/.ash_history
 ubuntu-hirsute         default                mypod2                 mypod2                 242164  cat         0        0        -2  /etc/ld.so.cache
@@ -65,13 +65,13 @@ ubuntu-hirsute         default                mypod2                 mypod2     
 
 ``` bash
 $ sudo ig run --prog @./gadgets/trace_tcpconnect_x86.bpf.o --definition @./gadgets/trace_tcpconnect.yaml
-CONTAINER                                                        PID     TASK             SRC                                DST
+RUNTIME.CONTAINERNAME                                            PID     TASK             SRC                                DST
 mycontainer3                                                     1254254 wget             172.17.0.4:50072                   1.1.1.1:80
 mycontainer3                                                     1254254 wget             172.17.0.4:44408                   1.1.1.1:443
 
 $ sudo ig run --prog @./gadgets/trace_open_x86.bpf.o --definition @./gadgets/trace_open.yaml
 INFO[0000] Experimental features enabled
-CONTAINER                                           PID     COMM             UID      GID      RET       FNAME
+RUNTIME.CONTAINERNAME                               PID     COMM             UID      GID      RET       FNAME
 mycontainer3                                        62162   sh               0        0        3         /
 mycontainer3                                        62162   sh               0        0        3         /root/.ash_history
 mycontainer3                                        122110  cat              0        0        -2        /etc/ld.so.cache

--- a/docs/gadgets/script.md
+++ b/docs/gadgets/script.md
@@ -16,7 +16,7 @@ bpftrace documentation.
 ```bash
 # Files opened by process
 $ kubectl gadget script -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
-NODE                             OUTPUT
+K8S.NODE                         OUTPUT
 minikube-m02                     Attaching 1 probe...
 minikube-m02                     bpftrace /sys/devices/system/cpu/online
 minikube-m02                     bpftrace /sys/devices/system/cpu/online
@@ -39,7 +39,7 @@ minikube-m02                     runc
 
 # Run on a single node
 $ kubectl gadget script --node minikube -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
-NODE                             OUTPUT
+K8S.NODE                         OUTPUT
 minikube                         Attaching 1 probe...
 minikube                         kubelet /sys/fs/cgroup/cpu,cpuacct/kubepods/besteffort/poddc2af8ce-f414
 minikube                         kubelet /proc/1645/fd
@@ -68,7 +68,7 @@ minikube                         kubelet /sys/fs/cgroup/memory/kubepods
 # Syscall count by program
 $ kubectl gadget script -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
 
-NODE                             OUTPUT
+K8S.NODE                         OUTPUT
 minikube-m03                     Attaching 1 probe...
 minikube-m02                     Attaching 1 probe...
 minikube                         Attaching 1 probe...
@@ -102,7 +102,7 @@ $ wget https://raw.githubusercontent.com/iovisor/bpftrace/master/tools/loads.bt
 $ wc -l loads.bt
 41 loads.bt
 $ kubectl gadget script -e @./loads.bt
-NODE                                             OUTPUT
+K8S.NODE                                         OUTPUT
 minikube-docker                                  Attaching 2 probes...
 minikube-docker                                  Reading load averages... Hit Ctrl-C to end.
 minikube-docker                                  15:40:36 load averages: 2.960 2.451 2.166

--- a/docs/gadgets/snapshot/process.md
+++ b/docs/gadgets/snapshot/process.md
@@ -22,7 +22,7 @@ There is not any running process in the `demo` namespace now:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-NODE                NAMESPACE           POD                 CONTAINER           COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
 ```
 
 Create a pod on the `demo` namespace using the `nginx` image:
@@ -38,7 +38,7 @@ After the pod is running, we can try to get the list of running processes again:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-NODE                NAMESPACE           POD                 CONTAINER           COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
 ubuntu-hirsute      demo                mypod               mypod               nginx      411928    0         0
 ubuntu-hirsute      demo                mypod               mypod               nginx      411964    101       101
 ubuntu-hirsute      demo                mypod               mypod               nginx      411965    101       101
@@ -62,7 +62,7 @@ Now there is an additional `sleep` processes running in `mypod`:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-NODE                NAMESPACE           POD                 CONTAINER           COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
 ubuntu-hirsute      demo                mypod               mypod               nginx      411928    0         0
 ubuntu-hirsute      demo                mypod               mypod               nginx      411964    101       101
 ubuntu-hirsute      demo                mypod               mypod               nginx      411965    101       101
@@ -94,6 +94,6 @@ Run the snapshot process gadget, it'll print all process in the container:
 
 ```bash
 $ sudo ig snapshot process -c test-snapshot-process
-CONTAINER                                                    COMM             PID                  UID        GID
+RUNTIME.CONTAINERNAME                                        COMM             PID                  UID        GID
 test-snapshot-process                                        sh               329491               0          0
 ```

--- a/docs/gadgets/snapshot/socket.md
+++ b/docs/gadgets/snapshot/socket.md
@@ -33,7 +33,7 @@ done it also using the podname or labels:
 
 ```bash
 $ kubectl gadget snapshot socket -n test-socketcollector
-NODE                NAMESPACE           POD                PROTOCOL SRC                      DST                      STATUS
+K8S.NODE            K8S.NAMESPACE       K8S.POD            PROTOCOL SRC                      DST                      STATUS
 minikube-docker     test-socketcollect… nginx-app          TCP      r/0.0.0.0:80             r/0.0.0.0:0              LISTEN
 ```
 
@@ -52,7 +52,7 @@ $ kubectl exec -n test-socketcollector nginx-app -- /bin/bash -c "sed -i 's/list
 Now, we can check again with the snapshot socket gadget what the active socket is:
 
 ```bash
-NODE                NAMESPACE           POD                PROTOCOL SRC                      DST                      STATUS
+K8S.NODE            K8S.NAMESPACE       K8S.POD            PROTOCOL SRC                      DST                      STATUS
 minikube-docker     test-socketcollect… nginx-app          TCP      r/0.0.0.0:8080           r/0.0.0.0:0              LISTEN
 ```
 

--- a/docs/gadgets/top/block-io.md
+++ b/docs/gadgets/top/block-io.md
@@ -20,7 +20,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget top block-io
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
 ```
 
 Indeed, it is waiting for I/O to occur.
@@ -33,7 +33,7 @@ $ kubectl exec -ti test-pod -- dd if=/dev/zero of=/tmp/foo count=16384
 On *the first terminal*, you should see:
 
 ```
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
 minikube         default          test-pod         test-pod         7767    dd               W   0      0      1564672 3046     4
 ```
 
@@ -61,7 +61,7 @@ Start the gadget on another terminal and you'll see the activity produced by the
 
 ```bash
 $ sudo ig top block-io -c test-top-block-io
-CONTAINER                               PID         COMM                  R/W MAJOR                MINOR                BYTES                TIME                 OPS
+RUNTIME.CONTAINERNAME                   PID         COMM                  R/W MAJOR                MINOR                BYTES                TIME                 OPS
 test-top-block-io                       63666       sync                  W   253                  0                    24576                428                  5
 test-top-block-io                       63715       dd                    W   253                  0                    2097152              4816                 5
 ...

--- a/docs/gadgets/top/ebpf.md
+++ b/docs/gadgets/top/ebpf.md
@@ -16,7 +16,7 @@ So first, start `top ebpf` in a terminal. You should see something like:
 
 ```bash
 $ kubectl gadget top ebpf
-NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
+K8S.NODE         PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
 minikube         503      Tracing          ig_top_ebpf_it   573222  gadgettracerman           54.09µs       1069            12B        1
 minikube         187      CGroupDevice                                                        2.292µs          1             0B        0
 minikube         13       CGroupSKB                                                                0s          0             0B        0
@@ -29,7 +29,7 @@ Now, in a second terminal, start `top file` on the _gadget_ namespace to get som
 
 ```bash
 $ kubectl gadget top file -n gadget
-NODE             NAMESPACE        POD                            CONTAINER        PID     COMM             READS  WRITES R_KB    W_KB    T FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             READS  WRITES R_KB    W_KB    T FILE
 minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    1      0      0       0       R cap_last_cap
 minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    2      0      8       0       R group
 minikube         gadget           gadget-k2mvp                   gadget           575955  gadgettracerman  2      0      8       0       R UTC
@@ -42,7 +42,7 @@ Some eBPF programs of type `Kprobe` should pop up, including their runtime and r
 
 ```bash
 $ kubectl gadget top ebpf
-NODE             PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
+K8S.NODE         PROGID   TYPE             NAME             PID     COMM                      RUNTIME   RUNCOUNT      MAPMEMORY MAPCOUNT
 minikube         506      Kprobe           ig_topfile_rd_e  573222  gadgettracerman         824.589µs       2076       40.95MiB        4
 minikube         505      Tracing          ig_top_ebpf_it   573222  gadgettracerman          47.171µs       1103            12B        1
 minikube         507      Kprobe           ig_topfile_wr_e  573222  gadgettracerman         609.645µs        836       40.95MiB        4
@@ -61,8 +61,8 @@ Combined with the `--sort cumulruntime` and `--timeout 60` parameters, you can f
 over a minute:
 
 ```bash
-$ kubectl-gadget top ebpf -o custom-columns=node,progid,type,name,pid,comm,cumulruntime,cumulruncount --sort cumulruntime --timeout 60
-NODE             PROGID   TYPE             NAME             PID     COMM                 CUMULRUNTIME CUMULRUNCOUNT
+$ kubectl-gadget top ebpf -o columns=k8s.node,progid,type,name,pid,comm,cumulruntime,cumulruncount --sort cumulruntime --timeout 60
+K8S.NODE         PROGID   TYPE             NAME             PID     COMM                 CUMULRUNTIME CUMULRUNCOUNT
 minikube         509      Tracing          ig_top_ebpf_it   573222  gadgettracerman        1.265693ms         15879
 minikube         187      CGroupDevice                                                       40.795µs            48
 minikube         256      CGroupDevice                                                        5.834µs             2

--- a/docs/gadgets/top/file.md
+++ b/docs/gadgets/top/file.md
@@ -17,7 +17,7 @@ all the events from the beginning:
 
 ```bash
 $ kubectl gadget top file -p mypod
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
 ...
 ```
 
@@ -37,7 +37,7 @@ written by the pod. For instace, apt-get is reading a lot of files in
 when updating the packages list and installing packages.
 
 ```bash
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
 ubuntu-hirsute   default          mypod            mypod            642727  apt-get          425    0      27022   0       R archive.ubuntu.com_ubuntu_dists_focal-updates_main_binary-amd64_Packages.lz4
 ubuntu-hirsute   default          mypod            mypod            642727  apt-get          278    0      17775   0       R archive.ubuntu.com_ubuntu_dists_focal_main_binary-amd64_Packages.lz4
 ubuntu-hirsute   default          mypod            mypod            642727  apt-get          244    0      15594   0       R security.ubuntu.com_ubuntu_dists_focal-security_main_binary-amd64_Packages.lz4
@@ -53,7 +53,7 @@ After the initial installation is done, we can see how git uses a
 temporary file to store the repository being cloned.
 
 ```
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
 ubuntu-hirsute   default          mypod            mypod            647042  git              0      1070   0       4280    R tmp_pack_2rpZd
 ```
 
@@ -98,6 +98,6 @@ Start the gadget and it'll show those operations:
 
 ```bash
 $ sudo ig top file -c test-top-file
-CONTAINER                              PID        COMM             READS                WRITES               RBYTES               WBYTES               T FILE
+RUNTIME.CONTAINERNAME                  PID        COMM             READS                WRITES               RBYTES               WBYTES               T FILE
 test-top-file                          139255     sh               0                    1                    0B                   4B                   R bar
 ```

--- a/docs/gadgets/top/tcp.md
+++ b/docs/gadgets/top/tcp.md
@@ -19,7 +19,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget top tcp
-NODE             NAMESPACE        POD              CONTAINER        PID       COMM      IP SRC                   DST                   SENT     RECV
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID       COMM      IP SRC                   DST                   SENT     RECV
 ```
 
 Indeed, it is waiting for TCP connection to occur.
@@ -32,7 +32,7 @@ $ kubectl exec -ti test-pod -- wget 1.1.1.1
 On *the first terminal*, you should see:
 
 ```
-NODE               NAMESPACE     POD        CONTAINER   PID         COMM       IP SRC                        DST                  SENT       RECV      
+K8S.NODE           K8S.NAMESPACE K8S.POD    CONTAINER   PID         COMM       IP SRC                        DST                  SENT       RECV      
 minikube-docker    default       test-pod   test-pod    289548      wget       4  p/default/test-pod:47228   r/1.1.1.1:443        296B       15.49KiB  
 minikube-docker    default       test-pod   test-pod    289540      wget       4  p/default/test-pod:42604   r/1.1.1.1:80         70B        381B      
 ```
@@ -61,7 +61,7 @@ Start the gadget, it'll show the different connections created the localhost:
 
 ```bash
 $ sudo ig top tcp -c test-top-tcp
-CONTAINER                  PID         COMM           IP SRC                               DST                               SENT          RECV
+RUNTIME.CONTAINERNAME      PID         COMM           IP SRC                               DST                               SENT          RECV
 test-top-tcp               2177846     nginx          4  127.0.0.1:80                      127.0.0.1:53130                   238B          73B
 test-top-tcp               2178303     curl           4  127.0.0.1:53130                   127.0.0.1:80                      73B           853B
 ```

--- a/docs/gadgets/trace/bind.md
+++ b/docs/gadgets/trace/bind.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace bind
-NODE             NAMESPACE        POD              CONTAINER        PID    COMM             PROTO  ADDR             PORT   OPTS   IF
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             PROTO  ADDR             PORT   OPTS   IF
 ```
 
 Indeed, it is waiting for socket binding to occur.
@@ -36,7 +36,7 @@ command terminated with exit code 1
 Go back to *the first terminal* and see:
 
 ```
-NODE             NAMESPACE        POD              CONTAINER        PID    COMM             PROTO  ADDR             PORT   OPTS   IF
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             PROTO  ADDR             PORT   OPTS   IF
 minikube         default          test-pod         test-pod         58208  nc               IP     ::               4242   .R...  0
 ```
 
@@ -58,7 +58,7 @@ Start the gadget first
 
 ```bash
 $ sudo ig trace bind -c test-trace-bind
-CONTAINER        PID     COMM             PROTO  ADDR             PORT    OPTS    IF
+K8S.CONTAINER    PID     COMM             PROTO  ADDR             PORT    OPTS    IF
 ```
 
 In another terminal, run a container that performs a bind operation
@@ -71,7 +71,7 @@ The gadget will print the event on the first terminal:
 
 ```bash
 $ sudo ig trace bind -c test-trace-bind
-CONTAINER        PID     COMM             PROTO  ADDR             PORT    OPTS    IF
+K8S.CONTAINER    PID     COMM             PROTO  ADDR             PORT    OPTS    IF
 test-trace-bind  380299  nc               TCP    ::               4242    .R...   0
 ```
 

--- a/docs/gadgets/trace/capabilities.md
+++ b/docs/gadgets/trace/capabilities.md
@@ -60,12 +60,12 @@ Let's use Inspektor Gadget to watch the capability checks:
 
 ```bash
 $ kubectl gadget trace capabilities --selector name=set-priority
-NODE             NAMESPACE  POD                     CONTAINER     PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
-minikube-docker  default    set-priorit…495c8-t88x8 set-priority  2711127  nice  setpriority  0    23  SYS_NICE  1      Deny
-minikube-docker  default    set-priorit…495c8-t88x8 set-priority  2711260  nice  setpriority  0    23  SYS_NICE  1      Deny
-minikube-docker  default    set-priorit…495c8-t88x8 set-priority  2711457  nice  setpriority  0    23  SYS_NICE  1      Deny
-minikube-docker  default    set-priorit…495c8-t88x8 set-priority  2711619  nice  setpriority  0    23  SYS_NICE  1      Deny
-minikube-docker  default    set-priorit…495c8-t88x8 set-priority  2711815  nice  setpriority  0    23  SYS_NICE  1      Deny
+K8S.NODE         K8S.NAMESPACE  K8S.POD                 K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
+minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711127  nice  setpriority  0    23  SYS_NICE  1      Deny
+minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711260  nice  setpriority  0    23  SYS_NICE  1      Deny
+minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711457  nice  setpriority  0    23  SYS_NICE  1      Deny
+minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711619  nice  setpriority  0    23  SYS_NICE  1      Deny
+minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711815  nice  setpriority  0    23  SYS_NICE  1      Deny
 ^C
 Terminating...
 ```
@@ -129,9 +129,9 @@ We can see the same checks but this time with the `Allow` verdict:
 
 ```bash
 $ kubectl gadget trace capabilities --selector name=set-priority
-NODE             NAMESPACE  POD                     CONTAINER     PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
-minikube-docker  default    set-priorit…66dff-nm5pt set-priority  2718069  nice  setpriority  0    23  SYS_NICE  1      Allow
-minikube-docker  default    set-priorit…66dff-nm5pt set-priority  2718291  nice  setpriority  0    23  SYS_NICE  1      Allow
+K8S.NODE         K8S.NAMESPACE  K8S.POD                 K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
+minikube-docker  default        set-priorit…66dff-nm5pt set-priority  2718069  nice  setpriority  0    23  SYS_NICE  1      Allow
+minikube-docker  default        set-priorit…66dff-nm5pt set-priority  2718291  nice  setpriority  0    23  SYS_NICE  1      Allow
 ^C
 Terminating...
 ```
@@ -161,7 +161,7 @@ $ kubectl run -ti --rm --restart=Never \
 
 ```
 $ kubectl gadget trace capabilities \
-    -o custom-columns=comm,syscall,capName,verdict,targetuserns,currentuserns,caps,capsnames
+    -o columns=comm,syscall,capName,verdict,targetuserns,currentuserns,caps,capsnames
 COMM             SYSCALL                      CAPNAME            VERDICT TARGETUSERNS        CURRENTUSERNS       CAPS                 CAPSNAMES
 chroot           chroot                       SYS_CHROOT         Allow   4026531837          4026531837          3fffffffff           chown,dac_override,dac_…
 ```
@@ -279,7 +279,7 @@ Start `ig`:
 
 ```bash
 $ ig trace capabilities -r docker -c test
-CONTAINER  PID      COMM     SYSCALL  UID  CAP CAPNAME      AUDIT  VERDICT
+RUNTIME.CONTAINERNAME  PID      COMM     SYSCALL  UID  CAP CAPNAME      AUDIT  VERDICT
 ```
 
 Start the test container exercising the capabilities:
@@ -295,16 +295,16 @@ OK
 Observe the resulting trace:
 
 ```
-CONTAINER  PID      COMM     SYSCALL  UID  CAP CAPNAME      AUDIT  VERDICT
-test       2609137  chown    chown    0    0   CHOWN        1      Allow
-test       2609137  chown    chown    0    0   CHOWN        1      Allow
-test       2609138  chmod    chmod    0    3   FOWNER       1      Allow
-test       2609138  chmod    chmod    0    4   FSETID       1      Allow
-test       2609138  chmod    chmod    0    4   FSETID       1      Allow
-test       2609694  chroot   chroot   0    18  SYS_CHROOT   1      Allow
-test       2610364  mount    mount    0    21  SYS_ADMIN    1      Allow
-test       2610364  mount    mount    0    21  SYS_ADMIN    1      Allow
-test       2633270  unshare  unshare  0    21  SYS_ADMIN    1      Allow
-test       2633270  nsenter  setns    0    21  SYS_ADMIN    1      Allow
-test       2633270  nsenter  setns    0    21  SYS_ADMIN    1      Allow
+RUNTIME.CONTAINERNAME  PID      COMM     SYSCALL  UID  CAP CAPNAME      AUDIT  VERDICT
+test                   2609137  chown    chown    0    0   CHOWN        1      Allow
+test                   2609137  chown    chown    0    0   CHOWN        1      Allow
+test                   2609138  chmod    chmod    0    3   FOWNER       1      Allow
+test                   2609138  chmod    chmod    0    4   FSETID       1      Allow
+test                   2609138  chmod    chmod    0    4   FSETID       1      Allow
+test                   2609694  chroot   chroot   0    18  SYS_CHROOT   1      Allow
+test                   2610364  mount    mount    0    21  SYS_ADMIN    1      Allow
+test                   2610364  mount    mount    0    21  SYS_ADMIN    1      Allow
+test                   2633270  unshare  unshare  0    21  SYS_ADMIN    1      Allow
+test                   2633270  nsenter  setns    0    21  SYS_ADMIN    1      Allow
+test                   2633270  nsenter  setns    0    21  SYS_ADMIN    1      Allow
 ```

--- a/docs/gadgets/trace/dns.md
+++ b/docs/gadgets/trace/dns.md
@@ -23,7 +23,7 @@ Start the dns gadget:
 
 ```bash
 $ kubectl gadget trace dns -n demo
-NODE                          NAMESPACE                     POD                           QR NAMESERVER      TYPE      QTYPE      NAME
+K8S.NODE                      K8S.NAMESPACE                 K8S.POD                       QR NAMESERVER      TYPE      QTYPE      NAME
 ```
 
 Run a pod on a different terminal and perform some DNS requests:
@@ -38,7 +38,7 @@ $ kubectl -n demo run mypod -it --image=wbitt/network-multitool -- /bin/sh
 The requests will be logged by the DNS gadget:
 
 ```bash
-NODE                 NAMESPACE            POD                  PID         TID         COMM        QR NAMESERVER      TYPE      QTYPE      NAME                RCODE
+K8S.NODE             K8S.NAMESPACE        K8S.POD              PID         TID         COMM        QR NAMESERVER      TYPE      QTYPE      NAME                RCODE
 minikube             demo                 mypod                1285309     1285310     isc-net-00… Q  8.8.4.4         OUTGOING  A          inspektor-gadget.i…        
 minikube             demo                 mypod                1285309     1285310     isc-net-00… R  8.8.4.4         HOST      A          inspektor-gadget.i… NoError
 minikube             demo                 mypod                1285594     1285595     isc-net-00… Q  8.8.4.4         OUTGOING  AAAA       inspektor-gadget.i…        

--- a/docs/gadgets/trace/exec.md
+++ b/docs/gadgets/trace/exec.md
@@ -32,7 +32,7 @@ ip-10-0-30-247 where myapp1-pod-2gs5r and myapp2-pod-mqfxv are running:
 
 ```bash
 $ kubectl gadget trace exec --selector role=demo --node ip-10-0-30-247
-NODE                NAMESPACE        POD              CONTAINER       PID     PPID    COMM            RET ARGS
+K8S.NODE            K8S.NAMESPACE    K8S.POD          K8S.CONTAINER   PID     PPID    COMM            RET ARGS
 ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728770  728166  date              0 /bin/date
 ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728771  728166  cat               0 /bin/cat /proc/version
 ip-10-0-30-247      default          myapp1-pod-2gs5r myapp1-pod      728772  728166  sleep             0 /bin/sleep 1
@@ -71,7 +71,7 @@ Let's start the gadget in a terminal:
 
 ```bash
 $ sudo ig trace exec -c test-trace-exec
-CONTAINER                                         PID        PPID       COMM             RET ARGS
+RUNTIME.CONTAINERNAME                             PID        PPID       COMM             RET ARGS
 ```
 
 Run a container that executes some binaries:
@@ -84,7 +84,7 @@ The tool will show the different processes executed by the container:
 
 ```bash
 $ sudo ig trace exec -c test-trace-exec
-CONTAINER                                         PID        PPID       COMM             RET ARGS
+RUNTIME.CONTAINERNAME                             PID        PPID       COMM             RET ARGS
 test-trace-exec                                   99081      99062      sh               0   /bin/sh -c while /bin/true ; do whoami ; sleep 3 ; done
 test-trace-exec                                   99125      99081      true             0   /bin/true
 test-trace-exec                                   99126      99081      whoami           0   /bin/whoami
@@ -102,6 +102,6 @@ by default and can be enabled by passing the `--cwd` flag:
 ```bash
 $ sudo ig trace exec  --cwd
 
-CONTAINER                       PID        PPID       COMM              RET ARGS                                      CWD
+RUNTIME.CONTAINERNAME           PID        PPID       COMM              RET ARGS                                      CWD
 mycontainer2                    287752     287360     mkdir             0   /bin/mkdir -p /tmp/bar/foo/               /
 mycontainer2                    287897     287360     cat               0   /bin/cat /dev/null                        /tmp/bar/foo

--- a/docs/gadgets/trace/fsslower.md
+++ b/docs/gadgets/trace/fsslower.md
@@ -20,7 +20,7 @@ Let's start the gadget before running our workload:
 
 ```bash
 $ kubectl gadget trace fsslower -f ext4 -m 1 -p mypod
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             T BYTES  OFFSET  LAT      FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             T BYTES  OFFSET  LAT      FILE
 ```
 
 With `-f` we're indicating the type of filesystem we want to trace,
@@ -43,7 +43,7 @@ We can see how fsslower shows the operations that are taking longer than 1ms:
 
 ```bash
 $ kubectl gadget trace fsslower -f ext4 -m 1 -p mypod
-NODE             NAMESPACE        POD              CONTAINER        PID     COMM             T BYTES  OFFSET  LAT      FILE
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             T BYTES  OFFSET  LAT      FILE
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       2.66     perl-modules-5.30.list-new
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       1.49     libperl5.30:amd64.list-new
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       1.45     control

--- a/docs/gadgets/trace/mount.md
+++ b/docs/gadgets/trace/mount.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace mount
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    COMM             PID     TID     MNTNS      CALL
 ```
 
 Indeed, it is waiting for `mount` and `umount` to be called.
@@ -40,7 +40,7 @@ command terminated with exit code 255
 Go back to *the first terminal* and see:
 
 ```bash
-NODE             NAMESPACE        POD              CONTAINER        COMM             PID     TID     MNTNS      CALL
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    COMM             PID     TID     MNTNS      CALL
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext3", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext2", MS_SILENT, "") = -2
 minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext4", MS_SILENT, "") = -2
@@ -70,7 +70,7 @@ Let's start the gadget in a terminal:
 
 ```bash
 $ sudo ig trace mount -c test-trace-mount
-CONTAINER                         COMM             PID        TID        CALL
+RUNTIME.CONTAINERNAME             COMM             PID        TID        CALL
 ```
 
 Run a container that uses mount:
@@ -83,7 +83,7 @@ The tool will show the different mount() calls that the container performed:
 
 ```bash
 $ sudo ig trace mount -c test-trace-mount
-CONTAINER                         COMM             PID        TID        CALL
+RUNTIME.CONTAINERNAME             COMM             PID        TID        CALL
 test-trace-mount                  mount            235385     235385     mount("/bar", "/foo", "ext3", MS_SILENT, "") = -2
 test-trace-mount                  mount            235385     235385     mount("/bar", "/foo", "ext2", MS_SILENT, "") = -2
 test-trace-mount                  mount            235385     235385     mount("/bar", "/foo", "ext4", MS_SILENT, "") = -2

--- a/docs/gadgets/trace/network.md
+++ b/docs/gadgets/trace/network.md
@@ -20,7 +20,7 @@ $ kubectl run -ti -n demo --image=busybox --restart=Never shell -- wget 1.1.1.1.
 
 * Observe the results:
 ```
-NODE             NAMESPACE        POD                            TYPE      PROTO  PORT    REMOTE
+K8S.NODE         K8S.NAMESPACE    K8S.POD                        TYPE      PROTO  PORT    REMOTE
 minikube         demo             shell                          OUTGOING  UDP    53      svc kube-system/kube-dns
 minikube         demo             shell                          OUTGOING  TCP    80      endpoint 1.1.1.1
 ```
@@ -31,7 +31,7 @@ Let's start the gadget in a terminal:
 
 ```bash
 $ sudo ig trace network -c test-container
-CONTAINER                       TYPE      PROTO PORT  REMOTE
+RUNTIME.CONTAINERNAME           TYPE      PROTO PORT  REMOTE
 ```
 
 Run a container that generates TCP and UDP network traffic:
@@ -44,7 +44,7 @@ The tools will show the network activity:
 
 ```bash
 $ sudo ig trace network -c test-container
-CONTAINER                       TYPE      PROTO PORT  REMOTE
+RUNTIME.CONTAINERNAME           TYPE      PROTO PORT  REMOTE
 demo                            OUTGOING  UDP   53    192.168.67.1
 demo                            OUTGOING  TCP   80    1.1.1.1
 ```

--- a/docs/gadgets/trace/oomkill.md
+++ b/docs/gadgets/trace/oomkill.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace oomkill -n oomkill-demo
-NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM            PAGES  TPID             TCOMM
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    KPID   KCOMM            PAGES  TPID             TCOMM
 ```
 
 The gadget is waiting for the OOM killer to get triggered and kill a process in `oomkill-demo` namespace (alternatively, we could use `-A` and get out-of-memory killer events in all namespaces).
@@ -39,7 +39,7 @@ command terminated with exit code 137
 Go back to *the first terminal* and see:
 
 ```bash
-NODE             NAMESPACE        POD              CONTAINER        KPID   KCOMM            PAGES  TPID             TCOMM
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    KPID   KCOMM            PAGES  TPID             TCOMM
 minikube         oomkill-demo     test-pod         test-container   11507  tail             32768  11507            tail
 ```
 

--- a/docs/gadgets/trace/open.md
+++ b/docs/gadgets/trace/open.md
@@ -21,7 +21,7 @@ thus tracing on all nodes for a pod called "mypod":
 
 ```bash
 $ kubectl gadget trace open --podname mypod
-NODE             NAMESPACE        POD              CONTAINER       PID    COMM               FD ERR PATH
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER   PID    COMM               FD ERR PATH
 ip-10-0-30-247   default          mypod            mypod           18455  whoami              3   0 /etc/passwd
 ip-10-0-30-247   default          mypod            mypod           18521  whoami              3   0 /etc/passwd
 ip-10-0-30-247   default          mypod            mypod           18525  whoami              3   0 /etc/passwd
@@ -46,7 +46,7 @@ Let's start the gadget in a terminal:
 
 ```bash
 $ sudo ig trace open -c test-trace-open
-CONTAINER                                                  PID        COMM             FD    ERR PATH
+RUNTIME.CONTAINERNAME                                      PID        COMM             FD    ERR PATH
 ```
 
 Run a container that opens some files:
@@ -59,7 +59,7 @@ The tool will show the different files opened by the container:
 
 ```bash
 $ sudo ig trace open -c test-trace-open
-CONTAINER                                                  PID        COMM             FD    ERR PATH
+RUNTIME.CONTAINERNAME                                      PID        COMM             FD    ERR PATH
 test-trace-open                                            630417     whoami           3     0   /etc/passwd
 test-trace-open                                            630954     whoami           3     0   /etc/passwd
 ```
@@ -69,7 +69,7 @@ will add the column `FULLPATH` that contains the absolute path of the file with 
 
 ```bash
 $ sudo ./ig trace open -c test-trace-open-fullpath --full-path
-CONTAINER                     PID        COMM             FD  ERR PATH                            FULLPATH
+RUNTIME.CONTAINERNAME         PID        COMM             FD  ERR PATH                            FULLPATH
 test-trace-open-fullpath      1330356    cat              3   0   /etc/passwd                     /etc/passwd
 test-trace-open-fullpath      1330401    cat              3   0   ../etc/mtab                     /proc/22/mounts
 ```

--- a/docs/gadgets/trace/signal.md
+++ b/docs/gadgets/trace/signal.md
@@ -20,7 +20,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace signal
-NODE             NAMESPACE        POD              CONTAINER        PID    COMM             SIGNAL    TPID   RET
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             SIGNAL    TPID   RET
 ```
 
 Indeed, it is waiting for signals to be sent.
@@ -33,7 +33,7 @@ $ kubectl exec -ti debian -- sh -c 'sleep 3 & kill -kill $!'
 Go back to *the first terminal* and see:
 
 ```
-NODE             NAMESPACE        POD              CONTAINER        PID    COMM             SIGNAL    TPID   RET
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             SIGNAL    TPID   RET
 minikube         default          debian           debian           129484 sh               SIGKILL   129491 0
 minikube         default          debian           debian           129484 sh               SIGHUP    129491 0
 minikube         default          debian           debian           129484 sh               SIGHUP    129484 0
@@ -91,7 +91,7 @@ The gadget will show that sh killed a process.
 
 ```bash
 $ sudo ig trace signal -c test-trace-signal
-CONTAINER                  PID        COMM          SIGNAL      TPID       RET
+RUNTIME.CONTAINERNAME      PID        COMM          SIGNAL      TPID       RET
 test-trace-signal          11131      sh            SIGKILL     11162      0
 test-trace-signal          11131      sh            SIGHUP      11131      0
 ```

--- a/docs/gadgets/trace/sni.md
+++ b/docs/gadgets/trace/sni.md
@@ -14,7 +14,7 @@ we can run:
 
 ```bash
 $ kubectl gadget trace sni
-NODE               NAMESPACE          POD                PID        TID       COMM      NAME
+K8S.NODE           K8S.NAMESPACE      K8S.POD            PID        TID       COMM      NAME
 ```
 
 To generate some output for this example, let's create a demo pod in *another terminal*:
@@ -36,7 +36,7 @@ Location: https://github.com/ [following]
 Go back to *the first terminal* and see:
 
 ```
-NODE               NAMESPACE          POD                PID        TID       COMM      NAME
+K8S.NODE           K8S.NAMESPACE      K8S.POD            PID        TID       COMM      NAME
 minikube           default            ubuntu             3917791    3917791   wget      www.github.com
 minikube           default            ubuntu             3917791    3917791   wget      github.com
 minikube           default            ubuntu             3917812    3917812   wget      wikimedia.org
@@ -63,7 +63,7 @@ Run the gadget in a terminal
 
 ```bash
 $ sudo ig trace sni -r docker -c test-trace-sni
-CONTAINER                              PID        TID        COMM             NAME
+RUNTIME.CONTAINERNAME                  PID        TID        COMM             NAME
 ```
 
 Run a containers that establishs a TLS connection with a remote endpoint:
@@ -81,6 +81,6 @@ The gadget will show that Server Name Indication used by the request.
 
 ```bash
 $ sudo ig trace sni -r docker -c test-trace-sni
-CONTAINER                              PID        TID        COMM             NAME
+RUNTIME.CONTAINERNAME                  PID        TID        COMM             NAME
 test-trace-sni                         3944366    3944366    wget             example.com
 ```

--- a/docs/gadgets/trace/tcp.md
+++ b/docs/gadgets/trace/tcp.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace tcp
-NODE                NAMESPACE           POD                 CONTAINER           T PID        COMM       IP SRC                DST               
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       T PID        COMM       IP SRC                DST               
 ```
 
 Indeed, it is waiting for TCP connection to be established in the `default` namespace (you can use `-A` to monitor all namespaces and then be sure to not miss any event).
@@ -40,7 +40,7 @@ index.html           100% |*****************************************************
 Go back to *the first terminal* and see:
 
 ```bash
-NODE                NAMESPACE           POD                 CONTAINER           T PID        COMM       IP SRC                DST               
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       T PID        COMM       IP SRC                DST               
 minikube-docker     default             bb                  bb                  C 253124     wget       4  p/default/bb:50192 o/188.114.96.3:443
 ```
 
@@ -98,6 +98,6 @@ The gadget will print that connection on the first terminal
 
 ```bash
 $ sudo ig trace tcp -c test-trace-tcp
-CONTAINER                 T PID        COMM          IP SRC                      DST                     
+RUNTIME.CONTAINERNAME     T PID        COMM          IP SRC                      DST                     
 test-trace-tcp            C 269349     wget          4  172.17.0.2:46502         93.184.216.34:443 
 ```

--- a/docs/gadgets/trace/tcpconnect.md
+++ b/docs/gadgets/trace/tcpconnect.md
@@ -29,7 +29,7 @@ In our trace tcpconnect gadget terminal we can now see the logged connection:
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod
-NODE                     NAMESPACE                POD                      CONTAINER                PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443
 ```
@@ -92,7 +92,7 @@ Switching to the gadget trace tcpconnnect terminal, we see the same connections 
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod  # (still running in old terminal)
-NODE                     NAMESPACE                POD                      CONTAINER                PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80   # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443  # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:40676   r/1.1.1.1:80
@@ -115,7 +115,7 @@ there is no redirect visible to port 443:
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod  # (still running in old terminal)
-NODE                     NAMESPACE                POD                      CONTAINER                PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80   # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443  # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:40676   r/1.1.1.1:80   # (previous output)
@@ -157,7 +157,7 @@ The gadget will show the connection and related information to it.
 
 ```bash
 $ sudo ig trace tcpconnect -c test-tcp-connect
-CONTAINER                                  PID        COMM             IP SRC                                        DST
+RUNTIME.CONTAINERNAME                      PID        COMM             IP SRC                                        DST
 test-tcp-connect                           2021739    wget             4  172.17.0.2:4784                            1.1.1.1:80
 test-tcp-connect                           2021739    wget             4  172.17.0.2:14023                           1.1.1.1:443
 ```
@@ -182,7 +182,7 @@ Start the gadget on a terminal:
 
 ```bash
 $ kubectl gadget trace tcpconnect --latency
-CONTAINER                     PID        COMM             IP SRC                          DST                                  LATENCY```
+RUNTIME.CONTAINERNAME         PID        COMM             IP SRC                          DST                                  LATENCY```
 
 In another terminal, create a nginx service and a pod to send some http requests:
 
@@ -204,7 +204,7 @@ The first terminal show all those connections and their latency. In my case both
 the same node, so it's very low:
 
 ```bash
-NODE                  NAMESPACE      POD                CONTAINER          PID        COMM            IP SRC                         DST                               LATENCY
+K8S.NODE              K8S.NAMESPACE  K8S.POD            K8S.CONTAINER      PID        COMM            IP SRC                         DST                               LATENCY
 minikube-docker       default        myclientpod        myclientpod        2054329    curl            4  p/default/myclientpod:50306 s/default/nginx:80               47.069µs
 minikube-docker       default        myclientpod        myclientpod        2054338    curl            4  p/default/myclientpod:53378 s/default/nginx:80              120.017µs
 ```
@@ -222,7 +222,7 @@ the server again:
 Now the latency is a lot higher and has some variance because of the emulation configuration:
 
 ```bash
-NODE                  NAMESPACE      POD                CONTAINER          PID        COMM            IP SRC                         DST                               LATENCY
+K8S.NODE              K8S.NAMESPACE  K8S.POD            K8S.CONTAINER      PID        COMM            IP SRC                         DST                               LATENCY
 ...
 minikube-docker       default        myclientpod        myclientpod        2056697    curl            4  p/default/myclientpod:32415 s/default/nginx:80             7.820966ms
 minikube-docker       default        myclientpod        myclientpod        2056832    curl            4  p/default/myclientpod:32927 s/default/nginx:80            64.388825ms
@@ -235,7 +235,7 @@ Start the trace tcpconnect gadget on a first terminal:
 
 ```bash
 $ sudo ig trace tcpconnect --latency
-CONTAINER                     PID        COMM             IP SRC                          DST                                  LATENCY
+RUNTIME.CONTAINERNAME         PID        COMM             IP SRC                          DST                                  LATENCY
 ```
 
 Then, start a container and download a web page:
@@ -248,7 +248,7 @@ $ docker run -ti --rm --cap-add NET_ADMIN --name=netem wbitt/network-multitool -
 The first terminal will show the connections created and their latency:
 
 ```bash
-CONTAINER                     PID        COMM             IP SRC                          DST                                  LATENCY
+RUNTIME.CONTAINERNAME         PID        COMM             IP SRC                          DST                                  LATENCY
 netem                         2036550    wget             4  172.17.0.2:47250             1.1.1.1:80                       14.149828ms
 netem                         2036550    wget             4  172.17.0.2:44734             1.1.1.1:443                      15.025666ms
 ```
@@ -268,7 +268,7 @@ In this case the `wget` command takes way longer to complete the request. We can
 latency for those connections is more than one second as expected:
 
 ```bash
-CONTAINER                     PID        COMM             IP SRC                          DST                                  LATENCY
+RUNTIME.CONTAINERNAME         PID        COMM             IP SRC                          DST                                  LATENCY
 ...
 netem                         2037935    wget             4  172.17.0.2:38587             1.1.1.1:80                      1.006814808s
 ...

--- a/docs/gadgets/trace/tcpdrop.md
+++ b/docs/gadgets/trace/tcpdrop.md
@@ -13,7 +13,7 @@ In terminal 1, start the trace tcpdrop gadget:
 
 ```bash
 $ kubectl gadget trace tcpdrop
-NODE             NAMESPACE  POD    CONTAINER  PID     COMM  IP SRC                    DST                        STATE        TCPFLAGS  REASON
+K8S.NODE         K8S.NAMESPACE  K8S.POD K8s.CONTAINER  PID     COMM  IP SRC                    DST                        STATE        TCPFLAGS  REASON
 ```
 
 In terminal 2, start a pod and configure the network emulator to drop 25% of the packets:
@@ -31,9 +31,9 @@ root@shell:/# curl nginx
 The results in terminal 1 will show that some packets are dropped by the network emulator qdisc:
 
 ```
-NODE             NAMESPACE  POD    CONTAINER  PID     COMM  IP SRC                    DST                        STATE        TCPFLAGS  REASON
-minikube-docker  default    shell  shell      0             4  p/default/shell:45979  s/kube-system/kube-dns:53  ESTABLISHED  FIN       QDISC_DROP
-minikube-docker  default    shell  shell      406293  curl  4  p/default/shell:34482  s/default/nginx:80         ESTABLISHED  ACK       QDISC_DROP
+K8S.NODE         K8S.NAMESPACE  K8S.POD K8s.CONTAINER  PID     COMM  IP SRC                    DST                        STATE        TCPFLAGS  REASON
+minikube-docker  default        shell   shell          0             4  p/default/shell:45979  s/kube-system/kube-dns:53  ESTABLISHED  FIN       QDISC_DROP
+minikube-docker  default        shell   shell          406293  curl  4  p/default/shell:34482  s/default/nginx:80         ESTABLISHED  ACK       QDISC_DROP
 ```
 
 The network emulator uses a random generator to drop 25% of the packets.
@@ -47,7 +47,7 @@ It is possible to see more detailed information by reading specific columns or u
 
 ```
 $ kubectl gadget trace tcpdrop \
-    -o columns=node,namespace,pod,container,pid,comm,ip,src.addr,src.port,src.kind,src.ns,src.name,dst.addr,dst.port,dst.kind,dst.ns,dst.name,state,tcpflags,reason
+    -o columns=k8s.node,k8s.namespace,k8s.pod,k8s.container,pid,comm,ip,src.addr,src.port,src.kind,src.ns,src.name,dst.addr,dst.port,dst.kind,dst.ns,dst.name,state,tcpflags,reason
 ```
 
 ```

--- a/docs/gadgets/trace/tcpretrans.md
+++ b/docs/gadgets/trace/tcpretrans.md
@@ -13,7 +13,7 @@ In terminal 1, start the trace tcpretrans gadget:
 
 ```bash
 $ kubectl gadget trace tcpretrans
-NODE            NAMESPACE POD                   CONTAINER PID     COMM  IP SRC                    DST                   STATE     TCPFLAGS
+K8S.NODE        K8S.NAMESPACE K8S.POD               K8S.CONTAINER PID     COMM  IP SRC                    DST                   STATE     TCPFLAGS
 ```
 
 In terminal 2, start a pod and configure the network emulator to drop 25% of the packets. This will cause TCP retransmissions:
@@ -31,9 +31,9 @@ root@shell:/# curl nginx
 The results in terminal 1 will show that some TCP transmissions cause by the dropped packets:
 
 ```
-NODE            NAMESPACE POD                   CONTAINER PID     COMM  IP SRC                    DST                   STATE     TCPFLAGS
-minikube-docker default   shell                 shell     2952537 curl  4  p/default/shell:45742  s/default/nginx:80    FIN_WAIT1 FIN|ACK
-minikube-docker default   nginx-8f458dc5b-55b8n nginx     2839908 nginx 4  p/default/nginx-8f458d p/default/shell:45742 LAST_ACK  FIN|ACK
+K8S.NODE        K8S.NAMESPACE K8S.POD               K8S.CONTAINER PID     COMM  IP SRC                    DST                   STATE     TCPFLAGS
+minikube-docker default       shell                 shell         2952537 curl  4  p/default/shell:45742  s/default/nginx:80    FIN_WAIT1 FIN|ACK
+minikube-docker default       nginx-8f458dc5b-55b8n nginx         2839908 nginx 4  p/default/nginx-8f458d p/default/shell:45742 LAST_ACK  FIN|ACK
 ```
 
 ### With `ig`

--- a/docs/gadgets/traceloop.md
+++ b/docs/gadgets/traceloop.md
@@ -35,7 +35,7 @@ result lost forever? Let's check with the traceloop gadget:
 
 ```bash
 $ kubectl gadget traceloop list
-NODE                                    NAMESPACE                              POD                                    CONTAINER                              CONTAINERID
+K8S.NODE                                K8S.NAMESPACE                          K8S.POD                                K8S.CONTAINER                          CONTAINERID
 minikube                                kube-system                            kube-scheduler-minikube                kube-scheduler                         2b63eb745ce2cf
 ...
 minikube                                test                                   mypod                                  mypod                                  ef6f2d3f44b555

--- a/integration/inspektor-gadget/prometheus_test.go
+++ b/integration/inspektor-gadget/prometheus_test.go
@@ -130,10 +130,10 @@ EOF
 					expectedEntry := &Result{
 						Metric: map[string]string{
 							"__name__":        "executed_processes_total",
-							"container":       "test-pod",
+							"k8s_container":   "test-pod",
 							"job":             "gadget",
-							"namespace":       ns,
-							"pod":             "test-pod",
+							"k8s_namespace":   ns,
+							"k8s_pod":         "test-pod",
 							"instance":        "",
 							"otel_scope_name": "",
 						},

--- a/integration/inspektor-gadget/testdata/prometheus/counter.yaml
+++ b/integration/inspektor-gadget/testdata/prometheus/counter.yaml
@@ -5,8 +5,8 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - namespace
-      - pod
-      - container
+      - k8s.namespace
+      - k8s.pod
+      - k8s.container
     selector:
       - "comm:cat"

--- a/integration/run_helpers.go
+++ b/integration/run_helpers.go
@@ -59,23 +59,38 @@ func SetEventRuntimeContainerName(jsonObj map[string]interface{}, s string) {
 }
 
 func SetEventK8sNode(jsonObj map[string]interface{}, s string) {
-	jsonObj["node"] = s
+	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
+	if k8sMetadata != nil {
+		k8sMetadata["node"] = s
+	}
 }
 
 func SetEventK8sNamespace(jsonObj map[string]interface{}, s string) {
-	jsonObj["namespace"] = s
+	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
+	if k8sMetadata != nil {
+		k8sMetadata["namespace"] = s
+	}
 }
 
 func SetEventK8sPod(jsonObj map[string]interface{}, s string) {
-	jsonObj["pod"] = s
+	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
+	if k8sMetadata != nil {
+		k8sMetadata["pod"] = s
+	}
 }
 
 func SetEventK8sContainer(jsonObj map[string]interface{}, s string) {
-	jsonObj["container"] = s
+	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
+	if k8sMetadata != nil {
+		k8sMetadata["container"] = s
+	}
 }
 
 func SetEventK8sHostNetwork(jsonObj map[string]interface{}, b bool) {
-	jsonObj["hostnetwork"] = b
+	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
+	if k8sMetadata != nil {
+		k8sMetadata["hostNetwork"] = b
+	}
 }
 
 func RunEventToObj(t *testing.T, ev *runtypes.Event) map[string]interface{} {

--- a/pkg/columns/filter.go
+++ b/pkg/columns/filter.go
@@ -65,6 +65,19 @@ func WithTags(tags []string) ColumnFilter {
 	}
 }
 
+// WithAnyTag makes sure that all returned columns contain at least one of the given tags
+func WithAnyTag(tags []string) ColumnFilter {
+	tags = ToLowerStrings(tags)
+	return func(matcher ColumnMatcher) bool {
+		for _, tag := range tags {
+			if matcher.HasTag(tag) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 // WithoutTags makes sure that all returned columns contain none of the given tags
 func WithoutTags(tags []string) ColumnFilter {
 	tags = ToLowerStrings(tags)

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -201,16 +201,6 @@ func ownerReferenceEnrichment(
 func GetColumns() *columns.Columns[Container] {
 	cols := columns.MustCreateColumns[Container]()
 
-	// Display the runtime name, container ID and image name when listing containers
-	col, _ := cols.GetColumn("runtime.containerId")
-	col.Visible = true
-
-	col, _ = cols.GetColumn("runtime.runtimeName")
-	col.Visible = true
-
-	col, _ = cols.GetColumn("runtime.containerImageName")
-	col.Visible = true
-
 	cols.MustSetExtractor("runtime.containerImageName", func(container *Container) any {
 		if container == nil {
 			return ""

--- a/pkg/gadgets/snapshot/process/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/process/tracer/gadget.go
@@ -91,7 +91,7 @@ func (g *GadgetDesc) OutputFormats() (gadgets.OutputFormats, string) {
 }
 
 func (g *GadgetDesc) SortByDefault() []string {
-	return []string{"node", "namespace", "pod", "container", "comm", "pid", "tid", "ppid"}
+	return []string{"k8s.node", "k8s.namespace", "k8s.pod", "k8s.container", "comm", "pid", "tid", "ppid"}
 }
 
 func init() {

--- a/pkg/gadgets/snapshot/socket/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/socket/tracer/gadget.go
@@ -74,7 +74,7 @@ func (g *GadgetDesc) EventPrototype() any {
 
 func (g *GadgetDesc) SortByDefault() []string {
 	return []string{
-		"node", "namespace", "pod", "protocol", "status", "src", "dst", "inode",
+		"k8s.node", "k8s.namespace", "k8s.pod", "protocol", "status", "src", "dst", "inode",
 	}
 }
 

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -58,7 +58,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("container")
+		col, _ := cols.GetColumn("k8s.container")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -54,11 +54,11 @@ type Stats struct {
 func GetColumns() *columns.Columns[Stats] {
 	cols := columns.MustCreateColumns[Stats]()
 
-	col, _ := cols.GetColumn("namespace")
+	col, _ := cols.GetColumn("k8s.namespace")
 	col.Visible = false
-	col, _ = cols.GetColumn("pod")
+	col, _ = cols.GetColumn("k8s.pod")
 	col.Visible = false
-	col, _ = cols.GetColumn("container")
+	col, _ = cols.GetColumn("k8s.container")
 	col.Visible = false
 	col, _ = cols.GetColumn("runtime.containerName")
 	col.Visible = false

--- a/pkg/gadgets/trace/dns/types/dns.go
+++ b/pkg/gadgets/trace/dns/types/dns.go
@@ -65,7 +65,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("container")
+		col, _ := cols.GetColumn("k8s.container")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -74,7 +74,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("container")
+		col, _ := cols.GetColumn("k8s.container")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/trace/sni/types/snisnoop.go
+++ b/pkg/gadgets/trace/sni/types/snisnoop.go
@@ -40,7 +40,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("container")
+		col, _ := cols.GetColumn("k8s.container")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/traceloop/types/types.go
+++ b/pkg/gadgets/traceloop/types/types.go
@@ -75,7 +75,7 @@ func GetColumns() *columns.Columns[Event] {
 	// They can be printed later nonetheless with the following code snippet:
 	// column, _ := columns.GetColumn("pod")
 	// column.Visible = true
-	columns := []string{"node", "namespace", "pod", "container"}
+	columns := []string{"k8s.node", "k8s.namespace", "k8s.pod", "k8s.container"}
 	for _, name := range columns {
 		column, ok := cols.GetColumn(name)
 		if !ok {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -158,7 +158,7 @@ type CommonData struct {
 
 	// K8s contains the Kubernetes metadata of the object that generated the
 	// event
-	K8s K8sMetadata `json:"k8s,omitempty" columnTags:"kubernetes"`
+	K8s K8sMetadata `json:"k8s,omitempty" column:"k8s" columnTags:"kubernetes"`
 }
 
 func (c *CommonData) SetNode(node string) {


### PR DESCRIPTION
#1702 added support for k8s metadata in JSON/YAML but the support for columns was still missing. This PR allows the same information to be available as columns as well. 

Related: #737
Fixes: #2066 

## Idea

- Before this change both `ig` and `kubectl-gadget` would filter `k8s` and `runtime` columns respectively rather then hiding. So we will switch to marking them hidden as needed by each client.
- The hidden columns can be displayed using `-o columns` as needed by the user.
- `list-containers` needs an extra work but `k8s` metadata can also be displayed using `-o custom-columns`

## Tesing done

```
$ make minikube-start-containerd
$ make ig
$ docker cp ig minikube-containerd:/bin/ig
$ docker exec -it minikube-containerd bash
$ ig list-containers # same as before
RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID                                              RUNTIME.CONTAINERNAME   RUNTIME.CONTAINERIMAGENAME                                 
containerd          0a9cbc23a8409cf015e389fa71f2422f28dbea1129e66a40e38685fb67424ef6 coredns                 k8s.gcr.io/coredns/coredns:v1.8.6                          
containerd          5e48d5e717d89f2237eb0b364d9c8b6265f949e5600f642d55420e1a4922e2e2 etcd                    k8s.gcr.io/etcd:3.5.3-0 
$ ig list-containers -o custom-columns=runtime.containerid,runtime.containername,k8s.pod,k8s.namespace
RUNTIME.CONTAINERID                                              RUNTIME.CONTAINERNAME   K8S.POD                                     K8S.NAMESPACE
0a9cbc23a8409cf015e389fa71f2422f28dbea1129e66a40e38685fb67424ef6 coredns                 coredns-6d4b75cb6d-94hkg                    kube-system  
5e48d5e717d89f2237eb0b364d9c8b6265f949e5600f642d55420e1a4922e2e2 etcd                    etcd-minikube-containerd                    kube-system

$ ig trace open -o columns=runtime.containername,k8s.pod,k8s.namespace,pid,comm
RUNTIME.CONTAINERNAME                                                K8S.POD                                                             K8S.NAMESPACE                                                       PID        COMM            
gadget                                                               gadget-p4kvb                                                        gadget                                                              448891     runc:[2:INIT]   
gadget                                                               gadget-p4kvb                                                        gadget                                                              448891     runc:[2:INIT]   
```