### PR TITLE
CI: Print previous logs for gadget pods

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -290,9 +290,10 @@ func getPodLogs(ns string) string {
 	var sb strings.Builder
 	logCommands := []string{
 		fmt.Sprintf("kubectl get pods -n %s -o wide", ns),
-		fmt.Sprintf(`for pod in $(kubectl get pods -n %s -o name); do
-			kubectl logs -n %s $pod;
-		done`, ns, ns),
+		fmt.Sprintf(`for pod in $(kubectl get pods -n %[1]s -o name); do
+			kubectl logs -n %[1]s $pod --previous;
+			kubectl logs -n %[1]s $pod;
+		done`, ns),
 	}
 
 	for _, c := range logCommands {


### PR DESCRIPTION
We're missing the logs if a gadget pod crashes. Use `--previous` to print logs if the pod had crashed.

---

It happened for instance in https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7572632543/attempts/1#summary-20624243194.

```bash
command.go:273: Inspektor Gadget pod logs:
command.go:274: + kubectl get pods -n gadget -o wide
NAME           READY   STATUS    RESTARTS      AGE    IP           NODE                      NOMINATED NODE   READINESS GATES
gadget-d4z7x   1/1     Running   1 (39s ago)   109s   10.244.1.2   minikube-containerd-m02   <none>           <none>
gadget-sx6nw   1/1     Running   0             109s   10.244.0.3   minikube-containerd       <none>           <none>
+ kubectl get pods -n gadget -o name
+ kubectl logs -n gadget pod/gadget-d4z7x
time="2024-01-18T16:34:03Z" level=info msg="OS detected: Ubuntu 20.04.5 LTS"
time="2024-01-18T16:34:03Z" level=info msg="Kernel detected: 6.2.0-1018-azure"
time="2024-01-18T16:34:03Z" level=info msg="Gadget Image: ghcr.io/inspektor-gadget/inspektor-gadget:latest"
time="2024-01-18T16:34:03Z" level=info msg="Deployment options:"
time="2024-01-18T16:34:03Z" level=info msg="INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto"
time="2024-01-18T16:34:03Z" level=info msg="INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true"
time="2024-01-18T16:34:03Z" level=info msg="Inspektor Gadget version: d7f610b"
time="2024-01-18T16:34:03Z" level=info msg="Gadget Tracer Manager hook mode: auto"
time="2024-01-18T16:34:03Z" level=info msg="Starting the Gadget Tracer Manager..."
time="2024-01-18T16:34:03Z" level=info msg="Experimental features enabled"
time="2024-01-18T16:34:03Z" level=info msg="HostPID=false"
time="2024-01-18T16:34:03Z" level=info msg="HostNetwork=false"
time="2024-01-18T16:34:04Z" level=info msg="GadgetTracerManager: hook mode: fanotify+ebpf (auto)"
time="2024-01-18T16:34:04Z" level=info msg="GadgetTracerManager: enabling fallback podinformer"
time="2024-01-18T16:34:04Z" level=info msg="Starting Pod controller"
time="2024-01-18T16:34:04Z" level=info msg="gadget tracermgr set in kubemanager"
time="2024-01-18T16:34:04Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2024-01-18T16:34:04Z" level=warning msg="container gadget/gadget-d4z7x/gadget wasn't detected by the main hook! The fallback pod informer will add it."
time="2024-01-18T16:34:04Z" level=error msg="cgroup enricher: failed to get cgroup paths on container f86ad0205fdbf06ee232322c5806087d871ce6b224436df8583cc71e8be98a83: cgroup path not found in /proc/PID/cgroup"
time="2024-01-18T16:34:05Z" level=info msg="Starting trace controller manager"
time="2024-01-18T16:34:05Z" level=info msg="Reconcile trace gadget/traceloop-k8x4j (gadget traceloop, node minikube-containerd-m02)"
time="2024-01-18T16:34:05Z" level=info msg="No annotations. Nothing to do."
time="2024-01-18T16:34:10Z" level=info msg="Trace \"gadget/network-graph-2xsjg\" has been deleted"
+ kubectl logs -n gadget pod/gadget-sx6nw
time="2024-01-18T16:32:54Z" level=info msg="OS detected: Ubuntu 20.04.5 LTS"
time="2024-01-18T16:32:54Z" level=info msg="Kernel detected: 6.2.0-1018-azure"
time="2024-01-18T16:32:54Z" level=info msg="Gadget Image: ghcr.io/inspektor-gadget/inspektor-gadget:latest"
time="2024-01-18T16:32:54Z" level=info msg="Deployment options:"
time="2024-01-18T16:32:54Z" level=info msg="INSPEKTOR_GADGET_OPTION_HOOK_MODE=auto"
time="2024-01-18T16:32:54Z" level=info msg="INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER=true"
time="2024-01-18T16:32:54Z" level=info msg="Inspektor Gadget version: d7f610b"
time="2024-01-18T16:32:54Z" level=info msg="Gadget Tracer Manager hook mode: auto"
time="2024-01-18T16:32:54Z" level=info msg="Starting the Gadget Tracer Manager..."
time="2024-01-18T16:32:54Z" level=info msg="Experimental features enabled"
time="2024-01-18T16:32:54Z" level=info msg="HostPID=false"
time="2024-01-18T16:32:54Z" level=info msg="HostNetwork=false"
time="2024-01-18T16:32:54Z" level=info msg="GadgetTracerManager: hook mode: fanotify+ebpf (auto)"
time="2024-01-18T16:32:54Z" level=info msg="GadgetTracerManager: enabling fallback podinformer"
time="2024-01-18T16:32:54Z" level=info msg="Starting Pod controller"
time="2024-01-18T16:32:54Z" level=error msg="cgroup enricher: failed to get cgroup paths on container 15b4b81bc27418da38680eeb1c445887f4853c055c7eab2fc7afbff3df652e22: cgroup path not found in /proc/PID/cgroup"
time="2024-01-18T16:32:54Z" level=info msg="gadget tracermgr set in kubemanager"
time="2024-01-18T16:32:54Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2024-01-18T16:32:55Z" level=info msg="Starting trace controller manager"
time="2024-01-18T16:33:20Z" level=warning msg="Skip pod security-profiles-operator/spod-jdfn4: cannot find container (ID: containerd://855294762d5e1edbbba0c43aa610a6a260e3eb858e5aa384b108ddc5eacb0b00): got zero pid"
time="2024-01-18T16:33:20Z" level=warning msg="Skip pod security-profiles-operator/spod-jdfn4: cannot find container (ID: containerd://825f6a4da548b77c48d1b7bce9f78c4c413fda4a8742aabd8ac70790fbe8a8b3): got zero pid"
time="2024-01-18T16:33:59Z" level=info msg="Reconcile trace gadget/traceloop-sppqh (gadget traceloop, node minikube-containerd)"
time="2024-01-18T16:33:59Z" level=info msg="Gadget traceloop operation \"start\" on gadget/traceloop-sppqh"
time="2024-01-18T16:34:00Z" level=info msg="Gadget completed operation. Trace status will be updated accordingly"
time="2024-01-18T16:34:00Z" level=info msg="Updating new status of trace \"gadget/traceloop-sppqh\": state=Started operationError=\"\" operationWarning=\"\" output=<2190 characters>"
time="2024-01-18T16:34:00Z" level=info msg="Reconcile trace gadget/traceloop-sppqh (gadget traceloop, node minikube-containerd)"
time="2024-01-18T16:34:00Z" level=info msg="No annotations. Nothing to do."
time="2024-01-18T16:34:03Z" level=info msg="Reconcile trace gadget/network-graph-2xsjg (gadget network-graph, node minikube-containerd)"
time="2024-01-18T16:34:03Z" level=info msg="Gadget network-graph operation \"start\" on gadget/network-graph-2xsjg"
time="2024-01-18T16:34:04Z" level=info msg="Gadget completed operation. Trace status will be updated accordingly"
time="2024-01-18T16:34:04Z" level=info msg="Updating new status of trace \"gadget/network-graph-2xsjg\": state=Started operationError=\"\" operationWarning=\"\" output=<0 characters>"
time="2024-01-18T16:34:04Z" level=info msg="Reconcile trace gadget/network-graph-2xsjg (gadget network-graph, node minikube-containerd)"
time="2024-01-18T16:34:04Z" level=info msg="No annotations. Nothing to do."
time="2024-01-18T16:34:04Z" level=info msg="Reconcile trace gadget/network-graph-2xsjg (gadget network-graph, node minikube-containerd)"
time="2024-01-18T16:34:04Z" level=info msg="No annotations. Nothing to do."
time="2024-01-18T16:34:09Z" level=info msg="Reconcile trace gadget/network-graph-2xsjg (gadget network-graph, node minikube-containerd)"
time="2024-01-18T16:34:09Z" level=info msg="Deleting gadget/network-graph-2xsjg"
time="2024-01-18T16:34:10Z" level=info msg="Let trace gadget/network-graph-2xsjg be deleted"
time="2024-01-18T16:34:10Z" level=info msg="Trace \"gadget/network-graph-2xsjg\" has been deleted"
time="2024-01-18T16:34:23Z" level=info msg="Reconcile trace gadget/traceloop-sppqh (gadget traceloop, node minikube-containerd)"
time="2024-01-18T16:34:23Z" level=info msg="No annotations. Nothing to do."
```

The `gadget-d4z7x` pod have crashed one, but there is not any indication of why in the logs as we're missing the ones for the crashed instance.