### PR TITLE
integration/TraceOOMKill: Don't check triggered uid & gid

### DIFF
--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -38,9 +38,7 @@ func TestTraceOOMKill(t *testing.T) {
 					WithRuntimeMetadata(*containerRuntime),
 					WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime),
 				),
-				KilledComm:   "tail",
-				TriggeredUid: 1000,
-				TriggeredGid: 2000,
+				KilledComm: "tail",
 			}
 
 			normalize := func(e *oomkillTypes.Event) {
@@ -57,6 +55,8 @@ func TestTraceOOMKill(t *testing.T) {
 				e.KilledPid = 0
 				e.Pages = 0
 				e.TriggeredPid = 0
+				e.TriggeredUid = 0
+				e.TriggeredGid = 0
 				e.TriggeredComm = ""
 				e.MountNsID = 0
 
@@ -90,7 +90,7 @@ spec:
         memory: "128Mi"
     command: ["/bin/sh", "-c"]
     args:
-    - setuidgid 1000:2000 sh -c "while true; do tail /dev/zero; done"
+    - while true; do tail /dev/zero; done
 `, ns)
 
 	commands := []*Command{

--- a/integration/inspektor-gadget/run_trace_oomkill_test.go
+++ b/integration/inspektor-gadget/run_trace_oomkill_test.go
@@ -38,13 +38,13 @@ func runTraceOOMKill(t *testing.T, ns string, cmd string) {
 
 			expectedTraceOOMKillJsonObj := map[string]interface{}{
 				"fpid":      0,
-				"fuid":      1000,
-				"fgid":      2000,
+				"fuid":      0,
+				"fgid":      0,
 				"tpid":      0,
 				"pages":     0,
 				"mntns_id":  0,
 				"timestamp": "",
-				"fcomm":     "tail",
+				"fcomm":     "",
 				"tcomm":     "tail",
 			}
 
@@ -58,7 +58,10 @@ func runTraceOOMKill(t *testing.T, ns string, cmd string) {
 				SetEventRuntimeContainerID(m, "")
 				SetEventRuntimeContainerName(m, "")
 
+				m["fcomm"] = ""
 				m["fpid"] = uint32(0)
+				m["fuid"] = uint32(0)
+				m["fgid"] = uint32(0)
 				m["tpid"] = uint32(0)
 				m["pages"] = uint32(0)
 				m["mntns_id"] = 0
@@ -86,7 +89,7 @@ spec:
         memory: "128Mi"
     command: ["/bin/sh", "-c"]
     args:
-    - setuidgid 1000:2000 sh -c "while true; do tail /dev/zero; done"
+    - while true; do tail /dev/zero; done
 `, ns)
 
 	commands := []*Command{

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -37,10 +37,8 @@ func TestTraceOOMKill(t *testing.T) {
 		StartAndStop: true,
 		ValidateOutput: func(t *testing.T, output string) {
 			expectedEntry := &traceoomkillTypes.Event{
-				Event:        BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
-				KilledComm:   "tail",
-				TriggeredUid: 1000,
-				TriggeredGid: 2000,
+				Event:      BuildBaseEvent(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
+				KilledComm: "tail",
 			}
 			expectedEntry.K8s.ContainerName = "test-pod-container"
 
@@ -49,6 +47,8 @@ func TestTraceOOMKill(t *testing.T) {
 				e.KilledPid = 0
 				e.Pages = 0
 				e.TriggeredPid = 0
+				e.TriggeredUid = 0
+				e.TriggeredGid = 0
 				e.TriggeredComm = ""
 				e.MountNsID = 0
 
@@ -81,7 +81,7 @@ spec:
         memory: "128Mi"
     command: ["/bin/sh", "-c"]
     args:
-    - setuidgid 1000:2000 sh -c "while true; do tail /dev/zero; done"
+    - while true; do tail /dev/zero; done
 `, ns)
 
 	commands := []*Command{


### PR DESCRIPTION
## integration/TraceOOMKill: Don't check triggered uid & gid

It can't be assured that our `tail` process will trigger the oomkill. It could be another process with another uid and gid

## Example

Locally I got these multiple of 2 events. One time `tail` triggered the oom and another time `conmon` triggered it

```
        {"runtime":{"runtimeName":"cri-o","containerId":"dd176d59db623d05640f601d4d99af0df12b165e0493426cee88039fc44cb779","containerImageName":"docker.io/library/busybox:latest"},"k8s":{"node":"minikube-cri-o","namespace":"test-trace-oomkill-2366462858275538090","podName":"test-pod","podLabels":{"run":"test-pod"},"containerName":"test-pod-container"},"timestamp":1706176347489993010,"type":"normal","mountnsid":4026532886,"kpid":295521,"kcomm":"tail","pages":32768,"tpid":295273,"tuid":0,"tgid":0,"tcomm":"conmon"}
        {"runtime":{"runtimeName":"cri-o","containerId":"dd176d59db623d05640f601d4d99af0df12b165e0493426cee88039fc44cb779","containerImageName":"docker.io/library/busybox:latest"},"k8s":{"node":"minikube-cri-o","namespace":"test-trace-oomkill-2366462858275538090","podName":"test-pod","podLabels":{"run":"test-pod"},"containerName":"test-pod-container"},"timestamp":1706176347573634121,"type":"normal","mountnsid":4026532886,"kpid":295522,"kcomm":"tail","pages":32768,"tpid":295522,"tuid":1000,"tgid":2000,"tcomm":"tail"}
```
