### PR TITLE
run: Show help even if no oci image was given

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -259,6 +259,14 @@ func buildCommandFromGadget(
 			// Before running the gadget, we need to get the gadget info to create the
 			// parser based on it
 			if isRunGadget {
+				if len(args) == 0 {
+					if showHelp, _ := cmd.Flags().GetBool("help"); showHelp {
+						additionalMessage := "Specify the gadget image to get more information about it"
+						cmd.Long = fmt.Sprintf("%s\n\n%s", cmd.Short, additionalMessage)
+						return cmd.Help()
+					}
+				}
+
 				var err error
 				gadgetInfo, err = runtime.GetGadgetInfo(ctx, gadgetDesc, gadgetParams, args)
 				if err != nil {


### PR DESCRIPTION
# run: Show help even if no oci image was given

resolves #2005

When we don't specify an oci image the `run` gadget still tried to show all available columns. For this it has to look into the BTF code stored in the oci image.

To resolve the problem this PR implements the following behavior:
1. If no oci image is given the help is printed without any columns. Additionally the message `To see available columns for a specific gadget image, the oci image needs to specified as an argument` will be shown in the help output (See Testing done)
2. If a valid oci image is given, the help behaves like always did
3. If an invalid oci image is given, the help prints an error if the oci image url is malformed, can't be found, ....

## Testing done

### Without oci image
```bash
➭ go run --exec "sudo -E" ./cmd/ig/... run --help
INFO[0000] Experimental features enabled                
Run a containerized gadget
  To see available columns for a specific gadget image, the oci image needs to specified as an argument

Usage:
  ig run [flags]

Flags:
      --authfile string         (default "/var/lib/ig/config.json")
//*****SNIP*****
  -o, --output string          Output format (json, jsonpretty, yaml).
                               
                               JSON (json)
                                 The output of the gadget is returned as raw JSON
                               JSON Prettified (jsonpretty)
                                 The output of the gadget is returned as prettified JSON
                               YAML (yaml)
                                 The output of the gadget is returned as YAML
                               
                                (default "columns")
  -t, --timeout int            Number of seconds that the gadget will run for, 0 to disable

```
### With valid oci image
```bash
➭ go run --exec "sudo -E" ./cmd/ig/... run ghcr.io/inspektor-gadget/gadget/trace_open:latest --help
INFO[0000] Experimental features enabled                
Run a containerized gadget

Usage:
  ig run [flags]

Flags:
      --authfile string         (default "/var/lib/ig/config.json")
//*****SNIP*****
  -o, --output string          Output format (jsonpretty, yaml, json, columns).
                               
                               Columns (columns)
                                 The output of the gadget is formatted in human readable columns.
                                 You can optionally specify the columns to output using '-o columns=col1,col2,col3' etc.
                                 Columns can be prefixed with '+' or '-' to add or remove columns relative to the default columns.
                                 Columns 'k8s' and 'runtime' are expanded to all available columns for the respective environment.
                                   Available columns:
                                     comm
                                     flags
//*****SNIP*****
                                     runtime.containerImageName
                                     runtime.containerName
                                     runtime.runtimeName
                                     timestamp
                                     uid
                                   Default columns: runtime.containerName,pid,comm,uid,gid,ret,fname
                               
                               JSON (json)
                                 The output of the gadget is returned as raw JSON
                               JSON Prettified (jsonpretty)
                                 The output of the gadget is returned as prettified JSON
                               YAML (yaml)
                                 The output of the gadget is returned as YAML
                               
                                (default "columns")
```
### With invalid oci image url
```bash
➭ go run --exec "sudo -E" ./cmd/ig/... run ghcr.io/inspektor-ga --help                             
INFO[0000] Experimental features enabled                
Error: getting gadget info: get ebpf program and definition: get ebpf program: pull image: download to local repository: failed to resolve ghcr.io/inspektor-ga:latest: GET "https://ghcr.io/v2/inspektor-ga/manifests/latest": response status code 400: name invalid: invalid repository name
exit status 1
```