### PR TITLE
gadget-container: Fix regex to detect if CRI-O is used.

### DIFF
--- a/gadget-container/entrypoint/entrypoint.go
+++ b/gadget-container/entrypoint/entrypoint.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var crioRegex = regexp.MustCompile(`^1:name=systemd:.*/crio-[0-9a-f]*\.scope$`)
+var crioRegex = regexp.MustCompile(`1:name=systemd:.*/crio-[0-9a-f]*\.scope`)
 
 func getPrettyName() (string, error) {
 	path := filepath.Join(host.HostRoot, "/etc/os-release")


### PR DESCRIPTION
Fixes: b268d38758cf ("gadget-container: Add golang version of entrypoint.sh.")