### PR TITLE
cmd: Relative columns and expanding runtime/k8s

### DIFF
--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -129,9 +129,10 @@ func GetKubernetesColumns() []string {
 }
 
 func GetContainerRuntimeColumns() []string {
-	// TODO: Add ContainerID, ContainerRuntimeName, ContainerRuntimeNamespace.
-	// See https://github.com/inspektor-gadget/inspektor-gadget/issues/737.
 	return []string{
-		"container",
+		"runtime.runtimeName",
+		"runtime.containerId",
+		"runtime.containerName",
+		"runtime.containerImageName",
 	}
 }

--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -62,7 +62,7 @@ func NewListContainersCmd() *cobra.Command {
 			}
 
 			if !optionWatch {
-				parser, err := commonutils.NewGadgetParserWithK8sAndRuntimeInfo(&commonFlags.OutputConfig, setColumnVisibility(containercollection.GetColumns()))
+				parser, err := commonutils.NewGadgetParserWithK8sAndRuntimeInfo(&commonFlags.OutputConfig, columnsWithAdjustedVisibility(containercollection.GetColumns()))
 				if err != nil {
 					return commonutils.WrapInErrParserCreate(err)
 				}
@@ -75,7 +75,7 @@ func NewListContainersCmd() *cobra.Command {
 				return nil
 			}
 
-			cols := setColumnVisibility(columns.MustCreateColumns[containercollection.PubSubEvent]())
+			cols := columnsWithAdjustedVisibility(columns.MustCreateColumns[containercollection.PubSubEvent]())
 			cols.SetExtractor("event", func(event *containercollection.PubSubEvent) any {
 				return event.Type.String()
 			})
@@ -166,7 +166,7 @@ func printPubSubEvent(parser *commonutils.GadgetParser[containercollection.PubSu
 	return nil
 }
 
-func setColumnVisibility[T containercollection.Container | containercollection.PubSubEvent](cols *columns.Columns[T]) *columns.Columns[T] {
+func columnsWithAdjustedVisibility[T containercollection.Container | containercollection.PubSubEvent](cols *columns.Columns[T]) *columns.Columns[T] {
 	for _, c := range cols.GetColumnMap(columns.WithTag("kubernetes")) {
 		c.Visible = false
 	}

--- a/docs/gadgets/common-features.md
+++ b/docs/gadgets/common-features.md
@@ -90,8 +90,21 @@ Each entry is preceded by the end of directives markers (`---`).
 ### Custom Columns
 
 Using `-o columns=column1,column2` we can choose which columns to
-print. We can use the JSON output to know the names of all the available
-columns for a given gadget.
+print. You can use gadget help to see which columns are available:
+
+```bash
+$ kubectl gadget trace open -h
+...
+  Available columns:
+    comm
+    err
+    fd
+    flags
+    fullPath (requires --full-path)
+    gid
+    k8s.container
+...
+```
 
 For example, when tracing which processes were killed because of the node
 running out of memory, we can choose to only print the PID and command of
@@ -101,6 +114,26 @@ the killed process:
 $ kubectl gadget trace oomkill -A -o columns=kpid,kcomm
 KPID   KCOMM
 15182  tail
+```
+
+Also, we can use the `+` and `-` prefixes to add or remove columns relative to the default columns.
+For example, in case we want to add `uid` and `gid` columns to the default columns for trace open gadget:
+
+```bash
+$ kubectl gadget trace open -A -o columns=+uid,+gid
+K8S.NODE      K8S.NAMESPACE K8S.POD       K8S.CONTAINER PID     COMM   FD ERR PATH                     UID        GID
+miniku…docker default       test-p…-v6rqg nginx         1149213 docke… 3  0   /etc/ld.so.cache         0          0
+
+```
+
+Columns `k8s` and `runtime` are expanded to all available columns for the respective environment.
+For example, in case we want `trace tcp` gadget to print events with only `runtime` columns:
+
+```bash
+$ kubectl gadget trace tcp -o columns=-k8s,+runtime
+RUNTIME.RUNTIMENAME RUNTIM… RUNTIME.CONTAIN… RUNTIME… T PID      COMM     IP SRC                    DST
+docker              8df2cb… k8s_nginx_test-… nginx    A 1163696  nginx    4  p/default/test-pod-67c r/10.244.0.1:58570
+docker              8df2cb… k8s_nginx_test-… nginx    X 1163696  nginx    4  p/default/test-pod-67c r/10.244.0.1:58570
 ```
 
 ## Run for a specific amount of time

--- a/integration/run_helpers.go
+++ b/integration/run_helpers.go
@@ -38,57 +38,49 @@ func SetEventMountNsID(jsonObj map[string]interface{}, mountNsID uint64) {
 }
 
 func SetEventRuntimeName(jsonObj map[string]interface{}, runtimeName eventtypes.RuntimeName) {
-	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
-	if runtimeMetadata != nil {
+	if runtimeMetadata := jsonObj["runtime"].(map[string]interface{}); runtimeMetadata != nil {
 		runtimeMetadata["runtimeName"] = runtimeName
 	}
 }
 
 func SetEventRuntimeContainerID(jsonObj map[string]interface{}, s string) {
-	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
-	if runtimeMetadata != nil {
+	if runtimeMetadata := jsonObj["runtime"].(map[string]interface{}); runtimeMetadata != nil {
 		runtimeMetadata["containerId"] = s
 	}
 }
 
 func SetEventRuntimeContainerName(jsonObj map[string]interface{}, s string) {
-	runtimeMetadata := jsonObj["runtime"].(map[string]interface{})
-	if runtimeMetadata != nil {
+	if runtimeMetadata := jsonObj["runtime"].(map[string]interface{}); runtimeMetadata != nil {
 		runtimeMetadata["containerName"] = s
 	}
 }
 
 func SetEventK8sNode(jsonObj map[string]interface{}, s string) {
-	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
-	if k8sMetadata != nil {
+	if k8sMetadata := jsonObj["k8s"].(map[string]interface{}); k8sMetadata != nil {
 		k8sMetadata["node"] = s
 	}
 }
 
 func SetEventK8sNamespace(jsonObj map[string]interface{}, s string) {
-	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
-	if k8sMetadata != nil {
+	if k8sMetadata := jsonObj["k8s"].(map[string]interface{}); k8sMetadata != nil {
 		k8sMetadata["namespace"] = s
 	}
 }
 
 func SetEventK8sPod(jsonObj map[string]interface{}, s string) {
-	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
-	if k8sMetadata != nil {
+	if k8sMetadata := jsonObj["k8s"].(map[string]interface{}); k8sMetadata != nil {
 		k8sMetadata["pod"] = s
 	}
 }
 
 func SetEventK8sContainer(jsonObj map[string]interface{}, s string) {
-	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
-	if k8sMetadata != nil {
+	if k8sMetadata := jsonObj["k8s"].(map[string]interface{}); k8sMetadata != nil {
 		k8sMetadata["container"] = s
 	}
 }
 
 func SetEventK8sHostNetwork(jsonObj map[string]interface{}, b bool) {
-	k8sMetadata := jsonObj["k8s"].(map[string]interface{})
-	if k8sMetadata != nil {
+	if k8sMetadata := jsonObj["k8s"].(map[string]interface{}); k8sMetadata != nil {
 		k8sMetadata["hostNetwork"] = b
 	}
 }


### PR DESCRIPTION
This PR add support for relative columns and expanding `runtime` and `k8s` columns. 

Fixes: #1881 #737

## Testing Done

### ig

```
→ sudo ./ig trace open -o columns=+uid
RUNTIME.CONTAINERNAME                                                         PID        COMM             FD       ERR PATH                                                                              UID       
minikube-docker                                                               448161     cri-dockerd      12       0   /etc/cni/net.d                                                                    0         
minikube-docker                                                               448161     cri-dockerd      12       0   /etc/cni/net.d/1-k8s.conflist                                                     0  
```
```
→ sudo ./ig trace open -o columns=+k8s,-k8s.node
K8S.NAMESPACE                 K8S.POD                      K8S.CONTAINER                RUNTIME.CONTAINERNAME        PID        COMM            FD ERR PATH
gadget                        gadget-jklcl                 gadget                       k8s_gadget_gadget-jklcl_gad… 1012215    gadgettracerman 45 0   /host/proc
gadget                        gadget-jklcl                 gadget                       k8s_gadget_gadget-jklcl_gad… 1012215    gadgettracerman 45 0   /host/proc
```

### kubectl-gadget

```
→ ./kubectl-gadget trace open -o columns=+uid -A
K8S.NODE                         K8S.NAMESPACE                    K8S.POD                          K8S.CONTAINER                   PID        COMM             FD  ERR PATH                              UID       
minikube-docker                  gadget                           gadget-bz76n                     gadget                          972603     gadgettracerman  75  0   /host/proc                        0         
minikube-docker                  kube-system                      etcd-minikube-docker             etcd                            449139     etcd             85  0   /var/lib/minikube/etcd/member/sn… 0
```

```
→ ./kubectl-gadget trace open -o columns=-k8s,+runtime -A
RUNTIME.RUNTIMENAME RUNTIME.CONTAINERID    RUNTIME.CONTAINERNAME                              RUNTIME.CONTAINERIMAGENAME  PID        COMM             FD   ERR PATH                                                
docker              fdede0377670be1205339… k8s_gadget_gadget-bz76n_gadget_fdb8600e-8bb4-4906… sha256:af50d4954f0e11e23d6… 972603     gadgettracerman  75   0   /host/proc                                          
docker              fdede0377670be1205339… k8s_gadget_gadget-bz76n_gadget_fdb8600e-8bb4-4906… sha256:af50d4954f0e11e23d6… 994875     runc:[2:INIT]    5    0   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size 
```

## Todo

- [x] Find a way to add `k8s.node` to `ig` ? (Use `os.Hostname()` for now, I see [other tools](https://github.com/kubernetes/node-problem-detector/blob/v0.6/cmd/options/options.go#L119) follow similar approach)