### PR TITLE
integration: Add timeout for all tests

### DIFF
--- a/integration/ig/k8s/Makefile
+++ b/integration/ig/k8s/Makefile
@@ -50,4 +50,4 @@ test-%: build build-tests
 	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ln -sf /var/lib/minikube/binaries/$(KUBERNETES_VERSION)/kubectl /bin/kubectl" && \
 	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ln -sf /etc/kubernetes/admin.conf /root/.kube/config" && \
 	echo "Running test in minikube with profile $${MINIKUBE_PROFILE} ..." && \
-	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ig-integration.test -test.v -integration -container-runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}"
+	$(MINIKUBE) -p $${MINIKUBE_PROFILE} ssh "sudo ig-integration.test -test.v -test.timeout 30m -integration -container-runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}"

--- a/integration/ig/non-k8s/Makefile
+++ b/integration/ig/non-k8s/Makefile
@@ -22,5 +22,5 @@ test: test-$(CONTAINER_RUNTIME)
 test-%: build
 	cp ../../../ig-linux-amd64 ig
 	go test -c -o ./ig-docker-integration.test ./...
-	sudo ./ig-docker-integration.test -test.v -integration -runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}
+	sudo ./ig-docker-integration.test -test.v -test.timeout 30m -integration -runtime $* -dnstester-image $(DNSTESTER_IMAGE) $${INTEGRATION_TESTS_PARAMS}
 	rm -f ./ig-docker-integration.test ./ig


### PR DESCRIPTION
Avoid integration tests to remain stuck forever:
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7553752554/job/20565654462?pr=2370
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7546441014/job/20544600632
