### PR TITLE
gadgets: Fix trace_dns and trace_tcpretrans failing to run

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -51,13 +51,13 @@ structs:
     - name: anaddr
       attributes:
         width: 16
-    - name: netns
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
+#    - name: netns
+#      description: 'TODO: Fill field description'
+#      attributes:
+#        width: 16
+#        alignment: left
+#        hidden: true
+#        ellipsis: end
     - name: tid
       description: 'TODO: Fill field description'
       attributes:

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -45,13 +45,13 @@ structs:
         width: 16
         alignment: left
         ellipsis: end
-    - name: netns
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
+#    - name: netns
+#      description: 'TODO: Fill field description'
+#      attributes:
+#        width: 16
+#        alignment: left
+#        hidden: true
+#        ellipsis: end
     - name: state
       description: 'TODO: Fill field description'
       attributes:

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -476,6 +476,11 @@ func (m *GadgetMetadata) populateStruct(btfStruct *btf.Struct) error {
 			continue
 		}
 
+		// TODO: temporary disable netns as it causes a duplicated column registration issue
+		if member.Name == "netns" {
+			continue
+		}
+
 		// check if field already exists
 		if _, ok := existingFields[member.Name]; ok {
 			log.Debugf("Field %q already exists, skipping", member.Name)


### PR DESCRIPTION
Gadgets were failing with the following error:

Error: calling custom parser: getting columns: adding fields: duplicate column name "netns"

This commit workaround that by disabling the netns column until a proper fix is implemented.


