### PR TITLE
run: Fix panic if no flags are provided

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -263,8 +263,8 @@ func buildCommandFromGadget(
 					if showHelp, _ := cmd.Flags().GetBool("help"); showHelp {
 						additionalMessage := "Specify the gadget image to get more information about it"
 						cmd.Long = fmt.Sprintf("%s\n\n%s", cmd.Short, additionalMessage)
-						return cmd.Help()
 					}
+					return cmd.Help()
 				}
 
 				var err error


### PR DESCRIPTION
Fix panic if no args are provided to `run`

```
→ go run -exec 'sudo -E' ./cmd/ig run
INFO[0000] Experimental features enabled                
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/run/tracer.(*GadgetDesc).GetGadgetInfo(0xc0008393e0?, 0x452c6b0?, {0x5d93d70, 0x0, 0x4?})
        /home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/run/tracer/run.go:86 +0x259
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).GetGadgetInfo(0x1ae6007?, {0x410b3b8?, 0x3992320?}, {0x452c6b0, 0x5d93d70}, 0x4?, {0x5d93d70, 0x0, 0x0})
        /home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local/local.go:90 +0x7c
github.com/inspektor-gadget/inspektor-gadget/cmd/common.buildCommandFromGadget.func2(0xc0003eef00, {0x5d93d70?, 0x1?, 0x0?})
        /home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/cmd/common/registry.go:271 +0x3f5
github.com/spf13/cobra.(*Command).execute(0xc0003eef00, {0x5d93d70, 0x0, 0x0})
        /home/qasim/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003ee300)
        /home/qasim/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/qasim/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
        /home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/cmd/ig/main.go:72 +0x239
exit status 2

```