### PR TITLE
kubectl-gadget/ig-k8s: change connection to gadget service from exec to port-forward

### DIFF
--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -61,9 +60,9 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 			return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
 		}
 
-		socketURL, err := url.Parse(socket)
+		socketType, socketPath, err := api.ParseSocketAddress(socket)
 		if err != nil {
-			return fmt.Errorf("invalid daemon-socket address %q: %w", socketURL, err)
+			return fmt.Errorf("invalid daemon-socket address: %w", err)
 		}
 
 		gid := 0
@@ -76,17 +75,6 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 			gid = tmpGid
 		} else {
 			return fmt.Errorf("group %q not found", group)
-		}
-
-		var socketPath string
-		socketType := socketURL.Scheme
-		switch socketType {
-		default:
-			return fmt.Errorf("invalid type for daemon-socket %q; please use 'unix' or 'tcp'", socketType)
-		case "unix":
-			socketPath = socketURL.Path
-		case "tcp":
-			socketPath = socketURL.Host
 		}
 
 		log.Infof("starting Inspektor Gadget daemon at %q", socket)

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -569,7 +569,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	info("Retrieving Gadget Catalog...\n")
-	err = grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy).UpdateDeployInfo()
+	rt := grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
+	rt.Init(rt.GlobalParamDescs().ToParams())
+	err = rt.UpdateDeployInfo()
 	if err != nil {
 		fmt.Printf("> failed: %v\n", err)
 	}

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -71,8 +71,14 @@ func main() {
 	}
 
 	runtime := grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
-	runtime.Init(runtime.GlobalParamDescs().ToParams())
+	runtimeGlobalParams := runtime.GlobalParamDescs().ToParams()
+	common.AddFlags(rootCmd, runtimeGlobalParams, nil, runtime)
+	runtime.Init(runtimeGlobalParams)
 	if !skipInfo {
+		// evaluate flags early for runtimeGlobalFlags; this will make
+		// sure that --connection-method has already been parsed when calling
+		// InitDeployInfo()
+		rootCmd.ParseFlags(os.Args[1:])
 		runtime.InitDeployInfo()
 	}
 

--- a/pkg/gadget-service/api/helpers.go
+++ b/pkg/gadget-service/api/helpers.go
@@ -14,17 +14,25 @@
 
 package api
 
