### PR TITLE
Show experimental commands in all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Available Commands:
   help        Help about any command
   profile     Profile different subsystems
   prometheus  Expose metrics using prometheus
+  run         Run a containerized gadget (experimental)
   script      Run a bpftrace-compatible scripts
   snapshot    Take a snapshot of a subsystem and print it
   sync        Synchronize gadget information with server

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -98,7 +99,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.updateMetadata, "update-metadata", false, "Update the metadata according to the eBPF code")
 	cmd.Flags().BoolVar(&opts.validateMetadata, "validate-metadata", true, "Validate the metadata file before building the gadget image")
 
-	return cmd
+	return utils.MarkExperimental(cmd)
 }
 
 func runBuild(opts *cmdOpts) error {

--- a/cmd/common/image/image.go
+++ b/cmd/common/image/image.go
@@ -14,7 +14,11 @@
 
 package image
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+)
 
 func NewImageCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -28,5 +32,5 @@ func NewImageCmd() *cobra.Command {
 	cmd.AddCommand(NewTagCmd())
 	cmd.AddCommand(NewListCmd())
 
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns/formatter/textcolumns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
@@ -58,5 +59,5 @@ func NewListCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&noTrunc, "no-trunc", false, "Don't truncate output")
 
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/image/pull.go
+++ b/cmd/common/image/pull.go
@@ -44,5 +44,5 @@ func NewPullCmd() *cobra.Command {
 		},
 	}
 	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/image/push.go
+++ b/cmd/common/image/push.go
@@ -49,5 +49,5 @@ func NewPushCmd() *cobra.Command {
 		},
 	}
 	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/image/tag.go
+++ b/cmd/common/image/tag.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -42,5 +43,5 @@ func NewTagCmd() *cobra.Command {
 		},
 	}
 
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/login.go
+++ b/cmd/common/login.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -45,5 +46,5 @@ func NewLoginCmd() *cobra.Command {
 	loginFlagSet := auth.GetLoginFlags(&o.loginOpts)
 	loginFlagSet.Lookup("authfile").Value.Set(oci.DefaultAuthFile)
 	cmd.Flags().AddFlagSet(loginFlagSet)
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/logout.go
+++ b/cmd/common/logout.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -43,5 +44,5 @@ func NewLogoutCmd() *cobra.Command {
 	logoutFlagSet := auth.GetLogoutFlags(&o.logoutOpts)
 	logoutFlagSet.Lookup("authfile").Value.Set(oci.DefaultAuthFile)
 	cmd.Flags().AddFlagSet(logoutFlagSet)
-	return cmd
+	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -713,6 +713,13 @@ func buildCommandFromGadget(
 	for _, operatorParams := range operatorsParamsCollection {
 		AddFlags(cmd, operatorParams, skipParams, runtime)
 	}
+
+	if exp, ok := gadgetDesc.(gadgets.GadgetExperimental); ok {
+		if exp.Experimental() {
+			utils.MarkExperimental(cmd)
+		}
+	}
+
 	return cmd
 }
 

--- a/cmd/common/utils/experimental.go
+++ b/cmd/common/utils/experimental.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
+)
+
+const (
+	errMsgExperimental = "this command can only be used when experimental features are enabled"
+)
+
+func replaceFunc(f func(cmd *cobra.Command, args []string)) func(cmd *cobra.Command, args []string) {
+	if f == nil || experimental.Enabled() {
+		return f
+	}
+
+	return func(cmd *cobra.Command, args []string) {
+		fmt.Println(errMsgExperimental)
+	}
+}
+
+func replaceFuncE(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
+	if f == nil || experimental.Enabled() {
+		return f
+	}
+
+	return func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf(errMsgExperimental)
+	}
+}
+
+func MarkExperimental(cmd *cobra.Command) *cobra.Command {
+	cmd.Short += " (experimental)"
+
+	if !experimental.Enabled() {
+		// Allow printing help when -h is passed.
+		cmd.DisableFlagParsing = false
+		// Ignore unknown flags so that we can print help when -h is passed.
+		cmd.FParseErrWhitelist.UnknownFlags = true
+	}
+
+	cmd.Run = replaceFunc(cmd.Run)
+	cmd.PreRun = replaceFunc(cmd.PreRun)
+	cmd.PostRun = replaceFunc(cmd.PostRun)
+	cmd.RunE = replaceFuncE(cmd.RunE)
+	cmd.PreRunE = replaceFuncE(cmd.PreRunE)
+	cmd.PostRunE = replaceFuncE(cmd.PostRunE)
+
+	return cmd
+}

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -74,11 +74,9 @@ func main() {
 	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
 
 	rootCmd.AddCommand(newDaemonCommand(runtime))
-	if experimental.Enabled() {
-		rootCmd.AddCommand(image.NewImageCmd())
-		rootCmd.AddCommand(common.NewLoginCmd())
-		rootCmd.AddCommand(common.NewLogoutCmd())
-	}
+	rootCmd.AddCommand(image.NewImageCmd())
+	rootCmd.AddCommand(common.NewLoginCmd())
+	rootCmd.AddCommand(common.NewLogoutCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -168,3 +168,8 @@ type GadgetInstantiate interface {
 	// should not run any code that depends on cleanup
 	NewInstance() (Gadget, error)
 }
+
+// GadgetExperimental allows to mark a gadget as experimental.
+type GadgetExperimental interface {
+	Experimental() bool
+}

--- a/pkg/gadgets/run/tracer/run.go
+++ b/pkg/gadgets/run/tracer/run.go
@@ -17,6 +17,7 @@ package tracer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -116,6 +117,10 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 
 func (g *GadgetDesc) Parser() parser.Parser {
 	return nil
+}
+
+func (g *GadgetDesc) Experimental() bool {
+	return true
 }
 
 // getGadgetType returns the type of the gadget according to the gadget being run.
@@ -260,6 +265,9 @@ func fillTypeHints(spec *ebpf.CollectionSpec, params map[string]types.EBPFParam)
 }
 
 func (g *GadgetDesc) GetGadgetInfo(params *params.Params, args []string) (*types.GadgetInfo, error) {
+	if !experimental.Enabled() {
+		return nil, errors.New("run needs experimental features to be enabled")
+	}
 	return getGadgetInfo(params, args, log.StandardLogger())
 }
 
@@ -641,7 +649,5 @@ func (g *GadgetDesc) EventPrototype() any {
 }
 
 func init() {
-	if experimental.Enabled() {
-		gadgetregistry.Register(&GadgetDesc{})
-	}
+	gadgetregistry.Register(&GadgetDesc{})
 }

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -42,6 +42,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	bpfiterns "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/bpf-iter-ns"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
 )
 
 // keep aligned with pkg/gadgets/common/types.h
