### PR TITLE
docs: Replace linkds to linux.die.net

### DIFF
--- a/docs/gadgets/profile/block-io.md
+++ b/docs/gadgets/profile/block-io.md
@@ -19,16 +19,14 @@ The histogram shows the number of I/O operations (`count` column) that lie in
 the latency range `interval-start` -> `interval-end` (`usecs` column), which,
 as the columns name indicates, is given in microseconds.
 
-For this guide, we will use
-[the `stress` tool](https://linux.die.net/man/1/stress) that allows us to load
-and stress the system in many different ways. In particular, we will use
-the `--io` flag that will generate a given number of workers to spin on the
-[sync() syscall](https://man7.org/linux/man-pages/man2/sync.2.html). In this
-way, we will generate disk I/O that we will analyse using the biolatency
-gadget.
+For this guide, we will use [the `stress` tool](https://man.archlinux.org/man/stress.1) that allows
+us to load and stress the system in many different ways. In particular, we will use the `--io` flag
+that will generate a given number of workers to spin on the [sync()
+syscall](https://man7.org/linux/man-pages/man2/sync.2.html). In this way, we will generate disk I/O
+that we will analyse using the biolatency gadget.
 
-For further details, please refer to
-[the BCC documentation](https://github.com/iovisor/bcc/blob/master/tools/biolatency_example.txt).
+For further details, please refer to [the BCC
+documentation](https://github.com/iovisor/bcc/blob/master/tools/biolatency_example.txt).
 
 ### On Kubernetes
 

--- a/docs/gadgets/trace/capabilities.md
+++ b/docs/gadgets/trace/capabilities.md
@@ -10,16 +10,15 @@ description: >
 The trace capabilities gadget allows us to see what capability security checks
 are triggered by applications running in Kubernetes Pods.
 
-Linux [capabilities](https://linux.die.net/man/7/capabilities) allow for a finer
-privilege control because they can give root-like capabilities to processes without
-giving them full root access. They can also be taken away from root processes.
-If a pod is directly executing programs as root, we can further lock it down
-by taking capabilities away. Sometimes we need to add capabilities which
-are not there by default. You can see the list of default and available
-capabilities [in Docker](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
-Specially if our pod is directly run as user instead of root (runAsUser: ID),
-we can give some more capabilities (think as partly root) and still take all
-unused capabilities to really lock it down.
+Linux [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) allow for a finer
+privilege control because they can give root-like capabilities to processes without giving them full
+root access. They can also be taken away from root processes. If a pod is directly executing
+programs as root, we can further lock it down by taking capabilities away. Sometimes we need to add
+capabilities which are not there by default. You can see the list of default and available
+capabilities [in
+Docker](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+Specially if our pod is directly run as user instead of root (runAsUser: ID), we can give some more
+capabilities (think as partly root) and still take all unused capabilities to really lock it down.
 
 ### On Kubernetes
 


### PR DESCRIPTION
For an unknown reason linux.die.net returns 403 when used with wget:

```
$ wget -4 https://linux.die.net/man/1/stress
--2023-09-18 14:40:37--  https://linux.die.net/man/1/stress Resolving linux.die.net (linux.die.net)... 104.26.0.94, 172.67.69.187, 104.26.1.94 Connecting to linux.die.net (linux.die.net)|104.26.0.94|:443... connected. HTTP request sent, awaiting response... 403 Forbidden 2023-09-18 14:40:37 ERROR 403: Forbidden.
```

This is causing our "broken links" CI job to fail. This commit switches to alternative locations for those manuals.

