### PR TITLE
image: Add test for build/list/tag/push/pull/remove

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1019,6 +1019,23 @@ jobs:
 
         make ig-tests
 
+  test-components:
+    name: Test components
+    # level: 1
+    runs-on: ubuntu-latest
+    needs:
+      - build-helper-images
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+    - name: Run component tests
+      run: |
+        make EBPF_BUILDER=${{ needs.build-helper-images.outputs.ebpf_builder_image }} component-tests
+
   check-secrets:
     name: Check repo secrets
     # level: 0
@@ -1462,6 +1479,7 @@ jobs:
       - test-integration-minikube
       - test-integration-aks
       - test-integration-aro
+      - test-components
       - test-ig
       - test-integration-k8s-ig
       - test-integration-non-k8s-ig

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,11 @@ integration-tests: kubectl-gadget
 			-gadget-tag $(GADGET_TAG) \
 			$$INTEGRATION_TESTS_PARAMS
 
+
+.PHONY: component-tests
+component-tests:
+	go test -exec sudo -v ./integration/components/... -integration -timeout 5m --builder-image $(EBPF_BUILDER)
+
 .PHONY: generate-documentation
 generate-documentation:
 	go run -tags docs cmd/gen-doc/gen-doc.go -repo $(shell pwd)

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -88,7 +88,7 @@ func NewBuildCmd() *cobra.Command {
 
 			opts.path = args[0]
 
-			return runBuild(opts)
+			return runBuild(cmd, opts)
 		},
 	}
 
@@ -102,7 +102,7 @@ func NewBuildCmd() *cobra.Command {
 	return utils.MarkExperimental(cmd)
 }
 
-func runBuild(opts *cmdOpts) error {
+func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 	conf := &buildFile{
 		EBPFSource: DEFAULT_EBPF_SOURCE,
 		Wasm:       DEFAULT_WASM,
@@ -186,7 +186,7 @@ func runBuild(opts *cmdOpts) error {
 		return err
 	}
 
-	fmt.Printf("Successfully built %s\n", desc.String())
+	cmd.Printf("Successfully built %s\n", desc.String())
 
 	return nil
 }

--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -17,7 +17,6 @@ package image
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -52,7 +51,7 @@ func NewListCmd() *cobra.Command {
 				})
 			}
 			formatter := textcolumns.NewFormatter(cols.GetColumnMap())
-			formatter.WriteTable(os.Stdout, images)
+			formatter.WriteTable(cmd.OutOrStdout(), images)
 			return nil
 		},
 	}

--- a/cmd/common/image/pull.go
+++ b/cmd/common/image/pull.go
@@ -34,12 +34,12 @@ func NewPullCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			image := args[0]
 
-			fmt.Printf("Pulling %s...\n", image)
+			cmd.Printf("Pulling %s...\n", image)
 			desc, err := oci.PullGadgetImage(context.TODO(), image, &authOpts)
 			if err != nil {
 				return fmt.Errorf("pulling gadget: %w", err)
 			}
-			fmt.Printf("Successfully pulled %s\n", desc.String())
+			cmd.Printf("Successfully pulled %s\n", desc.String())
 			return nil
 		},
 	}

--- a/cmd/common/image/push.go
+++ b/cmd/common/image/push.go
@@ -34,12 +34,12 @@ func NewPushCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			image := args[0]
 
-			fmt.Printf("Pushing %s...\n", image)
+			cmd.Printf("Pushing %s...\n", image)
 			desc, err := oci.PushGadgetImage(context.TODO(), image, &authOpts)
 			if err != nil {
 				return fmt.Errorf("pushing gadget: %w", err)
 			}
-			fmt.Printf("Successfully pushed %s\n", desc.String())
+			cmd.Printf("Successfully pushed %s\n", desc.String())
 			return nil
 		},
 	}

--- a/cmd/common/image/remove.go
+++ b/cmd/common/image/remove.go
@@ -38,7 +38,7 @@ func NewRemoveCmd() *cobra.Command {
 				return fmt.Errorf("removing gadget image: %w", err)
 			}
 
-			fmt.Printf("Successfully removed %s\n", image)
+			cmd.Printf("Successfully removed %s\n", image)
 
 			return nil
 		},

--- a/cmd/common/image/tag.go
+++ b/cmd/common/image/tag.go
@@ -38,7 +38,7 @@ func NewTagCmd() *cobra.Command {
 				return fmt.Errorf("tagging image: %w", err)
 			}
 
