### PR TITLE
Makefile: Fix 'gadget-container' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ install/gadgetctl: gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH)
 	mkdir -p ~/.local/bin/
 	cp gadgetctl-$(GOHOSTOS)-$(GOHOSTARCH) ~/.local/bin/gadgetctl
 
+.PHONY: gadget-container
 gadget-container:
 	if $(ENABLE_BTFGEN) == "true" ; then \
 		./tools/getbtfhub.sh && \
@@ -190,8 +191,9 @@ gadget-container:
 			BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ -j$(nproc); \
 	fi
 	docker buildx build --load -t $(CONTAINER_REPO):$(IMAGE_TAG) \
-		-f Dockerfiles/gadget-$*.Dockerfile .
+		-f Dockerfiles/gadget.Dockerfile .
 
+.PHONY: cross-gadget-container
 cross-gadget-container:
 	if $(ENABLE_BTFGEN) == "true" ; then \
 		./tools/getbtfhub.sh && \
@@ -202,7 +204,7 @@ cross-gadget-container:
 	fi
 	docker buildx build --platform=$(PLATFORMS) -t $(CONTAINER_REPO):$(IMAGE_TAG) \
 		--push \
-		-f Dockerfiles/gadget-$*.Dockerfile .
+		-f Dockerfiles/gadget.Dockerfile .
 
 push-gadget-container:
 	docker push $(CONTAINER_REPO):$(IMAGE_TAG)


### PR DESCRIPTION
#2094 renamed 'gadget-%-container' target to 'gadget-container' but we have a file named 'gadget-container' so the image is never built with make saying: make: 'gadget-container' is up to date.

## Testing done

```
$ make gadget-container # or make miniukube-deploy works fine
...
 => CACHED [stage-2  9/11] COPY gadget-container/hooks/nri/conf.json /opt/hooks/nri/                                                                                                                          0.0s
 => CACHED [stage-2 10/11] COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace                                                                                                                           0.0s
 => CACHED [stage-2 11/11] RUN rm -f /var/run                                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:241753311ce99f8182fedecfa96493a20f72db6b72dd05dac483fcc566166813                                                                                                                  0.0s
 => => naming to ghcr.io/inspektor-gadget/inspektor-gadget:latest    
```
