### PR TITLE
cmd: Ignore unknown flags when parsing params early

### DIFF
--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
@@ -68,18 +69,12 @@ func main() {
 		// sure that --remote-address has already been parsed when calling
 		// InitDeployInfo(), so it can target the specified address
 
-		// Do not error out on unknown flags, but still validate currently
-		// known ones.
-		// Other flags will be validated in the `Execute()` call and unknown
-		// ones will be rejected
-		rootCmd.FParseErrWhitelist.UnknownFlags = true
-		err := rootCmd.ParseFlags(os.Args[1:])
+		err := commonutils.ParseEarlyFlags(rootCmd)
 		if err != nil {
 			// Analogous to cobra error message
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		rootCmd.FParseErrWhitelist.UnknownFlags = false
 		runtime.InitDeployInfo()
 	}
 

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +67,19 @@ func main() {
 		// evaluate flags early for runtimeGlobalFlags; this will make
 		// sure that --remote-address has already been parsed when calling
 		// InitDeployInfo(), so it can target the specified address
-		rootCmd.ParseFlags(os.Args[1:])
+
+		// Do not error out on unknown flags, but still validate currently
+		// known ones.
+		// Other flags will be validated in the `Execute()` call and unknown
+		// ones will be rejected
+		rootCmd.FParseErrWhitelist.UnknownFlags = true
+		err := rootCmd.ParseFlags(os.Args[1:])
+		if err != nil {
+			// Analogous to cobra error message
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		rootCmd.FParseErrWhitelist.UnknownFlags = false
 		runtime.InitDeployInfo()
 	}
 

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -78,7 +79,19 @@ func main() {
 		// evaluate flags early for runtimeGlobalFlags; this will make
 		// sure that --connection-method has already been parsed when calling
 		// InitDeployInfo()
-		rootCmd.ParseFlags(os.Args[1:])
+
+		// Do not error out on unknown flags, but still validate currently
+		// known ones.
+		// Other flags will be validated in the `Execute()` call and unknown
+		// ones will be rejected
+		rootCmd.FParseErrWhitelist.UnknownFlags = true
+		err := rootCmd.ParseFlags(os.Args[1:])
+		if err != nil {
+			// Analogous to cobra error message
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		rootCmd.FParseErrWhitelist.UnknownFlags = false
 		runtime.InitDeployInfo()
 	}
 

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/k8s"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -80,18 +81,12 @@ func main() {
 		// sure that --connection-method has already been parsed when calling
 		// InitDeployInfo()
 
-		// Do not error out on unknown flags, but still validate currently
-		// known ones.
-		// Other flags will be validated in the `Execute()` call and unknown
-		// ones will be rejected
-		rootCmd.FParseErrWhitelist.UnknownFlags = true
-		err := rootCmd.ParseFlags(os.Args[1:])
+		err := commonutils.ParseEarlyFlags(rootCmd)
 		if err != nil {
 			// Analogous to cobra error message
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		rootCmd.FParseErrWhitelist.UnknownFlags = false
 		runtime.InitDeployInfo()
 	}
 


### PR DESCRIPTION
When connecting to a server we need to have informations about the connection itself. That is why we parse the flags as early as possible. Even before we have all of them available, because the flags are derived from the servers information.

This commit enableds the option to ignore unknown flags on this early flag parsing, so we can get information on the connection flags without erroring out.

## Replicating the issue before this patch

Run `ig` in daemon mode in a terminal:
```bash
$ sudo -E ./ig daemon -H tcp://127.0.0.1:9999
```
Open a new terminal and do the following:
```bash
$ rm ~/.ig/info.json
$ ./gadgetctl top file --all-files --remote-address tcp://127.0.0.1:9999
WARN[0005] could not load gadget info from remote: dialing random target: dialing "unix:///var/run/ig/ig.socket" ("local"): dialing "unix:///var/run/ig/ig.socket" ("local"): context deadline exceeded 
Error: unknown command "top" for "gadgetctl"
Run 'gadgetctl --help' for usage.
```