### PR TITLE
integration: Normalize ContainerImageDigest in all tests

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -127,7 +127,20 @@ out:
 				continue out
 			}
 		}
-		t.Fatalf("output doesn't contain the expected entry: %+v", expectedEntry)
+
+		var str strings.Builder
+
+		str.WriteString("output doesn't contain the expected entry\n")
+		str.WriteString("captured:\n")
+		for _, entry := range entries {
+			entryJson, _ := json.Marshal(entry)
+			str.WriteString(string(entryJson))
+			str.WriteString("\n")
+		}
+		expectedEntryJson, _ := json.Marshal(expectedEntry)
+		str.WriteString("expected:\n")
+		str.WriteString(string(expectedEntryJson))
+		t.Fatal(str.String())
 	}
 }
 

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -57,6 +57,7 @@ func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
 			e.Operations = 0
 
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 
 			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 			if isDockerRuntime {

--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -93,6 +93,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesToMatch(t, output, normalize, expectedEntry)
@@ -146,6 +147,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/audit_seccomp_test.go
+++ b/integration/inspektor-gadget/audit_seccomp_test.go
@@ -109,6 +109,7 @@ EOF
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -55,6 +55,7 @@ func TestProfileCpu(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/snapshot_process_test.go
+++ b/integration/inspektor-gadget/snapshot_process_test.go
@@ -68,6 +68,7 @@ func TestSnapshotProcess(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesInArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -91,6 +91,7 @@ func TestSnapshotSocket(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerImageDigest = ""
 				}
 
 				ExpectEntriesInArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/top_blockio_test.go
+++ b/integration/inspektor-gadget/top_blockio_test.go
@@ -47,6 +47,7 @@ func newTopBlockIOCmd(ns string, cmd string, startAndStop bool, isDockerRuntime 
 			e.Runtime.RuntimeName = ""
 			e.Runtime.ContainerName = ""
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 		}
 
 		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -51,6 +51,7 @@ func newTopEbpfCmd(cmd string, startAndStop bool) *Command {
 			e.Runtime.RuntimeName = ""
 			e.Runtime.ContainerName = ""
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 		}
 
 		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/top_file_test.go
+++ b/integration/inspektor-gadget/top_file_test.go
@@ -45,6 +45,7 @@ func newTopFileCmd(ns, cmd string, startAndStop bool, isDockerRuntime bool) *Com
 			e.Runtime.RuntimeName = ""
 			e.Runtime.ContainerName = ""
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 		}
 
 		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -59,6 +59,7 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool
 			e.Runtime.RuntimeName = ""
 			e.Runtime.ContainerName = ""
 			e.Runtime.ContainerID = ""
+			e.Runtime.ContainerImageDigest = ""
 		}
 
 		ExpectEntriesInMultipleArrayToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_bind_test.go
+++ b/integration/inspektor-gadget/trace_bind_test.go
@@ -58,6 +58,7 @@ func TestTraceBind(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectAllToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -80,6 +80,7 @@ func TestTraceCapabilities(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -150,6 +150,7 @@ func TestTraceDns(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 
 				if e.Qr == tracednsTypes.DNSPktTypeResponse {
 					e.DstPort = 0

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -80,6 +80,7 @@ func TestTraceExec(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -61,6 +61,7 @@ func TestTraceFsslower(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_mount_test.go
+++ b/integration/inspektor-gadget/trace_mount_test.go
@@ -61,6 +61,7 @@ func TestTraceMount(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -122,6 +122,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntries...)

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -57,6 +57,7 @@ func TestTraceOOMKill(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectAllToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -60,6 +60,7 @@ func TestTraceOpen(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_signal_test.go
+++ b/integration/inspektor-gadget/trace_signal_test.go
@@ -54,6 +54,7 @@ func TestTraceSignal(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -56,6 +56,7 @@ func TestTraceSni(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectAllToMatch(t, output, normalize, expectedEntry)

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -70,6 +70,7 @@ func TestTraceTcp(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			fmt.Printf("output: %s\n", output)

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -68,6 +68,7 @@ func TestTraceTcpconnect(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)
@@ -135,6 +136,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 				e.Runtime.RuntimeName = ""
 				e.Runtime.ContainerName = ""
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerImageDigest = ""
 			}
 
 			ExpectEntriesToMatch(t, output, normalize, expectedEntry)


### PR DESCRIPTION
This field is not available in all cases, hence normalize it.

Related https://github.com/inspektor-gadget/inspektor-gadget/issues/2358