### PR TITLE
Update code of conduct to the CNCF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Inspektor Gadget Project Code of Conduct
+
+The Inspektor Gadget project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/docs/devel/CONTRIBUTING.md
+++ b/docs/devel/CONTRIBUTING.md
@@ -303,8 +303,8 @@ should be manually cleaned up.
 
 ### Code of Conduct
 
-Please refer to the Kinvolk
-[Code of Conduct](https://github.com/kinvolk/contribution/blob/master/CODE_OF_CONDUCT.md).
+Inspektor Gadget follows the CNCF
+[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 ### Authoring PRs
 


### PR DESCRIPTION
Update to the CNCF CoC now that we're a CNCF project.

Adds the top-level file so that Github picks it up and shows that we have a CoC.