### PR TITLE
Revert "ig: Fix host.Init() workaround flags"

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -26,7 +25,6 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
-	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/ig/containers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -59,15 +57,6 @@ func main() {
 		containers.NewListContainersCmd(),
 		common.NewVersionCmd(),
 	)
-
-	// evaluate flags early; this will make sure that flags for host are evaluated before
-	// calling host.Init()
-	err := commonutils.ParseEarlyFlags(rootCmd)
-	if err != nil {
-		// Analogous to cobra error message
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
 
 	runtime := local.New()
 	hiddenColumnTags := []string{"kubernetes"}


### PR DESCRIPTION
This reverts commit 92e0a1864227dd0f1eee3336b4adeaaa9980cb15.

This somehow broke the CI https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/6721665482. It's not clear why, so let's revert this and make the release. 