### PR TITLE
pkg/columns/json: Implement FormatEntries()

### DIFF
--- a/pkg/columns/formatter/json/json_test.go
+++ b/pkg/columns/formatter/json/json_test.go
@@ -50,7 +50,7 @@ func TestJSONFormatter_FormatEntry(t *testing.T) {
 		`{"name": "Alice", "age": 32, "size": 1.74, "balance": 1000, "canDance": true}`,
 		`{"name": "Bob", "age": 26, "size": 1.73, "balance": -200, "canDance": true}`,
 		`{"name": "Eve", "age": 99, "size": 5.12, "balance": 1000000, "canDance": false}`,
-		``,
+		`null`,
 	}
 	formatter := NewFormatter(testColumns)
 	for i, entry := range testEntries {
@@ -81,12 +81,73 @@ func TestJSONFormatter_PrettyFormatEntry(t *testing.T) {
   "balance": 1000000,
   "canDance": false
 }`,
-		``,
+		`null`,
 	}
 	formatter := NewFormatter(testColumns, WithPrettyPrint())
 	for i, entry := range testEntries {
 		assert.Equal(t, expected[i], formatter.FormatEntry(entry))
 	}
+}
+
+func TestJSONFormatter_FormatEntries(t *testing.T) {
+	type testCase struct {
+		entries  []*testStruct
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"nil": {
+			entries:  nil,
+			expected: "null",
+		},
+		"empty": {
+			entries:  []*testStruct{},
+			expected: "[]",
+		},
+		"multiple": {
+			entries:  testEntries,
+			expected: `[{"name": "Alice", "age": 32, "size": 1.74, "balance": 1000, "canDance": true}, {"name": "Bob", "age": 26, "size": 1.73, "balance": -200, "canDance": true}, {"name": "Eve", "age": 99, "size": 5.12, "balance": 1000000, "canDance": false}, null]`,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			formatter := NewFormatter(testColumns)
+			assert.Equal(t, test.expected, formatter.FormatEntries(test.entries))
+		})
+	}
+}
+
+func TestJSONFormatter_PrettyFormatEntries(t *testing.T) {
+	expected := `[
+  {
+    "name": "Alice",
+    "age": 32,
+    "size": 1.74,
+    "balance": 1000,
+    "canDance": true
+  },
+  {
+    "name": "Bob",
+    "age": 26,
+    "size": 1.73,
+    "balance": -200,
+    "canDance": true
+  },
+  {
+    "name": "Eve",
+    "age": 99,
+    "size": 5.12,
+    "balance": 1000000,
+    "canDance": false
+  },
+  null
+]`
+
+	formatter := NewFormatter(testColumns, WithPrettyPrint())
+	assert.Equal(t, expected, formatter.FormatEntries(testEntries))
 }
 
 func BenchmarkFormatter(b *testing.B) {


### PR DESCRIPTION
    075f2b1e4fd9 ("pkg/columns: add json formatter") implemented a function
    to marshal a single entry to json using the columns information. This
    commit introduces a new function to marshal a slice of entries to a
    json array.
---

This was initially proposed in https://github.com/inspektor-gadget/inspektor-gadget/pull/1866, but since merging that PR is taking a bit long, I decided to extract some commits in a separated PR to help with the review process. 