### PR TITLE
Rename ebpf builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's
 # This version number must be kept in sync with CI workflow lint one.
 LINTER_VERSION ?= v1.49.0
 
-EBPF_BUILDER ?= ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder
+EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder
 
 DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
 

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -49,7 +49,7 @@ import (
 var makefile []byte
 
 const (
-	DEFAULT_BUILDER_IMAGE = "ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder:latest"
+	DEFAULT_BUILDER_IMAGE = "ghcr.io/inspektor-gadget/ebpf-builder:latest"
 	DEFAULT_EBPF_SOURCE   = "program.bpf.c"
 	DEFAULT_METADATA      = "gadget.yaml"
 	ARCH_AMD64            = "amd64"

--- a/docs/images.md
+++ b/docs/images.md
@@ -118,7 +118,7 @@ Usage:
   ig image build PATH [flags]
 
 Flags:
-      --builder-image string   Builder image to use (default "ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder:latest")
+      --builder-image string   Builder image to use (default "ghcr.io/inspektor-gadget/ebpf-builder:latest")
   -f, --file string            Path to build.yaml (default "build.yaml")
   -h, --help                   help for build
   -l, --local                  Build using local tools

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
-BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder:latest
+BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
 IG ?= ig
 GADGETS = \
 	trace_dns \


### PR DESCRIPTION
Rename from ghcr.io/inspektor-gadget/inspektor-gadget-ebpf-builder to ghcr.io/inspektor-gadget/ebpf-builder as "inspektor-gadget" is redundant.

---

I pushed the image manually, however it should be automatically pushed once https://github.com/inspektor-gadget/inspektor-gadget/issues/1420 is fixed.