### PR TITLE
run: Fix a lot of leakages and implement support for multiple socket filter programs

### DIFF
--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -124,11 +124,7 @@ func (t *Tracer) Init(gadgetCtx gadgets.GadgetContext) error {
 	return nil
 }
 
-// Close is needed because of the StartStopGadget interface
 func (t *Tracer) Close() {
-}
-
-func (t *Tracer) Stop() {
 	if t.collection != nil {
 		t.collection.Close()
 		t.collection = nil
@@ -146,6 +142,9 @@ func (t *Tracer) Stop() {
 	}
 	if t.socketEnricher != nil {
 		t.socketEnricher.Close()
+	}
+	if t.networkTracer != nil {
+		t.networkTracer.Close()
 	}
 }
 
@@ -599,7 +598,7 @@ func (t *Tracer) Run(gadgetCtx gadgets.GadgetContext) error {
 	t.config.Metadata = info.GadgetMetadata
 
 	if err := t.installTracer(params); err != nil {
-		t.Stop()
+		t.Close()
 		return fmt.Errorf("install tracer: %w", err)
 	}
 


### PR DESCRIPTION
All of this started while investigating [this comment](https://github.com/inspektor-gadget/inspektor-gadget/pull/2248#pullrequestreview-1757941868), which refers to https://github.com/inspektor-gadget/inspektor-gadget/issues/2108. I found that we weren't releasing the network tracer, and then I found that the issue was worst and we're not releasing any programs at all when running image-based gadgets.

## How to test

### Before this fix

Before running any gadget, there are some programs and maps in the node:

```bash
$ sudo bpftool prog list --json | jq length
28
$ sudo bpftool map list --json | jq length
40
```

Run a gadget, and terminate it as soon as it prints some events.

```bash
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:latest -A
... // ctrl + C
```

The number of open programs and maps increased:

```bash 
$ sudo bpftool prog list --json | jq length
30
$ sudo bpftool map list --json | jq length
51
```

If you run the gadget again, they keep increasing

```bash 

$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:latest -A
... // ctrl + C

$ sudo bpftool prog list --json | jq length
32
$ sudo bpftool map list --json | jq length
53
```

The situation is worst with a networking gadget:

```bash 
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:latest -A
... // ctrl + C

$ sudo bpftool prog list --json | jq length
45
$ sudo bpftool map list --json | jq length
59

$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:latest -A.
... // ctrl + C

$ sudo bpftool prog list --json | jq length
58
$ sudo bpftool map list --json | jq length
68
```

A lot of maps named [tail_call](https://github.com/inspektor-gadget/inspektor-gadget/blob/c1cc966f4f16ac3d0fdd7a39b66d5182ece16acb/pkg/gadgets/internal/networktracer/bpf/dispatcher.bpf.c#L15) and the dns program itself are leaked

```bash 
$ sudo bpftool map list name tail_call
22521: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type socket_filter  owner jited
22576: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type socket_filter  owner jited
22616: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
22617: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type socket_filter  owner jited
22657: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
22658: prog_array  name tail_call  flags 0x0
	key 4B  value 4B  max_entries 1  memlock 4096B
	owner_prog_type socket_filter  owner jited

$ sudo bpftool prog list name ig_trace_dns
6083: socket_filter  name ig_trace_dns  tag 73eb506774d37c0f  gpl
	loaded_at 2023-11-30T20:32:43+0000  uid 0
	xlated 7272B  jited 4152B  memlock 8192B  map_ids 22635,22637,22631,22636
	btf_id 9806
	pids gadgettracerman(802944)
6122: socket_filter  name ig_trace_dns  tag 73eb506774d37c0f  gpl
	loaded_at 2023-11-30T20:33:05+0000  uid 0
	xlated 7272B  jited 4152B  memlock 8192B  map_ids 22676,22678,22672,22677
	btf_id 9861
	pids gadgettracerman(802944)
```

### After this fix 

Before running any gadget, there are some programs and maps in the node:

```bash 
$ sudo bpftool prog list --json | jq length
28
$ sudo bpftool map list --json | jq length
39
```
Run a gadget, and terminate it as soon as it prints some events.

```bash
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:latest -A
... // ctrl + C
```

The number of open programs and maps is the same as before

```bash 
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:latest -A
... // ctrl + C

$ sudo bpftool prog list --json | jq length
28
$ sudo bpftool map list --json | jq length
39
```

Running the dns gadget has the same behaviour

```bash
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:latest -A
... // ctrl + C

$ sudo bpftool prog list --json | jq length
30
$ sudo bpftool map list --json | jq length
42
```

In this case the numbers increased because the socket enricher is lazily-loaded, if we run again the numbers keep constant:

```
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:latest -A
... // ctrl + C

$ sudo bpftool prog list --json | jq length
30
$ sudo bpftool map list --json | jq length
42
```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/2108