### PR TITLE
Disable cgo explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ kubectl-gadget: kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
 	cp kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) kubectl-gadget
 
 kubectl-gadget-%: phony_explicit
-	export GO111MODULE=on && \
+	export GO111MODULE=on CGO_ENABLED=0 && \
 	export GOOS=$(shell echo $* |cut -f1 -d-) GOARCH=$(shell echo $* |cut -f2 -d-) && \
 	go build -ldflags $(LDFLAGS) \
 		-tags withoutebpf \

--- a/gadget-container/Makefile
+++ b/gadget-container/Makefile
@@ -9,7 +9,7 @@ TARGET_ARCH ?= $(shell go env GOHOSTARCH)
 .PHONY: gadgettracermanager
 gadgettracermanager:
 	mkdir -p bin
-	GO111MODULE=on GOOS=linux GOARCH=$(TARGET_ARCH) go build \
+	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build \
 		-o bin/gadgettracermanager \
 		./gadgettracermanager/
 
@@ -18,13 +18,13 @@ gadgettracermanager:
 .PHONY: ocihookgadget
 ocihookgadget:
 	mkdir -p bin
-	GO111MODULE=on GOOS=linux GOARCH=$(TARGET_ARCH) go build \
+	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build \
 		-o bin/ocihookgadget \
 		./hooks/oci/main.go
 
 .PHONY: nrigadget
 nrigadget:
 	mkdir -p bin
-	GO111MODULE=on GOOS=linux GOARCH=$(TARGET_ARCH) go build \
+	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build \
 		-o bin/nrigadget \
 		./hooks/nri/main.go


### PR DESCRIPTION
According to the documentation [0]: "The cgo tool is enabled by default for native builds on systems where it is expected to work", hence we need to set CGO_ENABLED=0 to explicitly disable it.

It was causing a lot of warnings in make kubectl-gadget on my system:

```
$ make kubectl-gadget
export GO111MODULE=on && \
export GOOS=linux GOARCH=amd64 && \
go build -ldflags "-X main.version=`git describe --tags --always`-dirty -X main.gadgetimage=ghcr.io/inspektor-gadget/inspektor-gadget:latest -extldflags '-static'" \
	-tags withoutebpf \
	-o kubectl-gadget-${GOOS}-${GOARCH} \
	github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget
/usr/bin/ld: /tmp/go-link-2694774814/000027.o: in function `pluginOpen':
/_/plugin/plugin_dlopen.go:19: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000008.o: in function `mygetgrouplist':
/_/os/user/getgrouplist_unix.go:15: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000007.o: in function `mygetgrgid_r':
/_/os/user/cgo_lookup_cgo.go:45: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000007.o: in function `mygetgrnam_r':
/_/os/user/cgo_lookup_cgo.go:54: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000007.o: in function `mygetpwnam_r':
/_/os/user/cgo_lookup_cgo.go:36: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000007.o: in function `mygetpwuid_r':
/_/os/user/cgo_lookup_cgo.go:27: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-2694774814/000004.o: in function `_cgo_cbcce81e6342_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
cp kubectl-gadget-linux-amd64 kubectl-gadget
```