-			fmt.Printf("Successfully tagged with %s\n", desc.String())
+			cmd.Printf("Successfully tagged with %s\n", desc.String())
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.5.0
 	github.com/docker/cli v24.0.7+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -90,7 +91,6 @@ require (
 	github.com/containers/storage v1.51.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect

--- a/integration/components/image/image_test.go
+++ b/integration/components/image/image_test.go
@@ -1,0 +1,216 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	commonImage "github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestImage(t *testing.T) {
+	// ensure that experimental is enabled
+	os.Setenv("IG_EXPERIMENTAL", "true")
+
+	// start registry
+	r := StartRegistry(t, "test-image-registry")
+	t.Cleanup(func() {
+		r.Stop(t)
+	})
+	if len(r.PortBindings()) == 0 || r.PortBindings()["5000/tcp"] == nil {
+		t.Fatal("registry port not exposed")
+	}
+	pb := r.PortBindings()["5000/tcp"][0]
+	registryAddr := fmt.Sprintf("%s:%s", pb.HostIP, pb.HostPort)
+
+	testReg := "reg.com"
+	testRepo := "repo1"
+	testTag := "tag1"
+	testLocalImage := fmt.Sprintf("%s/%s:%s", testReg, testRepo, testTag)
+	testRegistryImage := fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, testTag)
+
+	// ensure all images are removed
+	t.Cleanup(func() {
+		// remove local image
+		cmd := commonImage.NewRemoveCmd()
+		cmd.SetArgs([]string{testLocalImage})
+		cmd.Execute()
+
+		// remove registry image
+		cmd = commonImage.NewRemoveCmd()
+		cmd.SetArgs([]string{testRegistryImage})
+		cmd.Execute()
+	})
+
+	type testCase struct {
+		name           string
+		cmd            *cobra.Command
+		args           []string
+		expectedStdout []string
+		expectedStderr []string
+		negateExpected bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "build",
+			cmd:  commonImage.NewBuildCmd(),
+			args: []string{
+				"--builder-image", *testBuilderImage, "--tag", testLocalImage, "../../../gadgets/trace_open",
+			},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully built %s", testLocalImage),
+			},
+		},
+		{
+			name: "list",
+			cmd:  commonImage.NewListCmd(),
+			args: []string{},
+			expectedStdout: []string{
+				testRepo,
+				testTag,
+			},
+		},
+		{
+			name: "tag",
+			cmd:  commonImage.NewTagCmd(),
+			args: []string{testLocalImage, testRegistryImage},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully tagged with %s", testRegistryImage),
+			},
+		},
+		{
+			name: "push",
+			cmd:  commonImage.NewPushCmd(),
+			args: []string{testRegistryImage, "--insecure"},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully pushed %s", testRegistryImage),
+			},
+		},
+		{
+			name: "push-invalid-image",
+			cmd:  commonImage.NewPushCmd(),
+			args: []string{"unknown", "--insecure"},
+			expectedStderr: []string{
+				"failed to resolve ghcr.io/inspektor-gadget/gadget/unknown:latest: not found",
+			},
+		},
+		{
+			name: "push-unknown-tag",
+			cmd:  commonImage.NewPushCmd(),
+			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure"},
+			expectedStderr: []string{
+				fmt.Sprintf("%s/%s:%s: not found", registryAddr, testRepo, "unknown"),
+			},
+		},
+		{
+			name: "remove-local-image",
+			cmd:  commonImage.NewRemoveCmd(),
+			args: []string{testLocalImage},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully removed %s", testLocalImage),
+			},
+		},
+		{
+			name: "remove-registry-image",
+			cmd:  commonImage.NewRemoveCmd(),
+			args: []string{testRegistryImage},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully removed %s", testRegistryImage),
+			},
+		},
+		{
+			name:           "validate-remove",
+			cmd:            commonImage.NewListCmd(),
+			args:           []string{},
+			negateExpected: true,
+			// can't use combined repository here as REPOSITORY column can be truncated
+			expectedStdout: []string{
+				registryAddr,
+				testRepo,
+			},
+		},
+		{
+			name: "pull",
+			cmd:  commonImage.NewPullCmd(),
+			args: []string{testRegistryImage, "--insecure"},
+			expectedStdout: []string{
+				fmt.Sprintf("Successfully pulled %s", testRegistryImage),
+			},
+		},
+		{
+			name: "validate-pull",
+			cmd:  commonImage.NewListCmd(),
+			args: []string{},
+			expectedStdout: []string{
+				registryAddr,
+				testTag,
+			},
+		},
+		{
+			name: "pull-invalid-image",
+			cmd:  commonImage.NewPullCmd(),
+			args: []string{"unknown", "--insecure"},
+			expectedStderr: []string{
+				"failed to resolve ghcr.io/inspektor-gadget/gadget/unknown:latest",
+			},
+		},
+		{
+			name: "pull-unknown-tag",
+			cmd:  commonImage.NewPullCmd(),
+			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure"},
+			expectedStderr: []string{
+				fmt.Sprintf("%s/%s:%s: not found", registryAddr, testRepo, "unknown"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			tc.cmd.SetArgs(tc.args)
+			tc.cmd.SetOut(&stdout)
+			tc.cmd.SetErr(&stderr)
+			err := tc.cmd.Execute()
+			if len(tc.expectedStderr) > 0 {
+				require.NotNil(t, err)
+				for _, expected := range tc.expectedStderr {
+					if tc.negateExpected {
+						require.NotContains(t, stderr.String(), expected)
+						continue
+					}
+					require.Contains(t, stderr.String(), expected)
+				}
+				return
+			}
+			require.Nil(t, err)
+			require.Empty(t, stderr.String())
+			for _, expected := range tc.expectedStdout {
+				if tc.negateExpected {
+					require.NotContains(t, stdout.String(), expected)
+					continue
+				}
+				require.Contains(t, stdout.String(), expected)
+			}
+		})
+	}
+}

