### PR TITLE
flags: Clone to avoid modifying os.Args

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -187,9 +187,19 @@ func ParseEarlyFlags(cmd *cobra.Command) error {
 		cmd.FParseErrWhitelist.UnknownFlags = false
 	}()
 	// temporary workaround for https://github.com/inspektor-gadget/inspektor-gadget/pull/2174#issuecomment-1780923952
-	args := removeSplitSortArgs(os.Args[1:])
+	args := cloneStringSlice(os.Args[1:]) // clone to avoid modifying the original os.Args
+	args = removeSplitSortArgs(args)
 	// --help should be handled after we registered all commands
 	args = removeHelpArg(args)
 	err := cmd.ParseFlags(args)
 	return err
+}
+
+// TODO: Use slices.Clone() when we upgrade to Go 1.21
+// See: https://cs.opensource.google/go/x/exp/+/7918f672:slices/slices.go;l=336
+func cloneStringSlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	return append([]string{}, s...)
 }

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/ig/containers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -57,6 +59,15 @@ func main() {
 		containers.NewListContainersCmd(),
 		common.NewVersionCmd(),
 	)
+
+	// evaluate flags early; this will make sure that flags for host are evaluated before
+	// calling host.Init()
+	err := commonutils.ParseEarlyFlags(rootCmd)
+	if err != nil {
+		// Analogous to cobra error message
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	runtime := local.New()
 	hiddenColumnTags := []string{"kubernetes"}


### PR DESCRIPTION
If we try to shrink args (to drop '--sort ...') e.g from `top file --sort -writes -m 10 --timeout 10 --interval 10` we end up reusing the underlying array and hence the original os.Args end up getting modified resulting in `top file -m 10 --timeout 10 --interval 10 --interval 10`. The commit clones the slice to ensure os.Args stay untouched and evaluated correctly later on.

## Testing done

### before the PR

```
→ ./kubectl-gadget  snapshot process --sort pid  --all-namespaces
K8S.NODE                                   K8S.NAMESPACE                             K8S.POD                                   K8S.CONTAINER                             COMM             PID                  UID        GID       
minikube-docker                            gadget                                    gadget-76f66                              gadget                                    gadgettracerman  3591435              0          0         
minikube-docker                            kube-system                               storage-provisioner                       storage-provisioner                       storage-provisi  3269857              0          0         
minikube-docker                            kube-system                               coredns-6d4b75cb6d-9dsjr                  coredns                                   coredns          3269733              0          0         
minikube-docker                            kube-system                               kube-proxy-swnds                          kube-proxy                                kube-proxy       3269478              0          0         
minikube-docker                            kube-system                               kube-apiserver-minikube-docker            kube-apiserver                            kube-apiserver   3268122              0          0         
minikube-docker                            kube-system                               kube-controller-manager-minikube-docker   kube-controller-manager                   kube-controller  3268080              0          0         
minikube-docker                            kube-system                               etcd-minikube-docker                      etcd                                      etcd             3268070              0          0         
minikube-docker                            kube-system                               kube-scheduler-minikube-docker            kube-scheduler                            kube-scheduler   3268062              0          0   
```

### After the PR

```
→ ./kubectl-gadget  snapshot process --sort pid  --all-namespaces
K8S.NODE                                   K8S.NAMESPACE                             K8S.POD                                   K8S.CONTAINER                             COMM             PID                  UID        GID       
minikube-docker                            kube-system                               kube-scheduler-minikube-docker            kube-scheduler                            kube-scheduler   3268062              0          0         
minikube-docker                            kube-system                               etcd-minikube-docker                      etcd                                      etcd             3268070              0          0         
minikube-docker                            kube-system                               kube-controller-manager-minikube-docker   kube-controller-manager                   kube-controller  3268080              0          0         
minikube-docker                            kube-system                               kube-apiserver-minikube-docker            kube-apiserver                            kube-apiserver   3268122              0          0         
minikube-docker                            kube-system                               kube-proxy-swnds                          kube-proxy                                kube-proxy       3269478              0          0         
minikube-docker                            kube-system                               coredns-6d4b75cb6d-9dsjr                  coredns                                   coredns          3269733              0          0         
minikube-docker                            kube-system                               storage-provisioner                       storage-provisioner                       storage-provisi  3269857              0          0         
minikube-docker                            gadget                                    gadget-76f66                              gadget                                    gadgettracerman  3591435              0          0     
```
**Note:**  You need `sort` before `--all-namespace` to ensure while shrinking the args we modify the order of items in [`removeSplitSortArgs`](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/cmd/common/utils/flags.go#L163) to reproduce the issue.