### PR TITLE
image: Use empty descriptor if no metadata file is provided

### DIFF
--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	k8syaml "sigs.k8s.io/yaml"
@@ -110,7 +111,7 @@ func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (
 		return nil, err
 	}
 
-	if len(gadget.Metadata) == 0 {
+	if bytes.Equal(gadget.Metadata, ocispec.DescriptorEmptyJSON.Data) {
 		// metadata is not present. synthesize something on the fly from the spec
 		if err := ret.GadgetMetadata.Populate(spec); err != nil {
 			return nil, err

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -148,6 +148,16 @@ func createMetadataDesc(ctx context.Context, target oras.Target, metadataFilePat
 	return defDesc, nil
 }
 
+func createEmptyDesc(ctx context.Context, target oras.Target) (ocispec.Descriptor, error) {
+	emptyDesc := ocispec.DescriptorEmptyJSON
+	emptyDesc.ArtifactType = eBPFObjectMediaType
+	err := pushDescriptorIfNotExists(ctx, target, emptyDesc, bytes.NewReader(emptyDesc.Data))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing empty descriptor: %w", err)
+	}
+	return emptyDesc, nil
+}
+
 func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, progFilePath, arch string) (ocispec.Descriptor, error) {
 	progDesc, err := createEbpfProgramDesc(ctx, target, progFilePath)
 	if err != nil {
@@ -161,6 +171,12 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 		defDesc, err = createMetadataDesc(ctx, target, metadataFilePath)
 		if err != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("creating metadata descriptor: %w", err)
+		}
+	} else {
+		// Create an empty descriptor
+		defDesc, err = createEmptyDesc(ctx, target)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating empty descriptor: %w", err)
 		}
 	}
 


### PR DESCRIPTION
As mentioned in the artifact usage [1] of image spec, if we don't have config we should use an empty descriptor [2]. This should avoid running into issues when pushing the images to registry since most of them [don't support](https://github.com/opencontainers/image-spec/issues/1025) "no config" option.

[1] - https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage
[2] - https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidance-for-an-empty-descriptor

## Testing done

### running
```
→ sudo rm -rf /var/lib/ig
→ DIR=$(mktemp -d)
→ cp gadgets/trace_open/program.bpf.c $DIR
→ go run -exec "sudo -E" ./cmd/ig image build -t localhost:5000/trace_open:latest $DIR
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/trace_open:latest@sha256:a3088f32924f4a00f975c06310c0c125d39023d26fdff27844ca4cfadd6ac603
→ go run -exec "sudo -E" ./cmd/ig run localhost:5000/trace_open:latest 
...

```
### pushing
```
→ docker run --rm -d -p 5000:5000 --name registry registry:2
go run -exec "sudo -E" ./cmd/ig image push --insecure localhost:5000/trace_open:latest
```
### pushing (w/o empty descriptor)

```
→ go run -exec "sudo -E" ./cmd/ig image push --insecure localhost:5000/trace_open:latest 
INFO[0000] Experimental features enabled                
Pushing localhost:5000/trace_open:latest...
Error: pushing gadget: copying to remote repository: invalid reference
exit status 1

```
