### PR TITLE
[integration-tests] Add helpers for Jobs 

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -659,6 +659,16 @@ func DeleteRemainingNamespacesCommand() *Command {
 	}
 }
 
+// WaitUntilJobCompleteCommand returns a Command which waits until the job with the specified name in
+// the given namespace is complete.
+func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
+	return &Command{
+		Name:           fmt.Sprintf("WaitForJob: %s", jobname),
+		Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete -n %s %s", namespace, jobname),
+		ExpectedString: fmt.Sprintf("job.batch/%s condition met\n", jobname),
+	}
+}
+
 // WaitUntilPodReadyCommand returns a Command which waits until pod with the specified name in
 // the given as parameter namespace is ready.
 func WaitUntilPodReadyCommand(namespace string, podname string) *Command {

--- a/integration/inspektor-gadget/run_insecure_test.go
+++ b/integration/inspektor-gadget/run_insecure_test.go
@@ -45,17 +45,14 @@ func TestRunInsecure(t *testing.T) {
 
 	// copy gadget image to insecure registry
 	orasCpCmds := []*Command{
-		JobCommand("copier", "ghcr.io/oras-project/oras:v1.1.0", ns, "oras", []string{
+		JobCommand("copier", "ghcr.io/oras-project/oras:v1.1.0", ns,
+			"oras",
 			"copy",
 			"--to-plain-http",
 			fmt.Sprintf("%s/trace_open:%s", *gadgetRepository, *gadgetTag),
 			fmt.Sprintf("%s:5000/trace_open:%s", registryIP, *gadgetTag),
-		}...),
-		{
-			Name:           "WaitForCopierJob",
-			Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete -n %s copier", ns),
-			ExpectedString: "job.batch/copier condition met\n",
-		},
+		),
+		WaitUntilJobCompleteCommand(ns, "copier"),
 	}
 	RunTestSteps(orasCpCmds, t)
 


### PR DESCRIPTION
# [integration-tests] Add helpers for Jobs 

Adds two functions to help in the integration tests:
1. `JobCommand` to create jobs
2. `WaitUntilJobCompleteCommand` which waits until the job completes