### PR TITLE
gadgettracermanager: Make gRPC buffer size configurable.

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -103,6 +103,8 @@ spec:
               value: "/host"
             - name: IG_EXPERIMENTAL
               value: {{ .Values.config.experimental | quote }}
+            - name: EVENTS_BUFFER_LENGTH
+              value: {{ .Values.config.eventsBufferLength | quote }}
           securityContext:
             # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate
             # SELinux context [2] to be able to mount host directories with correct permissions.

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -10,7 +10,8 @@
         "containerdSocketPath",
         "crioSocketPath",
         "dockerSocketPath",
-        "experimental"
+        "experimental",
+        "eventsBufferLength"
       ],
       "properties": {
         "hookMode": {
@@ -38,6 +39,9 @@
         },
         "experimental": {
           "type": "boolean"
+        },
+        "eventsBufferLength": {
+          "type": "string"
         }
       }
     },

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -26,6 +26,9 @@ config:
   # -- Enable experimental features
   experimental: false
 
+  # -- Events buffer length. A low value could impact horizontal scaling.
+  eventsBufferLength: "16384"
+
 image:
   # -- Container repository for the container image
   repository: ghcr.io/inspektor-gadget/inspektor-gadget

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -84,6 +84,7 @@ var (
 	nodeSelector        string
 	experimentalVar     bool
 	skipSELinuxOpts     bool
+	eventBufferLength   uint64
 )
 
 var supportedHooks = []string{"auto", "crio", "podinformer", "nri", "fanotify", "fanotify+ebpf"}
@@ -162,6 +163,11 @@ func init() {
 		"skip-selinux-opts", "",
 		false,
 		"skip setting SELinux options on the gadget pod")
+	deployCmd.PersistentFlags().Uint64VarP(
+		&eventBufferLength,
+		"events-buffer-length", "",
+		16384,
+		"The events buffer length. A low value could impact horizontal scaling.")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -451,6 +457,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				case experimental.EnvName:
 					value := experimental.Enabled() || experimentalVar
 					gadgetContainer.Env[i].Value = strconv.FormatBool(value)
+				case "EVENTS_BUFFER_LENGTH":
+					gadgetContainer.Env[i].Value = strconv.FormatUint(eventBufferLength, 10)
 				}
 			}
 

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -313,7 +314,16 @@ func main() {
 			go startController(node, tracerManager)
 		}
 
-		service := gadgetservice.NewService(log.StandardLogger())
+		stringBufferLength := os.Getenv("EVENTS_BUFFER_LENGTH")
+		if stringBufferLength == "" {
+			log.Fatalf("Environment variable EVENTS_BUFFER_LENGTH not set")
+		}
+
+		bufferLength, err := strconv.ParseUint(stringBufferLength, 10, 64)
+		if err != nil {
+			log.Fatalf("Parsing EVENTS_BUFFER_LENGTH %q: %v", stringBufferLength, err)
+		}
+		service := gadgetservice.NewService(log.StandardLogger(), bufferLength)
 
 		socketType, socketPath, err := api.ParseSocketAddress(gadgetServiceHost)
 		if err != nil {

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -183,6 +183,8 @@ spec:
               value: "/host"
             - name: IG_EXPERIMENTAL
               value: "false"
+            - name: EVENTS_BUFFER_LENGTH
+              value: "16384"
           securityContext:
             # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate
             # SELinux context [2] to be able to mount host directories with correct permissions.


### PR DESCRIPTION
This commit adds flags and environment values to set gRPC buffer size rather than having it hardcoded.
The default value size is set to 16384 to improve horizontal scaling.