--- a/integration/components/image/integration_test.go
+++ b/integration/components/image/integration_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	integration      = flag.Bool("integration", false, "run integration tests")
+	testBuilderImage = flag.String("builder-image", "ghcr.io/inspektor-gadget/ebpf-builder:latest", "ebpf builder image")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if !*integration {
+		fmt.Println("Skipping image tests")
+		os.Exit(0)
+	}
+
+	fmt.Println("Running image tests")
+	os.Exit(m.Run())
+}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -23,10 +23,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -275,4 +277,18 @@ func GetIPVersion(t *testing.T, address string) uint8 {
 	}
 	t.Fatalf("Failed to determine IP version for address %s", address)
 	return 0
+}
+
+func StartRegistry(t *testing.T, name string) testutils.Container {
+	t.Helper()
+
+	c := testutils.NewDockerContainer(name, "registry serve /etc/docker/registry/config.yml",
+		testutils.WithImage("registry:2"),
+		testutils.WithoutWait(),
+		testutils.WithPortBindings(nat.PortMap{
+			"5000/tcp": []nat.PortBinding{{HostIP: "127.0.0.1"}},
+		}),
+	)
+	c.Start(t)
+	return c
 }

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -41,6 +41,18 @@ type Container interface {
 	Running() bool
 }
 
