### PR TITLE
Add `watch` permission for `services`

### DIFF
--- a/charts/gadget/templates/clusterrole.yaml
+++ b/charts/gadget/templates/clusterrole.yaml
@@ -12,8 +12,9 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["services"]
-    # list services is needed by network-policy gadget.
-    verbs: ["list"]
+    # list is needed by network-policy gadget
+    # watch is needed by operators enriching with service informations
+    verbs: ["list", "watch"]
   - apiGroups: ["gadget.kinvolk.io"]
     resources: ["traces", "traces/status"]
     # For traces, we need all rights on them as we define this resource.

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
@@ -116,7 +118,11 @@ func (m *KubeNameResolverInstance) enrich(ev any) {
 	kubeNameResolver, _ := ev.(KubeNameResolverInterface)
 	containerInfo, _ := ev.(operators.ContainerInfoGetters)
 
-	pods, _ := m.manager.k8sInventory.GetPods()
+	pods, err := m.manager.k8sInventory.GetPods()
+	if err != nil {
+		log.Warnf("getting pods from k8s inventory: %v", err)
+		return
+	}
 	for _, pod := range pods {
 		if pod.Namespace == containerInfo.GetNamespace() && pod.Name == containerInfo.GetPod() {
 			owner := ""

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -23,8 +23,9 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["services"]
-    # list services is needed by network-policy gadget.
-    verbs: ["list"]
+    # list is needed by network-policy gadget
+    # watch is needed by operators enriching with service informations
+    verbs: ["list", "watch"]
   - apiGroups: ["gadget.kinvolk.io"]
     resources: ["traces", "traces/status"]
     # For traces, we need all rights on them as we define this resource.


### PR DESCRIPTION
After https://github.com/inspektor-gadget/inspektor-gadget/pull/2347 changed the way we keep a up-to-date list of all pods and services (watchers instead of polling) everything seem to work.
IPs get resolved successfully to pod names and service names.

But in the gadget logs we see the following:
`1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.0/tools/cache/reflector.go:229: Failed to watch *v1.Service: unknown (get services)`

This PR adds the missing watch permissions for our ServiceAccount.

(I also added logging of the returned errors, but in this case they didn't help at all and logged nothing -> no error)