### PR TITLE
Don't use vishvananda/netns fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,4 @@ require (
 
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.13.1-0.20230315234915-a26de2d610c3
 
-replace github.com/vishvananda/netns => github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6
-
 replace oras.land/oras-go/v2 => oras.land/oras-go/v2 v2.0.0-20240123101058-64fedf45bfd3

--- a/go.mod
+++ b/go.mod
@@ -3,69 +3,66 @@ module github.com/inspektor-gadget/inspektor-gadget
 go 1.21
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/cilium/ebpf v0.12.3
+	github.com/containerd/containerd v1.7.12
 	github.com/containerd/nri v0.5.0
 	github.com/containers/common v0.57.3
+	github.com/containers/image/v5 v5.29.2
+	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/distribution/reference v0.5.0
+	github.com/docker/cli v25.0.1+incompatible
 	github.com/docker/docker v25.0.1+incompatible
+	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/giantswarm/crd-docs-generator v0.11.0
+	github.com/godbus/dbus/v5 v5.1.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/kr/pretty v0.3.1
+	github.com/moby/moby v25.0.1+incompatible
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.31.1
+	github.com/opencontainers/image-spec v1.1.0-rc6
 	github.com/opencontainers/runtime-spec v1.1.0
+	github.com/prometheus/client_golang v1.18.0
 	github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20210917134616-9c00a300bb7a
 	github.com/seccomp/libseccomp-golang v0.10.0 // indirect
+	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/viper v1.18.2
+	github.com/stretchr/testify v1.8.4
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+	github.com/tklauser/numcpus v0.7.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/vishvananda/netns v0.0.4
+	go.opentelemetry.io/otel v1.22.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.45.0
+	go.opentelemetry.io/otel/metric v1.22.0
+	go.opentelemetry.io/otel/sdk/metric v1.22.0
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
+	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.16.0
 	golang.org/x/term v0.16.0
+	golang.org/x/text v0.14.0
 	google.golang.org/grpc v1.61.0
 	google.golang.org/protobuf v1.32.0
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.1
 	k8s.io/apiextensions-apiserver v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/cli-runtime v0.29.1
 	k8s.io/client-go v0.29.1
 	k8s.io/code-generator v0.29.1
+	k8s.io/cri-api v0.29.1
+	oras.land/oras-go/v2 v2.3.1
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/security-profiles-operator v0.8.2
 	sigs.k8s.io/yaml v1.4.0
-)
-
-require (
-	github.com/blang/semver v3.5.1+incompatible
-	github.com/containerd/containerd v1.7.12
-	github.com/containers/image/v5 v5.29.2
-	github.com/coreos/go-systemd/v22 v22.5.0
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/distribution/reference v0.5.0
-	github.com/docker/cli v25.0.1+incompatible
-	github.com/docker/go-connections v0.5.0
-	github.com/godbus/dbus/v5 v5.1.0
-	github.com/google/go-cmp v0.6.0
-	github.com/hashicorp/go-multierror v1.1.1
-	github.com/kr/pretty v0.3.1
-	github.com/moby/moby v25.0.1+incompatible
-	github.com/opencontainers/image-spec v1.1.0-rc6
-	github.com/prometheus/client_golang v1.18.0
-	github.com/shopspring/decimal v1.3.1
-	github.com/spf13/viper v1.18.2
-	github.com/stretchr/testify v1.8.4
-	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
-	github.com/tklauser/numcpus v0.7.0
-	go.opentelemetry.io/otel v1.22.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.45.0
-	go.opentelemetry.io/otel/metric v1.22.0
-	go.opentelemetry.io/otel/sdk/metric v1.22.0
-	golang.org/x/sync v0.6.0
-	golang.org/x/text v0.14.0
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/cri-api v0.29.1
-	oras.land/oras-go/v2 v2.3.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,6 @@ github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6 h1:fQqkJ+WkYfzy6BoUh32fr9uYrXfOGtsfw0skMQkfOic=
-github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -392,6 +390,9 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -486,6 +487,7 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/netnsenter/netnsenter.go
+++ b/pkg/netnsenter/netnsenter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vishvananda/netns"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+	netnsig "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/netns"
 )
 
 func NetnsEnter(pid int, f func() error) error {
@@ -35,7 +36,7 @@ func NetnsEnter(pid int, f func() error) error {
 	origns, _ := netns.Get()
 	defer origns.Close()
 
-	netnsHandle, err := netns.GetFromPidWithAltProcfs(pid, host.HostProcFs)
+	netnsHandle, err := netnsig.GetFromPidWithAltProcfs(pid, host.HostProcFs)
 	if err != nil {
 		return err
 	}

--- a/pkg/rawsock/rawsock.go
+++ b/pkg/rawsock/rawsock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vishvananda/netns"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+	netnsig "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/netns"
 )
 
 // Both openRawSock and htons are from github.com/cilium/ebpf:
@@ -49,7 +50,7 @@ func OpenRawSock(pid uint32) (int, error) {
 		origns, _ := netns.Get()
 		defer origns.Close()
 
-		netnsHandle, err := netns.GetFromPidWithAltProcfs(int(pid), host.HostProcFs)
+		netnsHandle, err := netnsig.GetFromPidWithAltProcfs(int(pid), host.HostProcFs)
 		if err != nil {
 			return -1, err
 		}

--- a/pkg/utils/netns/netns.go
+++ b/pkg/utils/netns/netns.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package netns is a small wrapper around github.com/vishvananda/netns that provides
+// GetFromPidWithAltProcfs() and GetFromThreadWithAltProcfs().
+// TODO: Remove once https://github.com/vishvananda/netns/pull/76 is merged
+package netns
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netns"
+)
+
+// GetFromPidWithAltProcfs gets a handle to the network namespace of a given
+// pid using the specified procfs path.
+func GetFromPidWithAltProcfs(pid int, procfs string) (netns.NsHandle, error) {
+	return netns.GetFromPath(fmt.Sprintf("%s/%d/ns/net", procfs, pid))
+}
+
+// GetFromThreadWithAltProcfs gets a handle to the network namespace of a given
+// pid and tid using the specified procfs path.
+func GetFromThreadWithAltProcfs(pid, tid int, procfs string) (netns.NsHandle, error) {
+	return netns.GetFromPath(fmt.Sprintf("%s/%d/task/%d/ns/net", procfs, pid, tid))
+}


### PR DESCRIPTION
Use upstream version of netns and move custom functions from
fork to utils package. Once https://github.com/vishvananda/netns/pull/76
is merged we can remove the custom functions and use upstream.

