### PR TITLE
Enrich events with image digest

### DIFF
--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -69,6 +69,7 @@ func newListContainerTestStep(
 
 				c.K8s.PodLabels = nil
 				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {
@@ -282,6 +283,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerImageDigest = ""
 
 				// Docker and CRI-O use a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -56,6 +56,7 @@ func TestProfileCpu(t *testing.T) {
 				e.Count = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -57,6 +57,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -55,6 +55,7 @@ func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.WriteBytes = 0
 
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 
 			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			if isDockerRuntime {

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -67,6 +67,7 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Received = 0
 
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 
 			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			if isDockerRuntime {

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -202,6 +202,7 @@ func TestTraceDns(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -117,6 +117,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Tid = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -430,6 +430,7 @@ func (cc *ContainerCollection) EnrichByMntNs(event *eventtypes.CommonData, mount
 		event.Runtime.ContainerName = container.Runtime.ContainerName
 		event.Runtime.ContainerID = container.Runtime.ContainerID
 		event.Runtime.ContainerImageName = container.Runtime.ContainerImageName
+		event.Runtime.ContainerImageDigest = container.Runtime.ContainerImageDigest
 	}
 }
 
@@ -457,6 +458,7 @@ func (cc *ContainerCollection) EnrichByNetNs(event *eventtypes.CommonData, netns
 		event.Runtime.ContainerName = containers[0].Runtime.ContainerName
 		event.Runtime.ContainerID = containers[0].Runtime.ContainerID
 		event.Runtime.ContainerImageName = containers[0].Runtime.ContainerImageName
+		event.Runtime.ContainerImageDigest = containers[0].Runtime.ContainerImageDigest
 		return
 	}
 	if containers[0].K8s.PodName != "" && containers[0].K8s.Namespace != "" {

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -51,6 +51,7 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	container.Runtime.RuntimeName = containerData.Runtime.RuntimeName
 	container.Runtime.ContainerName = containerData.Runtime.ContainerName
 	container.Runtime.ContainerImageName = containerData.Runtime.ContainerImageName
+	container.Runtime.ContainerImageDigest = containerData.Runtime.ContainerImageDigest
 
 	// Kubernetes
 	container.K8s.Namespace = containerData.K8s.Namespace

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -279,13 +279,16 @@ func (c *ContainerdClient) taskAndContainerToContainerData(task *containerTask, 
 		return nil, fmt.Errorf("getting image of container %q: %w", container.ID(), err)
 	}
 
+	imageMetadata := image.Metadata()
+
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
 			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:        container.ID(),
-				ContainerName:      getContainerName(container, labels),
-				RuntimeName:        types.RuntimeNameContainerd,
-				ContainerImageName: image.Name(),
+				ContainerID:          container.ID(),
+				ContainerName:        getContainerName(container, labels),
+				RuntimeName:          types.RuntimeNameContainerd,
+				ContainerImageName:   image.Name(),
+				ContainerImageDigest: imageMetadata.Target.Digest.String(),
 			},
 			State: task.status,
 		},

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -107,6 +107,8 @@ func TestRuntimeClientInterface(t *testing.T) {
 				for _, eData := range expectedData {
 					found := false
 					for _, cData := range containers {
+						// ContainerImageDigest may vary among versions, so we do not check it for now
+						cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
 						if cmp.Equal(*cData, eData.ContainerData) {
 							found = true
 							break
@@ -122,6 +124,8 @@ func TestRuntimeClientInterface(t *testing.T) {
 
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainer(eData.Runtime.ContainerID)
+					// ContainerImageDigest may vary among versions, so we do not check it for now
+					cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
 					require.True(t, cmp.Equal(*cData, eData.ContainerData),
@@ -134,6 +138,8 @@ func TestRuntimeClientInterface(t *testing.T) {
 
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainerDetails(eData.Runtime.ContainerID)
+					// ContainerImageDigest may vary among versions, so we do not check it for now
+					cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -34,6 +34,7 @@ func init() {
 	columns.MustRegisterTemplate("pod", "width:30,ellipsis:middle")
 	columns.MustRegisterTemplate("container", "width:30")
 	columns.MustRegisterTemplate("containerImageName", "width:30")
+	columns.MustRegisterTemplate("containerImageDigest", "width:30")
 	columns.MustRegisterTemplate("comm", "maxWidth:16")
 	columns.MustRegisterTemplate("pid", "minWidth:7")
 	columns.MustRegisterTemplate("uid", "minWidth:8")
@@ -126,10 +127,14 @@ type BasicRuntimeMetadata struct {
 	// OR
 	// i.e. 6e38f40d628d, when truncated
 	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName,hide"`
+
+	// ContainerImageDigest is the (repo) digest of the container image where the event comes from
+	// Only events of initial containers (cri-o and containerd) are enriched with image digest
+	ContainerImageDigest string `json:"containerImageDigest,omitempty" column:"containerImageDigest,hide"`
 }
 
 func (b *BasicRuntimeMetadata) IsEnriched() bool {
-	return b.RuntimeName != RuntimeNameUnknown && b.RuntimeName != "" && b.ContainerID != "" && b.ContainerName != "" && b.ContainerImageName != ""
+	return b.RuntimeName != RuntimeNameUnknown && b.RuntimeName != "" && b.ContainerID != "" && b.ContainerName != "" && b.ContainerImageName != "" && b.ContainerImageDigest != ""
 }
 
 type BasicK8sMetadata struct {
@@ -182,6 +187,7 @@ func (c *CommonData) SetContainerMetadata(k8s *BasicK8sMetadata, runtime *BasicR
 	c.Runtime.ContainerName = runtime.ContainerName
 	c.Runtime.ContainerID = runtime.ContainerID
 	c.Runtime.ContainerImageName = runtime.ContainerImageName
+	c.Runtime.ContainerImageDigest = runtime.ContainerImageDigest
 }
 
 func (c *CommonData) GetNode() string {


### PR DESCRIPTION
# [cri-o and containerd] Enrich events with image digest

This PR adds `ContainerImageDigest` column to initial events of cri-o and containerd containers. 

New containers enrichment is currently blocked because of image digest missing from OCI annotations. Will be cared of in a future iteration.

## How to use

`RUNTIME.CONTAINERIMAGEDIGEST` column is by default hidden and can be manually added with `ig list-containers -o custom-columns=runtime.containerimagename,runtime.containerimagedigest`

Part of #1310
