### PR TITLE
image build: add wasm

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -1,5 +1,6 @@
 ARG CLANG_LLVM_VERSION=15
 ARG LIBBPF_VERSION=v1.2.2
+ARG TINYGO_VERSION=0.30.0
 
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
@@ -13,6 +14,7 @@ RUN git clone --branch ${LIBBPF_VERSION} --depth 1 https://github.com/libbpf/lib
 
 FROM golang:1.20
 ARG CLANG_LLVM_VERSION
+ARG TINYGO_VERSION
 # libc-dev is needed for various headers, among others
 # /usr/include/arch-linux-gnu/asm/types.h.
 # libc-dev-i386 is needed on amd64 to provide <gnu/stubs-32.h>.
@@ -27,6 +29,22 @@ RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LL
 	&& update-alternatives --install /usr/local/bin/clang clang $(which clang-$CLANG_LLVM_VERSION) 100
 
 COPY --from=builder /usr/include/bpf /usr/include/bpf
+
+RUN \
+	DEB=tinygo.deb && \
+	ARCH=$(dpkg --print-architecture) && \
+	wget --quiet https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_${ARCH}.deb -O $DEB && \
+	if [ "${ARCH}" = 'amd64' ] ; then \
+		SHA='abcef56b2ae04e27253df409b32d0b7abb5ae76ed493db75b2f80659cbf59363c85919836116780adcad051c652e991dc46fa6ae7cec31a4fa3bdb68d2123621'; \
+	elif [ "${ARCH}" = 'arm64' ] ; then \
+		SHA='d121940aa1cd366c865f1600c88decf2a9db6891234f738024702891ecff94958848ce6bb3191b3a34250ab7091bc3e35b27cc612d7324f48a4d148869fa306f'; \
+	else \
+		echo "${ARCH} is not supported" 2>&1 ; \
+		exit 1; \
+	fi && \
+	echo $SHA $DEB | sha512sum -c && \
+	dpkg -i $DEB && \
+	rm -f $DEB
 
 # To avoid hitting this:
 # failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied

--- a/cmd/common/image/Makefile.build
+++ b/cmd/common/image/Makefile.build
@@ -13,9 +13,24 @@ TARGETS = \
 	#
 
 .PHONY: all
-all: $(TARGETS)
+all: $(TARGETS) wasm
 
 $(OUTPUTDIR)/%.bpf.o: $(EBPFSOURCE)
 	$(CLANG) $(BASECFLAGS) $(CFLAGS) -D __TARGET_ARCH_$(subst amd64,x86,$*) \
 		-c $< -I /usr/include/gadget/$*/ -o $@
 	$(LLVM-STRIP) -g $@
+
+.PHONY: wasm
+ifeq ($(WASM),)
+wasm:
+	# No wasm file found. Nothing to do.
+else ifeq (go,$(patsubst %.go,go,$(WASM)))
+wasm: $(WASM)
+	tinygo build -o $(OUTPUTDIR)/program.wasm -target=wasi --no-debug $^
+else ifeq (wasm,$(patsubst %.wasm,wasm,$(WASM)))
+wasm:
+	# Wasm file already compiled. Nothing to do.
+else
+wasm:
+	$(error Unsupported wasm file type: $(notdir $(WASM)))
+endif

--- a/docs/images.md
+++ b/docs/images.md
@@ -143,6 +143,7 @@ Successfully built sha256:adf9a4c636421d09e038eefa15623176195b0de482b25972e09b8b
 The building process is controlled by the `build.yaml` file. The following parameters are available:
 - `ebpfsource`: eBPF source code file. It defaults to `program.bpf.c`.
 - `metadata`: File containing metadata about the gadget. It defaults to `gadget.yaml`.
+- `wasm`: Wasm module. It is unset by default.
 
 By default, the build command looks for `build.yaml` in PATH. It can be changed with the `--file` flag:
 
@@ -176,6 +177,14 @@ In this case it's possible to control some of the tools used by setting some env
 ```bash
 $ sudo CLANG=clang-15 LLVM-STRIP=llvm-strip-15 ig image build . -f mybuild.yaml --local
 ```
+
+##### Wasm module
+
+A gadget can optionally include a wasm module. The wasm file is specified in the `wasm` field of `build.yaml`.
+
+Supported files:
+- `*.wasm`: prebuilt wasm module
+- `*.go`: automatically built with tinygo
 
 #### `list`
 

--- a/gadgets/trace_dns/build.yaml
+++ b/gadgets/trace_dns/build.yaml
@@ -1,0 +1,1 @@
+wasm: program.go

--- a/gadgets/trace_dns/go.mod
+++ b/gadgets/trace_dns/go.mod
@@ -1,0 +1,7 @@
+module main
+
+go 1.19
+
+require (
+	github.com/wapc/wapc-guest-tinygo v0.3.3
+)

--- a/gadgets/trace_dns/go.sum
+++ b/gadgets/trace_dns/go.sum
@@ -1,0 +1,2 @@
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/gadgets/trace_dns/program.go
+++ b/gadgets/trace_dns/program.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	wapc "github.com/wapc/wapc-guest-tinygo"
+)
+
+func main() {
+	wapc.RegisterFunctions(wapc.Functions{})
+}


### PR DESCRIPTION
# image build: add wasm

This PR adds the possibility to add a wasm module in a gadget image.

There are no changes in the CLI flags. This can be used by adding an entry in `build.yaml`:
```
wasm: program.go
```

The following file types are supported:
* `*.wasm`: pre-compiled wasm module
* `*.go`: Inspektor Gadget will compile it with tinygo

The wasm module is not executed. This will be for the next PRs.

## How to use

```
docker build -f Dockerfiles/ebpf-builder.Dockerfile -t ghcr.io/inspektor-gadget/ebpf-builder:alban_wasm2 .
sudo -E ig image build --builder-image=ghcr.io/inspektor-gadget/ebpf-builder:alban_wasm2 -t ghcr.io/inspektor-gadget/gadget/trace_dns:test gadgets/trace_dns/
sudo -E ig run ghcr.io/inspektor-gadget/gadget/trace_dns:test
```

## Testing done

As above.