### PR TITLE
ig: add daemon mode

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -160,13 +160,14 @@ jobs:
       - name: Check if added dependencies do not contain CVE.
         uses: actions/dependency-review-action@v3
 
-  build-kubectl-gadget:
-    name: kubectl-gadget
+  build-clients:
+    name: clients
     # level: 0
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        client: [kubectl-gadget, gadgetctl]
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
         exclude:
@@ -187,7 +188,7 @@ jobs:
         registry: ${{ env.REGISTRY }}
         container-image: ${{ env.CONTAINER_REPO }}
         bcc: false
-    - name: Build kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}
+    - name: Build ${{ matrix.client }}-${{ matrix.os }}-${{ matrix.arch }}
       run: |
         git checkout
 
@@ -199,26 +200,26 @@ jobs:
           exit 1
         fi
 
-        kubectl_gadget=kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}
+        client=${{ matrix.client }}-${{ matrix.os }}-${{ matrix.arch }}
 
         CONTAINER_REPO=${{ steps.set-repo-determine-image-tag.outputs.container-repo }} \
         IMAGE_TAG=${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
-        make $kubectl_gadget
+        make $client
 
         # Prepare assets for release and actions artifacts
-        platform=$(echo ${kubectl_gadget} | cut -d- -f3-4)
+        platform='${{ matrix.os }}-${{ matrix.arch }}'
         mkdir $platform
-        cp $kubectl_gadget $platform/kubectl-gadget
+        cp $client $platform/${{ matrix.client }}
         cp LICENSE $platform/
         tar --sort=name --owner=root:0 --group=root:0 \
-          -czf ${kubectl_gadget}.tar.gz -C $platform \
-          kubectl-gadget LICENSE
+          -czf ${client}.tar.gz -C $platform \
+          ${{ matrix.client }} LICENSE
         rm -rf $platform
-    - name: Add kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact.
+    - name: Add ${{ matrix.client }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact.
       uses: actions/upload-artifact@master
       with:
-        name: kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
-        path: /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        name: ${{ matrix.client }}-${{ matrix.os }}-${{ matrix.arch }}-tar-gz
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/${{ matrix.client }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
 
   btfgen:
     name: btfgen
@@ -1090,7 +1091,7 @@ jobs:
     needs:
       - check-secrets
       - test-unit
-      - build-kubectl-gadget
+      - build-clients
       - build-ig
       - build-gadget-container-images
       - publish-gadget-images-manifest
@@ -1189,7 +1190,7 @@ jobs:
     needs:
       - check-secrets
       - test-unit
-      - build-kubectl-gadget
+      - build-clients
       - build-ig
       - build-gadget-container-images
       - publish-gadget-images-manifest
@@ -1237,7 +1238,7 @@ jobs:
     # level: 3
     needs:
       - test-unit
-      - build-kubectl-gadget
+      - build-clients
       - build-ig
       - build-gadget-container-images
       - build-helper-images
@@ -1377,13 +1378,13 @@ jobs:
     - name: Rename all artifacts to *-${{ github.ref_name }}.tar.gz
       shell: bash
       run: |
-        for i in kubectl-gadget-*-*-tar-gz/kubectl-gadget-*-*.tar.gz ig-*-*-tar-gz/ig-*-*.tar.gz; do
+        for i in kubectl-gadget-*-*-tar-gz/kubectl-gadget-*-*.tar.gz ig-*-*-tar-gz/ig-*-*.tar.gz gadgetctl-*-*-tar-gz/gadgetctl-*-*.tar.gz; do
           mv $i $(dirname $i)/$(basename $i .tar.gz)-${{ github.ref_name }}.tar.gz
         done
     - name: Compute checksums for all artifacts
       shell: bash
       run: |
-        for i in kubectl-gadget-*-*-tar-gz/kubectl-gadget-*-*.tar.gz ig-*-*-tar-gz/ig-*-*.tar.gz inspektor-gadget-${{ github.ref_name }}.yaml ig_packages/*; do
+        for i in kubectl-gadget-*-*-tar-gz/kubectl-gadget-*-*.tar.gz ig-*-*-tar-gz/ig-*-*.tar.gz gadgetctl-*-*-tar-gz/gadgetctl-*-*.tar.gz inspektor-gadget-${{ github.ref_name }}.yaml ig_packages/*; do
           hash=$(sha256sum $i | cut -d' ' -f1)
           echo "${hash}  $(basename $i)" >> SHA256SUMS
         done
@@ -1412,6 +1413,12 @@ jobs:
       uses: csexton/release-asset-action@v2
       with:
         pattern: "ig-*-*-tar-gz/ig-*-*.tar.gz"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        release-url: ${{ steps.create_release.outputs.upload_url }}
+    - name: Upload gadgetctl *.tar.gz binary
+      uses: csexton/release-asset-action@v2
+      with:
+        pattern: "gadgetctl-*-*-tar-gz/gadgetctl-*-*.tar.gz"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}
     - name: Upload YAML

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ include crd.mk
 include tests.mk
 include minikube.mk
 
-LDFLAGS := "-X main.version=$(VERSION) \
+LDFLAGS := "-X github.com/inspektor-gadget/inspektor-gadget/cmd/common.version=$(VERSION) \
 -X main.gadgetimage=$(CONTAINER_REPO):$(IMAGE_TAG) \
 -extldflags '-static'"
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,36 @@ install/kubectl-gadget: kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH)
 	mkdir -p ~/.local/bin/
 	cp kubectl-gadget-$(GOHOSTOS)-$(GOHOSTARCH) ~/.local/bin/kubectl-gadget
 
+GADGETCTL_TARGETS = \
+	gadgetctl-linux-amd64 \
+	gadgetctl-linux-arm64 \
+	gadgetctl-darwin-amd64 \
+	gadgetctl-darwin-arm64 \
+	gadgetctl-windows-amd64
+
+.PHONY: list-gadgetctl-targets
+list-gadgetctl-targets:
+	@echo $(GADGETCTL_TARGETS)
+
+.PHONY: gadgetctl-all
+gadgetctl-all: $(GADGETCTL_TARGETS) gadgetctl
+
+gadgetctl: gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH)
+	cp gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH) gadgetctl
+
+gadgetctl-%: phony_explicit
+	export GO111MODULE=on CGO_ENABLED=0 && \
+	export GOOS=$(shell echo $* |cut -f1 -d-) GOARCH=$(shell echo $* |cut -f2 -d-) && \
+	go build -ldflags $(LDFLAGS) \
+		-tags withoutebpf \
+		-o gadgetctl-$${GOOS}-$${GOARCH} \
+		github.com/inspektor-gadget/inspektor-gadget/cmd/gadgetctl
+
+.PHONY: install/gadgetctl
+install/gadgetctl: gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH)
+	mkdir -p ~/.local/bin/
+	cp gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH) ~/.local/bin/gadgetctl
+
 GADGET_CONTAINERS = \
 	gadget-default-container \
 	gadget-bcc-container

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Available Commands:
   prometheus  Expose metrics using prometheus
   script      Run a bpftrace-compatible scripts
   snapshot    Take a snapshot of a subsystem and print it
-  sync        Synchronize gadget information with your cluster
+  sync        Synchronize gadget information with server
   top         Gather, sort and periodically report events according to a given criteria
   trace       Trace and print system events
   traceloop   Get strace-like logs of a container from the past

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -52,13 +52,10 @@ func AddCommandsFromRegistry(rootCmd *cobra.Command, runtime runtime.Runtime, hi
 	// Build lookup
 	lookup := make(map[string]*cobra.Command)
 
-	// Add global runtime flags
-	addFlags(rootCmd, runtimeGlobalParams, nil, runtime)
-
 	// Add operator global flags
 	operatorsGlobalParamsCollection := operators.GlobalParamsCollection()
 	for _, operatorParams := range operatorsGlobalParamsCollection {
-		addFlags(rootCmd, operatorParams, nil, runtime)
+		AddFlags(rootCmd, operatorParams, nil, runtime)
 	}
 
 	// Add all known gadgets to cobra in their respective categories
@@ -597,14 +594,14 @@ func buildCommandFromGadget(
 	gadgetParams.Add(*gadgets.GadgetParams(gadgetDesc, parser).ToParams()...)
 
 	// Add runtime flags
-	addFlags(cmd, runtimeParams, skipParams, runtime)
+	AddFlags(cmd, runtimeParams, skipParams, runtime)
 
 	// Add gadget flags
-	addFlags(cmd, gadgetParams, skipParams, runtime)
+	AddFlags(cmd, gadgetParams, skipParams, runtime)
 
 	// Add operator flags
 	for _, operatorParams := range operatorsParamsCollection {
-		addFlags(cmd, operatorParams, skipParams, runtime)
+		AddFlags(cmd, operatorParams, skipParams, runtime)
 	}
 	return cmd
 }
@@ -618,7 +615,7 @@ func mustSkip(skipParams []params.ValueHint, valueHint params.ValueHint) bool {
 	return false
 }
 
-func addFlags(cmd *cobra.Command, params *params.Params, skipParams []params.ValueHint, runtime runtime.Runtime) {
+func AddFlags(cmd *cobra.Command, params *params.Params, skipParams []params.ValueHint, runtime runtime.Runtime) {
 	defer func() {
 		if err := recover(); err != nil {
 			panic(fmt.Sprintf("registering params for command %q: %v", cmd.Use, err))

--- a/cmd/common/sync.go
+++ b/cmd/common/sync.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/spf13/cobra"
+
+	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
+)
+
+func NewSyncCommand(runtime *grpcruntime.Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "sync",
+		Short: "Synchronize gadget information with server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runtime.UpdateDeployInfo()
+		},
+	}
+}

--- a/cmd/common/version.go
+++ b/cmd/common/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2023 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package common
 
 import (
 	"fmt"
@@ -20,10 +20,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// This variable is used by the "version" command and is set during build.
+// version is filled out by the Makefile at build
 var version = "undefined"
 
-func newVersionCmd() *cobra.Command {
+func Version() string {
+	return version
+}
+
+func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Show version",

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
+	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
+)
+
+var infoSkipCommands = []string{"version"}
+
+func main() {
+	if experimental.Enabled() {
+		log.Info("Experimental features enabled")
+	}
+
+	rootCmd := &cobra.Command{
+		Use:   filepath.Base(os.Args[0]),
+		Short: "Collection of gadgets for containers",
+	}
+	common.AddVerboseFlag(rootCmd)
+
+	skipInfo := false
+	for _, arg := range os.Args[1:] {
+		for _, skipCmd := range infoSkipCommands {
+			if strings.ToLower(arg) == skipCmd {
+				skipInfo = true
+			}
+		}
+	}
+
+	rootCmd.AddCommand(common.NewVersionCmd())
+
+	runtime := grpcruntime.New()
+
+	runtimeGlobalParams := runtime.GlobalParamDescs().ToParams()
+	common.AddFlags(rootCmd, runtimeGlobalParams, nil, runtime)
+	err := runtime.Init(runtimeGlobalParams)
+	if err != nil {
+		log.Fatalf("initializing runtime: %v", err)
+	}
+
+	if !skipInfo {
+		// evaluate flags early for runtimeGlobalFlags; this will make
+		// sure that --remote-address has already been parsed when calling
+		// InitDeployInfo(), so it can target the specified address
+		rootCmd.ParseFlags(os.Args[1:])
+		runtime.InitDeployInfo()
+	}
+
+	hiddenColumnTags := []string{"kubernetes"}
+	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
+
+	rootCmd.AddCommand(common.NewSyncCommand(runtime))
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	environment.Environment = environment.Local
+}

--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -1,0 +1,102 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
+)
+
+func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
+	daemonCmd := &cobra.Command{
+		Use:          "daemon",
+		Short:        "Run Inspektor Gadget as a daemon",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+	}
+
+	var socket string
+	var group string
+
+	daemonCmd.PersistentFlags().StringVarP(
+		&group,
+		"group",
+		"G",
+		"0",
+		"Group name or id that the unix socket should use (if daemon-socket is set to e.g. unix:///path/to.socket)")
+
+	daemonCmd.PersistentFlags().StringVarP(
+		&socket,
+		"host",
+		"H",
+		api.DefaultDaemonPath,
+		"The socket to listen on for new requests. Can be a unix socket"+
+			" (unix:///path/to.socket) or a tcp socket (tcp://127.0.0.1:1234)")
+
+	daemonCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if os.Geteuid() != 0 {
+			return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
+		}
+
+		socketURL, err := url.Parse(socket)
+		if err != nil {
+			return fmt.Errorf("invalid daemon-socket address %q: %w", socketURL, err)
+		}
+
+		gid := 0
+		if tmpGroup, err := user.LookupGroup(group); err == nil {
+			gid, err = strconv.Atoi(tmpGroup.Gid)
+			if err != nil {
+				return fmt.Errorf("unexpected non-numeric group id %q for group %q", tmpGroup.Gid, group)
+			}
+		} else if tmpGid, err := strconv.Atoi(group); err == nil {
+			gid = tmpGid
+		} else {
+			return fmt.Errorf("group %q not found", group)
+		}
+
+		var socketPath string
+		socketType := socketURL.Scheme
+		switch socketType {
+		default:
+			return fmt.Errorf("invalid type for daemon-socket %q; please use 'unix' or 'tcp'", socketType)
+		case "unix":
+			socketPath = socketURL.Path
+		case "tcp":
+			socketPath = socketURL.Host
+		}
+
+		log.Infof("starting Inspektor Gadget daemon at %q", socket)
+		service := gadgetservice.NewService(log.StandardLogger())
+		return service.Run(gadgetservice.RunConfig{
+			SocketType: socketType,
+			SocketPath: socketPath,
+			SocketGID:  gid,
+		})
+	}
+
+	return daemonCmd
+}

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -62,6 +62,7 @@ func main() {
 	hiddenColumnTags := []string{"kubernetes"}
 	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
 
+	rootCmd.AddCommand(newDaemonCommand(runtime))
 	if experimental.Enabled() {
 		rootCmd.AddCommand(image.NewImageCmd())
 		rootCmd.AddCommand(common.NewLoginCmd())

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	rootCmd.AddCommand(
 		containers.NewListContainersCmd(),
-		newVersionCmd(),
+		common.NewVersionCmd(),
 	)
 
 	runtime := local.New()

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -49,6 +49,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	"sigs.k8s.io/yaml"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
@@ -448,7 +449,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				case "GADGET_IMAGE":
 					gadgetContainer.Env[i].Value = image
 				case "INSPEKTOR_GADGET_VERSION":
-					gadgetContainer.Env[i].Value = version
+					gadgetContainer.Env[i].Value = common.Version()
 				case "INSPEKTOR_GADGET_OPTION_HOOK_MODE":
 					gadgetContainer.Env[i].Value = hookMode
 				case "INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER":

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -593,7 +593,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	info("Retrieving Gadget Catalog...\n")
-	err = grpcruntime.New(true).UpdateDeployInfo()
+	err = grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy).UpdateDeployInfo()
 	if err != nil {
 		fmt.Printf("> failed: %v\n", err)
 	}

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -81,13 +81,7 @@ func main() {
 	// Advise category is still being handled by CRs for now
 	rootCmd.AddCommand(advise.NewAdviseCmd())
 
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "sync",
-		Short: "Synchronize gadget information with your cluster",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runtime.UpdateDeployInfo()
-		},
-	})
+	rootCmd.AddCommand(common.NewSyncCommand(runtime))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -70,7 +70,11 @@ func main() {
 		}
 	}
 
-	runtime := grpcruntime.New(skipInfo)
+	runtime := grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
+	runtime.Init(runtime.GlobalParamDescs().ToParams())
+	if !skipInfo {
+		runtime.InitDeployInfo()
+	}
 
 	namespace, _ := utils.GetNamespace()
 	runtime.SetDefaultValue(gadgets.K8SNamespace, namespace)

--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -23,25 +23,23 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 )
 
-// This variable is used by the "version" command and is set during build.
-var version = "undefined"
-
 func init() {
 	rootCmd.AddCommand(versionCmd)
 
-	utils.KubectlGadgetVersion, _ = semver.New(version[1:])
+	utils.KubectlGadgetVersion, _ = semver.New(common.Version()[1:])
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Client version:", version)
+		fmt.Println("Client version:", common.Version())
 
 		client, err := k8sutil.NewClientsetFromConfigFlags(utils.KubernetesConfigFlags)
 		if err != nil {

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -315,7 +315,10 @@ func main() {
 
 		service := gadgetservice.NewService(log.StandardLogger())
 		go func() {
-			err := service.Run("unix", gadgetServiceSocketFile)
+			err := service.Run(gadgetservice.RunConfig{
+				SocketType: "unix",
+				SocketPath: gadgetServiceSocketFile,
+			})
 			if err != nil {
 				log.Fatalf("failed to start Gadget Service: %v", err)
 			}

--- a/pkg/gadget-service/api/consts.go
+++ b/pkg/gadget-service/api/consts.go
@@ -25,4 +25,5 @@ const (
 
 const (
 	GadgetServiceSocket = "/run/gadgetservice.socket"
+	DefaultDaemonPath   = "unix:///var/run/ig/ig.socket"
 )

--- a/pkg/runtime/grpc/k8s-exec-dialer.go
+++ b/pkg/runtime/grpc/k8s-exec-dialer.go
@@ -42,7 +42,7 @@ type k8sExecConn struct {
 }
 
 // NewK8SExecConn connects to a Pod using the Kubernetes API Server and launches a socat
-func NewK8SExecConn(ctx context.Context, pod gadgetPod, timeout time.Duration) (net.Conn, error) {
+func NewK8SExecConn(ctx context.Context, pod target, timeout time.Duration) (net.Conn, error) {
 	readerExt, writer := io.Pipe()
 	reader, writerExt := io.Pipe()
 	conn := &k8sExecConn{
@@ -58,7 +58,7 @@ func NewK8SExecConn(ctx context.Context, pod gadgetPod, timeout time.Duration) (
 	// set GroupVersion and NegotiatedSerializer for RESTClient
 	factory.SetKubernetesDefaults(config)
 
-	conn.podName = pod.name
+	conn.podName = pod.addressOrPod
 
 	config.Timeout = timeout
 

--- a/pkg/runtime/grpc/option.go
+++ b/pkg/runtime/grpc/option.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcruntime
+
+type Option func(runtime *Runtime)
+
+func WithConnectUsingK8SProxy(runtime *Runtime) {
+	runtime.connectionMode = ConnectionModeKubernetesProxy
+}


### PR DESCRIPTION
This adds support to run `ig` in daemon mode as a service. A new binary called `gadgetctl` has been added to serve as a client for `ig` running in said daemon mode. By default, ig listens on a unix socket when started with `./ig daemon` and `gadgetctl` uses that same socket to connect to by default.

The `grpc-runtime` has been changed to also allow direct gRPC connections - still: most of the code is shared.

### Running as root

#### First terminal

```bash
./ig daemon
```

#### Second terminal
```bash
./gadgetctl trace open
```

### Daemon as root, gadgetctl as other user

Use the gid of a group that you want to have access to the service.

#### First terminal (as root)

```bash
./ig daemon --daemon-group 1000
```

#### Second terminal (as member of group 1000)
```bash
./gadgetctl trace open
```


## Todos:

* [x] documentation
* [x] CI

---

Resolves #1681
Requires #2067