### PR TITLE
Refactor pkg/oci

### DIFF
--- a/cmd/common/image/push.go
+++ b/cmd/common/image/push.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"oras.land/oras-go/v2"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
@@ -31,43 +30,24 @@ type pushOptions struct {
 }
 
 func NewPushCmd() *cobra.Command {
-	o := pushOptions{}
+	var authOpts oci.AuthOptions
 	cmd := &cobra.Command{
 		Use:          "push IMAGE",
 		Short:        "Push the specified image to a remote registry",
 		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expected exactly one argument")
+			image := args[0]
+
+			fmt.Printf("Pushing %s...\n", image)
+			desc, err := oci.PushGadgetImage(context.TODO(), image, &authOpts)
+			if err != nil {
+				return fmt.Errorf("pushing gadget: %w", err)
 			}
-			o.image = args[0]
-			return runPush(o)
+			fmt.Printf("Successfully pushed %s\n", desc.String())
+			return nil
 		},
 	}
-	utils.AddRegistryAuthVariablesAndFlags(cmd, &o.authOpts)
+	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
 	return cmd
-}
-
-func runPush(o pushOptions) error {
-	ociStore, err := oci.GetLocalOciStore()
-	if err != nil {
-		return fmt.Errorf("get oci store: %w", err)
-	}
-
-	repo, err := oci.NewRepository(o.image, &o.authOpts)
-	if err != nil {
-		return fmt.Errorf("create remote repository: %w", err)
-	}
-	targetImage, err := oci.NormalizeImage(o.image)
-	if err != nil {
-		return fmt.Errorf("normalize image: %w", err)
-	}
-	fmt.Printf("Pushing %s...\n", targetImage)
-	desc, err := oras.Copy(context.TODO(), ociStore, targetImage, repo, targetImage, oras.DefaultCopyOptions)
-	if err != nil {
-		return fmt.Errorf("copy to remote repository: %w", err)
-	}
-
-	fmt.Printf("Successfully pushed %s@%s\n", targetImage, desc.Digest)
-	return nil
 }

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -16,6 +16,7 @@ package tracer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -23,9 +24,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
-	"oras.land/oras-go/v2"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
@@ -80,49 +79,19 @@ func (g *GadgetDesc) Parser() parser.Parser {
 	return nil
 }
 
