### PR TITLE
oci: wasm modules are no longer stored in the wasm architecture

### DIFF
--- a/docs/reference/oci.md
+++ b/docs/reference/oci.md
@@ -39,6 +39,16 @@ different media type among the following:
 - `application/vnd.gadget.ebpf.program.v1+binary`
 - `application/vnd.gadget.wasm.program.v1+binary`
 
+### The ebpf layer
+
+There must be exactly one layer with the ebpf media type. It must not be empty.
+Its content must be a valid ELF file.
+
+### The wasm layer
+
+There must be at most one layer with the wasm media type. If present, it must
+not be empty and it must be a valid wasm file.
+
 ## Image labels
 
 TODO

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -117,27 +117,20 @@ func pushDescriptorIfNotExists(ctx context.Context, target oras.Target, desc oci
 	return nil
 }
 
-func createEbpfProgramDesc(ctx context.Context, target oras.Target, progFilePath string, arch string) (ocispec.Descriptor, error) {
+func createLayerDesc(ctx context.Context, target oras.Target, progFilePath, mediaType string) (ocispec.Descriptor, error) {
 	progBytes, err := os.ReadFile(progFilePath)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("reading eBPF program file: %w", err)
 	}
-	mediaType := ""
-	switch arch {
-	case ArchWasm:
-		mediaType = wasmObjectMediaType
-	default:
-		mediaType = eBPFObjectMediaType
-	}
 	progDesc := content.NewDescriptorFromBytes(mediaType, progBytes)
 	progDesc.Annotations = map[string]string{
-		ocispec.AnnotationTitle:       "program.o",
+		ocispec.AnnotationTitle:       "TODO: title",
 		ocispec.AnnotationAuthors:     "TODO: authors",
 		ocispec.AnnotationDescription: "TODO: description",
 	}
 	err = pushDescriptorIfNotExists(ctx, target, progDesc, bytes.NewReader(progBytes))
 	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("pushing eBPF program: %w", err)
+		return ocispec.Descriptor{}, fmt.Errorf("pushing %q layer: %w", mediaType, err)
 	}
 
 	return progDesc, nil
@@ -169,8 +162,8 @@ func createEmptyDesc(ctx context.Context, target oras.Target) (ocispec.Descripto
 	return emptyDesc, nil
 }
 
-func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, progFilePath, arch string) (ocispec.Descriptor, error) {
-	progDesc, err := createEbpfProgramDesc(ctx, target, progFilePath, arch)
+func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, progFilePath, wasmFilePath, arch string) (ocispec.Descriptor, error) {
+	progDesc, err := createLayerDesc(ctx, target, progFilePath, eBPFObjectMediaType)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("creating and pushing eBPF descriptor: %w", err)
 	}
@@ -199,6 +192,14 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 		Config: defDesc,
 		Layers: []ocispec.Descriptor{progDesc},
 	}
+	if wasmFilePath != "" {
+		wasmDesc, err := createLayerDesc(ctx, target, wasmFilePath, wasmObjectMediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating and pushing wasm descriptor: %w", err)
+		}
+		manifest.Layers = append(manifest.Layers, wasmDesc)
+	}
+
 	manifestJson, err := json.Marshal(manifest)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("marshalling manifest: %w", err)
@@ -229,16 +230,9 @@ func createImageIndex(ctx context.Context, target oras.Target, o *BuildGadgetIma
 	layers := []ocispec.Descriptor{}
 
 	for arch, path := range o.EBPFObjectPaths {
-		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, path, arch)
+		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, path, o.WasmObjectPath, arch)
 		if err != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", arch, err)
-		}
-		layers = append(layers, manifestDesc)
-	}
-	if o.WasmObjectPath != "" {
-		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, o.WasmObjectPath, ArchWasm)
-		if err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", ArchWasm, err)
 		}
 		layers = append(layers, manifestDesc)
 	}


### PR DESCRIPTION
The wasm program is now in an OCI layer.

Before this patch, the OCI image had 3 architectures with only one layer each:
1. amd64
2. arm64
3. wasm

After this patch, the OCI image has 2 architectures:
1. amd64
2. arm64

And each architecture has 1 or 2 layers with different media types:
- application/vnd.gadget.ebpf.program.v1+binary
- application/vnd.gadget.wasm.program.v1+binary

This patch initially comes from #2204. But I would like to get it merged early before the rest of #2204 is ready.

This is a potentially breaking change. However, the currently published image-based gadgets don't make use of wasm yet, so no existing gadget shoud break.