### PR TITLE
trace/exec: Fix crash when using --cwd

### DIFF
--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -171,12 +171,12 @@ func (t *Tracer) run() {
 
 		argsCount := 0
 		buf := []byte{}
-		args := bpfEvent.Args
+		args := &bpfEvent.Args
 
 		if t.config.GetCwd {
 			bpfEventWithCwd := (*execsnoopWithCwdEvent)(unsafe.Pointer(&record.RawSample[0]))
 			event.Cwd = gadgets.FromCString(bpfEventWithCwd.Cwd[:])
-			args = bpfEventWithCwd.Args
+			args = &bpfEventWithCwd.Args
 		}
 
 		for i := 0; i < int(bpfEvent.ArgsSize) && argsCount < int(bpfEvent.ArgsCount); i++ {


### PR DESCRIPTION
The ebpf code has some optimization to only send the right amount of bytes used to hold the arguments.
(See around L200 in pkg/gadgets/trace/exec/tracer/bpf/execsnoop.bpf.c). bpf2go defines `Args` as `[7680]uint8` and the tracer was using `args := bpfEvent.Args`, hence copying the array. It an issue since it's trying to copy memory outside the sample received from the perf ring buffer.

### Testing

The issue is easy to reproduce on the local machine (at least on mine):

```bash
# Something that generates events 
$ docker run --rm -it --name myfoo2 docker.io/library/busybox:latest sh -c 'while true; do cat /dev/null; done;'

$ go build ./cmd/ig/ && bash -c 'for i in {1..30}; do sudo ./ig trace exec --cwd --timeout 2 || exit 1; done'
...

myfoo2                          1862038    35334      cat               0   /bin/cat /dev/null                        /                                       
myfoo2                          1862039    35334      cat               0   /bin/cat /dev/null                        /                                       
unexpected fault address 0xc005400000
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x2 addr=0xc005400000 pc=0x35fa293]

goroutine 87 [running]:
runtime.throw({0x4405a4d?, 0xc000680400?})
	/usr/local/go/src/runtime/panic.go:1077 +0x5c fp=0xc003501c18 sp=0xc003501be8 pc=0x1b8477c
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:875 +0x285 fp=0xc003501c78 sp=0xc003501c18 pc=0x1b9bf25
github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer.(*Tracer).run(0xc0002e0a10)
	/home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/gadgets/trace/exec/tracer/tracer.go:179 +0x813 fp=0xc003503fc8 sp=0xc003501c78 pc=0x35fa293
github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer.(*Tracer).Run.func2()
	/home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/gadgets/trace/exec/tracer/tracer.go:212 +0x25 fp=0xc003503fe0 sp=0xc003503fc8 pc=0x35fa625
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc003503fe8 sp=0xc003503fe0 pc=0x1bb93c1
created by github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/exec/tracer.(*Tracer).Run in goroutine 1
	/home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/gadgets/trace/exec/tracer/tracer.go:212 +0x27c
```

### Bug Investigation

It's not clear to me why this bug doesn't happen more often. The code with the defect was introduced in 34edb8bbf7604624ca527a8c4a0fcfec08d61f82. I used git bisect and found out that it started to happen only after 62a333d4. I first thought it that it was related to the overwritable perf ring support, I tried to use git bisect on ebpf-go and found out that this only happens after https://github.com/cilium/ebpf/commit/8fa4c9018dfeb91433ade155253b823c862170c3. I have no idea why it doesn't happen before that commit. 

ref 
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7668492610/attempts/1#summary-20900541744
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7698411059/attempts/1#summary-20978538872
