### PR TITLE
Dockerfile: Remove 'gcc-multilib'

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -13,10 +13,9 @@ RUN git clone --branch ${LIBBPF_VERSION} --depth 1 https://github.com/libbpf/lib
 
 FROM golang:1.19
 ARG CLANG_LLVM_VERSION
-# gcc-multilib is needed for <asm/types.h>.
 # lsb-release wget software-properties-common gnupg are needed by llvm.sh script
 RUN apt-get update \
-	&& apt-get install -y gcc-multilib lsb-release wget software-properties-common gnupg
+	&& apt-get install -y lsb-release wget software-properties-common gnupg
 # install clang 15
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LLVM_VERSION \
 	&& update-alternatives --install /usr/local/bin/llvm-strip llvm-strip $(which llvm-strip-$CLANG_LLVM_VERSION) 100 \


### PR DESCRIPTION
It fixes following error while building image for arm64:

```
E: Package 'gcc-multilib' has no installation candidate
```
