### PR TITLE
load btf from kernel modules

### DIFF
--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -169,11 +169,13 @@ static __always_inline bool has_upper_layer()
 	struct dentry *upperdentry;
 
 	if (bpf_core_type_exists(struct ovl_inode___gadget)) {
+		bpf_printk("ovl_inode exists, using BTF automatically");
 		struct ovl_inode___gadget *oi = container_of(
 			inode, struct ovl_inode___gadget, vfs_inode);
 		bpf_probe_read_kernel(&upperdentry, sizeof upperdentry,
 				      &oi->__upperdentry);
 	} else {
+		bpf_printk("ovl_inode does not exist, using bpf_core_type_size");
 		bpf_probe_read_kernel(&upperdentry, sizeof upperdentry,
 				      ((void *)inode) +
 					      bpf_core_type_size(struct inode));

--- a/go.mod
+++ b/go.mod
@@ -204,4 +204,6 @@ replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.13.1
 
 replace github.com/vishvananda/netns => github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6
 
+replace github.com/cilium/ebpf => github.com/brycekahle/ebpf v0.0.0-20240123210446-5a8c94d45b4f
+
 replace oras.land/oras-go/v2 => oras.land/oras-go/v2 v2.0.0-20231221070400-5073458982fd

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/brycekahle/ebpf v0.0.0-20240123210446-5a8c94d45b4f h1:gsyvpTbHp8t4uvcvK+T08TM2ATN6+cpeAQcA2CzXav4=
+github.com/brycekahle/ebpf v0.0.0-20240123210446-5a8c94d45b4f/go.mod h1:9BszLnmZR7oucpa/kBbVVf1ts3BoUSpltcnNp1hQkVw=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -34,8 +36,6 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/ebpf v0.12.3 h1:8ht6F9MquybnY97at+VDZb3eQQr8ev79RueWeVaEcG4=
-github.com/cilium/ebpf v0.12.3/go.mod h1:TctK1ivibvI3znr66ljgi4hqOT8EYQjz1KWBfb1UVgM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
@@ -136,6 +136,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -36,6 +36,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/btfgen"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -408,8 +409,13 @@ func (t *Tracer) installTracer(gadgetCtx gadgets.GadgetContext) error {
 
 	// Load the ebpf objects
 	err = t.loadeBPFObjects(loadingOptions{
-		collectionOptions: ebpf.CollectionOptions{MapReplacements: mapReplacements},
-		tracerMapName:     tracerMapName,
+		collectionOptions: ebpf.CollectionOptions{
+			MapReplacements: mapReplacements,
+			Programs: ebpf.ProgramOptions{
+				KernelTypes: btfgen.GetBTFSpec(),
+			},
+		},
+		tracerMapName: tracerMapName,
 	})
 	if err != nil {
 		return fmt.Errorf("loading eBPF objects: %w", err)


### PR DESCRIPTION
# load btf from kernel modules

With https://github.com/cilium/ebpf/pull/1300, cilium/ebpf is able to load the btf from kernel modules.

See https://github.com/inspektor-gadget/inspektor-gadget/pull/2400#discussion_r1465028972

## How to use



## Testing done

```
$ sudo -E ./ig image build -t myregistry/trace-exec:debug ./gadgets/trace_exec
$ go run -exec 'sudo -E' ./cmd/ig/... run myregistry/trace-exec:debug -o columns=comm,ret,args,upper_layer
```
In another shell:
```
# cat /sys/kernel/tracing/trace_pipe
```
I tried both cases, when it succeeds or fails to load the overlay btf:
```
           <...>-155263  [001] ...21 122321.370091: bpf_trace_printk: ovl_inode exists, using BTF automatically
           <...>-155443  [002] ...21 122366.925450: bpf_trace_printk: ovl_inode does not exist, using bpf_core_type_size
```
