### PR TITLE
run: Fix timestamp, mount and net ns columns

### DIFF
--- a/gadgets/snapshot_process/gadget.yaml
+++ b/gadgets/snapshot_process/gadget.yaml
@@ -30,6 +30,10 @@ structs:
       description: Group ID
       attributes:
         template: uid
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns
 ebpfParams:
   show_threads:
     key: threads

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -54,13 +54,14 @@ structs:
     - name: anaddr
       attributes:
         width: 16
-#    - name: netns
-#      description: 'TODO: Fill field description'
-#      attributes:
-#        width: 16
-#        alignment: left
-#        hidden: true
-#        ellipsis: end
+    - name: netns
+      description: 'Network namespace inode id'
+      attributes:
+        template: ns
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns
     - name: tid
       description: 'TODO: Fill field description'
       attributes:

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -7,6 +7,9 @@ tracers:
 structs:
   event_t:
     fields:
+    - name: timestamp
+      attributes:
+        template: timestamp
     - name: src
       description: Source endpoint
       attributes:

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -29,7 +29,7 @@
 #define MAX_ADDR_ANSWERS 1
 
 struct event_t {
-	__u64 timestamp;
+	gadget_timestamp timestamp;
 
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -66,6 +66,10 @@ structs:
         alignment: left
         hidden: true
         ellipsis: end
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns
 ebpfParams:
   ignore_failed:
     key: ignore-failed

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -7,6 +7,9 @@ tracers:
 structs:
   event:
     fields:
+    - name: timestamp
+      attributes:
+        template: timestamp
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -22,7 +22,7 @@
 
 struct event {
 	gadget_mntns_id mntns_id;
-	__u64 timestamp;
+	gadget_timestamp timestamp;
 	__u32 pid;
 	__u32 ppid;
 	__u32 uid;

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -7,6 +7,9 @@ tracers:
 structs:
   event:
     fields:
+    - name: timestamp
+      attributes:
+        template: timestamp
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -40,6 +40,10 @@ structs:
       attributes:
         width: 32
         minWidth: 24
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns
 ebpfParams:
   targ_failed:
     key: failed

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -21,7 +21,7 @@ struct args_t {
 };
 
 struct event {
-	__u64 timestamp;
+	gadget_timestamp timestamp;
 	/* user terminology for pid: */
 	__u32 pid;
 	__u32 uid;

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -7,6 +7,9 @@ tracers:
 structs:
   event:
     fields:
+    - name: timestamp
+      attributes:
+        template: timestamp
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -37,3 +37,7 @@ structs:
         alignment: left
         ellipsis: end
         hidden: true
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -37,7 +37,7 @@ struct event {
 	struct gadget_l4endpoint_t dst;
 
 	__u8 task[TASK_COMM_LEN];
-	__u64 timestamp;
+	gadget_timestamp timestamp;
 	__u32 pid;
 	__u32 uid;
 	__u32 gid;

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -48,13 +48,14 @@ structs:
         width: 16
         alignment: left
         ellipsis: end
-#    - name: netns
-#      description: 'TODO: Fill field description'
-#      attributes:
-#        width: 16
-#        alignment: left
-#        hidden: true
-#        ellipsis: end
+    - name: netns
+      description: 'Network namespace inode id'
+      attributes:
+        template: ns
+    - name: mntns_id
+      description: 'Mount namespace inode id'
+      attributes:
+        template: ns
     - name: state
       description: 'TODO: Fill field description'
       attributes:

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -7,6 +7,9 @@ tracers:
 structs:
   event:
     fields:
+    - name: timestamp
+      attributes:
+        template: timestamp
     - name: src
       attributes:
         minWidth: 24

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -29,7 +29,7 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	__u64 timestamp;
+	gadget_timestamp timestamp;
 	__u8 state;
 	__u8 tcpflags;
 	__u32 reason;

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -28,4 +28,10 @@ struct gadget_l4endpoint_t {
 // Inode id of a mount namespace. It's used to enrich the event in user space
 typedef __u64 gadget_mntns_id;
 
+// gadget_timestamp is a type that represents the nanoseconds since the system boot. Gadgets can use
+// this type to provide a timestamp. The value contained must be the one returned by
+// bpf_ktime_get_boot_ns() and it's automatically converted by Inspektor Gadget to a human friendly
+// time.
+typedef __u64 gadget_timestamp;
+
 #endif /* __TYPES_H */

--- a/integration/inspektor-gadget/run_snapshot_process_test.go
+++ b/integration/inspektor-gadget/run_snapshot_process_test.go
@@ -52,7 +52,7 @@ func TestRunSnapshotProcess(t *testing.T) {
 			StartAndStop: true,
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-					Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				})
 
 				expectedSnapshotProcessJsonObj := map[string]interface{}{
@@ -67,7 +67,6 @@ func TestRunSnapshotProcess(t *testing.T) {
 				expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedSnapshotProcessJsonObj)
 
 				normalize := func(m map[string]interface{}) {
-					SetEventTimestamp(m, 0)
 					SetEventMountNsID(m, 0)
 
 					SetEventK8sNode(m, "")

--- a/integration/inspektor-gadget/run_snapshot_process_test.go
+++ b/integration/inspektor-gadget/run_snapshot_process_test.go
@@ -56,19 +56,18 @@ func TestRunSnapshotProcess(t *testing.T) {
 				})
 
 				expectedSnapshotProcessJsonObj := map[string]interface{}{
-					"comm": "nc",
-					"uid":  0,
-					"gid":  0,
-					"pid":  0,
-					"tid":  0,
-					"ppid": 0,
+					"comm":     "nc",
+					"uid":      0,
+					"gid":      0,
+					"pid":      0,
+					"tid":      0,
+					"ppid":     0,
+					"mntns_id": 0,
 				}
 
 				expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedSnapshotProcessJsonObj)
 
 				normalize := func(m map[string]interface{}) {
-					SetEventMountNsID(m, 0)
-
 					SetEventK8sNode(m, "")
 
 					// TODO: Verify container runtime and container name
@@ -76,6 +75,7 @@ func TestRunSnapshotProcess(t *testing.T) {
 					SetEventRuntimeContainerID(m, "")
 					SetEventRuntimeContainerName(m, "")
 
+					m["mntns_id"] = 0
 					m["pid"] = uint32(0)
 					m["tid"] = uint32(0)
 					m["ppid"] = uint32(0)

--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -37,24 +37,24 @@ func TestRunTraceOpen(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceOpenJsonObj := map[string]interface{}{
-				"comm":  "cat",
-				"fname": "/dev/null",
-				"uid":   1000,
-				"gid":   1111,
-				"ret":   3,
-				"flags": 0,
-				"pid":   0,
-				"mode":  0,
+				"comm":      "cat",
+				"fname":     "/dev/null",
+				"uid":       1000,
+				"gid":       1111,
+				"ret":       3,
+				"flags":     0,
+				"pid":       0,
+				"mode":      0,
+				"timestamp": "",
 			}
 
 			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceOpenJsonObj)
 
 			normalize := func(m map[string]interface{}) {
-				SetEventTimestamp(m, 0)
 				SetEventMountNsID(m, 0)
 
 				SetEventK8sNode(m, "")
@@ -64,6 +64,7 @@ func TestRunTraceOpen(t *testing.T) {
 				SetEventRuntimeContainerID(m, "")
 				SetEventRuntimeContainerName(m, "")
 
+				m["timestamp"] = ""
 				m["pid"] = uint32(0)
 			}
 

--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -49,14 +49,13 @@ func TestRunTraceOpen(t *testing.T) {
 				"flags":     0,
 				"pid":       0,
 				"mode":      0,
+				"mntns_id":  0,
 				"timestamp": "",
 			}
 
 			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceOpenJsonObj)
 
 			normalize := func(m map[string]interface{}) {
-				SetEventMountNsID(m, 0)
-
 				SetEventK8sNode(m, "")
 
 				// TODO: Verify container runtime and container name
@@ -65,6 +64,7 @@ func TestRunTraceOpen(t *testing.T) {
 				SetEventRuntimeContainerName(m, "")
 
 				m["timestamp"] = ""
+				m["mntns_id"] = 0
 				m["pid"] = uint32(0)
 			}
 

--- a/integration/run_helpers.go
+++ b/integration/run_helpers.go
@@ -29,10 +29,6 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-func SetEventTimestamp(jsonObj map[string]interface{}, timestamp eventtypes.Time) {
-	jsonObj["timestamp"] = timestamp.String()
-}
-
 func SetEventMountNsID(jsonObj map[string]interface{}, mountNsID uint64) {
 	jsonObj["mntns"] = mountNsID
 }

--- a/integration/run_helpers.go
+++ b/integration/run_helpers.go
@@ -29,10 +29,6 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-func SetEventMountNsID(jsonObj map[string]interface{}, mountNsID uint64) {
-	jsonObj["mntns"] = mountNsID
-}
-
 func SetEventRuntimeName(jsonObj map[string]interface{}, runtimeName eventtypes.RuntimeName) {
 	if runtimeMetadata := jsonObj["runtime"].(map[string]interface{}); runtimeMetadata != nil {
 		runtimeMetadata["runtimeName"] = runtimeName

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -470,50 +470,47 @@ func (g *GadgetDesc) getColumns(info *types.GadgetInfo) (*columns.Columns[types.
 		attrs := field2ColumnAttrs(&field)
 		attrs.Order = 1000 + i
 
-		switch typedMember := member.Type.(type) {
-		case *btf.Struct:
-			switch typedMember.Name {
-			case types.L3EndpointTypeName:
-				// Take the value here, otherwise it'll use the wrong value after
-				// it's increased
-				index := l3endpointCounter
-				// Add the column that is enriched
-				eventtypes.MustAddVirtualL3EndpointColumn(cols, attrs, func(e *types.Event) eventtypes.L3Endpoint {
-					if len(e.L3Endpoints) == 0 {
-						return eventtypes.L3Endpoint{}
-					}
-					return e.L3Endpoints[index].L3Endpoint
-				})
-				// Add a single column for each field in the endpoint
-				addL3EndpointColumns(cols, member.Name, func(e *types.Event) eventtypes.L3Endpoint {
-					if len(e.L3Endpoints) == 0 {
-						return eventtypes.L3Endpoint{}
-					}
-					return e.L3Endpoints[index].L3Endpoint
-				})
-				l3endpointCounter++
-				continue
-			case types.L4EndpointTypeName:
-				// Take the value here, otherwise it'll use the wrong value after
-				// it's increased
-				index := l4endpointCounter
-				// Add the column that is enriched
-				eventtypes.MustAddVirtualL4EndpointColumn(cols, attrs, func(e *types.Event) eventtypes.L4Endpoint {
-					if len(e.L4Endpoints) == 0 {
-						return eventtypes.L4Endpoint{}
-					}
-					return e.L4Endpoints[index].L4Endpoint
-				})
-				// Add a single column for each field in the endpoint
-				addL4EndpointColumns(cols, member.Name, func(e *types.Event) eventtypes.L4Endpoint {
-					if len(e.L4Endpoints) == 0 {
-						return eventtypes.L4Endpoint{}
-					}
-					return e.L4Endpoints[index].L4Endpoint
-				})
-				l4endpointCounter++
-				continue
-			}
+		switch member.Type.TypeName() {
+		case types.L3EndpointTypeName:
+			// Take the value here, otherwise it'll use the wrong value after
+			// it's increased
+			index := l3endpointCounter
+			// Add the column that is enriched
+			eventtypes.MustAddVirtualL3EndpointColumn(cols, attrs, func(e *types.Event) eventtypes.L3Endpoint {
+				if len(e.L3Endpoints) == 0 {
+					return eventtypes.L3Endpoint{}
+				}
+				return e.L3Endpoints[index].L3Endpoint
+			})
+			// Add a single column for each field in the endpoint
+			addL3EndpointColumns(cols, member.Name, func(e *types.Event) eventtypes.L3Endpoint {
+				if len(e.L3Endpoints) == 0 {
+					return eventtypes.L3Endpoint{}
+				}
+				return e.L3Endpoints[index].L3Endpoint
+			})
+			l3endpointCounter++
+			continue
+		case types.L4EndpointTypeName:
+			// Take the value here, otherwise it'll use the wrong value after
+			// it's increased
+			index := l4endpointCounter
+			// Add the column that is enriched
+			eventtypes.MustAddVirtualL4EndpointColumn(cols, attrs, func(e *types.Event) eventtypes.L4Endpoint {
+				if len(e.L4Endpoints) == 0 {
+					return eventtypes.L4Endpoint{}
+				}
+				return e.L4Endpoints[index].L4Endpoint
+			})
+			// Add a single column for each field in the endpoint
+			addL4EndpointColumns(cols, member.Name, func(e *types.Event) eventtypes.L4Endpoint {
+				if len(e.L4Endpoints) == 0 {
+					return eventtypes.L4Endpoint{}
+				}
+				return e.L4Endpoints[index].L4Endpoint
+			})
+			l4endpointCounter++
+			continue
 		}
 
 		rType := getType(member.Type)

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -463,6 +463,7 @@ func (g *GadgetDesc) getColumns(info *types.GadgetInfo) (*columns.Columns[types.
 
 	l3endpointCounter := 0
 	l4endpointCounter := 0
+	timestampsCounter := 0
 
 	for i, field := range eventStruct.Fields {
 		member := members[field.Name]
@@ -510,6 +511,21 @@ func (g *GadgetDesc) getColumns(info *types.GadgetInfo) (*columns.Columns[types.
 				return e.L4Endpoints[index].L4Endpoint
 			})
 			l4endpointCounter++
+			continue
+		case types.TimestampTypeName:
+			// Take the value here, otherwise it'll use the wrong value after
+			// it's increased
+			index := timestampsCounter
+			err := cols.AddColumn(attrs, func(e *types.Event) any {
+				if len(e.Timestamps) == 0 {
+					return ""
+				}
+				return e.Timestamps[index].String()
+			})
+			if err != nil {
+				return nil, fmt.Errorf("adding timestamp column: %w", err)
+			}
+			timestampsCounter++
 			continue
 		}
 

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -390,10 +390,10 @@ func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []b
 	}
 
 	return func(data []byte) *types.Event {
-		// get mnt_ns_id for enriching the event
-		mtn_ns_id := uint64(0)
+		// get mntNsId for enriching the event
+		mntNsId := uint64(0)
 		if mountNsIdFound {
-			mtn_ns_id = *(*uint64)(unsafe.Pointer(&data[mntNsIdstart]))
+			mntNsId = *(*uint64)(unsafe.Pointer(&data[mntNsIdstart]))
 		}
 
 		// enrich endpoints
@@ -409,7 +409,7 @@ func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []b
 			case 6:
 				size = 16
 			default:
-				gadgetCtx.Logger().Warnf("bad IP version received: %d", endpointC.version)
+				logger.Warnf("bad IP version received: %d", endpointC.version)
 				continue
 			}
 
@@ -451,12 +451,12 @@ func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []b
 		}
 
 		return &types.Event{
-			Type:          eventtypes.NORMAL,
-			WithMountNsID: eventtypes.WithMountNsID{MountNsID: mtn_ns_id},
-			RawData:       data,
-			L3Endpoints:   l3endpoints,
-			L4Endpoints:   l4endpoints,
-			Timestamps:    timestamps,
+			Type:        eventtypes.NORMAL,
+			MountNsID:   mntNsId,
+			RawData:     data,
+			L3Endpoints: l3endpoints,
+			L4Endpoints: l4endpoints,
+			Timestamps:  timestamps,
 		}
 	}
 }

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -292,10 +292,34 @@ func (t *Tracer) installTracer(params *params.Params) error {
 	return nil
 }
 
+func verifyGadgetUint64Typedef(t btf.Type) error {
+	typDef, ok := t.(*btf.Typedef)
+	if !ok {
+		return fmt.Errorf("not a typedef")
+	}
+
+	underlying, err := getUnderlyingType(typDef)
+	if err != nil {
+		return err
+	}
+
+	intM, ok := underlying.(*btf.Int)
+	if !ok {
+		return fmt.Errorf("not an integer")
+	}
+
+	if intM.Size != 8 {
+		return fmt.Errorf("bad sized. Expected 8, got %d", intM.Size)
+	}
+
+	return nil
+}
+
 // processEventFunc returns a callback that parses a binary encoded event in data, enriches and
 // returns it.
 func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []byte) *types.Event {
 	typ := t.eventType
+	logger := gadgetCtx.Logger()
 
 	var mntNsIdstart uint32
 	mountNsIdFound := false
@@ -321,35 +345,22 @@ func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []b
 	for _, member := range typ.Members {
 		switch member.Type.TypeName() {
 		case types.MntNsIdTypeName:
-			typDef, ok := member.Type.(*btf.Typedef)
-			if !ok {
+			if err := verifyGadgetUint64Typedef(member.Type); err != nil {
+				logger.Warn("%s is not a uint64: %s", member.Name, err)
 				continue
 			}
-
-			underlying, err := getUnderlyingType(typDef)
-			if err != nil {
-				continue
-			}
-
-			intM, ok := underlying.(*btf.Int)
-			if !ok {
-				continue
-			}
-
-			if intM.Size != 8 {
-				continue
-			}
-
 			mntNsIdstart = member.Offset.Bytes()
 			mountNsIdFound = true
 		case types.L3EndpointTypeName:
 			typ, ok := member.Type.(*btf.Struct)
 			if !ok {
-				gadgetCtx.Logger().Warn("%s is not a struct", member.Name)
+				logger.Warn("%s is not a struct", member.Name)
 				continue
 			}
-			if typ.Size != uint32(unsafe.Sizeof(l3EndpointT{})) {
-				gadgetCtx.Logger().Warn("%s is not the expected size", member.Name)
+			expectedSize := uint32(unsafe.Sizeof(l3EndpointT{}))
+			if typ.Size != expectedSize {
+				logger.Warn("%s has a wrong size, expected %d, got %d", member.Name,
+					expectedSize, typ.Size)
 				continue
 			}
 			e := endpointDef{name: member.Name, start: member.Offset.Bytes(), typ: L3}
@@ -357,11 +368,13 @@ func (t *Tracer) processEventFunc(gadgetCtx gadgets.GadgetContext) func(data []b
 		case types.L4EndpointTypeName:
 			typ, ok := member.Type.(*btf.Struct)
 			if !ok {
-				gadgetCtx.Logger().Warn("%s is not a struct", member.Name)
+				logger.Warn("%s is not a struct", member.Name)
 				continue
 			}
-			if typ.Size != uint32(unsafe.Sizeof(l4EndpointT{})) {
-				gadgetCtx.Logger().Warn("%s is not the expected size", member.Name)
+			expectedSize := uint32(unsafe.Sizeof(l4EndpointT{}))
+			if typ.Size != expectedSize {
+				logger.Warn("%s has a wrong size, expected %d, got %d", member.Name,
+					expectedSize, typ.Size)
 				continue
 			}
 			e := endpointDef{name: member.Name, start: member.Offset.Bytes(), typ: L4}

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -50,6 +50,9 @@ const (
 
 	// Name of the type to store a mount namespace inode id
 	MntNsIdTypeName = "gadget_mntns_id"
+
+	// Name of the type to store a timestamp
+	TimestampTypeName = "gadget_timestamp"
 )
 
 type EBPFParam struct {
@@ -477,11 +480,6 @@ func (m *GadgetMetadata) populateStruct(btfStruct *btf.Struct) error {
 	}
 
 	for _, member := range btfStruct.Members {
-		// skip some specific members
-		if member.Name == "timestamp" {
-			log.Debug("Ignoring timestamp field: see https://github.com/inspektor-gadget/inspektor-gadget/issues/2000")
-			continue
-		}
 		// TODO: temporary disable mount ns as it'll be duplicated otherwise
 		if member.Type.TypeName() == MntNsIdTypeName {
 			continue

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -480,16 +480,6 @@ func (m *GadgetMetadata) populateStruct(btfStruct *btf.Struct) error {
 	}
 
 	for _, member := range btfStruct.Members {
-		// TODO: temporary disable mount ns as it'll be duplicated otherwise
-		if member.Type.TypeName() == MntNsIdTypeName {
-			continue
-		}
-
-		// TODO: temporary disable netns as it causes a duplicated column registration issue
-		if member.Name == "netns" {
-			continue
-		}
-
 		// check if field already exists
 		if _, ok := existingFields[member.Name]; ok {
 			log.Debugf("Field %q already exists, skipping", member.Name)

--- a/pkg/gadgets/run/types/types.go
+++ b/pkg/gadgets/run/types/types.go
@@ -43,21 +43,23 @@ type Event struct {
 	// Message when Type is ERR, WARN, DEBUG or INFO
 	Message string `json:"message,omitempty"`
 
-	eventtypes.WithMountNsID
-	eventtypes.WithNetNsID
-
 	L3Endpoints []L3Endpoint      `json:"l3endpoints,omitempty"`
 	L4Endpoints []L4Endpoint      `json:"l4endpoints,omitempty"`
 	Timestamps  []eventtypes.Time `json:"timestamps,omitempty"`
+
+	MountNsID uint64 `json:"-"`
+	NetNsID   uint64 `json:"-"`
 
 	// Raw event sent by the ebpf program
 	RawData []byte `json:"raw_data,omitempty"`
 }
 
-type GadgetInfo struct {
-	GadgetMetadata *GadgetMetadata
-	ProgContent    []byte
-	GadgetType     gadgets.GadgetType
+func (ev *Event) GetMountNSID() uint64 {
+	return ev.MountNsID
+}
+
+func (ev *Event) GetNetNSID() uint64 {
+	return ev.NetNsID
 }
 
 func (ev *Event) GetEndpoints() []*eventtypes.L3Endpoint {
@@ -81,6 +83,12 @@ func GetColumns() *columns.Columns[Event] {
 type Printer interface {
 	Output(payload string)
 	Logf(severity logger.Level, fmt string, params ...any)
+}
+
+type GadgetInfo struct {
+	GadgetMetadata *GadgetMetadata
+	ProgContent    []byte
+	GadgetType     gadgets.GadgetType
 }
 
 // RunGadgetDesc represents the different methods implemented by the run gadget descriptor.

--- a/pkg/gadgets/run/types/types.go
+++ b/pkg/gadgets/run/types/types.go
@@ -34,12 +34,21 @@ type L4Endpoint struct {
 }
 
 type Event struct {
-	eventtypes.Event
+	// Do not use eventtypes.Event because we don't want to have the timestamp column.
+	eventtypes.CommonData
+
+	// Type indicates the kind of this event
+	Type eventtypes.EventType `json:"type"`
+
+	// Message when Type is ERR, WARN, DEBUG or INFO
+	Message string `json:"message,omitempty"`
+
 	eventtypes.WithMountNsID
 	eventtypes.WithNetNsID
 
-	L3Endpoints []L3Endpoint `json:"l3endpoints,omitempty"`
-	L4Endpoints []L4Endpoint `json:"l4endpoints,omitempty"`
+	L3Endpoints []L3Endpoint      `json:"l3endpoints,omitempty"`
+	L4Endpoints []L4Endpoint      `json:"l4endpoints,omitempty"`
+	Timestamps  []eventtypes.Time `json:"timestamps,omitempty"`
 
 	// Raw event sent by the ebpf program
 	RawData []byte `json:"raw_data,omitempty"`
@@ -66,12 +75,6 @@ func (ev *Event) GetEndpoints() []*eventtypes.L3Endpoint {
 
 func GetColumns() *columns.Columns[Event] {
 	return columns.MustCreateColumns[Event]()
-}
-
-func Base(ev eventtypes.Event) *Event {
-	return &Event{
-		Event: ev,
-	}
 }
 
 // Printer is implemented by objects that can print information, like frontends.


### PR DESCRIPTION
This PR fixes different issues with those columns. Please check each commit to have more details.

### How to test

Compile and run the trace_exec gadget, now the timestmap and mount ns id columns are present and have the right value:

```bash
$ sudo -E ig run exec -o columns=+timestamp,-uid,-gid,+mntns_id
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME              PID                PPID               COMM             RETVAL             TIMESTAMP                           MNTNS_ID     
blissful_payne                     361269             301887             wget             0                  2023-10-30T17:29:22.226031553-05:00 4026536859   
blissful_payne                     361272             301887             wget             0                  2023-10-30T17:29:22.856169737-05:00 4026536859   
minikube                           361274             90110              runc             0                  2023-10-30T17:29:23.434730080-05:00 4026535434   
minikube                           361280             90110              docker-init      0                  2023-10-30T17:29:23.439138617-05:00 4026535434   
minikube                           361281             90110              runc             0                  2023-10-30T17:29:23.712409860-05:00 4026535434   
minikube                           361287             90110              docker-init      0                  2023-10-30T17:29:23.716652975-05:00 4026535434
```

(The same applies for the netns column in the trace dns and trace tcpretrans gadgets)

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/2000