### PR TITLE
pkg/helpers: Fix logic to detect if kernel supports bpf_ktime_get_boo…

### DIFF
--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -196,20 +196,26 @@ var (
 // in the current kernel. False negatives are possible if BTF is not available.
 func DetectBpfKtimeGetBootNs() bool {
 	bpfKtimeGetBootNsOnce.Do(func() {
+		bpfKtimeGetBootNsExists = false
+
 		btfSpec, err := btf.LoadKernelSpec()
 		if err != nil {
-			bpfKtimeGetBootNsExists = false
 			return
 		}
 
 		enum := &btf.Enum{}
 		err = btfSpec.TypeByName("bpf_func_id", &enum)
 		if err != nil {
-			bpfKtimeGetBootNsExists = false
 			return
 		}
 
-		bpfKtimeGetBootNsExists = len(enum.Values) >= BpfKtimeGetBootNsFuncID
+		for _, value := range enum.Values {
+			if value.Name == "BPF_FUNC_ktime_get_boot_ns" && value.Value == BpfKtimeGetBootNsFuncID {
+				bpfKtimeGetBootNsExists = true
+
+				return
+			}
+		}
 	})
 
 	return bpfKtimeGetBootNsExists


### PR DESCRIPTION
…t_ns().

The kernel defines many BPF helpers functions and all of them have an ID [1]. Sadly, we cannot compare the number of helper functions with the ID to know if the kernel supports the given function.
Indeed, the kernel defines two abstract helper functions:
* unspec which has ID 0 [2]
* and __BPF_FUNC_MAX_ID which indicates the last ID [3].

The solution is then to test that latest helper is __BPF_FUNC_MAX_ID and that bpf_ktime_get_boot_ns() ID is lower.

Fixes: f87486947273 ("Rewrite detectBpfKtimeGetBootNs using sync.Once")
Fixes: ffb7d9910f2d ("gadgets: get timestamp from userspace on Linux <5.7")
[1]: https://github.com/torvalds/linux/blob/0e945134b680040b8613e962f586d91b6d40292d/include/uapi/linux/bpf.h#L5646
[2]: https://github.com/torvalds/linux/blob/0e945134b680040b8613e962f586d91b6d40292d/include/uapi/linux/bpf.h#L5647
[3]: https://github.com/torvalds/linux/blob/0e945134b680040b8613e962f586d91b6d40292d/include/uapi/linux/bpf.h#L5873