### PR TITLE
run/types: Remove unused field

### DIFF
--- a/pkg/gadgets/run/types/types.go
+++ b/pkg/gadgets/run/types/types.go
@@ -41,8 +41,6 @@ type Event struct {
 
 	// Raw event sent by the ebpf program
 	RawData []byte `json:"raw_data,omitempty"`
-	// How to flatten this?
-	Data interface{} `json:"data"`
 }
 
 type GadgetInfo struct {


### PR DESCRIPTION
Remove this field to avoid confusion on the code.
