### PR TITLE
ci: Run public-key-check on push.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1086,7 +1086,9 @@ jobs:
     # to secrets.
     # So, we skip this job when run by dependabot and from a PR coming from a
     # fork.
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    # We still need to run this job on push, otherwise it will not be run when
+    # we merge something on main.
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v4
       - name: Install Cosign


### PR DESCRIPTION
Otherwise, it will not be run when we merge something on main and its whole tree (including tests on AKS and ARO) would be skipped.

Fixes: 4f3b53746e68 ("ci: Skip public key check when run by dependabot or from fork.")