@@ -101,6 +102,10 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 }
 
 func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
+	if !experimental.Enabled() {
+		return errors.New("run needs experimental features to be enabled")
+	}
+
 	t.config = &Config{}
 	t.containers = make(map[string]*containercollection.Container)
 	t.networkTracers = make(map[string]*networktracer.Tracer[types.Event])


### PR DESCRIPTION
This commit changes the logic to show the experimental commands on the CLI even if the experimental mode is not enabled. This allows these commands to have a better discoverability.

Experimental commands are shown:

```bash
$ sudo ig
Collection of gadgets for containers
...
  image           Manage gadget images (experimental)
...
  login           Login to a container registry (experimental)
  logout          Logout of a container registry (experimental)
...
  run             Run a containerized gadget (experimental)
```

and their help
```bash 
$ sudo ig login -h
Login to a container registry on a specified server.

Usage:
  ig login [command options] REGISTRY [flags]
...

$ sudo ig run -h
Run a containerized gadget (experimental)

Usage:
  ig run [flags]

... 
```

but they can't be run:

```bash
$ sudo ig login 
Error: this command can only be used when experimental features are enabled

$ sudo ig run
Error: this command can only be used when experimental features are enabled
```

Commands work fine when experimental mode is enabled:
```bash
$ sudo IG_EXPERIMENTAL=true ig image list
INFO[0000] Experimental features enabled                
REPOSITORY                                                               TAG                                                                      DIGEST      
docker.io/library/mygadget                                               latest                                                                   4b3cf9bd7077
ghcr.io/inspektor-gadget/gadget/trace_open                               latest                                                                   28a480836f3a


$ sudo IG_EXPERIMENTAL=true ig run mygadget
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                       PID             MNTNS_ID                      COMM                   FILENAME               FOO 
```

cc @blixtra 











