### PR TITLE
pkg/gadgets: Add cifs support to trace fsslower.

### DIFF
--- a/pkg/gadgets/trace/fsslower/tracer/gadget.go
+++ b/pkg/gadgets/trace/fsslower/tracer/gadget.go
@@ -63,7 +63,7 @@ func (g *GadgetDesc) ParamDescs() params.ParamDescs {
 			Title:          "Filesystem",
 			DefaultValue:   "ext4",
 			Description:    "Filesystem to trace",
-			PossibleValues: []string{"btrfs", "ext4", "nfs", "xfs"},
+			PossibleValues: []string{"btrfs", "cifs-direct", "cifs-loose", "cifs-strict", "ext4", "nfs", "xfs"},
 		},
 	}
 }

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -75,6 +75,27 @@ var fsConfMap = map[string]fsConf{
 		fsync:  "btrfs_sync_file",
 		statfs: "btrfs_statfs",
 	},
+	"cifs-direct": {
+		read:   "cifs_direct_readv",
+		write:  "cifs_direct_writev",
+		open:   "cifs_open",
+		fsync:  "cifs_fsync",
+		statfs: "cifs_statfs",
+	},
+	"cifs-loose": {
+		read:   "cifs_loose_read_iter",
+		write:  "cifs_file_write_iter",
+		open:   "cifs_open",
+		fsync:  "cifs_fsync",
+		statfs: "cifs_statfs",
+	},
+	"cifs-strict": {
+		read:   "cifs_strict_readv",
+		write:  "cifs_strict_writev",
+		open:   "cifs_open",
+		fsync:  "cifs_strict_fsync",
+		statfs: "cifs_statfs",
+	},
 	"ext4": {
 		read:   "ext4_file_read_iter",
 		write:  "ext4_file_write_iter",


### PR DESCRIPTION
Hi.


In this PR, I added support to `cifs` in `trace fsslower`:

```bash
root@vm-amd64:~# ./share/kinvolk/inspektor-gadget/ig trace fsslower --host -f cifs -m 0 > /tmp/cifs &
...
root@vm-amd64:~# more /tmp/cifs 
RUNTIME.CONTAINERNAME          PID              COMM             T      BYTES   
  OFFSET        LAT FILE                    
                               338              cat              O          0   
       0        962 perf.data               
                               339              cat              O          0   
       0       1467 perf.data               
                               340              cat              O          0   
       0        987 perf.data
```


Best regards.