-// TODO: this could be part of pkg/oci
-func getProgAndDefinition(params *params.Params, args []string) ([]byte, []byte, error) {
-	if len(args) != 1 {
-		return nil, nil, fmt.Errorf("one argument expected: received %d", len(args))
-	}
-	image, err := oci.NormalizeImage(args[0])
-	if err != nil {
-		return nil, nil, fmt.Errorf("normalize image: %w", err)
-	}
-
-	var imageStore oras.Target
-	imageStore, err = oci.GetLocalOciStore()
-	if err != nil {
-		log.Debugf("get oci store: %s", err)
-		imageStore = oci.GetMemoryStore()
-	}
-	authOpts := oci.AuthOptions{
+func (g *GadgetDesc) GetGadgetInfo(params *params.Params, args []string) (*types.GadgetInfo, error) {
+	authOpts := &oci.AuthOptions{
 		AuthFile: params.Get("authfile").AsString(),
 	}
-
-	prog, err := oci.GetEbpfProgram(imageStore, &authOpts, image)
+	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get ebpf program: %w", err)
-	}
-
-	def, err := oci.GetDefinition(imageStore, &authOpts, image)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get definition: %w", err)
-	}
-
-	return prog, def, nil
-}
-
-func (g *GadgetDesc) GetGadgetInfo(params *params.Params, args []string) (*types.GadgetInfo, error) {
-	progContent, definitionBytes, err := getProgAndDefinition(params, args)
-	if err != nil {
-		return nil, fmt.Errorf("get ebpf program and definition: %w", err)
+		return nil, fmt.Errorf("getting gadget image: %w", err)
 	}
 
 	ret := &types.GadgetInfo{
-		ProgContent: progContent,
+		ProgContent: gadget.EbpfObject,
 	}
-	if err := yaml.Unmarshal(definitionBytes, &ret.GadgetDefinition); err != nil {
+	if err := yaml.Unmarshal(gadget.Metadata, &ret.GadgetDefinition); err != nil {
 		return nil, fmt.Errorf("unmarshaling definition: %w", err)
 	}
 

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -36,6 +36,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/networktracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/internal/socketenricher"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/run/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -444,11 +445,15 @@ func (t *Tracer) runPrint(gadgetCtx gadgets.GadgetContext) {
 }
 
 func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
-	var err error
-
 	params := gadgetCtx.GadgetParams()
 	args := gadgetCtx.Args()
-	t.config.ProgContent, _, err = getProgAndDefinition(params, args)
+
+	authOpts := &oci.AuthOptions{
+		AuthFile: params.Get("authfile").AsString(),
+	}
+
+	var err error
+	t.config.ProgContent, err = oci.GetEbpfObject(gadgetCtx.Context(), args[0], authOpts)
 	if err != nil {
 		return fmt.Errorf("get ebpf program: %w", err)
 	}

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -1,0 +1,208 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+)
+
+const (
+	ArchAmd64 = "amd64"
+	ArchArm64 = "arm64"
+)
+
+const (
+	eBPFObjectMediaType = "application/vnd.gadget.ebpf.program.v1+binary"
+	metadataMediaType   = "application/vnd.gadget.config.v1+yaml"
+)
+
+type BuildGadgetImageOpts struct {
+	// List of eBPF objects to include in the image. The key is the architecture and the value
+	// is the path to the eBPF object.
+	EBPFObjectPaths map[string]string
+	// Path to the metadata file.
+	MetadataPath string
+}
+
+// BuildGadgetImage creates an OCI image with the objects provided in opts. The image parameter in
+// the "name:tag" format is used to name and tag the created image. If it's empty the image is not
+// named.
+func BuildGadgetImage(ctx context.Context, opts *BuildGadgetImageOpts, image string) (*GadgetImageDesc, error) {
+	ociStore, err := getLocalOciStore()
+	if err != nil {
+		return nil, fmt.Errorf("getting oci store: %w", err)
+	}
+
+	indexDesc, err := createImageIndex(ctx, ociStore, opts)
+	if err != nil {
+		return nil, fmt.Errorf("creating image index: %w", err)
+	}
+
+	imageDesc := &GadgetImageDesc{
+		Digest: indexDesc.Digest.String(),
+	}
+
+	if image != "" {
+		targetImage, err := normalizeImageName(image)
+		if err != nil {
+			return nil, fmt.Errorf("normalizing image: %w", err)
+		}
+
+		err = ociStore.Tag(ctx, indexDesc, targetImage.String())
+		if err != nil {
+			return nil, fmt.Errorf("tagging manifest: %w", err)
+		}
+
+		imageDesc.Repository = targetImage.Name()
+		if ref, ok := targetImage.(reference.Tagged); ok {
+			imageDesc.Tag = ref.Tag()
+		}
+	}
+
+	return imageDesc, nil
+}
+
+func pushDescriptorIfNotExists(ctx context.Context, target oras.Target, desc ocispec.Descriptor, contentReader io.Reader) error {
+	err := target.Push(ctx, desc, contentReader)
+	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return fmt.Errorf("pushing descriptor: %w", err)
+	}
+	return nil
+}
+
+func createEbpfProgramDesc(ctx context.Context, target oras.Target, progFilePath string) (ocispec.Descriptor, error) {
+	progBytes, err := os.ReadFile(progFilePath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("reading eBPF program file: %w", err)
+	}
+	progDesc := content.NewDescriptorFromBytes(eBPFObjectMediaType, progBytes)
+	progDesc.Annotations = map[string]string{
+		ocispec.AnnotationTitle:       "program.o",
+		ocispec.AnnotationAuthors:     "TODO: authors",
+		ocispec.AnnotationDescription: "TODO: description",
+	}
+	err = pushDescriptorIfNotExists(ctx, target, progDesc, bytes.NewReader(progBytes))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing eBPF program: %w", err)
+	}
+
+	return progDesc, nil
+}
+
+func createMetadataDesc(ctx context.Context, target oras.Target, metadataFilePath string) (ocispec.Descriptor, error) {
+	metadataBytes, err := os.ReadFile(metadataFilePath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("reading metadata file: %w", err)
+	}
+	defDesc := content.NewDescriptorFromBytes(metadataMediaType, metadataBytes)
+	defDesc.Annotations = map[string]string{
+		ocispec.AnnotationTitle: "config.yaml",
+	}
+	err = pushDescriptorIfNotExists(ctx, target, defDesc, bytes.NewReader(metadataBytes))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing metadata file: %w", err)
+	}
+	return defDesc, nil
+}
+
+func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, progFilePath, arch string) (ocispec.Descriptor, error) {
+	progDesc, err := createEbpfProgramDesc(ctx, target, progFilePath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("creating and pushing eBPF descriptor: %w", err)
+	}
+
+	// Read the metadata file into a byte array
+	defDesc, err := createMetadataDesc(ctx, target, metadataFilePath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("creating metadata descriptor: %w", err)
+	}
+
+	// Create the manifest which combines everything and push it to the memory store
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		Config: defDesc,
+		Layers: []ocispec.Descriptor{progDesc},
+	}
+	manifestJson, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("marshalling manifest: %w", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestJson)
+	manifestDesc.Platform = &ocispec.Platform{
+		Architecture: arch,
+		OS:           "linux",
+	}
+
+	exists, err := target.Exists(ctx, manifestDesc)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("checking if manifest exists: %w", err)
+	}
+	if exists {
+		return manifestDesc, nil
+	}
+	err = pushDescriptorIfNotExists(ctx, target, manifestDesc, bytes.NewReader(manifestJson))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
+	}
+
+	return manifestDesc, nil
+}
+
+func createImageIndex(ctx context.Context, target oras.Target, o *BuildGadgetImageOpts) (ocispec.Descriptor, error) {
+	// Read the eBPF program files and push them to the memory store
+	layers := []ocispec.Descriptor{}
+
+	for arch, path := range o.EBPFObjectPaths {
+		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, path, arch)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", arch, err)
+		}
+		layers = append(layers, manifestDesc)
+	}
+
+	// Create the index which combines the architectures and push it to the memory store
+	index := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: layers,
+	}
+	indexJson, err := json.Marshal(index)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("marshalling manifest: %w", err)
+	}
+	indexDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageIndex, indexJson)
+	err = pushDescriptorIfNotExists(ctx, target, indexDesc, bytes.NewReader(indexJson))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest index: %w", err)
+	}
+	return indexDesc, nil
+}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -73,7 +73,7 @@ func TestGetRepositoryFromImage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			repository, err := GetRepositoryFromImage(test.image)
+			repository, err := getRepositoryFromImage(test.image)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -142,7 +142,7 @@ func TestGetTagFromImage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			tag, err := GetTagFromImage(test.image)
+			tag, err := getTagFromImage(test.image)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -207,14 +207,14 @@ func TestNormalizeImage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			image, err := NormalizeImage(test.image)
+			imageRef, err := normalizeImageName(test.image)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, test.imageExpected, image)
+			require.Equal(t, test.imageExpected, imageRef.String())
 		})
 	}
 }
@@ -268,7 +268,7 @@ func TestGetHostString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			host, err := GetHostString(test.image)
+			host, err := getHostString(test.image)
 			if test.err {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
This is a complete refactoring of the oci package. The whole idea is to implement all the OCI related functionalities we need in this package, avoiding other parts of the code having to interact with packages like "github.com/docker" or "oras.land/oras-go/v2".

The reasoning behind is:
- We can concentrate all OCI related code in the same place
- It's a lot easier to test if it's a separated package

This package now provides methods for pulling, pushing, tagging and building OCI images. Other methods that we previously exposed are now internal.

This commit also:
- Uses -ing in all error messages
- Small esthetic changes to cmd/*

NOTE: Ideally this should be multiple commits, but it's rather difficult to split a refactor like it into smaller pieces.


