### PR TITLE
image-based-gadgets: Introduce gadget pull secret

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -172,6 +172,11 @@ spec:
               name: cgroup
             - mountPath: /sys/fs/bpf
               name: bpffs
+            {{- if .Values.config.mountPullSecret }}
+            - mountPath: /var/run/secrets/gadget/pull-secret
+              name: pull-secret
+              readOnly: true
+            {{- end }}
       nodeSelector:
         {{- .Values.nodeSelector | toYaml | nindent 8 }}
       affinity:
@@ -197,3 +202,12 @@ spec:
         - name: debugfs
           hostPath:
             path: /sys/kernel/debug
+        {{- if .Values.config.mountPullSecret }}
+        - name: pull-secret
+          secret:
+            defaultMode: 420
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+            secretName: gadget-pull-secret
+        {{- end }}

--- a/charts/gadget/templates/role.yaml
+++ b/charts/gadget/templates/role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
+  name: {{ include "gadget.fullname" . }}-role
+  namespace: {{ include "gadget.namespace" . }}
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    # get secrets is needed for retrieving pull secret.
+    verbs: [ "get" ]

--- a/charts/gadget/templates/rolebinding.yaml
+++ b/charts/gadget/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
+  name: {{ include "gadget.fullname" . }}-role-binding
+  namespace: {{ include "gadget.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gadget.fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "gadget.fullname" . }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -2,13 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Skip Helm labels
-skipLabels: true
-
-# -- Labels to be added to all other resources.
-additionalLabels:
-  labels: {}
-
 config:
   # -- How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify, fanotify+ebpf")
   hookMode: auto
@@ -28,6 +21,9 @@ config:
 
   # -- Events buffer length. A low value could impact horizontal scaling.
   eventsBufferLength: "16384"
+
+  # -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from private registry
+  mountPullSecret: false
 
 image:
   # -- Container repository for the container image
@@ -53,3 +49,10 @@ tolerations:
     operator: Exists
   - effect: NoExecute
     operator: Exists
+
+# -- Skip Helm labels
+skipLabels: true
+
+# -- Labels to be added to all other resources.
+additionalLabels:
+  labels: {}

--- a/docs/gadgets/run.md
+++ b/docs/gadgets/run.md
@@ -57,6 +57,65 @@ ubuntu-hirsute         default                mypod2                 mypod2     
 ubuntu-hirsute         default                mypod2                 mypod2                 242164  cat         0        0        3   /dev/null
 ```
 
+### Private registries in Kubernetes
+
+In order to use private registries, you will need a [Kubernetes secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) having credentials to access the registry.
+
+There are two different ways to use this support:
+
+#### Defining a default secret when deploying Inspektor Gadget
+
+This approach creates a secret that will be used by default when pulling the gadget images. It requires to have a `docker-registry` secret named `gadget-pull-secret` in the `gadget` namespace:
+
+Let's create the `gadget` namespace if it doesn't exist:
+
+```bash
+$ kubectl create namespace gadget
+```
+
+then create the secret:
+
+```bash
+$ kubectl create secret docker-registry gadget-pull-secret -n gadget --docker-server=MYSERVER --docker-username=MYUSERNAME --docker-password=MYPASSWORD
+```
+
+or you can create the secret from a file:
+
+```bash
+$ kubectl create secret docker-registry gadget-pull-secret -n gadget --from-file=.dockerconfigjson=$HOME/.docker/config.json
+```
+
+then, deploy Inspektor Gadget:
+
+```bash
+$ kubectl gadget deploy ...
+```
+
+this secret will be used by default when running a gadget:
+
+
+```bash
+$ kubectl gadget run myprivateregistry.io/trace_tcpconnect:latest
+```
+
+#### Specifying the secret when running a gadget
+
+It's possible to pass a secret each time a gadget is run, you'd need to follow a similar approach as above to create the secret:
+
+```bash
+# from credentials
+$ kubectl create secret docker-registry my-pull-secret -n gadget --docker-server=MYSERVER --docker-username=MYUSERNAME --docker-password=MYPASSWORD
+
+# from a file
+$ kubectl create secret docker-registry my-pull-secret -n gadget --from-file=.dockerconfigjson=$HOME/.docker/config.json
+```
+
+Then, it can be used each time a gadget is run:
+
+```bash
+$ kubectl gadget run myprivateregistry.io/trace_tcpconnect:latest --pull-secret my-pull-secret
+```
+
 ## With `ig`
 
 ``` bash

--- a/gadget-container/entrypoint/entrypoint.go
+++ b/gadget-container/entrypoint/entrypoint.go
@@ -29,9 +29,13 @@ import (
 	nriv1 "github.com/containerd/nri/types/v1"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
+
+const gadgetPullSecretPath = "/var/run/secrets/gadget/pull-secret/config.json"
 
 var crioRegex = regexp.MustCompile(`1:name=systemd:.*/crio-[0-9a-f]*\.scope`)
 
@@ -194,6 +198,27 @@ func installNRIHooks() error {
 	return nil
 }
 
+func hasGadgetPullSecret() bool {
+	_, err := os.Stat(gadgetPullSecretPath)
+	return err == nil
+}
+
+func prepareGadgetPullSecret() error {
+	log.Info("Preparing gadget pull secret")
+
+	err := os.MkdirAll("/var/lib/ig", 0o755)
+	if err != nil {
+		return fmt.Errorf("creating /var/lib/ig: %w", err)
+	}
+
+	err = os.Symlink(gadgetPullSecretPath, oci.DefaultAuthFile)
+	if err != nil {
+		return fmt.Errorf("creating symlink %s: %w", oci.DefaultAuthFile, err)
+	}
+
+	return nil
+}
+
 func main() {
 	if _, err := os.Stat(filepath.Join(host.HostRoot, "/bin")); os.IsNotExist(err) {
 		log.Fatalf("%s must be executed in a pod with access to the host via %s", os.Args[0], host.HostRoot)
@@ -223,6 +248,13 @@ func main() {
 	}
 
 	log.Infof("Inspektor Gadget version: %s", os.Getenv("INSPEKTOR_GADGET_VERSION"))
+
+	if hasGadgetPullSecret() {
+		err = prepareGadgetPullSecret()
+		if err != nil {
+			log.Fatalf("preparing gadget pull secret: %v", err)
+		}
+	}
 
 	path := "/proc/self/cgroup"
 	content, err := os.ReadFile(path)

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -47,6 +47,7 @@ const (
 	authfileParam         = "authfile"
 	insecureParam         = "insecure"
 	pullParam             = "pull"
+	pullSecret            = "pull-secret"
 )
 
 type GadgetDesc struct{}
@@ -104,6 +105,12 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			},
 			TypeHint: params.TypeString,
 		},
+		{
+			Key:         pullSecret,
+			Title:       "Pull secret",
+			Description: "Secret to use when pulling the gadget image",
+			TypeHint:    params.TypeString,
+		},
 	}
 }
 
@@ -127,8 +134,9 @@ func getGadgetType(spec *ebpf.CollectionSpec,
 
 func getGadgetInfo(params *params.Params, args []string, logger logger.Logger) (*types.GadgetInfo, error) {
 	authOpts := &oci.AuthOptions{
-		AuthFile: params.Get(authfileParam).AsString(),
-		Insecure: params.Get(insecureParam).AsBool(),
+		AuthFile:   params.Get(authfileParam).AsString(),
+		PullSecret: params.Get(pullSecret).AsString(),
+		Insecure:   params.Get(insecureParam).AsBool(),
 	}
 	gadget, err := oci.GetGadgetImage(context.TODO(), args[0], authOpts, params.Get(pullParam).AsString())
 	if err != nil {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -377,9 +377,10 @@ func newAuthClient(repository string, authOptions *AuthOptions) (*oras_auth.Clie
 
 	return &oras_auth.Client{
 		Credential: oras_auth.StaticCredential(hostString, oras_auth.Credential{
-			Username:    authConfig.Username,
-			Password:    authConfig.Password,
-			AccessToken: authConfig.Auth,
+			Username:     authConfig.Username,
+			Password:     authConfig.Password,
+			AccessToken:  authConfig.Auth,
+			RefreshToken: authConfig.IdentityToken,
 		}),
 	}, nil
 }

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -60,6 +60,32 @@ subjects:
     name: gadget
     namespace: gadget
 ---
+# Source: gadget/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gadget-role
+  namespace: gadget
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    # get secrets is needed for retrieving pull secret.
+    verbs: [ "get" ]
+---
+# Source: gadget/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gadget-role-binding
+  namespace: gadget
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gadget-role
+subjects:
+  - kind: ServiceAccount
+    name: gadget
+---
 # Source: gadget/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Currently there isn't a way to run gadgets from private registry in Kubernetes. This change mounts/symlinks the registry credentials to allow pulling gadgets from private registries. The flag `gadgetPullSecret` is inspired from [`imagePullSecrets`](https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod). 

Fixes: #2096 

## Testing done

### deploy

```bash
$ kubectl create ns gadget
# assuming you already did docker login qasimregistry.azurecr.io
$ kubectl create secret -n gadget docker-registry gadget-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json
$ ./kubectl-gadget deploy --image-pull-policy Never
$ ./kubectl-gadget run qasimregistry.azurecr.io/gadget/trace_open:latest -A
```

### helm

```bash
$ kubectl create ns gadget
# assuming you already did docker login qasimregistry.azurecr.io
$ kubectl create secret -n gadget docker-registry gadget-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json
$ make -C charts build
$ helm install -n gadget gadget --set config.mountPullSecret=true --set image.pullPolicy=Never --set config.experimental=true  ./charts/bin/gadget/
$ ./kubectl-gadget run qasimregistry.azurecr.io/gadget/trace_open:latest -A
```

### gadget

```bash
$ kubectl create secret -n gadget docker-registry gadget-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json
$ ./kubectl-gadget run qasimregistry.azurecr.io/gadget/trace_open:latest  --pull-secret gadget-pull-secret -A
```

## Todo

- [x] Documentation
- [x] Allow specifying gadgetPullSecret at runtime. (Will be handled later on when https://github.com/inspektor-gadget/inspektor-gadget/issues/2225 is fixed)



