### PR TITLE
trace/dns + trace/exec + trace/open: fix unsafe typecasting

### DIFF
--- a/pkg/gadgets/trace/dns/tracer/bpf/dns-common.h
+++ b/pkg/gadgets/trace/dns/tracer/bpf/dns-common.h
@@ -12,6 +12,7 @@
 // answers won't be sent to userspace.
 #define MAX_ADDR_ANSWERS 8
 
+// this needs to be manually kept in sync with dnsEventTAbbrev in tracer.go (without the anaddr field)
 struct event_t {
 	// Keep netns at the top: networktracer depends on it
 	__u32 netns;

--- a/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
+++ b/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
@@ -12,6 +12,7 @@
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)
 
+// this needs to be manually kept in sync with execsnoopEventAbbrev in tracer.go (without the args field)
 struct event {
 	__u64 mntns_id;
 	__u64 timestamp;

--- a/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
+++ b/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
@@ -13,6 +13,7 @@ struct start_t {
 	__u8 fname[NAME_MAX];
 };
 
+// this needs to be manually kept in sync with opensnoopEventAbbrev in tracer.go (without the full_fname field)
 struct event {
 	__u64 timestamp;
 	/* user terminology for pid: */


### PR DESCRIPTION
Before this change, we cast incoming events from the RawSample byte slice directly to expected types (like in other gadgets). However, in these gadgets, we optimized the data we send in eBPF to reduce load by not sending empty fields. Casting those abbreviated events to the full struct though makes them not backed by memory anymore - and thus unsafe to use. This change adds a new type for each gadget containing only the guaranteed parts that are sent and fills the (dynamic) remainder directly from the RawSample data. In case of changes to the original event layout, these new structs have to be updated as well.

This also fixes an issue with the trace/dns example.

Fixes #2337.