### PR TITLE
ci: Only release image without CVEs.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1375,6 +1375,7 @@ jobs:
       - build-gadgets-examples
       - package-helm-charts
       - check-secrets
+      - scan-gadget-container-images
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Hi.


I marked this PR as RFC as maybe we should be able to bypass this.
On the other hand, this is not a good thing to publish flawed images.


Best regards.