### PR TITLE
gadgets: Fix timestamp handling in old kernels

### DIFF
--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -268,6 +268,8 @@ func (t *Tracer) loadeBPFObjects(opts loadingOptions) error {
 		}
 	}
 
+	gadgets.FixBpfKtimeGetBootNs(t.spec.Programs)
+
 	t.collection, err = ebpf.NewCollectionWithOptions(t.spec, opts.collectionOptions)
 	if err != nil {
 		return fmt.Errorf("create BPF collection: %w", err)


### PR DESCRIPTION
Also use FixBpfKtimeGetBootNs() in the run command to fix eBPF programs before loading them. 

## Test

Use a kernel that doesn't have `BPF_FUNC_ktime_get_boot_ns`:  < 5.8 https://github.com/torvalds/linux/commit/71d19214776e61b33da48f7c1b46e522c7f78221

### Before 

```bash
$ sudo -E ./ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                       PID                     PPID                   COMM             UID                    GID                    RET…
Error: running gadget: running gadget: install tracer: loading eBPF objects: create BPF collection: program ig_execve_e: load program: invalid argument: invalid func unknown#125 (110 line(s) omitted)
```

### After 

```bash 
$ sudo -E ./ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest
INFO[0000] Experimental features enabled                
RUNTIME.CONTAINERNAME                       PID                     PPID                   COMM             UID                    GID                    RET…
```


