### PR TITLE
trace/open: Add missing extractor for flags

### DIFF
--- a/pkg/gadgets/trace/open/types/types.go
+++ b/pkg/gadgets/trace/open/types/types.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"io/fs"
+	"strings"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -41,7 +42,13 @@ type Event struct {
 }
 
 func GetColumns() *columns.Columns[Event] {
-	return columns.MustCreateColumns[Event]()
+	openColumns := columns.MustCreateColumns[Event]()
+
+	openColumns.MustSetExtractor("flags", func(event *Event) any {
+		return strings.Join(event.Flags, "|")
+	})
+
+	return openColumns
 }
 
 func Base(ev eventtypes.Event) *Event {


### PR DESCRIPTION
TL;DR: We're missing the extractor for the flags and they were always
empty in the columns representation.

Before this commit:

```bash
$ sudo ig trace open -o columns=flags
FLAGS


// ^^^^ empty entries
```

After this commit:

```bash
$ sudo ig trace open -o columns=flags
FLAGS
O_RDONLY|O_CLOEXEC
O_RDONLY|O_CLOEXEC
O_RDONLY|O_CLOEXEC
O_RDONLY|O_CLOEXEC
O_RDONLY|O_CLOEXEC
```

Long story:

3c9916449a05 ("pkg: Add support for flags for trace open.") introduced
support for the flag column but it didn't define a custom extractor, at 
that time the column was formatted as:

```bash
sudo ig trace open -o columns=flags
FLAGS
[O_RDONLY O_CLOEXEC]
[O_RDONLY O_CLOEXEC]
[O_RDONLY O_CLOEXEC]
[O_RDONLY O_CLOEXEC]
[O_RDONLY O_CLOEXEC]
[O_RDONLY O_CLOEXEC]
```

Later on, 5ad73284af88 ("pkg/columns: add support for dynamic fields")
modified the columns library **not** to format slices to strings, hence
after this commit the column was printed as empty.

It's also possible to fix this on the columns library, but having a
custom extractor allows us to provide a better formatting to the user.

Fixes: 3c9916449a05 ("pkg: Add support for flags for trace open.")
Fixes: 5ad73284af88 ("pkg/columns: add support for dynamic fields")

