### PR TITLE
fix: panic issue due to unavailable host network namespace inode

### DIFF
--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -664,14 +664,14 @@ func WithCgroupEnrichment() ContainerCollectionOption {
 
 // WithLinuxNamespaceEnrichment enables an enricher to add the namespaces metadata
 func WithLinuxNamespaceEnrichment() ContainerCollectionOption {
-	// GetNetNs() needs a pid in the host pid namespace: it uses $HOST_ROOT/proc/$pid/ns/net
-	// This needs CAP_SYS_PTRACE.
-	netnsHost, err := containerutils.GetNetNs(1)
-	if err != nil {
-		panic(fmt.Sprintf("getting host net ns inode: %s", err))
-	}
-
 	return func(cc *ContainerCollection) error {
+		// GetNetNs() needs a pid in the host pid namespace: it uses $HOST_ROOT/proc/$pid/ns/net
+		// This needs CAP_SYS_PTRACE.
+		netnsHost, err := containerutils.GetNetNs(1)
+		if err != nil {
+			return fmt.Errorf("getting host net ns inode: %w", err)
+		}
+
 		cc.containerEnrichers = append(cc.containerEnrichers, func(container *Container) bool {
 			pid := int(container.Pid)
 			if pid == 0 {

--- a/pkg/utils/host/namespaces.go
+++ b/pkg/utils/host/namespaces.go
@@ -59,7 +59,7 @@ func IsHostNetNs() (bool, error) {
 func isHostNamespace(nsKind string) (bool, error) {
 	if !initDone {
 		// HostProcFs can be overwritten by workarounds, so Init() must be called first.
-		panic("host.Init() must be called before calling isHostNamespace()")
+		return false, fmt.Errorf("host.Init() must be called before calling isHostNamespace()")
 	}
 
 	selfFileInfo, err := os.Stat("/proc/self/ns/" + nsKind)


### PR DESCRIPTION
Resolve a panic issue when getting an unavailable host namespace. Add error format to two functions: `WithLinuxNamespaceEnrichment` and `isHostNamespace`.

Fixes #1858 