-const (
-	EventTypeGadgetPayload uint32 = 0
-	EventTypeGadgetResult  uint32 = 1
-	EventTypeGadgetDone    uint32 = 2
-	EventTypeGadgetJobID   uint32 = 3
-
-	EventLogShift = 16
+import (
+	"fmt"
+	"net/url"
 )
 
-const (
-	GadgetServiceSocket = "/run/gadgetservice.socket"
-	GadgetServicePort   = 8080
-	DefaultDaemonPath   = "unix:///var/run/ig/ig.socket"
-)
+func ParseSocketAddress(addr string) (string, string, error) {
+	socketURL, err := url.Parse(addr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid socket address %q: %w", addr, err)
+	}
+	var socketPath string
+	socketType := socketURL.Scheme
+	switch socketType {
+	default:
+		return "", "", fmt.Errorf("invalid type %q for socket; please use 'unix' or 'tcp'", socketType)
+	case "unix":
+		socketPath = socketURL.Path
+	case "tcp":
+		socketPath = socketURL.Host
+	}
+	return socketType, socketPath, nil
+}

--- a/pkg/runtime/grpc/info.go
+++ b/pkg/runtime/grpc/info.go
@@ -60,7 +60,8 @@ func (r *Runtime) UpdateDeployInfo() error {
 }
 
 func (r *Runtime) loadRemoteDeployInfo() (*deployinfo.DeployInfo, error) {
-	ctx, cancelDial := context.WithTimeout(context.Background(), time.Second*ConnectTimeout)
+	timeout := time.Second * time.Duration(r.globalParams.Get(ParamConnectionTimeout).AsUint())
+	ctx, cancelDial := context.WithTimeout(context.Background(), timeout)
 	defer cancelDial()
 
 	// use default params for now

--- a/pkg/runtime/grpc/k8s-exec-dialer.go
+++ b/pkg/runtime/grpc/k8s-exec-dialer.go
@@ -119,14 +119,16 @@ func (k *k8sExecConn) RemoteAddr() net.Addr {
 	return &k8sAddress{podName: k.podName}
 }
 
-func (k *k8sExecConn) SetDeadline(t time.Time) error {
+// satisfying the net.Conn interface
+
+func (k *k8sExecConn) SetDeadline(_ time.Time) error {
 	return nil
 }
 
-func (k *k8sExecConn) SetReadDeadline(t time.Time) error {
+func (k *k8sExecConn) SetReadDeadline(_ time.Time) error {
 	return nil
 }
 
-func (k *k8sExecConn) SetWriteDeadline(t time.Time) error {
+func (k *k8sExecConn) SetWriteDeadline(_ time.Time) error {
 	return nil
 }

--- a/pkg/runtime/grpc/k8s-portfwd-dialer.go
+++ b/pkg/runtime/grpc/k8s-portfwd-dialer.go
@@ -1,0 +1,150 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/factory"
+)
+
+type k8sPortFwdDialer struct {
+	io.Writer
+	io.Reader
+	conn    httpstream.Connection
+	stream  httpstream.Stream
+	podName string
+}
+
+// NewK8SPortFwdConn connects to a Pod using PortForwarding via the Kubernetes API Server
+func NewK8SPortFwdConn(ctx context.Context, pod target, targetPort uint16, timeout time.Duration) (net.Conn, error) {
+	conn := &k8sPortFwdDialer{}
+
+	config, err := utils.KubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating RESTConfig: %w", err)
+	}
+
+	// set GroupVersion and NegotiatedSerializer for RESTClient
+	factory.SetKubernetesDefaults(config)
+
+	conn.podName = pod.addressOrPod
+
+	config.Timeout = timeout
+
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("creating roundtripper: %w", err)
+	}
+
+	targetURL, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, fmt.Errorf("parsing restConfig.Host: %w", err)
+	}
+
+	targetURL.Path = fmt.Sprintf("api/v1/namespaces/gadget/pods/%s/portforward", conn.podName)
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, targetURL)
+
+	newConn, _, err := dialer.Dial(portforward.PortForwardProtocolV1Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", targetPort))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(1))
+	errorStream, err := newConn.CreateStream(headers)
+	if err != nil {
+		newConn.Close()
+		return nil, fmt.Errorf("creating error stream for port forward: %w", err)
+	}
+	// we're not writing to this stream, but it is required for other streams to be able to connect
+	errorStream.Close()
+
+	go func() {
+		message, err := io.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			log.Errorf("k8sPortFwd connection: reading from error stream: %v", err)
+		case len(message) > 0:
+			log.Errorf("k8sPortFwd tcp connection: forwarding port: %v", string(message))
+			log.Errorf("Please make sure the --connection-method value matches your installation.")
+		}
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := newConn.CreateStream(headers)
+	if err != nil {
+		newConn.Close()
+		return nil, fmt.Errorf("creating data stream for port forward: %w", err)
+	}
+
+	conn.conn = newConn
+	conn.stream = dataStream
+	return conn, nil
+}
+
+func (k *k8sPortFwdDialer) Close() error {
+	k.stream.Close()
+	return k.conn.Close()
+}
+
+func (k *k8sPortFwdDialer) Read(b []byte) (n int, err error) {
+	return k.stream.Read(b)
+}
+
+func (k *k8sPortFwdDialer) Write(b []byte) (n int, err error) {
+	return k.stream.Write(b)
+}
+
+func (k *k8sPortFwdDialer) LocalAddr() net.Addr {
+	return nil
+}
+
+func (k *k8sPortFwdDialer) RemoteAddr() net.Addr {
+	return &k8sAddress{podName: k.podName}
+}
+
+// satisfying the net.Conn interface
+
+func (k *k8sPortFwdDialer) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (k *k8sPortFwdDialer) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (k *k8sPortFwdDialer) SetWriteDeadline(_ time.Time) error {
+	return nil
+}


### PR DESCRIPTION
This PR changes the default connection method used by `kubectl-gadget` to connect to the gadget-service running on the `gadgettracermgr`.

Until now, we executed a `socat` binary (using the exec method of the Kubernetes API server) inside the gadget pod to be able to forward gRPC traffic to a unix socket, to be able to talk to the gRPC endpoint of the gadget-service.

After this PR, the gadget-service will listen on a tcp socket by default (127.0.0.1:8080) and `kubectl-gadget` will connect to it using the port-forward method of the Kubernetes API server.

The reason that we used a unix socket in the past, was to properly secure the socket. As the gadget pod was running in the host network namespace, running our service on a tcp port would have exposed it on the host, making it accessible from unknown sources. Now that we're running in our own network namespace, we're not exposing it anymore outside of our own pod.

Advantages are:
* granting the previously required privilege to `exec` things on our gadget pod can be much more dangerous than just allowing a port forwarding to the gadget service
* removes the requirement of having to use (and bundling) the `socat` binary to actually connect to the previously used unix socket