### PR TITLE
add insecure flag to run command

### DIFF
--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -76,6 +76,13 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			DefaultValue: "true",
 			TypeHint:     params.TypeBool,
 		},
+		{
+			Key:          "insecure",
+			Title:        "insecure",
+			Description:  "Allow connections to HTTP only registries",
+			DefaultValue: "false",
+			TypeHint:     params.TypeBool,
+		},
 	}
 }
 
@@ -86,6 +93,7 @@ func (g *GadgetDesc) Parser() parser.Parser {
 func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (*types.GadgetInfo, error) {
 	authOpts := &oci.AuthOptions{
 		AuthFile: params.Get("authfile").AsString(),
+		Insecure: params.Get("insecure").AsBool(),
 	}
 	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts)
 	if err != nil {


### PR DESCRIPTION
Fixes #2142 
# Add insecure flag to `run` command
This commit allows the `insecure` flag to be passed to the `run` command, which in turn, allows connections to HTTP-only registries.

## How to use
`./kubectl-gadget run 192.168.1.150:5000/gadget/foo:latest --insecure `

## Testing done
I ran `./kubectl-gadget run 192.168.1.150:5000/gadget/foo:latest` and did not get `Error: unknown flag: --insecure`