### PR TITLE
Dockerfiles: Use cross compilation for kubectl-gadget Dockerfile.

### DIFF
--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -5,7 +5,6 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG BUILDARCH
 ARG VERSION=undefined
 ENV VERSION=${VERSION}
 ARG EBPF_BUILDER=ghcr.io/inspektor-gadget/ebpf-builder:latest

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -9,7 +9,10 @@
 ARG BUILDER_IMAGE=golang:1.20-bullseye
 ARG BASE_IMAGE=alpine:3.18
 
-FROM ${BUILDER_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/
@@ -24,7 +27,7 @@ ENV IMAGE_TAG=${IMAGE_TAG}
 
 # This COPY is limited by .dockerignore
 COPY ./ /gadget
-RUN cd /gadget && make kubectl-gadget
+RUN cd /gadget && GOHOSTOS=$TARGETOS GOHOSTARCH=$TARGETARCH make kubectl-gadget
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
Hi.

This PR makes `kubectl-gadget.Dockerfile` using cross compilation, it speeds up build for other architectures:

```bash
$ docker buildx build --load --platform=linux/arm64 -f Dockerfiles/kubectl-gadget.Dockerfile -t kubectl-gadget .
[+] Building 235.5s (14/14) FINISHED                                                                     docker-container:magical_sammet
 => [internal] load build definition from kubectl-gadget.Dockerfile                                                                 0.0s
 => => transferring dockerfile: 1.89kB                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                   0.0s
 => => transferring context: 2B                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                                      2.1s
 => [internal] load metadata for docker.io/library/golang:1.20-bullseye                                                             2.0s
...
 => [builder 5/5] RUN cd /gadget && GOHOSTOS=linux GOHOSTARCH=arm64 make kubectl-gadget                                            41.4s
...
 => importing to docker
$ docker run --rm -ti kubectl-gadget            francis/kubectl-gadget-docker-cross *%
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
/ #
# Other terminal
$ docker cp angry_shockley:/bin/kubectl-gadget /tmp 
Successfully copied 87.2MB to /tmp
$ file /tmp/kubectl-gadget                      francis/kubectl-gadget-docker-cross *%
/tmp/kubectl-gadget: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=jowbtesoByV0av3PcG9O/KQcXh1JQmFyFXFmi6AAs/yFwYPe_b5K_Poppn2F1f/kevBJNNvk740Te9iA4OM, with debug_info, not stripped
```

Best regards.