### PR TITLE
image: Use release image for ebpf-builder

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -261,7 +261,9 @@ jobs:
   build-ig:
     name: ig
     # level: 1
-    needs: btfgen
+    needs:
+      - btfgen
+      - build-helper-images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -297,7 +299,7 @@ jobs:
           sudo apt-get install qemu-user-static
         fi
 
-        make ig-linux-${{ matrix.platform }}
+        make EBPF_BUILDER=${{ needs.build-helper-images.outputs.ebpf_builder_image }} ig-linux-${{ matrix.platform }}
 
         # Prepare assets for release and actions artifacts
         mkdir ${{ matrix.platform }}
@@ -420,7 +422,9 @@ jobs:
   build-ig-container-images:
     name: ig img
     # level: 1
-    needs: btfgen
+    needs:
+      - btfgen
+      - build-helper-images
     runs-on: ubuntu-latest
     permissions:
       # allow publishing container image
@@ -487,6 +491,9 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}
+        build-args: |
+          VERSION=${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+          EBPF_BUILDER=${{ needs.build-helper-images.outputs.ebpf_builder_image }}
     - name: Publish ig ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
       uses: actions/upload-artifact@master
       with:
@@ -505,6 +512,9 @@ jobs:
         outputs: type=registry,name=${{ steps.set-repo-determine-image-tag.outputs.container-repo }},push=true,push-by-digest=true
         cache-from: type=local,src=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}
+        build-args: |
+          VERSION=${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+          EBPF_BUILDER=${{ needs.build-helper-images.outputs.ebpf_builder_image }}
     - name: Save ig ${{ matrix.os }} ${{ matrix.platform }} container image digest output
       id: published-ig-container-images
       if: github.event_name != 'pull_request'

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -8,6 +8,8 @@ ARG TARGETARCH
 ARG BUILDARCH
 ARG VERSION=undefined
 ENV VERSION=${VERSION}
+ARG EBPF_BUILDER=ghcr.io/inspektor-gadget/ebpf-builder:latest
+ENV EBPF_BUILDER=${EBPF_BUILDER}
 
 COPY go.mod go.sum /cache/
 RUN cd /cache && go mod download
@@ -16,7 +18,9 @@ ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget
 WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-		-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/cmd/common.version=${VERSION} -extldflags '-static'" \
+		-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/cmd/common.version=${VERSION} \
+                  -X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${EBPF_BUILDER} \
+                  -extldflags '-static'" \
 		-tags "netgo" \
 		-o ig-${TARGETOS}-${TARGETARCH} \
 		github.com/inspektor-gadget/inspektor-gadget/cmd/ig

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's
 # This version number must be kept in sync with CI workflow lint one.
 LINTER_VERSION ?= v1.49.0
 
-EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder
+EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
 
 DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
 
@@ -117,7 +117,7 @@ ig-%: phony_explicit
 			ARCH=$(subst linux-,,$*) BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ -j$(nproc); \
 	fi
 	docker buildx build --load --platform=$(subst -,/,$*) -t $@ -f Dockerfiles/ig.Dockerfile \
-		--build-arg VERSION=$(VERSION) .
+		--build-arg VERSION=$(VERSION) --build-arg EBPF_BUILDER=$(EBPF_BUILDER) .
 	docker create --name ig-$*-container $@
 	docker cp ig-$*-container:/usr/bin/ig $@
 	docker rm ig-$*-container

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -41,10 +41,12 @@ import (
 //go:embed Makefile.build
 var makefile []byte
 
+// It can be overridden at build time
+var builderImage = "ghcr.io/inspektor-gadget/ebpf-builder:latest"
+
 const (
-	DEFAULT_BUILDER_IMAGE = "ghcr.io/inspektor-gadget/ebpf-builder:latest"
-	DEFAULT_EBPF_SOURCE   = "program.bpf.c"
-	DEFAULT_METADATA      = "gadget.yaml"
+	DEFAULT_EBPF_SOURCE = "program.bpf.c"
+	DEFAULT_METADATA    = "gadget.yaml"
 )
 
 type buildFile struct {
@@ -71,7 +73,7 @@ func NewBuildCmd() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.local && opts.builderImage != DEFAULT_BUILDER_IMAGE {
+			if opts.local && opts.builderImage != builderImage {
 				return fmt.Errorf("--local and --builder-image cannot be used at the same time")
 			}
 
@@ -87,7 +89,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "build.yaml", "Path to build.yaml")
 	cmd.Flags().BoolVarP(&opts.local, "local", "l", false, "Build using local tools")
 	cmd.Flags().StringVarP(&opts.image, "tag", "t", "", "Name for the built image (format name:tag)")
-	cmd.Flags().StringVar(&opts.builderImage, "builder-image", DEFAULT_BUILDER_IMAGE, "Builder image to use")
+	cmd.Flags().StringVar(&opts.builderImage, "builder-image", builderImage, "Builder image to use")
 
 	return cmd
 }


### PR DESCRIPTION
As mentioned in the comment [here](https://github.com/inspektor-gadget/inspektor-gadget/pull/2135#pullrequestreview-1671244664), this PR will ensures that the `image build` command refers to versioned ebpf-builder for each release.

As per implementation, the `ebpf-builder` image name is only set for releases so it will keep using `DEFAULT_EBPF_BUILDER_IMAGE: ghcr.io/inspektor-gadget/ebpf-builder:latest` for all other cases.

## Testing done

- Did a [test release](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/6508344397) (v0.13.0) on the fork and [resulting binary](https://github.com/mqasimsarfraz/inspektor-gadget/suites/17192548593/artifacts/982522014) are showing the correction version:
```
→ sudo -E ./ig image build -h
INFO[0000] Experimental features enabled                
Build a gadget image

Usage:
  ig image build PATH [flags]

Flags:
      --builder-image string   Builder image to use (default "ghcr.io/mqasimsarfraz/ebpf-builder:v0.13.0")
  -f, --file string            Path to build.yaml (default "build.yaml")
  -h, --help                   help for build

```
