### PR TITLE
ci: Skip public key check when run by dependabot or from fork. 

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1080,6 +1080,13 @@ jobs:
     # level: 1
     needs: check-secrets
     runs-on: ubuntu-latest
+    # When this job is run by a PR coming from a fork, it will not have access
+    # to secrets.
+    # Also, unless specified in the secrets configuration, dependabot cannot access
+    # to secrets.
+    # So, we skip this job when run by dependabot and from a PR coming from a
+    # fork.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - name: Install Cosign


### PR DESCRIPTION
Jobs running from fork do not have access to secrets.
The same applies to dependabot, unless explicitly set in the secrets
configuration.
So, we skip this job when run from a fork or by dependabot.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/commit/7c004217391a4f9bd4a48bcee143fed80e3c50e0 ("Add Inspektor Gadget public key to source.")