### PR TITLE
cmd: Fix --authfile/--insecure flags

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -17,7 +17,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
@@ -177,7 +176,7 @@ func removeHelpArg(args []string) []string {
 	return args
 }
 
-func ParseEarlyFlags(cmd *cobra.Command) error {
+func ParseEarlyFlags(cmd *cobra.Command, rawArgs []string) error {
 	// Do not error out on unknown flags, but still validate currently
 	// known ones.
 	// Other flags will be validated in the `Execute()` call and unknown
@@ -188,7 +187,7 @@ func ParseEarlyFlags(cmd *cobra.Command) error {
 		cmd.FParseErrWhitelist.UnknownFlags = false
 	}()
 	// temporary workaround for https://github.com/inspektor-gadget/inspektor-gadget/pull/2174#issuecomment-1780923952
-	args := slices.Clone(os.Args[1:]) // clone to avoid modifying the original os.Args
+	args := slices.Clone(rawArgs) // clone to avoid modifying the original os.Args
 	args = removeSplitSortArgs(args)
 	// --help should be handled after we registered all commands
 	args = removeHelpArg(args)

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -69,7 +69,7 @@ func main() {
 		// sure that --remote-address has already been parsed when calling
 		// InitDeployInfo(), so it can target the specified address
 
-		err := commonutils.ParseEarlyFlags(rootCmd)
+		err := commonutils.ParseEarlyFlags(rootCmd, os.Args[1:])
 		if err != nil {
 			// Analogous to cobra error message
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// evaluate flags early; this will make sure that flags for host are evaluated before
 	// calling host.Init()
-	err := commonutils.ParseEarlyFlags(rootCmd)
+	err := commonutils.ParseEarlyFlags(rootCmd, os.Args[1:])
 	if err != nil {
 		// Analogous to cobra error message
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -81,7 +81,7 @@ func main() {
 		// sure that --connection-method has already been parsed when calling
 		// InitDeployInfo()
 
-		err := commonutils.ParseEarlyFlags(rootCmd)
+		err := commonutils.ParseEarlyFlags(rootCmd, os.Args[1:])
 		if err != nil {
 			// Analogous to cobra error message
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/integration/inspektor-gadget/run_insecure_test.go
+++ b/integration/inspektor-gadget/run_insecure_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestRunInsecure(t *testing.T) {
+	ns := GenerateTestNamespaceName("test-run-insecure")
+
+	t.Parallel()
+
+	commandsPreTest := []*Command{
+		CreateTestNamespaceCommand(ns),
+		PodCommand("registry", "docker.io/library/registry:2", ns, "", ""),
+		WaitUntilPodReadyCommand(ns, "registry"),
+	}
+
+	RunTestSteps(commandsPreTest, t)
+
+	t.Cleanup(func() {
+		commands := []*Command{
+			DeleteTestNamespaceCommand(ns),
+		}
+		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	registryIP := GetTestPodIP(t, ns, "registry")
+
+	// copy gadget image to insecure registry
+	orasCpCmds := []*Command{
+		{
+			Name: "Copy gadget image",
+			Cmd: fmt.Sprintf(`
+				kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: copier
+  namespace: %s
+spec:
+  template:
+    spec:
+      containers:
+      - name: copier
+        image: ghcr.io/oras-project/oras:v1.1.0
+        command:
+         - oras
+         - copy
+         - --to-plain-http
+         - %s/trace_open:%s
+         - %s:5000/trace_open:%s
+      restartPolicy: Never
+  backoffLimit: 4
+EOF`, ns, *gadgetRepository, *gadgetTag, registryIP, *gadgetTag),
+			ExpectedRegexp: "job.batch/copier created",
+		},
+		{
+			Name:           "WaitForCopierJob",
+			Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete -n %s copier", ns),
+			ExpectedString: "job.batch/copier condition met\n",
+		},
+	}
+	RunTestSteps(orasCpCmds, t)
+
+	// TODO: Ideally it should not depend on a real gadget, but we don't have a "test gadget" available yet.
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s:5000/trace_open:%s -n %s -o json --insecure", registryIP, *gadgetTag, ns)
+	runTraceOpen(t, ns, cmd)
+}


### PR DESCRIPTION
d1bccf6c124f ("gadgets/run: Support eBPF parameters") introduced a logic to remove the flags before calling GetGadgetInfo(), unfortunately it also broke the --authfile/--insecure flags as they were removed.

This commit changes the approach to use ParseEarlyFlags() to parse flags that are already known before contacting the server, like --insecure & --authfile, so they can be used by the server while it executes GetGadgetInfo().

Fixes: d1bccf6c124f ("gadgets/run: Support eBPF parameters")
Fix https://github.com/inspektor-gadget/inspektor-gadget/issues/2225

## How to test 

0. Push a gadget to a insecure registry. https://github.com/inspektor-gadget/inspektor-gadget/issues/2225 contains instructions for it. In my case I pushed it to 192.168.1.150:5000/foo:latest

I manually tested the following:

### ig 

```bash
sudo -E ig run 192.168.1.150:5000/foo:latest --insecure
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                  PID                  PPID                 COMM             UID                  GID                 RETVAL
```

### ig + gadgectl using default unix socket

```bash
$ sudo -E ig daemon
INFO[0000] Experimental features enabled                
INFO[0000] starting Inspektor Gadget daemon at "unix:///var/run/ig/ig.socket"
...

$ sudo -E ./gadgetctl run 192.168.1.150:5000/foo:latest 
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                  PID                  PPID                 COMM             UID                  GID                 RETVAL
```

###  ig + gadgectl  using tcp 

```bash
$ sudo -E ig daemon -H tcp://127.0.0.1:1234
INFO[0000] Experimental features enabled                
INFO[0000] starting Inspektor Gadget daemon at "tcp://127.0.0.1:1234"

...
$ ./gadgetctl run 192.168.1.150:5000/foo:latest --remote-address tcp://127.0.0.1:1234 --insecure
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                  PID                  PPID                 COMM             UID                  GID                 RETVAL
```

### kubectl gadget 

```bash
$ ./kubectl-gadget run 192.168.1.150:5000/foo:latest --insecure -A 
INFO[0000] Experimental features enabled                
K8S.NODE              K8S.NAMESPACE         K8S.POD               K8S.CONTAINER        PID         PPID        COMM        UID         GID         RETVAL
```

### TODO
- [X] Add integration tests for for --insecure

