### PR TITLE
run: expose prometheus metrics

### DIFF
--- a/docs/gadgets/prometheus.md
+++ b/docs/gadgets/prometheus.md
@@ -33,6 +33,21 @@ metrics:
       # defines the granularity of the labels to capture. See below.
 ```
 
+To use your own gadget, you can refer to the gadget as follows:
+
+```yaml
+metrics_name: dns_traffic
+metrics:
+  - name: dns_traffic
+    type: counter
+    category: ""
+    gadget: run
+    gadgetArgs:
+      - myregistry.azurecr.io/trace-dns:v1
+    labels:
+      # defines the granularity of the labels to capture. See below.
+```
+
 ### Filtering (aka Selectors)
 
 It's possible to configure Inspektor Gadget to only update metrics for some specific labels. This is

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -81,7 +81,7 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 }
 
 func (g *GadgetDesc) Parser() parser.Parser {
-	return nil
+	return parser.NewParser[types.Event](types.GetColumns())
 }
 
 func getUnderlyingType(tf *btf.Typedef) (btf.Type, error) {

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -22,14 +22,15 @@ import (
 )
 
 type Metric struct {
-	Name     string   `yaml:"name"`
-	Category string   `yaml:"category"`
-	Gadget   string   `yaml:"gadget"`
-	Type     string   `yaml:"type"`
-	Field    string   `yaml:"field,omitempty"`
-	Labels   []string `yaml:"labels,omitempty"`
-	Selector []string `yaml:"selector,omitempty"`
-	Bucket   Bucket   `yaml:"bucket,omitempty"`
+	Name       string   `yaml:"name"`
+	Category   string   `yaml:"category"`
+	Gadget     string   `yaml:"gadget"`
+	GadgetArgs []string `yaml:"gadgetArgs"`
+	Type       string   `yaml:"type"`
+	Field      string   `yaml:"field,omitempty"`
+	Labels     []string `yaml:"labels,omitempty"`
+	Selector   []string `yaml:"selector,omitempty"`
+	Bucket     Bucket   `yaml:"bucket,omitempty"`
 }
 
 type Config struct {
@@ -62,10 +63,6 @@ func ParseConfig(configBytes []byte) (*Config, error) {
 	for _, metric := range config.Metrics {
 		if metric.Name == "" {
 			return nil, errors.New("metric name is missing")
-		}
-
-		if metric.Category == "" {
-			return nil, fmt.Errorf("metric category is missing in %q", metric.Name)
 		}
 
 		if metric.Gadget == "" {

--- a/pkg/prometheus/config/config_test.go
+++ b/pkg/prometheus/config/config_test.go
@@ -67,9 +67,9 @@ func TestParseConfig(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "missing_metrics_category",
+			name: "accept_empty_category",
 			input: &Config{
-				MetricsName: "missing_metrics_category",
+				MetricsName: "accept_empty_category",
 				Metrics: []Metric{
 					{
 						Name:     "name",
@@ -79,7 +79,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			name: "missing_metrics_gadget",

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -165,7 +165,7 @@ func handleMetric(
 		runtimeParams,
 		gadgetDesc,
 		gadgetParams,
-		nil, // TODO: where do I get this?
+		metricCommon.GadgetArgs,
 		operatorsParamCollection,
 		parser,
 		logger.DefaultLogger(),


### PR DESCRIPTION
Allow containerized gadgets to expose Prometheus metrics.

This PR makes the feature work and enable the configuration file to select the gadget. Hopefully the user interface will be improved later on.

## How to use

Prepare my-prometheus-config.yaml as follows:
```
metrics_name: guide
metrics:
  - name: dns_traffic
    type: counter
    category: ""
    gadget: run
    gadgetArgs:
      - albantest.azurecr.io/trace-dns:v3
    labels:
      - namespace
      - pod
      - container
```

```
$ sudo -E ig prometheus --config @my-prometheus-config.yaml
INFO[0000] Experimental features enabled                
INFO[0000] Running. Press Ctrl + C to finish            
INFO[0000] Publishing metrics...                        
```

## Testing done

Tested in this branch:
https://github.com/alban/inspektor-gadget/tree/alban_asg2023

## TODO

I am not sure if this should be done in this PR or later on:

- [ ] Exposing the gadget name via `category=""`, `gadget=run` & `gadgetArgs` is awkward. The configuration file should be reworked.