### PR TITLE
Makefile: Ensure we always load the newest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,10 @@ clang-format:
 LIVENESS_PROBE ?= true
 .PHONY: minikube-deploy
 minikube-deploy: minikube-start gadget-container kubectl-gadget
+	# Remove all resources created by Inspektor Gadget
+	./kubectl-gadget undeploy || true
+	# Remove the image from Minikube
+	$(MINIKUBE) image rm $(CONTAINER_REPO):$(IMAGE_TAG) || true
 	@echo "Image on the host:"
 	docker image list --format "table {{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Size}}" |grep $(CONTAINER_REPO):$(IMAGE_TAG)
 	@echo
@@ -306,8 +310,6 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
 		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
-	# Remove all resources created by Inspektor Gadget.
-	./kubectl-gadget undeploy || true
 	./kubectl-gadget deploy --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s


### PR DESCRIPTION
Currently if you re-run the `make minikube-deploy` (w/o `make minikube-clean`) with any changes (e.g to gadget-container directory), `minikube` end up using the old. This change solves the issue by removing the image before deploying every time:

## Testing Done

### before

```
$ make minikube-deploy
# make changes to gadget-container directory
$ make minikube-deploy
...
Image on the host:
docker image list --format "table {{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Size}}" |grep ghcr.io/inspektor-gadget/inspektor-gadget:latest
f80638db3630   ghcr.io/inspektor-gadget/inspektor-gadget:latest                  291MB
...
...
Image in Minikube:
/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/bin/minikube/minikube-v1.29.0 image ls --format=table | grep "ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*latest" || \
        (echo "Image ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*latest was not correctly loaded into Minikube" && false)
| ghcr.io/inspektor-gadget/inspektor-gadget | latest                | aff99cdb50ac0 | 295MB  |
...
```

### after

```
$ make minikube-deploy
# make changes to gadget-container directory
$ make minikube-deploy
...
Image on the host:
docker image list --format "table {{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Size}}" |grep ghcr.io/inspektor-gadget/inspektor-gadget:latest
f80638db3630   ghcr.io/inspektor-gadget/inspektor-gadget:latest                  291MB
...
...
Image in Minikube:
/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/bin/minikube/minikube-v1.29.0 image ls --format=table | grep "ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*latest" || \
        (echo "Image ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*latest was not correctly loaded into Minikube" && false)
| ghcr.io/inspektor-gadget/inspektor-gadget | latest                | f80638db3630 | 295MB  |
...
```