### PR TITLE
CRI: Enrich with initial PodLabels

### DIFF
--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -56,6 +56,9 @@ type CommonFlags struct {
 
 	// ContainerdNamespace is the namespace used by containerd
 	ContainerdNamespace string
+
+	// UseCri specifies whether to use the CRI API to talk to the runtime
+	UseCri bool
 }
 
 func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
@@ -95,12 +98,13 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 			r := &containerutilsTypes.RuntimeConfig{
 				Name:       runtimeName,
 				SocketPath: socketPath,
+				Extra: containerutilsTypes.ExtraConfig{
+					UseCri: commonFlags.UseCri,
+				},
 			}
 
 			if namespace != "" {
-				r.Extra = &containerutilsTypes.ExtraConfig{
-					Namespace: namespace,
-				}
+				r.Extra.Namespace = namespace
 			}
 
 			commonFlags.RuntimeConfigs = append(commonFlags.RuntimeConfigs, r)
@@ -155,6 +159,13 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		"containerd-namespace",
 		constants.K8sContainerdNamespace,
 		"Namespace used by containerd",
+	)
+
+	command.PersistentFlags().BoolVar(
+		&commonFlags.UseCri,
+		"use-cri",
+		false,
+		"Use CRI API to retrieve more K8s information, but ignore non K8s containers",
 	)
 }
 

--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.labels,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.labels,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -187,6 +187,17 @@ func WithContainerImageName(imageName string, isDockerRuntime bool) CommonDataOp
 	}
 }
 
