### PR TITLE
runtimes/grpc: Fix connection leakage

### DIFF
--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -266,7 +266,7 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext) (runtime.CombinedGa
 	return r.runGadgetOnTargets(gadgetCtx, paramMap, targets)
 }
 
-func (r *Runtime) getClientFromRandomTarget(ctx context.Context, runtimeParams *params.Params) (api.GadgetManagerClient, error) {
+func (r *Runtime) getConnToRandomTarget(ctx context.Context, runtimeParams *params.Params) (*grpc.ClientConn, error) {
 	targets, err := r.getTargets(ctx, runtimeParams)
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ func (r *Runtime) getClientFromRandomTarget(ctx context.Context, runtimeParams *
 	if err != nil {
 		return nil, fmt.Errorf("dialing %q (%q): %w", target.addressOrPod, target.node, err)
 	}
-	return api.NewGadgetManagerClient(conn), nil
+	return conn, nil
 }
 
 func (r *Runtime) runGadgetOnTargets(

--- a/pkg/runtime/grpc/info.go
+++ b/pkg/runtime/grpc/info.go
@@ -65,10 +65,12 @@ func (r *Runtime) loadRemoteDeployInfo() (*deployinfo.DeployInfo, error) {
 
 	// use default params for now
 	params := r.ParamDescs().ToParams()
-	client, err := r.getClientFromRandomTarget(ctx, params)
+	conn, err := r.getConnToRandomTarget(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("dialing random target: %w", err)
 	}
+	defer conn.Close()
+	client := api.NewGadgetManagerClient(conn)
 
 	info, err := client.GetInfo(ctx, &api.InfoRequest{Version: "1.0"})
 	if err != nil {


### PR DESCRIPTION
Refactor the code a bit to allow the caller to close the connection.

Fixes: 2a15d06e4d73 ("pkg/runtime/grpc: add support for direct gRPC connections")