+func (c *containerSpec) ID() string {
+	return c.id
+}
+
+func (c *containerSpec) Pid() int {
+	return c.pid
+}
+
+func (c *containerSpec) Running() bool {
+	return c.started
+}
+
 var SupportedContainerRuntimes = []types.RuntimeName{
 	types.RuntimeNameDocker,
 	types.RuntimeNameContainerd,

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -27,9 +29,10 @@ type containerSpec struct {
 	options *containerOptions
 
 	// Internal state
-	id      string
-	pid     int
-	started bool
+	id           string
+	pid          int
+	started      bool
+	portBindings nat.PortMap
 }
 
 type Container interface {
@@ -39,6 +42,7 @@ type Container interface {
 	ID() string
 	Pid() int
 	Running() bool
+	PortBindings() nat.PortMap
 }
 
 func (c *containerSpec) ID() string {
@@ -51,6 +55,10 @@ func (c *containerSpec) Pid() int {
 
 func (c *containerSpec) Running() bool {
 	return c.started
+}
+
+func (c *containerSpec) PortBindings() nat.PortMap {
+	return c.portBindings
 }
 
 var SupportedContainerRuntimes = []types.RuntimeName{

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -107,6 +107,9 @@ func (c *ContainerdContainer) Run(t *testing.T) {
 	if c.options.seccompProfile != "" {
 		t.Fatalf("testutils/containerd: seccomp profiles are not supported yet")
 	}
+	if c.options.portBindings != nil {
+		t.Fatalf("testutils/containerd: Port bindings are not supported yet")
+	}
 
 	var spec specs.Spec
 	container, err := c.client.NewContainer(c.nsCtx, c.name,

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -57,18 +57,6 @@ type ContainerdContainer struct {
 	exitStatus <-chan containerd.ExitStatus
 }
 
-func (c *ContainerdContainer) Running() bool {
-	return c.started
-}
-
-func (c *ContainerdContainer) ID() string {
-	return c.id
-}
-
-func (c *ContainerdContainer) Pid() int {
-	return c.pid
-}
-
 func (c *ContainerdContainer) initClientAndCtx() error {
 	var err error
 	c.client, err = containerd.New("/run/containerd/containerd.sock",

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -73,6 +73,10 @@ func (d *DockerContainer) Run(t *testing.T) {
 		hostConfig.SecurityOpt = []string{fmt.Sprintf("seccomp=%s", d.options.seccompProfile)}
 	}
 
+	if d.options.portBindings != nil {
+		hostConfig.PortBindings = d.options.portBindings
+	}
+
 	resp, err := d.client.ContainerCreate(d.options.ctx, &container.Config{
 		Image: d.options.image,
 		Cmd:   []string{"/bin/sh", "-c", d.cmd},
@@ -101,6 +105,7 @@ func (d *DockerContainer) Run(t *testing.T) {
 		t.Fatalf("Failed to inspect container: %s", err)
 	}
 	d.pid = containerJSON.State.Pid
+	d.portBindings = containerJSON.NetworkSettings.Ports
 
 	if d.options.logs {
 		out, err := d.client.ContainerLogs(d.options.ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -46,18 +46,6 @@ type DockerContainer struct {
 	client *client.Client
 }
 
-func (d *DockerContainer) Running() bool {
-	return d.started
-}
-
-func (d *DockerContainer) ID() string {
-	return d.id
-}
-
-func (d *DockerContainer) Pid() int {
-	return d.pid
-}
-
 func (d *DockerContainer) initClient() error {
 	var err error
 	d.client, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -14,7 +14,11 @@
 
 package testutils
 
-import "context"
+import (
+	"context"
+
+	"github.com/docker/go-connections/nat"
+)
 
 const (
 	DefaultContainerImage    = "docker.io/library/busybox"
@@ -32,6 +36,7 @@ type containerOptions struct {
 	wait           bool
 	logs           bool
 	removal        bool
+	portBindings   nat.PortMap
 
 	// forceDelete is mostly used for debugging purposes, when a container
 	// fails to be deleted and we want to force it.
@@ -98,6 +103,13 @@ func WithoutLogs() Option {
 func withoutRemoval() Option {
 	return func(opts *containerOptions) {
 		opts.removal = false
+	}
+}
+
+// WithPortBindings sets the exposed ports of the container
+func WithPortBindings(portBindings nat.PortMap) Option {
+	return func(opts *containerOptions) {
+		opts.portBindings = portBindings
 	}
 }
 


### PR DESCRIPTION
Add tests for image commands, the idea is to start a local registry and test all the image operations against it. This change will also introduce the idea of `component-tests` to allow writing tests for specific components like image commands, hooks, etc. Having said that, the other idea was to be renaming the current integration tests as `e2e tests` and use `integration test` for these tests.

### Testing done

```bash
 → make component-tests 
go test -exec sudo -v ./integration/components/... -integration -timeout 5m
Running image tests
=== RUN   TestImage
    docker.go:117: Container "test-image-registry" output:
        �time="2023-12-08T14:35:18.641154534Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." go.version=go1.20.8 instance.id=f84391c9-343a-43d8-9996-92733eb5c815 service=registry version=2.8.3 
        �time="2023-12-08T14:35:18.641200598Z" level=info msg="redis not configured" go.version=go1.20.8 instance.id=f84391c9-343a-43d8-9996-92733eb5c815 service=registry version=2.8.3 
        �time="2023-12-08T14:35:18.641248704Z" level=info msg="Starting upload purge in 10m0s" go.version=go1.20.8 instance.id=f84391c9-343a-43d8-9996-92733eb5c815 service=registry version=2.8.3 
        �time="2023-12-08T14:35:18.641327322Z" level=info msg="using inmemory blob descriptor cache" go.version=go1.20.8 instance.id=f84391c9-343a-43d8-9996-92733eb5c815 service=registry version=2.8.3 
        �time="2023-12-08T14:35:18.641498751Z" level=info msg="listening on [::]:5000" go.version=go1.20.8 instance.id=f84391c9-343a-43d8-9996-92733eb5c815 service=registry version=2.8.3 
=== RUN   TestImage/build
=== RUN   TestImage/list
=== RUN   TestImage/tag
=== RUN   TestImage/push
--- PASS: TestImage (5.67s)
    --- PASS: TestImage/build (1.06s)
    --- PASS: TestImage/list (0.00s)
    --- PASS: TestImage/tag (0.00s)
    --- PASS: TestImage/push (0.11s)
PASS
ok      github.com/inspektor-gadget/inspektor-gadget/integration/components/image       5.703s

```

### Future work

- Support `image export/import` commands so we can decouple build test from rest of the tests. (or can put oci-store content in `testdata` and use it)
- Validate image manifest/descriptor for the built image e.g author information etc.
