### PR TITLE
ci: Add write permission to security events when building ig. 

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -251,8 +251,6 @@ jobs:
     name: btfgen
     # level: 0
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -289,6 +287,8 @@ jobs:
       - btfgen
       - build-helper-images
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is needed by CodeQL to be able to report events.

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
Fixes: https://github.com/inspektor-gadget/inspektor-gadget/commit/f04d95b078d5eb6eee289cedd27dc38f7aa0d9e6 ("ci: Add CWE checks for ig.")
[1]: https://github.com/github/codeql/issues/8843#issuecomment-1108467590