### PR TITLE
kubectl-gadget: Add --deploy flag to all commands

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -100,15 +100,13 @@ var supportedHooks = []string{"auto", "crio", "podinformer", "nri", "fanotify", 
 
 func init() {
 	commonutils.AddRuntimesSocketPathFlags(deployCmd, &runtimesConfig)
+	addGeneralDeployFlags(deployCmd)
+
 	strLevels = make([]string, len(log.AllLevels))
 	for i, level := range log.AllLevels {
 		strLevels[i] = level.String()
 	}
-	deployCmd.PersistentFlags().StringVarP(
-		&image,
-		"image", "",
-		gadgetimage,
-		"container image")
+	// These flags are only usefull for the deploy command itself
 	deployCmd.PersistentFlags().StringVarP(
 		&imagePullPolicy,
 		"image-pull-policy", "",
@@ -186,7 +184,16 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(
 		&appArmorprofile,
 		"apparmor-profile", "", "unconfined", "AppArmor profile to use")
+
 	rootCmd.AddCommand(deployCmd)
+}
+
+func addGeneralDeployFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(
+		&image,
+		"image", "",
+		gadgetimage,
+		"container image")
 }
 
 func info(outFile *os.File, format string, args ...any) {


### PR DESCRIPTION
If the flag is set Inspektor Gadget is deployed before running the specified command. After the command finished its execution, Inspektor Gadget will be undeployed


```bash
./kubectl-gadget trace tcp --deploy
deploy true
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating DaemonSet/gadget...
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Retrieving Gadget Catalog...
Inspektor Gadget successfully deployed
K8S.NODE             K8S.NAMESPACE        K8S.POD              K8S.CONTAINER       T PID        COMM       IP SRC                       DST                      
minikube-docker      default              test-pod             test-pod            C 2077488    wget       4  p/default/test-pod:57674  r/216.58.212.163:80      
minikube-docker      default              test-pod             test-pod            X 2077488    wget       4  p/default/test-pod:57674  r/216.58.212.163:80      
minikube-docker      default              test-pod             test-pod            C 2077488    wget       4  p/default/test-pod:59654  r/142.250.185.227:80     
minikube-docker      default              test-pod             test-pod            X 2077488    wget       4  p/default/test-pod:59654  r/142.250.185.227:80     
^CRemoving traces...
Removing CRD...
Removing cluster role binding...
Removing cluster role...
Removing namespace...
Waiting for namespace to be removed...
Inspektor Gadget successfully removed
```