### PR TITLE
Allow running Inspektor Gadget in parallel namespaces

### DIFF
--- a/charts/gadget/templates/clusterrole.yaml
+++ b/charts/gadget/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "gadget.fullname" . }}-cluster-role
+  name: {{ include "gadget.namespace" . }}-gadget-cluster-role
   {{- if not .Values.skipLabels }}
   labels:
     {{- include "gadget.labels" . | nindent 4 }}

--- a/charts/gadget/templates/clusterrolebinding.yaml
+++ b/charts/gadget/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "gadget.fullname" . }}-cluster-role-binding
+  name: {{ include "gadget.namespace" . }}-gadget-cluster-role-binding
   {{- if not .Values.skipLabels }}
   labels:
     {{- include "gadget.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "gadget.fullname" . }}-cluster-role
+  name: {{ include "gadget.namespace" . }}-gadget-cluster-role
 subjects:
   - kind: ServiceAccount
     name: {{ include "gadget.fullname" . }}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -74,6 +74,8 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "{{ .Values.image.repository }}"
+            - name: GADGET_NAMESPACE
+              value: {{ include "gadget.namespace" . | quote }}
             - name: INSPEKTOR_GADGET_VERSION
               value: {{ include "gadget.image.tag" . | quote }}
             - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
               command:
                 - /bin/gadgettracermanager
                 - -liveness
+                - -socketfile=/run/{{ include "gadget.namespace" . }}-gadgettracermanager.socket
             periodSeconds: 5
             timeoutSeconds: 2
           readinessProbe:
@@ -61,6 +62,7 @@ spec:
               command:
                 - /bin/gadgettracermanager
                 - -liveness
+                - -socketfile=/run/{{ include "gadget.namespace" . }}-gadgettracermanager.socket
             periodSeconds: 5
             timeoutSeconds: 2
           env:

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -350,17 +350,6 @@ func createAffinity(client *kubernetes.Clientset) (*v1.Affinity, error) {
 
 func runDeploy(cmd *cobra.Command, args []string) error {
 	gadgetNamespace := runtimeGlobalParams.Get(grpcruntime.ParamGadgetNamespace).AsString()
-	if !printOnly {
-		gadgetNamespaces, err := utils.GetRunningGadgetNamespaces()
-		if err != nil {
-			return fmt.Errorf("searching for running Inspektor Gadget instances: %w", err)
-		}
-		if len(gadgetNamespaces) != 0 && gadgetNamespaces[0] != gadgetNamespace {
-			// Inspektor Gadget is the program name and therefore capitalized (Lint error ST1005)
-			//nolint:all
-			return fmt.Errorf("Inspektor Gadget is already deployed to the following namespaces: %v. Only a single instance is allowed", gadgetNamespaces)
-		}
-	}
 
 	found := false
 	for _, supportedHook := range supportedHooks {

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -528,22 +528,19 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if ns, isNs := object.(*v1.Namespace); isNs {
-			ns.Name = gadgetNamespace
-		}
-		if sa, isSa := object.(*v1.ServiceAccount); isSa {
-			sa.Namespace = gadgetNamespace
-		}
-		if crBinding, isCrBinding := object.(*rbacv1.ClusterRoleBinding); isCrBinding {
-			if len(crBinding.Subjects) == 1 {
-				crBinding.Subjects[0].Namespace = gadgetNamespace
+		switch o := object.(type) {
+		case *v1.Namespace:
+			o.Name = gadgetNamespace
+		case *v1.ServiceAccount:
+			o.Namespace = gadgetNamespace
+		case *rbacv1.ClusterRoleBinding:
+			if len(o.Subjects) == 1 {
+				o.Subjects[0].Namespace = gadgetNamespace
 			}
-		}
-		if role, isRole := object.(*rbacv1.Role); isRole {
-			role.Namespace = gadgetNamespace
-		}
-		if rBinding, isRole := object.(*rbacv1.RoleBinding); isRole {
-			rBinding.Namespace = gadgetNamespace
+		case *rbacv1.Role:
+			o.Namespace = gadgetNamespace
+		case *rbacv1.RoleBinding:
+			o.Namespace = gadgetNamespace
 		}
 
 		if printOnly {

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -456,9 +456,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			}
 			gadgetContainer.ImagePullPolicy = policy
 
+			socketArg := fmt.Sprintf("-socketfile=/run/%s-gadgettracermanager.socket", gadgetNamespace)
 			if !livenessProbe {
 				gadgetContainer.LivenessProbe = nil
+			} else {
+				gadgetContainer.LivenessProbe.Exec.Command = append(gadgetContainer.LivenessProbe.Exec.Command, socketArg)
 			}
+			gadgetContainer.ReadinessProbe.Exec.Command = append(gadgetContainer.ReadinessProbe.Exec.Command, socketArg)
 
 			for i := range gadgetContainer.Env {
 				switch gadgetContainer.Env[i].Name {

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -462,6 +462,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				switch gadgetContainer.Env[i].Name {
 				case "GADGET_IMAGE":
 					gadgetContainer.Env[i].Value = image
+				case "GADGET_NAMESPACE":
+					gadgetContainer.Env[i].Value = gadgetNamespace
 				case "INSPEKTOR_GADGET_VERSION":
 					gadgetContainer.Env[i].Value = common.Version()
 				case "INSPEKTOR_GADGET_OPTION_HOOK_MODE":

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -99,6 +99,8 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 	n := 7
 
 	gadgetNamespace := runtimeGlobalParams.Get(grpcruntime.ParamGadgetNamespace).AsString()
+	clusterRoleName := gadgetNamespace + utils.GadgetClusterRoleSuffix
+	clusterRoleBindingName := gadgetNamespace + utils.GadgetClusterRoleBindingSuffix
 
 again:
 	fmt.Println("Removing traces...")
@@ -150,22 +152,22 @@ again:
 	// 3. gadget cluster role binding
 	fmt.Println("Removing cluster role binding...")
 	err = k8sClient.RbacV1().ClusterRoleBindings().Delete(
-		context.TODO(), "gadget-cluster-role-binding", metav1.DeleteOptions{},
+		context.TODO(), clusterRoleBindingName, metav1.DeleteOptions{},
 	)
 	if err != nil && !errors.IsNotFound(err) {
 		errs = append(
-			errs, fmt.Sprintf("failed to remove \"gadget\" cluster role bindings: %s", err),
+			errs, fmt.Sprintf("failed to remove %q cluster role bindings: %s", clusterRoleBindingName, err),
 		)
 	}
 
 	// 4. gadget cluster role
 	fmt.Println("Removing cluster role...")
 	err = k8sClient.RbacV1().ClusterRoles().Delete(
-		context.TODO(), "gadget-cluster-role", metav1.DeleteOptions{},
+		context.TODO(), clusterRoleName, metav1.DeleteOptions{},
 	)
 	if err != nil && !errors.IsNotFound(err) {
 		errs = append(
-			errs, fmt.Sprintf("failed to remove \"gadget\" cluster role: %s", err),
+			errs, fmt.Sprintf("failed to remove %q cluster role: %s", clusterRoleName, err),
 		)
 	}
 

--- a/cmd/kubectl-gadget/utils/consts.go
+++ b/cmd/kubectl-gadget/utils/consts.go
@@ -19,4 +19,7 @@ const (
 	GadgetEnvironmentCRIOSocketpath       string = "INSPEKTOR_GADGET_CRIO_SOCKETPATH"
 	GadgetEnvironmentDockerSocketpath     string = "INSPEKTOR_GADGET_DOCKER_SOCKETPATH"
 	GadgetEnvironmentPodmanSocketpath     string = "INSPEKTOR_GADGET_PODMAN_SOCKETPATH"
+
+	GadgetClusterRoleSuffix        string = "-gadget-cluster-role"
+	GadgetClusterRoleBindingSuffix string = "-gadget-cluster-role-binding"
 )

--- a/cmd/kubectl-gadget/utils/trace.go
+++ b/cmd/kubectl-gadget/utils/trace.go
@@ -1029,8 +1029,8 @@ func genericStreams(
 		}
 		atomic.AddInt32(&streamCount, 1)
 		go func(nodeName, namespace, name string, index int) {
-			cmd := fmt.Sprintf("/bin/gadgettracermanager -call receive-stream -tracerid trace_%s_%s",
-				namespace, name)
+			cmd := fmt.Sprintf("/bin/gadgettracermanager -socketfile /run/%s-gadgettracermanager.socket -call receive-stream -tracerid trace_%s_%s",
+				gadgetNamespace, namespace, name)
 			postProcess.OutStreams[index].Node = nodeName
 			err := ExecPod(client, nodeName, gadgetNamespace, cmd,
 				postProcess.OutStreams[index], postProcess.ErrStreams[index])

--- a/docs/getting-started/install-kubernetes.md
+++ b/docs/getting-started/install-kubernetes.md
@@ -7,19 +7,23 @@ description: >
 
 <!-- toc -->
 - [Installing kubectl gadget](#installing-kubectl-gadget)
-  * [Using krew](#using-krew)
-  * [Install a specific release](#install-a-specific-release)
-  * [Compile from source](#compile-from-source)
+  - [Using krew](#using-krew)
+  - [Install a specific release](#install-a-specific-release)
+  - [Compile from source](#compile-from-source)
 - [Installing in the cluster](#installing-in-the-cluster)
-  * [Quick installation](#quick-installation)
-  * [Choosing the gadget image](#choosing-the-gadget-image)
-  * [Deploy to specific nodes](#deploy-to-specific-nodes)
-  * [Deploying into a custom namespace](#deploying-into-a-custom-namespace)
-  * [Hook Mode](#hook-mode)
-  * [Specific Information for Different Platforms](#specific-information-for-different-platforms)
-    + [Minikube](#minikube)
+  - [Quick installation](#quick-installation)
+  - [Choosing the gadget image](#choosing-the-gadget-image)
+  - [Deploy to specific nodes](#deploy-to-specific-nodes)
+  - [Deploying into a custom namespace](#deploying-into-a-custom-namespace)
+  - [Running multiple Inspektor Gadget instances in parallel](#running-multiple-inspektor-gadget-instances-in-parallel)
+  - [Hook Mode](#hook-mode)
+  - [Specific Information for Different Platforms](#specific-information-for-different-platforms)
+    - [Minikube](#minikube)
 - [Uninstalling from the cluster](#uninstalling-from-the-cluster)
 - [Version skew policy](#version-skew-policy)
+- [Installing `ig`](#installing-ig)
+  - [Install a specific release](#install-a-specific-release-1)
+  - [Compile from source](#compile-from-source-1)
 - [Experimental features](#experimental-features)
 <!-- /toc -->
 
@@ -112,6 +116,26 @@ By default Inspektor Gadget is deployed to the namespace `gadget`.
 This can be changed with the `--gadget-namespace` flag.
 When using gadgets (e.g. `kubectl gadget trace exec`) the deployed namespace is discovered automatically and no additional flags are needed during the usage.
 For `undeploy` the `--gadget-namespace` flag is mandatory.
+
+### Running multiple Inspektor Gadget instances in parallel
+
+It is possible to run multiple instances of Inspektor Gadget at the same time.
+To do so, they have to run in their own namespace, which is specified using `--gadget-namespace` at deploy time.
+The instances are version agnostic.
+
+No resources are shared between running instances besides a Custom Resource Definition (CRD).
+So when undeploying the `--skip-crd` flag **must be used** in order to preserve the CRD, if there are any other running Inspektor Gadget instances.
+Only the **last** instance can clean up these resources.
+
+```bash
+$ kubectl gadget deploy --gadget-namespace foo
+$ kubectl gadget deploy --gadget-namespace bar
+$ kubectl gadget deploy --gadget-namespace xyz
+...
+$ kubectl gadget undeploy --gadget-namespace foo --skip-crd
+$ kubectl gadget undeploy --gadget-namespace xyz --skip-crd
+$ kubectl gadget undeploy --gadget-namespace bar
+```
 
 ### Hook Mode
 

--- a/gadget-container/cleanup/cleanup.go
+++ b/gadget-container/cleanup/cleanup.go
@@ -89,8 +89,9 @@ func main() {
 	removeCRIOHooks()
 	removeNRIHooks()
 
+	gadgetNamespace := os.Getenv("GADGET_NAMESPACE")
 	os.RemoveAll("/sys/fs/bpf/gadget/")
-	os.Remove("/run/gadgettracermanager.socket")
+	os.Remove(fmt.Sprintf("/run/%s-gadgettracermanager.socket", gadgetNamespace))
 
 	log.Infof("Cleanup completed")
 }

--- a/gadget-container/cleanup/cleanup.go
+++ b/gadget-container/cleanup/cleanup.go
@@ -18,11 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	nriv1 "github.com/containerd/nri/types/v1"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
@@ -90,7 +92,7 @@ func main() {
 	removeNRIHooks()
 
 	gadgetNamespace := os.Getenv("GADGET_NAMESPACE")
-	os.RemoveAll("/sys/fs/bpf/gadget/")
+	os.RemoveAll(path.Join(gadgets.PinBasePath, fmt.Sprintf("%s-gadget", gadgetNamespace)))
 	os.Remove(fmt.Sprintf("/run/%s-gadgettracermanager.socket", gadgetNamespace))
 
 	log.Infof("Cleanup completed")

--- a/gadget-container/cleanup/cleanup.go
+++ b/gadget-container/cleanup/cleanup.go
@@ -27,16 +27,14 @@ import (
 )
 
 func removeCRIOHooks() {
-	for _, file := range []string{"ocihookgadget", "prestart.sh", "poststop.sh"} {
-		path := filepath.Join("/opt/hooks/oci", file)
-		hostPath := filepath.Join(host.HostRoot, path)
-		os.Remove(hostPath)
-	}
+	instanceDirname := os.Getenv("GADGET_NAMESPACE") + "-gadget"
+
+	os.RemoveAll(filepath.Join(host.HostRoot, "/opt/hooks/oci/", instanceDirname))
 
 	for _, file := range []string{"etc/containers/oci/hooks.d", "usr/share/containers/oci/hooks.d/"} {
 		hookPath := filepath.Join(host.HostRoot, file)
 		for _, config := range []string{"gadget-prestart.json", "gadget-poststop.json"} {
-			path := filepath.Join(hookPath, config)
+			path := filepath.Join(hookPath, fmt.Sprintf("%s-%s", instanceDirname, config))
 			os.Remove(path)
 		}
 	}

--- a/gadget-container/cleanup/cleanup.go
+++ b/gadget-container/cleanup/cleanup.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -42,7 +43,9 @@ func removeCRIOHooks() {
 }
 
 func removeNRIHooks() {
-	path := filepath.Join(host.HostRoot, "opt/nri/bin/nrigadget")
+	nriGadgetName := fmt.Sprintf("%s-nrigadget", os.Getenv("GADGET_NAMESPACE"))
+
+	path := filepath.Join(host.HostRoot, "opt/nri/bin", nriGadgetName)
 	os.Remove(path)
 
 	configPath := filepath.Join(host.HostRoot, "etc/nri/conf.json")
@@ -58,11 +61,11 @@ func removeNRIHooks() {
 	}
 
 	length := len(configList.Plugins)
-	if length == 1 && configList.Plugins[0].Type == "nrigadget" {
+	if length == 1 && configList.Plugins[0].Type == nriGadgetName {
 		os.Remove(configPath)
 	} else {
 		for i, plugin := range configList.Plugins {
-			if plugin.Type != "nrigadget" {
+			if plugin.Type != nriGadgetName {
 				continue
 			}
 

--- a/gadget-container/cleanup/cleanup.go
+++ b/gadget-container/cleanup/cleanup.go
@@ -89,6 +89,7 @@ func main() {
 	removeNRIHooks()
 
 	os.RemoveAll("/sys/fs/bpf/gadget/")
+	os.Remove("/run/gadgettracermanager.socket")
 
 	log.Infof("Cleanup completed")
 }

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -296,6 +296,7 @@ func main() {
 			NodeName:            node,
 			HookMode:            hookMode,
 			FallbackPodInformer: fallbackPodInformer,
+			GadgetNamespace:     os.Getenv("GADGET_NAMESPACE"),
 		})
 
 		if err != nil {

--- a/gadget-container/hooks/crio/gadget-poststop.json
+++ b/gadget-container/hooks/crio/gadget-poststop.json
@@ -5,7 +5,7 @@
     "args": [
       "sh",
       "-c",
-      "test ! -x /opt/hooks/oci/poststop.sh || /opt/hooks/oci/poststop.sh"
+      "test ! -x /opt/hooks/oci/{{.namespace}}-gadget/poststop.sh || /opt/hooks/oci/{{.namespace}}-gadget/poststop.sh {{.namespace}}"
     ]
   },
   "when": {

--- a/gadget-container/hooks/crio/gadget-prestart.json
+++ b/gadget-container/hooks/crio/gadget-prestart.json
@@ -5,7 +5,7 @@
     "args": [
       "sh",
       "-c",
-      "test ! -x /opt/hooks/oci/prestart.sh || /opt/hooks/oci/prestart.sh"
+      "test ! -x /opt/hooks/oci/{{.namespace}}-gadget/prestart.sh || /opt/hooks/oci/{{.namespace}}-gadget/prestart.sh {{.namespace}}"
     ]
   },
   "when": {

--- a/gadget-container/hooks/nri/conf.json
+++ b/gadget-container/hooks/nri/conf.json
@@ -2,7 +2,7 @@
     "version": "0.1",
     "plugins": [
         {
-            "type": "nrigadget",
+            "type": "{{.namespace}}-nrigadget",
             "conf": {
                 "socketFile": "/run/gadgettracermanager.socket"
             }

--- a/gadget-container/hooks/nri/conf.json
+++ b/gadget-container/hooks/nri/conf.json
@@ -4,7 +4,7 @@
         {
             "type": "{{.namespace}}-nrigadget",
             "conf": {
-                "socketFile": "/run/gadgettracermanager.socket"
+                "socketFile": "/run/{{.namespace}}-gadgettracermanager.socket"
             }
         }
     ]

--- a/gadget-container/hooks/oci/poststop.sh
+++ b/gadget-container/hooks/oci/poststop.sh
@@ -2,6 +2,6 @@
 # $1 is the gadget namespace name
 
 read JSON
-test -S /run/gadgettracermanager.socket || exit 0
-echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook poststop >> /var/log/$1-gadget.log 2>&1
+test -S /run/$1-gadgettracermanager.socket || exit 0
+echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook poststop -socketfile /run/$1-gadgettracermanager.socket >> /var/log/$1-gadget.log 2>&1
 exit 0

--- a/gadget-container/hooks/oci/poststop.sh
+++ b/gadget-container/hooks/oci/poststop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
-pidof gadgettracermanager > /dev/null || exit 0
+test -S /run/gadgettracermanager.socket || exit 0
 echo $JSON | /opt/hooks/oci/ocihookgadget -hook poststop >> /var/log/gadget.log 2>&1
 exit 0

--- a/gadget-container/hooks/oci/poststop.sh
+++ b/gadget-container/hooks/oci/poststop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+# $1 is the gadget namespace name
+
 read JSON
 test -S /run/gadgettracermanager.socket || exit 0
-echo $JSON | /opt/hooks/oci/ocihookgadget -hook poststop >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook poststop >> /var/log/$1-gadget.log 2>&1
 exit 0

--- a/gadget-container/hooks/oci/prestart.sh
+++ b/gadget-container/hooks/oci/prestart.sh
@@ -2,6 +2,6 @@
 # $1 is the gadget namespace name
 
 read JSON
-test -S /run/gadgettracermanager.socket || exit 0
-echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook prestart >> /var/log/$1-gadget.log 2>&1
+test -S /run/$1-gadgettracermanager.socket || exit 0
+echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook prestart -socketfile /run/$1-gadgettracermanager.socket >> /var/log/$1-gadget.log 2>&1
 exit 0

--- a/gadget-container/hooks/oci/prestart.sh
+++ b/gadget-container/hooks/oci/prestart.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+# $1 is the gadget namespace name
+
 read JSON
 test -S /run/gadgettracermanager.socket || exit 0
-echo $JSON | /opt/hooks/oci/ocihookgadget -hook prestart >> /var/log/gadget.log 2>&1
+echo $JSON | /opt/hooks/oci/$1-gadget/ocihookgadget -hook prestart >> /var/log/$1-gadget.log 2>&1
 exit 0

--- a/gadget-container/hooks/oci/prestart.sh
+++ b/gadget-container/hooks/oci/prestart.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 read JSON
-pidof gadgettracermanager > /dev/null || exit 0
+test -S /run/gadgettracermanager.socket || exit 0
 echo $JSON | /opt/hooks/oci/ocihookgadget -hook prestart >> /var/log/gadget.log 2>&1
 exit 0

--- a/pkg/gadgets/consts.go
+++ b/pkg/gadgets/consts.go
@@ -15,7 +15,7 @@
 package gadgets
 
 const (
-	PinPath = "/sys/fs/bpf/gadget"
+	PinBasePath = "/sys/fs/bpf"
 
 	PerfBufferPages = 64
 

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"runtime"
 	"sync"
 
@@ -258,7 +259,7 @@ func NewServer(conf *Conf) (*GadgetTracerManager, error) {
 		}
 
 		var err error
-		if g.containersMap, err = containersmap.NewContainersMap(gadgets.PinPath); err != nil {
+		if g.containersMap, err = containersmap.NewContainersMap(path.Join(gadgets.PinBasePath, fmt.Sprintf("%s-gadget", conf.GadgetNamespace))); err != nil {
 			return nil, fmt.Errorf("creating containers map: %w", err)
 		}
 
@@ -338,6 +339,7 @@ type Conf struct {
 	HookMode            string
 	FallbackPodInformer bool
 	TestOnly            bool
+	GadgetNamespace     string
 }
 
 // Close releases any resource that could be in use by the tracer manager, like

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -16,7 +16,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gadget-cluster-role
+  name: gadget-gadget-cluster-role
 rules:
   - apiGroups: [""]
     resources: ["namespaces", "nodes", "pods"]
@@ -50,11 +50,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gadget-cluster-role-binding
+  name: gadget-gadget-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gadget-cluster-role
+  name: gadget-gadget-cluster-role
 subjects:
   - kind: ServiceAccount
     name: gadget

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -134,6 +134,7 @@ spec:
               command:
                 - /bin/gadgettracermanager
                 - -liveness
+                - -socketfile=/run/gadget-gadgettracermanager.socket
             periodSeconds: 5
             timeoutSeconds: 2
           readinessProbe:
@@ -141,6 +142,7 @@ spec:
               command:
                 - /bin/gadgettracermanager
                 - -liveness
+                - -socketfile=/run/gadget-gadgettracermanager.socket
             periodSeconds: 5
             timeoutSeconds: 2
           env:

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -154,6 +154,8 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "ghcr.io/inspektor-gadget/inspektor-gadget"
+            - name: GADGET_NAMESPACE
+              value: "gadget"
             - name: INSPEKTOR_GADGET_VERSION
               value: "latest"
             - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE


### PR DESCRIPTION
## Allow running Inspektor Gadget in parallel namespaces

closes #2205 

The current strategy is to have multiple binaries (like `gadgettracermanager` etc. This is done so multiple users can use Inspektor Gadget at the same time with different versions in different namespaces. Not every user might now every other one.

## TODO
- [x] Right places?
- [x] Found all references to the `gadget` namespace
- [x] When having multiple instances of Inspektor Gadget deployed in different namespaces:
  - [x] Have different catalog contexts? See https://github.com/inspektor-gadget/inspektor-gadget/issues/2102 Wait for that Issue or not?
    - We will ignore that Issue for now. Future of the catalog is not known 
  - [x] How to handle `undeploy`? We have the Clusterrole which is shared between all "instances" of Inspektor Gadget in different namespaces
  - [x] Make sure entrypoint.sh (or Go equivalent in [Use distroless as base image #2207](https://github.com/inspektor-gadget/inspektor-gadget/pull/2207)) supports several deployments in parallel. See [comment](https://github.com/inspektor-gadget/inspektor-gadget/pull/2207/files#r1386464280)


## Testing done

1. Multiple deployments in different namespaces (up to 3)
2. Deploying and Undeploying doesn't affect any other namespace
3. Tested the helm chart