### PR TITLE
gadgets/Makefile: Exit on error when pushing gadget

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -33,7 +33,7 @@ $(GADGETS):
 push: build
 	@echo "Pushing all gadgets"
 	for GADGET in $(GADGETS); do \
-		sudo -E IG_EXPERIMENTAL=true $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		sudo -E IG_EXPERIMENTAL=true $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
 	done
 
 .PHONY:


### PR DESCRIPTION
Currently, if we fail to push a gadget the loop to push the gadgets continues and we can end up in a situation where we will skip a gadget. This change ensures we exit early as soon as we hit an error. [See](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7502979343/job/20427140031#step:7:76)

## Testing Done

Following run shows that after this change `make` will exit as soon as it hits the first error.

### Before

```
→ make -C gadgets GADGETS="trace_dns trace_exec trace_open" GADGET_REPOSITORY=localhost:5000/gadgets push 
make: Entering directory '/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/gadgets'
Building trace_dns
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_dns:latest@sha256:65713d9a47dc4fe48d1052630c0786404b126b0181ff92151bd07204e15f937d
Building trace_exec
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_exec:latest@sha256:7a4ab9026540ab598f1b67f1638ff42e770df15db85cbc801660c2a55e01c590
Building trace_open
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_open:latest@sha256:f5f37e28df9f06aa5d9b181688ef4174f593c07e1199bc58634eb19d815bb49b
Pushing all gadgets
for GADGET in trace_dns trace_exec trace_open; do \
        sudo -E IG_EXPERIMENTAL=true ig image push localhost:5000/gadgets/$GADGET:latest; \
done
INFO[0000] Experimental features enabled                
Pushing localhost:5000/gadgets/trace_dns:latest...
Error: pushing gadget: copying to remote repository: Head "https://localhost:5000/v2/gadgets/trace_dns/manifests/sha256:65713d9a47dc4fe48d1052630c0786404b126b0181ff92151bd07204e15f937d": dial tcp 127.0.0.1:5000: connect: connection refused
INFO[0000] Experimental features enabled                
Pushing localhost:5000/gadgets/trace_exec:latest...
Error: pushing gadget: copying to remote repository: Head "https://localhost:5000/v2/gadgets/trace_exec/manifests/sha256:7a4ab9026540ab598f1b67f1638ff42e770df15db85cbc801660c2a55e01c590": dial tcp 127.0.0.1:5000: connect: connection refused
INFO[0000] Experimental features enabled                
Pushing localhost:5000/gadgets/trace_open:latest...
Error: pushing gadget: copying to remote repository: Head "https://localhost:5000/v2/gadgets/trace_open/manifests/sha256:f5f37e28df9f06aa5d9b181688ef4174f593c07e1199bc58634eb19d815bb49b": dial tcp 127.0.0.1:5000: connect: connection refused
make: *** [Makefile:35: push] Error 1
make: Leaving directory '/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/gadgets'

```

### After

```
→ make -C gadgets GADGETS="trace_dns trace_exec trace_open" GADGET_REPOSITORY=localhost:5000/gadgets push 
make: Entering directory '/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/gadgets'
Building trace_dns
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_dns:qasim-gadgets-exit-on-error@sha256:65713d9a47dc4fe48d1052630c0786404b126b0181ff92151bd07204e15f937d
Building trace_exec
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_exec:qasim-gadgets-exit-on-error@sha256:7a4ab9026540ab598f1b67f1638ff42e770df15db85cbc801660c2a55e01c590
Building trace_open
INFO[0000] Experimental features enabled                
Successfully built localhost:5000/gadgets/trace_open:qasim-gadgets-exit-on-error@sha256:f5f37e28df9f06aa5d9b181688ef4174f593c07e1199bc58634eb19d815bb49b
Pushing all gadgets
for GADGET in trace_dns trace_exec trace_open; do \
        sudo -E IG_EXPERIMENTAL=true ig image push localhost:5000/gadgets/$GADGET:qasim-gadgets-exit-on-error || exit 1 ; \
done
INFO[0000] Experimental features enabled                
Pushing localhost:5000/gadgets/trace_dns:qasim-gadgets-exit-on-error...
Error: pushing gadget: copying to remote repository: Head "https://localhost:5000/v2/gadgets/trace_dns/manifests/sha256:65713d9a47dc4fe48d1052630c0786404b126b0181ff92151bd07204e15f937d": dial tcp 127.0.0.1:5000: connect: connection refused
make: *** [Makefile:35: push] Error 1
make: Leaving directory '/home/qasim/work/github.com/inspektor-gadget/inspektor-gadget/gadgets'

```
