### PR TITLE
run: Add pull policy `--pull` flag 

### DIFF
--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -46,6 +46,7 @@ const (
 	validateMetadataParam = "validate-metadata"
 	authfileParam         = "authfile"
 	insecureParam         = "insecure"
+	pullParam             = "pull"
 )
 
 type GadgetDesc struct{}
@@ -90,6 +91,18 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			DefaultValue: "false",
 			TypeHint:     params.TypeBool,
 		},
+		{
+			Key:          pullParam,
+			Title:        "Pull policy",
+			Description:  "Specify when the gadget image should be pulled",
+			DefaultValue: oci.PullImageMissing,
+			PossibleValues: []string{
+				oci.PullImageAlways,
+				oci.PullImageMissing,
+				oci.PullImageNever,
+			},
+			TypeHint: params.TypeString,
+		},
 	}
 }
 
@@ -102,7 +115,7 @@ func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (
 		AuthFile: params.Get(authfileParam).AsString(),
 		Insecure: params.Get(insecureParam).AsBool(),
 	}
-	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts)
+	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts, params.Get(pullParam).AsString())
 	if err != nil {
 		return nil, fmt.Errorf("getting gadget image: %w", err)
 	}

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -42,6 +42,12 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
 )
 
+const (
+	validateMetadataParam = "validate-metadata"
+	authfileParam         = "authfile"
+	insecureParam         = "insecure"
+)
+
 type GadgetDesc struct{}
 
 func (g *GadgetDesc) Name() string {
@@ -65,21 +71,21 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 	return params.ParamDescs{
 		// Hardcoded for now
 		{
-			Key:          "authfile",
+			Key:          authfileParam,
 			Title:        "Auth file",
 			DefaultValue: oci.DefaultAuthFile,
 			TypeHint:     params.TypeString,
 		},
 		{
-			Key:          types.ValidateMetadataParam,
+			Key:          validateMetadataParam,
 			Title:        "Validate metadata",
 			Description:  "Validate the gadget metadata before running the gadget",
 			DefaultValue: "true",
 			TypeHint:     params.TypeBool,
 		},
 		{
-			Key:          "insecure",
-			Title:        "insecure",
+			Key:          insecureParam,
+			Title:        "Insecure connection",
 			Description:  "Allow connections to HTTP only registries",
 			DefaultValue: "false",
 			TypeHint:     params.TypeBool,
@@ -93,8 +99,8 @@ func (g *GadgetDesc) Parser() parser.Parser {
 
 func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (*types.GadgetInfo, error) {
 	authOpts := &oci.AuthOptions{
-		AuthFile: params.Get("authfile").AsString(),
-		Insecure: params.Get("insecure").AsBool(),
+		AuthFile: params.Get(authfileParam).AsString(),
+		Insecure: params.Get(insecureParam).AsBool(),
 	}
 	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts)
 	if err != nil {
@@ -117,7 +123,7 @@ func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (
 			return nil, err
 		}
 	} else {
-		validate := params.Get(types.ValidateMetadataParam).AsBool()
+		validate := params.Get(validateMetadataParam).AsBool()
 
 		if err := yaml.Unmarshal(gadget.Metadata, &ret.GadgetMetadata); err != nil {
 			return nil, fmt.Errorf("unmarshaling metadata: %w", err)

--- a/pkg/gadgets/run/types/types.go
+++ b/pkg/gadgets/run/types/types.go
@@ -22,10 +22,6 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-const (
-	ValidateMetadataParam = "validate-metadata"
-)
-
 type L3Endpoint struct {
 	eventtypes.L3Endpoint
 	Name string

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -154,7 +154,7 @@ func pullIfNotExist(ctx context.Context, imageStore oras.Target, authOpts *AuthO
 	if err != nil {
 		return fmt.Errorf("creating remote repository: %w", err)
 	}
-	_, err = oras.Copy(ctx, repo, image, imageStore, image, oras.DefaultCopyOptions)
+	_, err = oras.Copy(ctx, repo, targetImage.String(), imageStore, targetImage.String(), oras.DefaultCopyOptions)
 	if err != nil {
 		return fmt.Errorf("downloading to local repository: %w", err)
 	}

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -105,44 +105,6 @@ func GetGadgetImage(ctx context.Context, image string, authOpts *AuthOptions) (*
 	}, nil
 }
 
-// GetEbpfObject pulls the gadget image and returns its eBPF object for the current architecture.
-func GetEbpfObject(ctx context.Context, image string, authOpts *AuthOptions) ([]byte, error) {
-	imageStore, err := getLocalOciStore()
-	if err != nil {
-		return nil, fmt.Errorf("getting local oci store: %w", err)
-	}
-
-	if err := pullIfNotExist(ctx, imageStore, authOpts, image); err != nil {
-		return nil, fmt.Errorf("pulling image %q: %w", image, err)
-	}
-
-	manifest, err := getImageManifestForArch(ctx, imageStore, image, authOpts)
-	if err != nil {
-		return nil, fmt.Errorf("getting arch manifest: %w", err)
-	}
-
-	return getEbpfProgramFromManifest(ctx, imageStore, manifest)
-}
-
-// GetMetadata pulls the gadget image and returns its metadata file.
-func GetMetadata(ctx context.Context, image string, authOpts *AuthOptions) ([]byte, error) {
-	imageStore, err := getLocalOciStore()
-	if err != nil {
-		return nil, fmt.Errorf("getting local oci store: %w", err)
-	}
-
-	if err := pullIfNotExist(ctx, imageStore, authOpts, image); err != nil {
-		return nil, fmt.Errorf("pulling image %q: %w", image, err)
-	}
-
-	manifest, err := getImageManifestForArch(ctx, imageStore, image, authOpts)
-	if err != nil {
-		return nil, fmt.Errorf("getting arch manifest: %w", err)
-	}
-
-	return getMetadataFromManifest(ctx, imageStore, manifest)
-}
-
 // PullGadgetImage pulls the gadget image and returns its descriptor.
 func PullGadgetImage(ctx context.Context, image string, authOpts *AuthOptions) (*GadgetImageDesc, error) {
 	ociStore, err := getLocalOciStore()


### PR DESCRIPTION
# run: Add pull policy `--pull` flag 

- `--pull missing` (default) only pulls the image when it is missing
- `--pull always` Pulls always
- `--pull never` Never pulls

The pull policy behavior is the same as Docker, but not the same as for K8s. For K8s in the default case the pull policy is missing, except when the `latest` tag is used. Then it is always pulling

Fixes #2101 
Slack Discussion: https://kubernetes.slack.com/archives/CSYL75LF6/p1697722813839619