### PR TITLE
[RFE] Added toleration to Inspektor Gadget manifest

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -184,7 +184,13 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        {{- if .Values.tolerations }}
+          {{- toYaml .Values.tolerations | nindent 8 }}
+        {{ end }}
       volumes:
         - name: host
           hostPath:

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -47,11 +47,7 @@ affinity: {}
 capabilities: {}
 
 # -- Tolerations used by `gadget` container
-tolerations:
-  - effect: NoSchedule
-    operator: Exists
-  - effect: NoExecute
-    operator: Exists
+tolerations: {}
 
 # -- Skip Helm labels
 skipLabels: true


### PR DESCRIPTION
## Added required toleration field values to Inspektor Gadget manifest

Fixes #1885

Removed hardcoded toleration key values from `values.yaml` file and specified them in`daemonset.yaml`.
Now custom tolerations can be added without overwriting the required tolerations.

## Testing done

Tested with emtpy toleration field in values.yaml, and ran command `make template`.
Also tested with other custom values in toleration field in values.yaml and ran `make template` the output yaml file generated specified the additional fields in proper format.

