### PR TITLE
Makefile: Fix gadget tag calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_TAG ?= $(shell ./tools/image-tag branch)
 
 MINIKUBE ?= minikube
 KUBERNETES_DISTRIBUTION ?= ""
-GADGET_TAG ?= $(shell ../tools/image-tag branch)
+GADGET_TAG ?= $(shell ./tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 
 GOHOSTOS ?= $(shell go env GOHOSTOS)


### PR DESCRIPTION
Before this commit:

```
make: ../tools/image-tag: Command not found
KUBECTL_GADGET="/home/mvb/kinvolk/ebpf/inspektor-gadget/kubectl-gadget" \
	go test ./integration/inspektor-gadget/... \
		-v \
		-integration \
		-timeout 30m \
		-k8s-distro "" \
		-k8s-arch amd64 \
		-image ghcr.io/inspektor-gadget/inspektor-gadget:latest \
		-dnstester-image "ghcr.io/inspektor-gadget/dnstester:latest" \
		-gadget-repository ghcr.io/inspektor-gadget/gadget \
		-gadget-tag  \
		$INTEGRATION_TESTS_PARAMS
flag needs an argument: -gadget-tag
```

Fixes: 145f7570b1f9 ("gadgets: Build OCI images instead of objects")
