### PR TITLE
columns: Avoid creating uneeded function

### DIFF
--- a/pkg/columns/columns.go
+++ b/pkg/columns/columns.go
@@ -616,10 +616,7 @@ func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatP
 			return "TODO"
 		}
 	case reflect.String:
-		ff := GetFieldFunc[string, T](column)
-		return func(entry *T) string {
-			return ff(entry)
-		}
+		return GetFieldFunc[string, T](column)
 	}
 	return func(entry *T) string {
 		return ""


### PR DESCRIPTION
The value returned by GetFieldFunc() can be used directly.

Found while reviewing https://github.com/inspektor-gadget/inspektor-gadget/pull/2122. 