### PR TITLE
containerd: Enrich events from new containers with imageDigest

### DIFF
--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -194,6 +194,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerImageDigest = ""
 
 				// Docker and CRI-O use a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in
@@ -374,6 +375,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 				e.Timestamp = ""
 
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -60,6 +60,7 @@ func TestTraceBind(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -81,6 +81,7 @@ func TestTraceCapabilities(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -307,6 +307,7 @@ func TestTraceDnsHost(t *testing.T) {
 				e.SrcIP = ""
 				e.SrcPort = 0
 				e.DstIP = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -93,6 +93,7 @@ func TestTraceExec(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -64,6 +64,7 @@ func TestTraceFsslower(t *testing.T) {
 				e.Latency = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -66,6 +66,7 @@ func TestTraceMount(t *testing.T) {
 				e.Fs = ""
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -61,6 +61,7 @@ func TestTraceOOMKill(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -65,6 +65,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Pid = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -59,6 +59,7 @@ func TestTraceSignal(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -59,6 +59,7 @@ func TestTraceSni(t *testing.T) {
 				e.Tid = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -73,6 +73,7 @@ func TestTraceTCP(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -72,6 +72,7 @@ func TestTraceTcpconnect(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {
@@ -148,6 +149,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				}
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -56,6 +56,7 @@ func TestFilterByContainerName(t *testing.T) {
 				c.Runtime.ContainerID = ""
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				c.Runtime.ContainerImageName = ""
+				c.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectAllInArrayToMatch(t, output, normalize, expectedContainer)
@@ -122,6 +123,7 @@ func TestWatchContainers(t *testing.T) {
 				e.Container.Runtime.ContainerID = ""
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Container.Runtime.ContainerImageName = ""
+				e.Container.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEvents...)

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -53,6 +53,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.Runtime.ContainerID = ""
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesInArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -136,6 +136,7 @@ func TestTraceDns(t *testing.T) {
 				e.Runtime.ContainerID = ""
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				e.SrcIP = ""
 				e.DstIP = ""

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -87,6 +87,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Runtime.ContainerID = ""
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -144,10 +144,11 @@ func (c *ContainerdClient) GetContainer(containerID string) (*runtimeclient.Cont
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
 			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:        container.ID(),
-				ContainerName:      getContainerName(container, labels),
-				RuntimeName:        types.RuntimeNameContainerd,
-				ContainerImageName: image.Name(),
+				ContainerID:          container.ID(),
+				ContainerName:        getContainerName(container, labels),
+				RuntimeName:          types.RuntimeNameContainerd,
+				ContainerImageName:   image.Name(),
+				ContainerImageDigest: image.Metadata().Target.Digest.String(),
 			},
 			State: runtimeclient.StateRunning,
 		},
@@ -279,8 +280,6 @@ func (c *ContainerdClient) taskAndContainerToContainerData(task *containerTask, 
 		return nil, fmt.Errorf("getting image of container %q: %w", container.ID(), err)
 	}
 
-	imageMetadata := image.Metadata()
-
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
 			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
@@ -288,7 +287,7 @@ func (c *ContainerdClient) taskAndContainerToContainerData(task *containerTask, 
 				ContainerName:        getContainerName(container, labels),
 				RuntimeName:          types.RuntimeNameContainerd,
 				ContainerImageName:   image.Name(),
-				ContainerImageDigest: imageMetadata.Target.Digest.String(),
+				ContainerImageDigest: image.Metadata().Target.Digest.String(),
 			},
 			State: task.status,
 		},

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -127,34 +127,7 @@ func (c *ContainerdClient) GetContainer(containerID string) (*runtimeclient.Cont
 		return nil, err
 	}
 
-	labels, err := container.Labels(c.ctx)
-	if err != nil {
-		return nil, fmt.Errorf("listing labels of container %q: %w", container.ID(), err)
-	}
-
-	image, err := container.Image(c.ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting image details %q: %w", container.ID(), err)
-	}
-
-	// State is getting set to `Running` here for the following reasons:
-	// 1. GetContainer is only getting called on new created containers
-	// 2. We would need to get the Task for the Container. containerd needs to aquire a mutex
-	//    that is currently hold by the creating process, which we interrupted -> deadlock
-	containerData := &runtimeclient.ContainerData{
-		Runtime: runtimeclient.RuntimeContainerData{
-			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:          container.ID(),
-				ContainerName:        getContainerName(container, labels),
-				RuntimeName:          types.RuntimeNameContainerd,
-				ContainerImageName:   image.Name(),
-				ContainerImageDigest: image.Metadata().Target.Digest.String(),
-			},
-			State: runtimeclient.StateRunning,
-		},
-	}
-	runtimeclient.EnrichWithK8sMetadata(containerData, labels)
-	return containerData, nil
+	return c.buildContainerData(container, nil)
 }
 
 func (c *ContainerdClient) GetContainerDetails(containerID string) (*runtimeclient.ContainerDetailsData, error) {
@@ -270,30 +243,7 @@ func (c *ContainerdClient) getContainerTask(container containerd.Container) (*co
 // Constructs a ContainerData from a containerTask and containerd.Container
 // The extra containerd.Container parameter saves an additional call to the API
 func (c *ContainerdClient) taskAndContainerToContainerData(task *containerTask, container containerd.Container) (*runtimeclient.ContainerData, error) {
-	labels, err := container.Labels(c.ctx)
-	if err != nil {
-		return nil, fmt.Errorf("listing labels of container %q: %w", container.ID(), err)
-	}
-
-	image, err := container.Image(c.ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting image of container %q: %w", container.ID(), err)
-	}
-
-	containerData := &runtimeclient.ContainerData{
-		Runtime: runtimeclient.RuntimeContainerData{
-			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:          container.ID(),
-				ContainerName:        getContainerName(container, labels),
-				RuntimeName:          types.RuntimeNameContainerd,
-				ContainerImageName:   image.Name(),
-				ContainerImageDigest: image.Metadata().Target.Digest.String(),
-			},
-			State: task.status,
-		},
-	}
-	runtimeclient.EnrichWithK8sMetadata(containerData, labels)
-	return containerData, nil
+	return c.buildContainerData(container, task)
 }
 
 // Checks if the K8s Label for the Containerkind equals to sandbox
@@ -333,4 +283,45 @@ func getContainerName(container containerd.Container, labels map[string]string) 
 	}
 
 	return container.ID()
+}
+
+// buildContainerData  retrieves and sets basic runtime metadata for a given container,
+// including its ID, name, runtime name, image name, and image digest. It also retrieves and sets
+// the container's state (which is set to "Running" by default, unless a container task is provided).
+func (c *ContainerdClient) buildContainerData(container containerd.Container, task *containerTask) (*runtimeclient.ContainerData, error) {
+	labels, err := container.Labels(c.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing labels of container %q: %w", container.ID(), err)
+	}
+
+	image, err := container.Image(c.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting image of container %q: %w", container.ID(), err)
+	}
+
+	// When `task` is nil, state is getting set to `Running` for the following reasons:
+	// 1. `buildContainerData` is called by `GetContainer`, which is only getting called on
+	//    new created containers
+	// 2. We would need to get the Task for the Container. containerd needs to acquire a mutex
+	//    that is currently hold by the creating process, which we interrupted -> deadlock
+	taskState := runtimeclient.StateRunning
+	if task != nil {
+		taskState = task.status
+	}
+
+	containerData := &runtimeclient.ContainerData{
+		Runtime: runtimeclient.RuntimeContainerData{
+			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+				ContainerID:          container.ID(),
+				ContainerName:        getContainerName(container, labels),
+				RuntimeName:          types.RuntimeNameContainerd,
+				ContainerImageName:   image.Name(),
+				ContainerImageDigest: image.Metadata().Target.Digest.String(),
+			},
+			State: taskState,
+		},
+	}
+	runtimeclient.EnrichWithK8sMetadata(containerData, labels)
+
+	return containerData, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -129,7 +129,8 @@ type BasicRuntimeMetadata struct {
 	ContainerImageName string `json:"containerImageName,omitempty" column:"containerImageName,hide"`
 
 	// ContainerImageDigest is the (repo) digest of the container image where the event comes from
-	// Only events of initial containers (cri-o and containerd) are enriched with image digest
+	// containerd: events from both initial and new containers are enriched
+	// crio: events from initial containers are enriched
 	ContainerImageDigest string `json:"containerImageDigest,omitempty" column:"containerImageDigest,hide"`
 }
 


### PR DESCRIPTION
# containerd: Enrich events from new containers with imageDigest

This PR adds `ContainerImageDigest` to events coming from new containerd containers.

It also partly implements #1911 by introducing `getBasicRuntimeMetadata` to remove code duplication in `GetContainer` and  `taskAndContainerToContainerData`.