+// WithPodLabels sets the PodLabels to facilitate the tests
+func WithPodLabels(podName string, namespace string, enable bool) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		if enable {
+			commonData.K8s.PodLabels = map[string]string{
+				"run": podName,
+			}
+		}
+	}
+}
+
 func BuildCommonData(namespace string, options ...CommonDataOption) eventtypes.CommonData {
 	e := eventtypes.CommonData{
 		K8s: eventtypes.K8sMetadata{
@@ -205,6 +216,12 @@ func BuildCommonData(namespace string, options ...CommonDataOption) eventtypes.C
 	return e
 }
 
+func BuildCommonDataK8s(namespace string, options ...CommonDataOption) eventtypes.CommonData {
+	e := BuildCommonData(namespace, options...)
+	WithPodLabels("test-pod", namespace, true)(&e)
+	return e
+}
+
 func BuildBaseEvent(namespace string, options ...CommonDataOption) eventtypes.Event {
 	e := eventtypes.Event{
 		Type:       eventtypes.NORMAL,
@@ -213,6 +230,12 @@ func BuildBaseEvent(namespace string, options ...CommonDataOption) eventtypes.Ev
 	for _, option := range options {
 		option(&e.CommonData)
 	}
+	return e
+}
+
+func BuildBaseEventK8s(namespace string, options ...CommonDataOption) eventtypes.Event {
+	e := BuildBaseEvent(namespace, options...)
+	WithPodLabels("test-pod", namespace, true)(&e.CommonData)
 	return e
 }
 

--- a/integration/ig/k8s/enrichment_pod_label_test.go
+++ b/integration/ig/k8s/enrichment_pod_label_test.go
@@ -56,7 +56,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 
 	listContainersCmd := &Command{
 		Name: "RunListContainers",
-		Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --use-cri", *containerRuntime),
+		Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --runtime-protocol=cri", *containerRuntime),
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedContainer := &containercollection.Container{
 				K8s: containercollection.K8sMetadata{
@@ -122,7 +122,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 
 	listContainersCmd := &Command{
 		Name:         "RunWatchContainers",
-		Cmd:          fmt.Sprintf("ig list-containers -o json --runtimes=%s --use-cri --watch", *containerRuntime),
+		Cmd:          fmt.Sprintf("ig list-containers -o json --runtimes=%s --runtime-protocol=cri --watch", *containerRuntime),
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker

--- a/integration/ig/k8s/enrichment_pod_label_test.go
+++ b/integration/ig/k8s/enrichment_pod_label_test.go
@@ -1,0 +1,206 @@
+// Copyright 2022 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestEnrichmentPodLabelExistingPod(t *testing.T) {
+	t.Parallel()
+
+	cn := "test-enrichment-pod-label-existing-pod"
+	pod := cn
+	ns := GenerateTestNamespaceName(pod)
+
+	t.Cleanup(func() {
+		commandsPostTest := []*Command{
+			DeleteTestNamespaceCommand(ns),
+		}
+		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		PodCommand(cn, "busybox", ns, `["sleep", "inf"]`, ""),
+		WaitUntilPodReadyCommand(ns, pod),
+	}
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+
+	podUID := GetPodUID(t, ns, pod)
+
+	// Containerd and docker shim name the container with the Kubernetes container
+	// name, while CRI-O use a composed name.
+	runtimeContainerName := cn
+	if *containerRuntime == ContainerRuntimeCRIO {
+		// Test container shouldn't have been restarted, so append "0".
+		runtimeContainerName = "k8s_" + cn + "_" + pod + "_" + ns + "_" + podUID + "_" + "0"
+	}
+
+	listContainersCmd := &Command{
+		Name: "RunListContainers",
+		Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --use-cri", *containerRuntime),
+		ValidateOutput: func(t *testing.T, output string) {
+			expectedContainer := &containercollection.Container{
+				K8s: containercollection.K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: cn,
+						PodName:       pod,
+						Namespace:     ns,
+						PodLabels: map[string]string{
+							"run": cn,
+						},
+					},
+					PodUID: podUID,
+				},
+				Runtime: containercollection.RuntimeMetadata{
+					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+						RuntimeName:        types.String2RuntimeName(*containerRuntime),
+						ContainerName:      runtimeContainerName,
+						ContainerImageName: "docker.io/library/busybox:latest",
+					},
+				},
+			}
+
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			if isDockerRuntime {
+				expectedContainer.Runtime.ContainerImageName = ""
+			}
+
+			normalize := func(c *containercollection.Container) {
+				c.Pid = 0
+				c.OciConfig = nil
+				c.Bundle = ""
+				c.Mntns = 0
+				c.Netns = 0
+				c.CgroupPath = ""
+				c.CgroupID = 0
+				c.CgroupV1 = ""
+				c.CgroupV2 = ""
+
+				c.SandboxId = ""
+				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerImageDigest = ""
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					c.Runtime.ContainerImageName = ""
+				}
+			}
+
+			ExpectEntriesInArrayToMatch(t, output, normalize, expectedContainer)
+		},
+	}
+
+	RunTestSteps([]*Command{listContainersCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+}
+
+func TestEnrichmentPodLabelNewPod(t *testing.T) {
+	t.Parallel()
+
+	cn := "test-enrichment-pod-label-new-pod"
+	pod := cn
+	ns := GenerateTestNamespaceName(pod)
+
+	listContainersCmd := &Command{
+		Name:         "RunWatchContainers",
+		Cmd:          fmt.Sprintf("ig list-containers -o json --runtimes=%s --use-cri --watch", *containerRuntime),
+		StartAndStop: true,
+		ValidateOutput: func(t *testing.T, output string) {
+			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			expectedEvent := &containercollection.PubSubEvent{
+				Type: containercollection.EventTypeAddContainer,
+				Container: &containercollection.Container{
+					K8s: containercollection.K8sMetadata{
+						BasicK8sMetadata: types.BasicK8sMetadata{
+							ContainerName: cn,
+							PodName:       pod,
+							Namespace:     ns,
+							PodLabels: map[string]string{
+								"run": cn,
+							},
+						},
+					},
+					Runtime: containercollection.RuntimeMetadata{
+						BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+							RuntimeName:        types.String2RuntimeName(*containerRuntime),
+							ContainerName:      cn,
+							ContainerImageName: "docker.io/library/busybox:latest",
+						},
+					},
+				},
+			}
+
+			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			if isDockerRuntime {
+				expectedEvent.Container.Runtime.ContainerImageName = ""
+			}
+
+			normalize := func(e *containercollection.PubSubEvent) {
+				e.Container.Pid = 0
+				e.Container.OciConfig = nil
+				e.Container.Bundle = ""
+				e.Container.Mntns = 0
+				e.Container.Netns = 0
+				e.Container.CgroupPath = ""
+				e.Container.CgroupID = 0
+				e.Container.CgroupV1 = ""
+				e.Container.CgroupV2 = ""
+				e.Timestamp = ""
+
+				e.Container.SandboxId = ""
+				e.Container.K8s.PodUID = ""
+				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerImageDigest = ""
+
+				// CRI-O uses a custom container name composed, among
+				// other things, by the pod UID. We don't know the pod UID in
+				// advance, so we can't match the expected container name.
+				// TODO: Create a test for this once we support filtering by k8s
+				// container name. See
+				// https://github.com/inspektor-gadget/inspektor-gadget/issues/1403.
+				if e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO {
+					e.Container.Runtime.ContainerName = cn
+				}
+
+				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				if isDockerRuntime {
+					e.Container.Runtime.ContainerImageName = ""
+				}
+			}
+
+			// Watching containers is a command that needs to be started before
+			// the container is created, so we can't filter by container name
+			// neither use ExpectAllInArrayToMatch here.
+			ExpectEntriesToMatch(t, output, normalize, expectedEvent)
+		},
+	}
+
+	commands := []*Command{
+		CreateTestNamespaceCommand(ns),
+		listContainersCmd,
+		SleepForSecondsCommand(2), // wait to ensure ig has started
+		PodCommand(pod, "busybox", ns, `["sleep", "inf"]`, ""),
+		WaitUntilPodReadyCommand(ns, pod),
+		DeleteTestNamespaceCommand(ns),
+	}
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+}

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -32,10 +32,12 @@ func TestProfileCpu(t *testing.T) {
 		Cmd:  fmt.Sprintf("ig profile cpu -K -o json --runtimes=%s --timeout 10", *containerRuntime),
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &cpuprofileTypes.Report{
 				CommonData: BuildCommonData(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm: "sh",
 			}

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -33,10 +33,12 @@ func TestSnapshotProcess(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &types.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Command: "nc",
 			}

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -29,10 +29,12 @@ import (
 func newTopBlockIOCmd(ns string, cmd string, startAndStop bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+		isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns,
 				WithRuntimeMetadata(*containerRuntime),
 				WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				WithPodLabels("test-pod", ns, isCrioRuntime),
 			),
 			Comm:  "dd",
 			Write: true,

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -26,9 +26,11 @@ import (
 func newTopFileCmd(ns string, cmd string, startAndStop bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+		isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns, WithRuntimeMetadata(*containerRuntime),
 				WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+				WithPodLabels("test-pod", ns, isCrioRuntime),
 			),
 			// echo is built-in
 			Comm:     "sh",

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -28,10 +28,12 @@ import (
 func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+		isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 		expectedEntry := &types.Stats{
 			CommonData: BuildCommonData(ns,
 				WithRuntimeMetadata(*containerRuntime),
 				WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+				WithPodLabels("test-pod", ns, isCrioRuntime),
 			),
 			Comm:      "curl",
 			IPVersion: syscall.AF_INET,

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -33,10 +33,12 @@ func TestTraceBind(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &bindTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:     "nc",
 				Protocol: "TCP",

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -33,10 +33,12 @@ func TestTraceCapabilities(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &capabilitiesTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:          "nice",
 				CapName:       "SYS_NICE",

--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -63,11 +63,13 @@ func TestTraceDns(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntries := []*dnsTypes.Event{
 				{
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
@@ -85,6 +87,7 @@ func TestTraceDns(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,
@@ -106,6 +109,7 @@ func TestTraceDns(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
@@ -123,6 +127,7 @@ func TestTraceDns(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,
@@ -144,6 +149,7 @@ func TestTraceDns(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeQuery,
@@ -161,6 +167,7 @@ func TestTraceDns(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "nslookup",
 					Qr:         dnsTypes.DNSPktTypeResponse,

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -40,11 +40,13 @@ func TestTraceExec(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntries := []*execTypes.Event{
 				{
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm: "sh",
 					Args: shArgs,
@@ -54,6 +56,7 @@ func TestTraceExec(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm:       "date",
 					Args:       dateArgs,
@@ -66,6 +69,7 @@ func TestTraceExec(t *testing.T) {
 					Event: BuildBaseEvent(ns,
 						WithRuntimeMetadata(*containerRuntime),
 						WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+						WithPodLabels("test-pod", ns, isCrioRuntime),
 					),
 					Comm: "sleep",
 					Args: sleepArgs,

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -36,10 +36,12 @@ func TestTraceFsslower(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &fsslowerTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm: "cat",
 				File: "foo",

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -35,10 +35,12 @@ func TestTraceMount(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &mountTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:      "mount",
 				Operation: "mount",

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -33,10 +33,12 @@ func TestTraceOOMKill(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &oomkillTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				KilledComm: "tail",
 			}
@@ -79,6 +81,8 @@ kind: Pod
 metadata:
   name: test-pod
   namespace: %s
+  labels:
+    run: test-pod
 spec:
   restartPolicy: Never
   terminationGracePeriodSeconds: 0

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -33,10 +33,12 @@ func TestTraceOpen(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &openTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:     "cat",
 				Fd:       3,

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -33,10 +33,12 @@ func TestTraceSignal(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &signalTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:   "sh",
 				Signal: "SIGTERM",

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -33,10 +33,12 @@ func TestTraceSni(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &sniTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm: "wget",
 				Name: "kubernetes.default.svc.cluster.local",

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -34,10 +34,12 @@ func TestTraceTCP(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &tcpTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:      "curl",
 				IPVersion: 4,

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -34,10 +34,12 @@ func TestTraceTcpconnect(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
 			expectedEntry := &tcpconnectTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:      "curl",
 				IPVersion: 4,
@@ -106,10 +108,13 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			isDockerRuntime := *containerRuntime == ContainerRuntimeDocker
+			isCrioRuntime := *containerRuntime == ContainerRuntimeCRIO
+
 			expectedEntry := &tcpconnectTypes.Event{
 				Event: BuildBaseEvent(ns,
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime),
+					WithPodLabels("test-pod", ns, isCrioRuntime),
 				),
 				Comm:      "curl",
 				IPVersion: 4,

--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -62,7 +62,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 			Cmd:  fmt.Sprintf(`$KUBECTL_GADGET advise network-policy monitor -n %s --timeout 5 --output - | tee ./networktrace-client.log`, nsClient),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &networkTypes.Event{
-					Event:     BuildBaseEvent(nsClient, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:     BuildBaseEventK8s(nsClient, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:      "nc",
 					Uid:       0,
 					Gid:       0,
@@ -115,7 +115,7 @@ func TestAdviseNetworkpolicy(t *testing.T) {
 				}
 
 				expectedEntry := &networkTypes.Event{
-					Event: BuildBaseEvent(nsServer, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event: BuildBaseEventK8s(nsServer, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					// The socket enricher can find the correct "comm" because it supports dual stack sockets
 					Comm:      "nc",
 					Uid:       0,

--- a/integration/inspektor-gadget/audit_seccomp_test.go
+++ b/integration/inspektor-gadget/audit_seccomp_test.go
@@ -159,6 +159,8 @@ kind: Pod
 metadata:
   name: test-pod
   namespace: %s
+  labels:
+    run: test-pod
 spec:
   securityContext:
     seccompProfile:
@@ -181,7 +183,7 @@ EOF
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s --timeout 15 -o json", ns),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &seccompauditTypes.Event{
-					Event:   BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:   BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Syscall: "unshare",
 					Code:    "kill_thread",
 					Comm:    "unshare",

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -40,7 +40,7 @@ func TestProfileCpu(t *testing.T) {
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -K --timeout 15 -o json", ns),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &profilecpuTypes.Report{
-					CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "sh",
 				}
 

--- a/integration/inspektor-gadget/run_snapshot_process_test.go
+++ b/integration/inspektor-gadget/run_snapshot_process_test.go
@@ -52,7 +52,7 @@ func TestRunSnapshotProcess(t *testing.T) {
 			StartAndStop: true,
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-					CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				})
 
 				expectedSnapshotProcessJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/run_trace_mount_test.go
+++ b/integration/inspektor-gadget/run_trace_mount_test.go
@@ -33,7 +33,7 @@ func runTraceMount(t *testing.T, ns string, cmd string) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceMountJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/run_trace_oomkill_test.go
+++ b/integration/inspektor-gadget/run_trace_oomkill_test.go
@@ -33,7 +33,7 @@ func runTraceOOMKill(t *testing.T, ns string, cmd string) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceOOMKillJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -33,7 +33,7 @@ func runTraceOpen(t *testing.T, ns string, cmd string) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceOpenJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/run_trace_signal_test.go
+++ b/integration/inspektor-gadget/run_trace_signal_test.go
@@ -33,7 +33,7 @@ func runTraceSignal(t *testing.T, ns string, cmd string) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceSignalJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/run_trace_sni_test.go
+++ b/integration/inspektor-gadget/run_trace_sni_test.go
@@ -33,7 +33,7 @@ func runTraceSni(t *testing.T, ns string, cmd string) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedBaseJsonObj := RunEventToObj(t, &types.Event{
-				CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			})
 
 			expectedTraceSniJsonObj := map[string]interface{}{

--- a/integration/inspektor-gadget/snapshot_process_test.go
+++ b/integration/inspektor-gadget/snapshot_process_test.go
@@ -53,7 +53,7 @@ func TestSnapshotProcess(t *testing.T) {
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET snapshot process -n %s -o json --node %s", ns, nodeName),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &snapshotprocessTypes.Event{
-					Event:   BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:   BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Command: "nc",
 				}
 				expectedEntry.K8s.Node = nodeName

--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -57,7 +57,7 @@ func TestSnapshotSocket(t *testing.T) {
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET snapshot socket -n %s -o json --node %s", ns, nodeName),
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedEntry := &snapshotsocketTypes.Event{
-					Event:    BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:    BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Protocol: "TCP",
 					SrcEndpoint: eventtypes.L4Endpoint{
 						L3Endpoint: eventtypes.L3Endpoint{

--- a/integration/inspektor-gadget/top_blockio_test.go
+++ b/integration/inspektor-gadget/top_blockio_test.go
@@ -28,7 +28,7 @@ import (
 func newTopBlockIOCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &topblockioTypes.Stats{
-			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+			CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			Write:      true,
 			Comm:       "dd",
 		}

--- a/integration/inspektor-gadget/top_file_test.go
+++ b/integration/inspektor-gadget/top_file_test.go
@@ -25,7 +25,7 @@ import (
 func newTopFileCmd(ns, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &topfileTypes.Stats{
-			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+			CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 			Reads:      0,
 			ReadBytes:  0,
 			Filename:   "date.txt",

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -27,7 +27,7 @@ import (
 func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool) *Command {
 	validateOutputFn := func(t *testing.T, output string) {
 		expectedEntry := &toptcpTypes.Stats{
-			CommonData: BuildCommonData(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
+			CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 			Comm:       "curl",
 			IPVersion:  syscall.AF_INET,
 			SrcEndpoint: eventtypes.L4Endpoint{

--- a/integration/inspektor-gadget/trace_bind_test.go
+++ b/integration/inspektor-gadget/trace_bind_test.go
@@ -37,7 +37,7 @@ func TestTraceBind(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracebindTypes.Event{
-				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:      "nc",
 				Protocol:  "TCP",
 				Addr:      "::",

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -41,7 +41,7 @@ func TestTraceCapabilities(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracecapabilitiesTypes.Event{
-				Event:         BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:         BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:          "nice",
 				CapName:       "SYS_NICE",
 				Cap:           23,

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -67,7 +67,7 @@ func TestTraceDns(t *testing.T) {
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*tracednsTypes.Event{
 				{
-					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -81,7 +81,7 @@ func TestTraceDns(t *testing.T) {
 					SrcIP:      busyBoxIP,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,
@@ -99,7 +99,7 @@ func TestTraceDns(t *testing.T) {
 					DstIP:      busyBoxIP,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeQuery,
 					Nameserver: dnsServer,
@@ -113,7 +113,7 @@ func TestTraceDns(t *testing.T) {
 					SrcIP:      busyBoxIP,
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "nslookup",
 					Qr:         tracednsTypes.DNSPktTypeResponse,
 					Nameserver: dnsServer,

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -43,13 +43,13 @@ func TestTraceExec(t *testing.T) {
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntries := []*traceexecTypes.Event{
 				{
-					Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event: BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:  "sh",
 					Args:  shArgs,
 					Cwd:   "/",
 				},
 				{
-					Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:       "date",
 					Args:       dateArgs,
 					Uid:        1000,
@@ -58,7 +58,7 @@ func TestTraceExec(t *testing.T) {
 					UpperLayer: true,
 				},
 				{
-					Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event: BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:  "sleep",
 					Args:  sleepArgs,
 					Uid:   1000,

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -42,7 +42,7 @@ func TestTraceFsslower(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracefsslowerType.Event{
-				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event: BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:  "cat",
 				File:  "foo",
 				Op:    "R",

--- a/integration/inspektor-gadget/trace_mount_test.go
+++ b/integration/inspektor-gadget/trace_mount_test.go
@@ -37,7 +37,7 @@ func TestTraceMount(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracemountTypes.Event{
-				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:      "mount",
 				Operation: "mount",
 				Retval:    -2,

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -56,7 +56,7 @@ func TestTraceNetwork(t *testing.T) {
 
 			expectedEntries := []*tracenetworkTypes.Event{
 				{
-					Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+					Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 					Comm:      "wget",
 					Uid:       0,
 					Gid:       0,
@@ -83,6 +83,7 @@ func TestTraceNetwork(t *testing.T) {
 									Namespace:     ns,
 									PodName:       "nginx-pod",
 									ContainerName: "nginx-pod",
+									PodLabels:     map[string]string{"run": "nginx-pod"},
 								},
 							},
 							Runtime: eventtypes.BasicRuntimeMetadata{

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -37,7 +37,7 @@ func TestTraceOOMKill(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &traceoomkillTypes.Event{
-				Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:      BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				KilledComm: "tail",
 			}
 			expectedEntry.K8s.ContainerName = "test-pod-container"
@@ -70,6 +70,8 @@ kind: Pod
 metadata:
   name: test-pod
   namespace: %s
+  labels:
+    run: test-pod
 spec:
   restartPolicy: Never
   terminationGracePeriodSeconds: 0

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -37,7 +37,7 @@ func TestTraceOpen(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &traceopenTypes.Event{
-				Event:    BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:    BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:     "cat",
 				Fd:       3,
 				Ret:      3,

--- a/integration/inspektor-gadget/trace_signal_test.go
+++ b/integration/inspektor-gadget/trace_signal_test.go
@@ -37,7 +37,7 @@ func TestTraceSignal(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracesignalTypes.Event{
-				Event:  BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event:  BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:   "sh",
 				Signal: "SIGTERM",
 			}

--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -37,7 +37,7 @@ func TestTraceSni(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracesniTypes.Event{
-				Event: BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				Event: BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:  "wget",
 				Name:  "inspektor-gadget.io",
 				Uid:   1000,

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -38,7 +38,7 @@ func TestTraceTcp(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpTypes.Event{
-				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
+				Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
 				IPVersion: 4,
 				Operation: "connect",

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -37,7 +37,7 @@ func TestTraceTcpconnect(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
+				Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{
@@ -100,7 +100,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &tracetcpconnectTypes.Event{
-				Event:     BuildBaseEvent(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
+				Event:     BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 				Comm:      "curl",
 				IPVersion: 4,
 				SrcEndpoint: eventtypes.L4Endpoint{

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -424,6 +424,7 @@ func (cc *ContainerCollection) EnrichByMntNs(event *eventtypes.CommonData, mount
 	if container != nil {
 		event.K8s.ContainerName = container.K8s.ContainerName
 		event.K8s.PodName = container.K8s.PodName
+		event.K8s.PodLabels = container.K8s.PodLabels
 		event.K8s.Namespace = container.K8s.Namespace
 
 		event.Runtime.RuntimeName = container.Runtime.RuntimeName
@@ -452,6 +453,7 @@ func (cc *ContainerCollection) EnrichByNetNs(event *eventtypes.CommonData, netns
 	if len(containers) == 1 {
 		event.K8s.ContainerName = containers[0].K8s.ContainerName
 		event.K8s.PodName = containers[0].K8s.PodName
+		event.K8s.PodLabels = containers[0].K8s.PodLabels
 		event.K8s.Namespace = containers[0].K8s.Namespace
 
 		event.Runtime.RuntimeName = containers[0].Runtime.RuntimeName
@@ -464,6 +466,7 @@ func (cc *ContainerCollection) EnrichByNetNs(event *eventtypes.CommonData, netns
 	if containers[0].K8s.PodName != "" && containers[0].K8s.Namespace != "" {
 		// Kubernetes containers within the same pod.
 		event.K8s.PodName = containers[0].K8s.PodName
+		event.K8s.PodLabels = containers[0].K8s.PodLabels
 		event.K8s.Namespace = containers[0].K8s.Namespace
 
 		// All containers in the same pod share the same container runtime

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -91,15 +91,13 @@ type RuntimeMetadata struct {
 
 type K8sMetadata struct {
 	types.BasicK8sMetadata `json:",inline"`
-	PodLabels              map[string]string `json:"podLabels,omitempty"`
-	PodUID                 string            `json:"podUID,omitempty"`
+	PodUID                 string `json:"podUID,omitempty"`
 
 	ownerReference *metav1.OwnerReference
 }
 
 type K8sSelector struct {
 	types.BasicK8sMetadata
-	PodLabels map[string]string
 }
 
 type RuntimeSelector struct {

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -50,6 +50,9 @@ type Container struct {
 	// See https://github.com/opencontainers/runtime-spec/blob/main/bundle.md
 	Bundle string `json:"bundle,omitempty"`
 
+	// SandboxId is the sandbox id for the corresponding pod
+	SandboxId string `json:"sandboxId,omitempty"`
+
 	// Linux metadata can be derived from the pid via /proc/$pid/...
 	Mntns       uint64 `json:"mntns,omitempty" column:"mntns,template:ns"`
 	Netns       uint64 `json:"netns,omitempty" column:"netns,template:ns"`

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -154,8 +154,8 @@ func (k *K8sClient) GetRunningContainers(pod *v1.Pod) []Container {
 					Namespace:     pod.GetNamespace(),
 					PodName:       pod.GetName(),
 					ContainerName: s.Name,
+					PodLabels:     labels,
 				},
-				PodLabels: labels,
 			},
 		}
 		containers = append(containers, containerDef)

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -55,10 +55,10 @@ func TestSelector(t *testing.T) {
 						Namespace:     "this-namespace",
 						PodName:       "this-pod",
 						ContainerName: "this-container",
-					},
-					PodLabels: map[string]string{
-						"key1": "value1",
-						"key2": "value2",
+						PodLabels: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
 					},
 				},
 			},
@@ -68,11 +68,11 @@ func TestSelector(t *testing.T) {
 						Namespace:     "this-namespace",
 						PodName:       "this-pod",
 						ContainerName: "this-container",
-					},
-					PodLabels: map[string]string{
-						"unrelated-label": "here",
-						"key1":            "value1",
-						"key2":            "value2",
+						PodLabels: map[string]string{
+							"unrelated-label": "here",
+							"key1":            "value1",
+							"key2":            "value2",
+						},
 					},
 				},
 			},
@@ -107,10 +107,10 @@ func TestSelector(t *testing.T) {
 						Namespace:     "this-namespace",
 						PodName:       "this-pod",
 						ContainerName: "this-container",
-					},
-					PodLabels: map[string]string{
-						"key1": "value1",
-						"key2": "value2",
+						PodLabels: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
 					},
 				},
 			},
@@ -120,10 +120,10 @@ func TestSelector(t *testing.T) {
 						Namespace:     "this-namespace",
 						PodName:       "this-pod",
 						ContainerName: "this-container",
-					},
-					PodLabels: map[string]string{
-						"key1": "value1",
-						"key2": "something-else",
+						PodLabels: map[string]string{
+							"key1": "value1",
+							"key2": "something-else",
+						},
 					},
 				},
 			},
@@ -328,10 +328,10 @@ func TestContainerResolver(t *testing.T) {
 				Namespace:     "another-namespace",
 				PodName:       "my-pod",
 				ContainerName: "container0",
-			},
-			PodLabels: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
+				PodLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
 			},
 		},
 	})
@@ -339,8 +339,10 @@ func TestContainerResolver(t *testing.T) {
 	// Look up containers with label 'key1=value1'
 	selectedContainers := cc.GetContainersBySelector(&ContainerSelector{
 		K8s: K8sSelector{
-			PodLabels: map[string]string{
-				"key1": "value1",
+			BasicK8sMetadata: types.BasicK8sMetadata{
+				PodLabels: map[string]string{
+					"key1": "value1",
+				},
 			},
 		},
 	})
@@ -355,9 +357,11 @@ func TestContainerResolver(t *testing.T) {
 	// Look up containers with label 'key1=value1' and 'key2=value2'
 	selector := ContainerSelector{
 		K8s: K8sSelector{
-			PodLabels: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
+			BasicK8sMetadata: types.BasicK8sMetadata{
+				PodLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
 			},
 		},
 	}

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -488,8 +488,7 @@ func WithKubernetesEnrichment(nodeName string, kubeconfig *rest.Config) Containe
 		cc.containerEnrichers = append(cc.containerEnrichers, func(container *Container) bool {
 			// Skip enriching if all k8s fields are already known.
 			// This is an optimization and to make sure to avoid erasing the fields in case of error.
-			if runtimeclient.IsEnrichedWithK8sMetadata(container.K8s.BasicK8sMetadata) &&
-				container.K8s.PodLabels != nil {
+			if runtimeclient.IsEnrichedWithK8sMetadata(container.K8s.BasicK8sMetadata) {
 				return true
 			}
 

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -46,19 +46,28 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
+func setIfEmptyStr[T ~string](s *T, v T) {
+	if *s == "" {
+		*s = v
+	}
+}
+
 func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData, container *Container) {
 	// Runtime
-	container.Runtime.ContainerID = containerData.Runtime.ContainerID
-	container.Runtime.RuntimeName = containerData.Runtime.RuntimeName
-	container.Runtime.ContainerName = containerData.Runtime.ContainerName
-	container.Runtime.ContainerImageName = containerData.Runtime.ContainerImageName
-	container.Runtime.ContainerImageDigest = containerData.Runtime.ContainerImageDigest
+	setIfEmptyStr(&container.Runtime.ContainerID, containerData.Runtime.ContainerID)
+	setIfEmptyStr(&container.Runtime.RuntimeName, containerData.Runtime.RuntimeName)
+	setIfEmptyStr(&container.Runtime.ContainerName, containerData.Runtime.ContainerName)
+	setIfEmptyStr(&container.Runtime.ContainerImageName, containerData.Runtime.ContainerImageName)
+	setIfEmptyStr(&container.Runtime.ContainerImageDigest, containerData.Runtime.ContainerImageDigest)
 
 	// Kubernetes
-	container.K8s.Namespace = containerData.K8s.Namespace
-	container.K8s.PodName = containerData.K8s.PodName
-	container.K8s.PodUID = containerData.K8s.PodUID
-	container.K8s.ContainerName = containerData.K8s.ContainerName
+	setIfEmptyStr(&container.K8s.Namespace, containerData.K8s.Namespace)
+	setIfEmptyStr(&container.K8s.PodName, containerData.K8s.PodName)
+	setIfEmptyStr(&container.K8s.PodUID, containerData.K8s.PodUID)
+	setIfEmptyStr(&container.K8s.ContainerName, containerData.K8s.ContainerName)
+	if container.K8s.PodLabels == nil {
+		container.K8s.PodLabels = containerData.K8s.PodLabels
+	}
 }
 
 func containerRuntimeEnricher(

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -729,7 +729,8 @@ func isEnrichedWithOCIConfigInfo(container *Container) bool {
 		container.K8s.ContainerName != "" &&
 		container.K8s.PodName != "" &&
 		container.K8s.Namespace != "" &&
-		container.K8s.PodUID != ""
+		container.K8s.PodUID != "" &&
+		container.SandboxId != ""
 }
 
 // WithOCIConfigEnrichment enriches container using provided OCI config
@@ -773,6 +774,9 @@ func WithOCIConfigEnrichment() ContainerCollectionOption {
 			}
 			if imageName := resolver.ContainerImageName(container.OciConfig.Annotations); imageName != "" {
 				container.Runtime.ContainerImageName = imageName
+			}
+			if podSandboxId := resolver.PodSandboxId(container.OciConfig.Annotations); podSandboxId != "" {
+				container.SandboxId = podSandboxId
 			}
 
 			return true

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cri"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
@@ -47,12 +48,16 @@ type ContainerdClient struct {
 	ctx    context.Context
 }
 
-func NewContainerdClient(socketPath string, config *containerutilsTypes.ExtraConfig) (runtimeclient.ContainerRuntimeClient, error) {
+func NewContainerdClient(socketPath string, config containerutilsTypes.ExtraConfig) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
 		socketPath = runtimeclient.ContainerdDefaultSocketPath
 	}
+	if config.UseCri {
+		return cri.NewCRIClient(types.RuntimeNameContainerd, socketPath, DefaultTimeout)
+	}
+
 	namespace := constants.K8sContainerdNamespace
-	if config != nil && config.Namespace != "" {
+	if config.Namespace != "" {
 		namespace = config.Namespace
 	}
 

--- a/pkg/container-utils/containerd/containerd_test.go
+++ b/pkg/container-utils/containerd/containerd_test.go
@@ -16,7 +16,7 @@ func TestNamespace(t *testing.T) {
 	// validate the container in k8s.io (default for ig) namespace
 	c1 := testutils.NewContainerdContainer("test-k8s-io", "sleep inf")
 	c1.Start(t)
-	k8sClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{})
+	k8sClient, err := NewContainerdClient("", "", nil)
 	t.Cleanup(func() {
 		k8sClient.Close()
 		c1.Stop(t)
@@ -33,7 +33,10 @@ func TestNamespace(t *testing.T) {
 	// validate the container in default (default for containerd) namespace
 	c2 := testutils.NewContainerdContainer("test-default", "sleep inf", testutils.WithNamespace("default"))
 	c2.Start(t)
-	defaultClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{Namespace: "default"})
+	config := &containerutilsTypes.ExtraConfig{
+		Namespace: "default",
+	}
+	defaultClient, err := NewContainerdClient("", "", config)
 	t.Cleanup(func() {
 		defaultClient.Close()
 		c2.Stop(t)
@@ -48,7 +51,10 @@ func TestNamespace(t *testing.T) {
 	require.Equal(t, "test-default", container.Runtime.ContainerName)
 
 	// validate we can't see the container in empty-ns namespace
-	emptyClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{Namespace: "empty-ns"})
+	config = &containerutilsTypes.ExtraConfig{
+		Namespace: "empty-ns",
+	}
+	emptyClient, err := NewContainerdClient("", "", config)
 	t.Cleanup(func() {
 		emptyClient.Close()
 	})

--- a/pkg/container-utils/containerd/containerd_test.go
+++ b/pkg/container-utils/containerd/containerd_test.go
@@ -16,7 +16,7 @@ func TestNamespace(t *testing.T) {
 	// validate the container in k8s.io (default for ig) namespace
 	c1 := testutils.NewContainerdContainer("test-k8s-io", "sleep inf")
 	c1.Start(t)
-	k8sClient, err := NewContainerdClient("", nil)
+	k8sClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{})
 	t.Cleanup(func() {
 		k8sClient.Close()
 		c1.Stop(t)
@@ -33,7 +33,7 @@ func TestNamespace(t *testing.T) {
 	// validate the container in default (default for containerd) namespace
 	c2 := testutils.NewContainerdContainer("test-default", "sleep inf", testutils.WithNamespace("default"))
 	c2.Start(t)
-	defaultClient, err := NewContainerdClient("", &containerutilsTypes.ExtraConfig{Namespace: "default"})
+	defaultClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{Namespace: "default"})
 	t.Cleanup(func() {
 		defaultClient.Close()
 		c2.Stop(t)
@@ -48,7 +48,7 @@ func TestNamespace(t *testing.T) {
 	require.Equal(t, "test-default", container.Runtime.ContainerName)
 
 	// validate we can't see the container in empty-ns namespace
-	emptyClient, err := NewContainerdClient("", &containerutilsTypes.ExtraConfig{Namespace: "empty-ns"})
+	emptyClient, err := NewContainerdClient("", containerutilsTypes.ExtraConfig{Namespace: "empty-ns"})
 	t.Cleanup(func() {
 		emptyClient.Close()
 	})

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -53,7 +53,7 @@ func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runt
 		if envsp := os.Getenv("INSPEKTOR_GADGET_DOCKER_SOCKETPATH"); envsp != "" && socketPath == "" {
 			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
-		return docker.NewDockerClient(socketPath)
+		return docker.NewDockerClient(socketPath, runtime.Extra.UseCri)
 	case types.RuntimeNameContainerd:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"); envsp != "" && socketPath == "" {

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -46,6 +46,11 @@ var AvailableRuntimes = []string{
 	types.RuntimeNamePodman.String(),
 }
 
+var AvailableRuntimeProtocols = []string{
+	containerutilsTypes.RuntimeProtocolInternal,
+	containerutilsTypes.RuntimeProtocolCRI,
+}
+
 func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runtimeclient.ContainerRuntimeClient, error) {
 	switch runtime.Name {
 	case types.RuntimeNameDocker:
@@ -53,13 +58,13 @@ func NewContainerRuntimeClient(runtime *containerutilsTypes.RuntimeConfig) (runt
 		if envsp := os.Getenv("INSPEKTOR_GADGET_DOCKER_SOCKETPATH"); envsp != "" && socketPath == "" {
 			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
-		return docker.NewDockerClient(socketPath, runtime.Extra.UseCri)
+		return docker.NewDockerClient(socketPath, runtime.RuntimeProtocol)
 	case types.RuntimeNameContainerd:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CONTAINERD_SOCKETPATH"); envsp != "" && socketPath == "" {
 			socketPath = filepath.Join(host.HostRoot, envsp)
 		}
-		return containerd.NewContainerdClient(socketPath, runtime.Extra)
+		return containerd.NewContainerdClient(socketPath, runtime.RuntimeProtocol, &runtime.Extra)
 	case types.RuntimeNameCrio:
 		socketPath := runtime.SocketPath
 		if envsp := os.Getenv("INSPEKTOR_GADGET_CRIO_SOCKETPATH"); envsp != "" && socketPath == "" {

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -32,6 +32,15 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
+// podLabelFilter is a set of labels that are used to filter out pod sandbox labels
+// that are not user given K8s labels of the pod
+var podLabelFilter = map[string]struct{}{
+	runtimeclient.ContainerLabelK8sContainerName: {},
+	runtimeclient.ContainerLabelK8sPodName:       {},
+	runtimeclient.ContainerLabelK8sPodNamespace:  {},
+	runtimeclient.ContainerLabelK8sPodUID:        {},
+}
+
 // CRIClient implements the ContainerRuntimeClient interface using the CRI
 // plugin interface to communicate with the different container runtimes.
 type CRIClient struct {
@@ -82,16 +91,60 @@ func listContainers(c *CRIClient, filter *runtime.ContainerFilter) ([]*runtime.C
 	return res.GetContainers(), nil
 }
 
+func listPodSandboxes(c *CRIClient, filter *runtime.PodSandboxFilter) ([]*runtime.PodSandbox, error) {
+	podRequest := &runtime.ListPodSandboxRequest{
+		Filter: filter,
+	}
+
+	podRes, err := c.client.ListPodSandbox(context.Background(), podRequest)
+	if err != nil {
+		return nil, fmt.Errorf("listing pod sandboxes with request %+v: %w", podRequest, err)
+	}
+
+	return podRes.Items, nil
+}
+
+func getPodSandbox(c *CRIClient, podSandboxID string) (*runtime.PodSandbox, error) {
+	podSandboxes, err := listPodSandboxes(c, &runtime.PodSandboxFilter{
+		Id: podSandboxID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podSandboxes) == 0 {
+		return nil, fmt.Errorf("pod sandbox %q not found", podSandboxID)
+	}
+	if len(podSandboxes) > 1 {
+		log.Errorf("CRIClient: found multiple pod sandboxes (%d) with ID %q. Taking the first one: %+v",
+			len(podSandboxes), podSandboxID, podSandboxes)
+	}
+	return podSandboxes[0], nil
+}
+
 func (c *CRIClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
 	containers, err := listContainers(c, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	podSandboxes, err := listPodSandboxes(c, nil)
+	if err != nil {
+		return nil, err
+	}
+	podSandboxesMap := make(map[string]*runtime.PodSandbox, len(podSandboxes))
+	for _, podSandbox := range podSandboxes {
+		podSandboxesMap[podSandbox.Id] = podSandbox
+	}
+
 	ret := make([]*runtimeclient.ContainerData, len(containers))
 
 	for i, container := range containers {
-		ret[i] = CRIContainerToContainerData(c.Name, container)
+		podSandbox, ok := podSandboxesMap[container.PodSandboxId]
+		if !ok {
+			return nil, fmt.Errorf("pod sandbox %q not found for container %q", container.PodSandboxId, container.Id)
+		}
+		ret[i] = buildContainerData(c.Name, container, podSandbox)
 	}
 
 	return ret, nil
@@ -106,14 +159,26 @@ func (c *CRIClient) GetContainer(containerID string) (*runtimeclient.ContainerDa
 	}
 
 	if len(containers) == 0 {
-		return nil, fmt.Errorf("container %q not found", containerID)
+		// Test if the containerID belongs to a pause container
+		_, err := getPodSandbox(c, containerID)
+		if err != nil {
+			// It is not a pause container or we got an error
+			return nil, fmt.Errorf("container %q not found", containerID)
+		}
+		return nil, runtimeclient.ErrPauseContainer
 	}
 	if len(containers) > 1 {
-		log.Warnf("CRIClient: multiple containers (%d) with ID %q. Taking the first one: %+v",
+		log.Errorf("CRIClient: multiple containers (%d) with ID %q. Taking the first one: %+v",
 			len(containers), containerID, containers)
 	}
 
-	return CRIContainerToContainerData(c.Name, containers[0]), nil
+	podSandbox, err := getPodSandbox(c, containers[0].PodSandboxId)
+	if err != nil {
+		return nil, err
+	}
+
+	containerData := buildContainerData(c.Name, containers[0], podSandbox)
+	return containerData, nil
 }
 
 func (c *CRIClient) GetContainerDetails(containerID string) (*runtimeclient.ContainerDetailsData, error) {
@@ -132,7 +197,45 @@ func (c *CRIClient) GetContainerDetails(containerID string) (*runtimeclient.Cont
 		return nil, err
 	}
 
-	return parseContainerDetailsData(c.Name, res.Status, res.Info)
+	podSandbox, err := c.getPodSandboxFromContainerID(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseContainerDetailsData(c.Name, res.Status, res.Info, podSandbox)
+}
+
+func (c *CRIClient) GetPodLabels(sandboxId string) (map[string]string, error) {
+	podSandbox, err := getPodSandbox(c, sandboxId)
+	if err != nil {
+		return nil, err
+	}
+
+	return getFilteredPodLabels(podSandbox), nil
+}
+
+func (c *CRIClient) getPodSandboxFromContainerID(containerID string) (*runtime.PodSandbox, error) {
+	containerID, err := runtimeclient.ParseContainerID(c.Name, containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	containers, err := listContainers(c, &runtime.ContainerFilter{
+		Id: containerID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("container %q not found", containerID)
+	}
+	if len(containers) > 1 {
+		log.Warnf("CRIClient: multiple containers (%d) with ID %q. Taking the first one: %+v",
+			len(containers), containerID, containers)
+	}
+
+	return getPodSandbox(c, containers[0].PodSandboxId)
 }
 
 func (c *CRIClient) Close() error {
@@ -146,11 +249,13 @@ func (c *CRIClient) Close() error {
 // parseContainerDetailsData parses the container status and extra information
 // returned by ContainerStatus() into a ContainerDetailsData structure.
 func parseContainerDetailsData(runtimeName types.RuntimeName, containerStatus CRIContainer,
-	extraInfo map[string]string,
+	extraInfo map[string]string, podSandbox *runtime.PodSandbox,
 ) (*runtimeclient.ContainerDetailsData, error) {
+	containerData := buildContainerData(runtimeName, containerStatus, podSandbox)
+
 	// Create container details structure to be filled.
 	containerDetailsData := &runtimeclient.ContainerDetailsData{
-		ContainerData: *CRIContainerToContainerData(runtimeName, containerStatus),
+		ContainerData: *containerData,
 	}
 
 	// Parse the extra info and fill the data.
@@ -297,12 +402,19 @@ func digestFromRef(imageRef string) string {
 	}
 }
 
-func CRIContainerToContainerData(runtimeName types.RuntimeName, container CRIContainer) *runtimeclient.ContainerData {
+func getFilteredPodLabels(podSandbox *runtime.PodSandbox) map[string]string {
+	labels := map[string]string{}
+	for k, v := range podSandbox.GetLabels() {
+		if _, ok := podLabelFilter[k]; !ok {
+			labels[k] = v
+		}
+	}
+	return labels
+}
+
+func buildContainerData(runtimeName types.RuntimeName, container CRIContainer, podSandbox *runtime.PodSandbox) *runtimeclient.ContainerData {
 	containerMetadata := container.GetMetadata()
 	image := container.GetImage()
-	// for crio imageRef has the following structure:
-	// k8s.gcr.io/kube-apiserver@sha256:4a165184c779c0a4f2d31d6676b7790589b977c3c8fbc0577dac2544fd69cade
-	// the hash being the image digest
 	imageRef := container.GetImageRef()
 
 	containerData := &runtimeclient.ContainerData{
@@ -320,6 +432,9 @@ func CRIContainerToContainerData(runtimeName types.RuntimeName, container CRICon
 
 	// Fill K8S information.
 	runtimeclient.EnrichWithK8sMetadata(containerData, container.GetLabels())
+
+	// Initial labels are stored in the pod sandbox
+	containerData.K8s.BasicK8sMetadata.PodLabels = getFilteredPodLabels(podSandbox)
 
 	// CRI-O does not use the same container name of Kubernetes as containerd.
 	// Instead, it uses a composed name as Docker does, but such name is not

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -52,7 +52,7 @@ type CRIClient struct {
 	client runtime.RuntimeServiceClient
 }
 
-func NewCRIClient(name types.RuntimeName, socketPath string, timeout time.Duration) (CRIClient, error) {
+func NewCRIClient(name types.RuntimeName, socketPath string, timeout time.Duration) (*CRIClient, error) {
 	conn, err := grpc.Dial(
 		socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -62,18 +62,16 @@ func NewCRIClient(name types.RuntimeName, socketPath string, timeout time.Durati
 		}),
 	)
 	if err != nil {
-		return CRIClient{}, err
+		return nil, err
 	}
 
-	cc := CRIClient{
+	return &CRIClient{
 		Name:        name,
 		SocketPath:  socketPath,
 		ConnTimeout: timeout,
 		conn:        conn,
 		client:      runtime.NewRuntimeServiceClient(conn),
-	}
-
-	return cc, nil
+	}, nil
 }
 
 func listContainers(c *CRIClient, filter *runtime.ContainerFilter) ([]*runtime.Container, error) {

--- a/pkg/container-utils/crio/crio.go
+++ b/pkg/container-utils/crio/crio.go
@@ -26,21 +26,10 @@ const (
 	DefaultTimeout = 2 * time.Second
 )
 
-type CrioClient struct {
-	criclient.CRIClient
-}
-
 func NewCrioClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
 		socketPath = runtimeclient.CrioDefaultSocketPath
 	}
 
-	criClient, err := criclient.NewCRIClient(types.RuntimeNameCrio, socketPath, DefaultTimeout)
-	if err != nil {
-		return nil, err
-	}
-
-	return &CrioClient{
-		CRIClient: criClient,
-	}, nil
+	return criclient.NewCRIClient(types.RuntimeNameCrio, socketPath, DefaultTimeout)
 }

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cgroups"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cri"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -46,9 +47,14 @@ type DockerClient struct {
 	socketPath string
 }
 
-func NewDockerClient(socketPath string) (runtimeclient.ContainerRuntimeClient, error) {
+func NewDockerClient(socketPath string, useCri bool) (runtimeclient.ContainerRuntimeClient, error) {
 	if socketPath == "" {
 		socketPath = runtimeclient.DockerDefaultSocketPath
+	}
+	if useCri {
+		// TODO: Configurable
+		socketPath = runtimeclient.CriDockerDefaultSocketPath
+		return cri.NewCRIClient(types.RuntimeNameDocker, socketPath, DefaultTimeout)
 	}
 
 	cli, err := client.NewClientWithOpts(

--- a/pkg/container-utils/oci-annotations/resolver_containerd.go
+++ b/pkg/container-utils/oci-annotations/resolver_containerd.go
@@ -29,6 +29,7 @@ const (
 	containerdContainerNameAnnotation = "io.kubernetes.cri.container-name"
 	containerdContainerTypeAnnotation = "io.kubernetes.cri.container-type"
 	containerdContainerImageName      = "io.kubernetes.cri.image-name"
+	containerdPodSandboxId            = "io.kubernetes.cri.sandbox-id"
 )
 
 type containerdResolver struct{}
@@ -55,6 +56,10 @@ func (containerdResolver) PodUID(annotations map[string]string) string {
 
 func (containerdResolver) PodNamespace(annotations map[string]string) string {
 	return annotations[containerdPodNamespaceAnnotation]
+}
+
+func (containerdResolver) PodSandboxId(annotations map[string]string) string {
+	return annotations[containerdPodSandboxId]
 }
 
 func (containerdResolver) Runtime() types.RuntimeName {

--- a/pkg/container-utils/oci-annotations/resolver_crio.go
+++ b/pkg/container-utils/oci-annotations/resolver_crio.go
@@ -27,6 +27,7 @@ const (
 	crioContainerNameAnnotation    = "io.kubernetes.container.name"
 	crioContainerTypeAnnotation    = "io.kubernetes.cri-o.ContainerType"
 	crioContainerImageName         = "io.kubernetes.cri-o.ImageName"
+	crioPodSandboxId               = "io.kubernetes.cri-o.SandboxID"
 )
 
 type crioResolver struct{}
@@ -53,6 +54,10 @@ func (crioResolver) PodUID(annotations map[string]string) string {
 
 func (crioResolver) PodNamespace(annotations map[string]string) string {
 	return annotations[crioPodNamespaceAnnotation]
+}
+
+func (crioResolver) PodSandboxId(annotations map[string]string) string {
+	return annotations[crioPodSandboxId]
 }
 
 func (crioResolver) Runtime() types.RuntimeName {

--- a/pkg/container-utils/oci-annotations/types.go
+++ b/pkg/container-utils/oci-annotations/types.go
@@ -38,6 +38,8 @@ type Resolver interface {
 	PodUID(annotations map[string]string) string
 	// PodNamespace returns the namespace of the pod to which container belongs
 	PodNamespace(annotations map[string]string) string
+	// PodSandboxId returns the sandbox id of the pod to which container belongs
+	PodSandboxId(annotations map[string]string) string
 	// Runtime returns runtime in which the container is running
 	Runtime() types.RuntimeName
 }

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -28,6 +28,7 @@ const (
 	PodmanDefaultSocketPath     = "/run/podman/podman.sock"
 	ContainerdDefaultSocketPath = "/run/containerd/containerd.sock"
 	DockerDefaultSocketPath     = "/run/docker.sock"
+	CriDockerDefaultSocketPath  = "/run/cri-dockerd.sock"
 )
 
 var ErrPauseContainer = errors.New("it is a pause container")

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -97,10 +97,10 @@ const (
 )
 
 const (
-	containerLabelK8sContainerName = "io.kubernetes.container.name"
-	containerLabelK8sPodName       = "io.kubernetes.pod.name"
-	containerLabelK8sPodNamespace  = "io.kubernetes.pod.namespace"
-	containerLabelK8sPodUID        = "io.kubernetes.pod.uid"
+	ContainerLabelK8sContainerName = "io.kubernetes.container.name"
+	ContainerLabelK8sPodName       = "io.kubernetes.pod.name"
+	ContainerLabelK8sPodNamespace  = "io.kubernetes.pod.namespace"
+	ContainerLabelK8sPodUID        = "io.kubernetes.pod.uid"
 )
 
 // ContainerRuntimeClient defines the interface to communicate with the
@@ -138,16 +138,16 @@ func ParseContainerID(expectedRuntime types.RuntimeName, containerID string) (st
 }
 
 func EnrichWithK8sMetadata(container *ContainerData, labels map[string]string) {
-	if containerName, ok := labels[containerLabelK8sContainerName]; ok {
+	if containerName, ok := labels[ContainerLabelK8sContainerName]; ok {
 		container.K8s.ContainerName = containerName
 	}
-	if podName, ok := labels[containerLabelK8sPodName]; ok {
+	if podName, ok := labels[ContainerLabelK8sPodName]; ok {
 		container.K8s.PodName = podName
 	}
-	if podNamespace, ok := labels[containerLabelK8sPodNamespace]; ok {
+	if podNamespace, ok := labels[ContainerLabelK8sPodNamespace]; ok {
 		container.K8s.Namespace = podNamespace
 	}
-	if podUID, ok := labels[containerLabelK8sPodUID]; ok {
+	if podUID, ok := labels[ContainerLabelK8sPodUID]; ok {
 		container.K8s.PodUID = podUID
 	}
 }

--- a/pkg/container-utils/types/types.go
+++ b/pkg/container-utils/types/types.go
@@ -16,13 +16,18 @@ package types
 
 import "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
+const (
+	RuntimeProtocolInternal = "internal"
+	RuntimeProtocolCRI      = "cri"
+)
+
 type ExtraConfig struct {
 	Namespace string
-	UseCri    bool
 }
 
 type RuntimeConfig struct {
-	Name       types.RuntimeName
-	SocketPath string
-	Extra      ExtraConfig
+	Name            types.RuntimeName
+	SocketPath      string
+	RuntimeProtocol string
+	Extra           ExtraConfig
 }

--- a/pkg/container-utils/types/types.go
+++ b/pkg/container-utils/types/types.go
@@ -18,10 +18,11 @@ import "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 
 type ExtraConfig struct {
 	Namespace string
+	UseCri    bool
 }
 
 type RuntimeConfig struct {
 	Name       types.RuntimeName
 	SocketPath string
-	Extra      *ExtraConfig
+	Extra      ExtraConfig
 }

--- a/pkg/gadget-collection/gadgets/helpers.go
+++ b/pkg/gadget-collection/gadgets/helpers.go
@@ -44,8 +44,8 @@ func ContainerSelectorFromContainerFilter(f *gadgetv1alpha1.ContainerFilter) *co
 				Namespace:     f.Namespace,
 				PodName:       f.Podname,
 				ContainerName: f.ContainerName,
+				PodLabels:     labels,
 			},
-			PodLabels: labels,
 		},
 	}
 }

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -214,8 +214,8 @@ func (m *KubeManagerInstance) PreGadgetRun() error {
 				Namespace:     m.params.Get(ParamNamespace).AsString(),
 				PodName:       m.params.Get(ParamPodName).AsString(),
 				ContainerName: m.params.Get(ParamContainerName).AsString(),
+				PodLabels:     labels,
 			},
-			PodLabels: labels,
 		},
 	}
 

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -47,6 +47,7 @@ const (
 	CrioSocketPath       = "crio-socketpath"
 	PodmanSocketPath     = "podman-socketpath"
 	ContainerdNamespace  = "containerd-namespace"
+	UseCri               = "use-cri"
 )
 
 type MountNsMapSetter interface {
@@ -109,6 +110,12 @@ func (l *LocalManager) GlobalParamDescs() params.ParamDescs {
 			Key:          ContainerdNamespace,
 			DefaultValue: constants.K8sContainerdNamespace,
 			Description:  "Containerd namespace to use",
+		},
+		{
+			Key:          UseCri,
+			DefaultValue: "false",
+			Description:  "Use CRI API to retrieve more K8s information, but ignore non K8s containers",
+			TypeHint:     params.TypeBool,
 		},
 	}
 }
@@ -196,11 +203,12 @@ partsLoop:
 		r := &containerutilsTypes.RuntimeConfig{
 			Name:       runtimeName,
 			SocketPath: socketPath,
+			Extra: containerutilsTypes.ExtraConfig{
+				UseCri: operatorParams.Get(UseCri).AsBool(),
+			},
 		}
 		if namespace != "" {
-			r.Extra = &containerutilsTypes.ExtraConfig{
-				Namespace: namespace,
-			}
+			r.Extra.Namespace = namespace
 		}
 
 		rc = append(rc, r)

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -47,7 +47,7 @@ const (
 	CrioSocketPath       = "crio-socketpath"
 	PodmanSocketPath     = "podman-socketpath"
 	ContainerdNamespace  = "containerd-namespace"
-	UseCri               = "use-cri"
+	RuntimeProtocol      = "runtime-protocol"
 )
 
 type MountNsMapSetter interface {
@@ -112,10 +112,9 @@ func (l *LocalManager) GlobalParamDescs() params.ParamDescs {
 			Description:  "Containerd namespace to use",
 		},
 		{
-			Key:          UseCri,
-			DefaultValue: "false",
-			Description:  "Use CRI API to retrieve more K8s information, but ignore non K8s containers",
-			TypeHint:     params.TypeBool,
+			Key:          RuntimeProtocol,
+			DefaultValue: "internal",
+			Description:  "Container runtime protocol. Supported values are: internal, cri",
 		},
 	}
 }
@@ -201,14 +200,12 @@ partsLoop:
 		}
 
 		r := &containerutilsTypes.RuntimeConfig{
-			Name:       runtimeName,
-			SocketPath: socketPath,
+			Name:            runtimeName,
+			SocketPath:      socketPath,
+			RuntimeProtocol: operatorParams.Get(RuntimeProtocol).AsString(),
 			Extra: containerutilsTypes.ExtraConfig{
-				UseCri: operatorParams.Get(UseCri).AsBool(),
+				Namespace: namespace,
 			},
-		}
-		if namespace != "" {
-			r.Extra.Namespace = namespace
 		}
 
 		rc = append(rc, r)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -139,13 +139,14 @@ func (b *BasicRuntimeMetadata) IsEnriched() bool {
 }
 
 type BasicK8sMetadata struct {
-	Namespace     string `json:"namespace,omitempty" column:"namespace,template:namespace"`
-	PodName       string `json:"podName,omitempty" column:"pod,template:pod"`
-	ContainerName string `json:"containerName,omitempty" column:"container,template:container"`
+	Namespace     string            `json:"namespace,omitempty" column:"namespace,template:namespace"`
+	PodName       string            `json:"podName,omitempty" column:"pod,template:pod"`
+	PodLabels     map[string]string `json:"podLabels,omitempty" column:"labels,hide"`
+	ContainerName string            `json:"containerName,omitempty" column:"container,template:container"`
 }
 
 func (b *BasicK8sMetadata) IsEnriched() bool {
-	return b.Namespace != "" && b.PodName != "" && b.ContainerName != ""
+	return b.Namespace != "" && b.PodName != "" && b.ContainerName != "" && b.PodLabels != nil
 }
 
 type K8sMetadata struct {
@@ -174,6 +175,7 @@ func (c *CommonData) SetNode(node string) {
 func (c *CommonData) SetPodMetadata(k8s *BasicK8sMetadata, runtime *BasicRuntimeMetadata) {
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace
+	c.K8s.PodLabels = k8s.PodLabels
 
 	// All containers in the same pod share the same container runtime
 	c.Runtime.RuntimeName = runtime.RuntimeName
@@ -183,6 +185,7 @@ func (c *CommonData) SetContainerMetadata(k8s *BasicK8sMetadata, runtime *BasicR
 	c.K8s.ContainerName = k8s.ContainerName
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace
+	c.K8s.PodLabels = k8s.PodLabels
 
 	c.Runtime.RuntimeName = runtime.RuntimeName
 	c.Runtime.ContainerName = runtime.ContainerName


### PR DESCRIPTION
# CRI: Enrich with initial PodLabels

CRI gives us the option to query the pod labels. This information is in the PodSandbox, but unfortunately this only gives us the initial pod labels. So the labels with which the pod was started. Updated labels are not possible with only reading PodSandbox

Since this information is only available through CRI, I introduced a switch (currently the flag is still todo), so the ContainerRuntimeEnrichment can be used with CRI only (instead of docker or containerd API).

This has the advantage that we are saving API calls, but would mean if one wants to see K8s Pod Labels with `ig` that non K8s containers will not be captured. This is an open question.

The other option is implemented in this branch: https://github.com/inspektor-gadget/inspektor-gadget/tree/burak/pod_label_2

Use with flag `--use-cri` for `ig`:
```bash
$ ig trace exec -o columns=k8s.pod,k8s.labels,runtime.containerName,comm --use-cri
K8S.POD                                                                K8S.LABELS                           RUNTIME.CONTAINERNAME                                                 COMM            
test-pod                                                               foo=bar,abc=xyz                      test-pod                                                              date            
gadget-9tvcn                                                           controller-revision-hash=74d5bc749,… gadget                                                                gadgettracerman 
gadget-9tvcn                                                           pod-template-generation=1,k8s-app=g… gadget                                                                gadgettracerman 
test-pod                                                               foo=bar,abc=xyz                      test-pod                                                              date            
test-pod                                                               foo=bar,abc=xyz                      test-pod                                                              date            
test-pod                                                               foo=bar,abc=xyz                      test-pod                                                              date            
test-pod                                                               foo=bar,abc=xyz                      test-pod                                                              date            
```

# TODO
- [ ] Use CRI only or additionally
- [x] Introduce flag for ContainerRuntimeEnrichment, to use CRI
- [ ] Introduce flag for specifying the path to the cri docker shim socket