### PR TITLE
examples/dns: Add missing call to host.Init()

### DIFF
--- a/examples/gadgets/basic/trace/dns/dns.go
+++ b/examples/gadgets/basic/trace/dns/dns.go
@@ -24,12 +24,19 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/tracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 func main() {
 	// In some kernel versions it's needed to bump the rlimits to
 	// use run BPF programs.
 	if err := rlimit.RemoveMemlock(); err != nil {
+		return
+	}
+
+	err := host.Init(host.Config{})
+	if err != nil {
+		fmt.Printf("error calling host init: %s\n", err)
 		return
 	}
 


### PR DESCRIPTION
It panics without this call.

panic: host.Init() must be called before calling isHostNamespace()

Fixes: a65dbbc6bcfd ("host package: workarounds for kubectl-debug and Windows")

@alban do you think it's ok to have this call there or should we move it to the tracer itself so users don't need to add this?
