### PR TITLE
traceloop: Fix logic around syscalls

### DIFF
--- a/pkg/gadgets/traceloop/tracer/tracer.go
+++ b/pkg/gadgets/traceloop/tracer/tracer.go
@@ -138,7 +138,8 @@ func (t *Tracer) install() error {
 	for name, def := range syscallDefs {
 		number, ok := syscalls.GetSyscallNumberByName(name)
 		if !ok {
-			return fmt.Errorf("getting syscall number of %q: %w", name, err)
+			// It's possible that the syscall doesn't exist for this architecture, skip it
+			continue
 		}
 
 		// We need to do so to avoid taking each time the same address.


### PR DESCRIPTION
It's possible that a given syscall doesn't exist for this architecture, hence just skip it instead of erroring out.

This was working before https://github.com/inspektor-gadget/inspektor-gadget/pull/2054 because `libseccomp.GetSyscallFromName` returns a "pseudo syscall number" (https://github.com/seccomp/libseccomp/issues/249 & https://man7.org/linux/man-pages/man3/seccomp_syscall_resolve_name.3.html). I think the correct behaviour is to skip that syscall as it don't actually exist on the system.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/pull/2054
