### PR TITLE
use client-go informers instead of active polling

### DIFF
--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -106,7 +106,7 @@ func (m *KubeIPResolverInstance) PostGadgetRun() error {
 }
 
 func (m *KubeIPResolverInstance) enrich(ev any) {
-	pods := m.manager.k8sInventory.GetPods()
+	pods, _ := m.manager.k8sInventory.GetPods()
 	endpoints := ev.(KubeIPResolverInterface).GetEndpoints()
 	for j := range endpoints {
 		// initialize to this default value if we don't find a match
@@ -114,7 +114,7 @@ func (m *KubeIPResolverInstance) enrich(ev any) {
 	}
 
 	found := 0
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		if pod.Spec.HostNetwork {
 			continue
 		}
@@ -134,9 +134,9 @@ func (m *KubeIPResolverInstance) enrich(ev any) {
 		}
 	}
 
-	svcs := m.manager.k8sInventory.GetSvcs()
+	svcs, _ := m.manager.k8sInventory.GetSvcs()
 
-	for _, svc := range svcs.Items {
+	for _, svc := range svcs {
 		for _, endpoint := range endpoints {
 			if svc.Spec.ClusterIP == endpoint.Addr {
 				endpoint.Kind = types.EndpointKindService

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -116,15 +116,15 @@ func (m *KubeNameResolverInstance) enrich(ev any) {
 	kubeNameResolver, _ := ev.(KubeNameResolverInterface)
 	containerInfo, _ := ev.(operators.ContainerInfoGetters)
 
-	pods := m.manager.k8sInventory.GetPods()
-	for i, pod := range pods.Items {
+	pods, _ := m.manager.k8sInventory.GetPods()
+	for _, pod := range pods {
 		if pod.Namespace == containerInfo.GetNamespace() && pod.Name == containerInfo.GetPod() {
 			owner := ""
 			// When the pod belongs to Deployment, ReplicaSet or DaemonSet, find the
 			// shorter name without the random suffix. That will be used to
 			// generate the network policy name.
-			if pods.Items[i].OwnerReferences != nil {
-				nameItems := strings.Split(pods.Items[i].Name, "-")
+			if pod.OwnerReferences != nil {
+				nameItems := strings.Split(pod.Name, "-")
 				if len(nameItems) > 2 {
 					owner = strings.Join(nameItems[:len(nameItems)-2], "-")
 				}


### PR DESCRIPTION
# use client-go informers instead of active polling

Use https://pkg.go.dev/k8s.io/client-go/informers instead of active polling in the `K8sInventoryCache` component.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

I don't know exactly how to test this change, help needed here.
