### PR TITLE
Allow using env variables to set runtime configuration for `ig`

### DIFF
--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -59,7 +59,7 @@ type CommonFlags struct {
 }
 
 func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
-	command.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	command.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// Runtimes Configuration
 		parts := strings.Split(commonFlags.Runtimes, ",")
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
@@ -164,7 +165,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/vbatts/tar-split v0.11.5 // indirect


### PR DESCRIPTION
# Allows using env vars to set runtime config

Fixes #1044

Instead of specifying flag values every time, users can set env vars and viper would bind these vars to their appropriate flag values.

Note: When both env var and flag value are set, flag value takes precedence.

## How to use

Notation for Env variables - should attach the `IG` prefix with the flag name. And if the flag contains `-` use `_` instead.

Example - --containerd-socketpath : IG_CONTAINERD_SOCKETPATH

## Testing done

```
$ ig list-containers --containerd-socketpath=/bar/foo --runtimes=containerd
$ ig snapshot process --containerd-socketpath=/bar/foo --runtimes=containerd
$ ig trace exec --containerd-socketpath=/bar/foo --runtimes=containerd
```
and 
```
$ export RUNTIMES=containerd
$ export CONTAINERD_SOCKETPATH=/bar/foo
$ ig list-containers
$ ig snapshot process
$ ig trace exec
```
Should give similar results.