### PR TITLE
ig: Fix host.Init() workaround flags

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/ig/containers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -57,6 +59,15 @@ func main() {
 		containers.NewListContainersCmd(),
 		common.NewVersionCmd(),
 	)
+
+	// evaluate flags early; this will make sure that flags for host are evaluated before
+	// calling host.Init()
+	err := commonutils.ParseEarlyFlags(rootCmd)
+	if err != nil {
+		// Analogous to cobra error message
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	runtime := local.New()
 	hiddenColumnTags := []string{"kubernetes"}


### PR DESCRIPTION
Use ParseEarlyFlags() on main to be sure flags from the host package are parsed when host.Init() is called.

### How to test

Deploy https://github.com/inspektor-gadget/inspektor-gadget/blob/main/docs/examples/pod-ig.yaml
(be sure the nodeName is removed or updated and the image used is the right one, main or compiled from this branch)

### Before this commit

```bash 
$ kubectl logs ig
error: filesystems tracefs not mounted (did you try --auto-mount-filesystems?)
```

### After this commit

Tracer prints events as expected
