### PR TITLE
Fix race conditions on container hook and runcfanotify

### DIFF
--- a/examples/container-hook/main.go
+++ b/examples/container-hook/main.go
@@ -27,7 +27,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
+	containerhook "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -159,11 +159,12 @@ func main() {
 		}
 	}
 
-	_, err = containerhook.NewContainerNotifier(callback)
+	notifier, err := containerhook.NewContainerNotifier(callback)
 	if err != nil {
 		fmt.Printf("containerhook failed: %v\n", err)
 		os.Exit(1)
 	}
+	defer notifier.Close()
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)

--- a/examples/runc-hook/main.go
+++ b/examples/runc-hook/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runcfanotify"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 var (
@@ -188,6 +189,8 @@ func callback(notif runcfanotify.ContainerEvent) {
 }
 
 func main() {
+	host.Init(host.Config{})
+
 	flag.Parse()
 	var err error
 	timeoutDuration, err = time.ParseDuration(*timeout)
@@ -231,11 +234,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	_, err = runcfanotify.NewRuncNotifier(callback)
+	notifier, err := runcfanotify.NewRuncNotifier(callback)
 	if err != nil {
 		fmt.Printf("runcfanotify failed: %v\n", err)
 		os.Exit(1)
 	}
+	defer notifier.Close()
 
 	// Graceful shutdown
 	exit := make(chan os.Signal, 1)


### PR DESCRIPTION
# Testing 

## Data race on containers map

1.  Build any of `examples/container-hook` or `examples/runc-hook` examples with -race enable:

```bash 
$ cd examples/container-hook/
$ go build -race .
$ sudo ./container-hook
```

2. Create a container in another terminal
```bash 
$ docker run --rm -it --name myfoo3 busybox:latest
```

The first terminal will show a data race:

```bash 
==================
WARNING: DATA RACE
Write at 0x00c0000aab40 by goroutine 28:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).AddWatchContainerTermination()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:333 +0x1b7
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).watchPidFileIterate()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:478 +0x552
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).monitorRuntimeInstance.func1()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:589 +0x1d2

Previous read at 0x00c0000aab40 by goroutine 23:
  runtime.mapiterinit()
      /usr/local/go/src/runtime/map.go:816 +0x0
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).watchContainersTermination()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:372 +0x306
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install.func1()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:314 +0x33

Goroutine 28 (running) created at:
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).monitorRuntimeInstance()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:585 +0x826
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).parseOCIRuntime()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:691 +0xb5e
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).watchRuntimeIterate()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:775 +0x96c
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).watchRuntimeBinary()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:610 +0xa4
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install.func2()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:315 +0x33

Goroutine 23 (running) created at:
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:314 +0x3f9
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:269 +0xc4
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.NewContainerNotifier()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:186 +0x1c8
  main.main()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/examples/container-hook/main.go:162 +0x3da
==================
```

## Data race on closed

I was only able to reproduce with ig

```bash 
$ go build -race ./cmd/ig/ 
$ sudo ig trace bind
...
```

In another terminal create a container:

```bash 
$ docker run --rm -it --name myfoo3 busybox:latest
```

Exit ig by Ctrl + C:
```bash 
^C==================
WARNING: DATA RACE
Write at 0x00c0001433e0 by main goroutine:
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).Close()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:784 +0x3a
  github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.NewManager.WithContainerFanotifyEbpf.func7.2()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-collection/options.go:633 +0x2e
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection.(*ContainerCollection).Close()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-collection/container-collection.go:523 +0x181
  github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.(*IGManager).Close()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/ig-manager/ig-manager.go:119 +0x30
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*LocalManager).Close()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/localmanager/localmanager.go:222 +0x45
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators.(*operatorWrapper).Close()
      <autogenerated>:1 +0x43
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators.Operators.Close()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/operators.go:199 +0xac
  github.com/inspektor-gadget/inspektor-gadget/cmd/common.buildCommandFromGadget.func2.11()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/cmd/common/registry.go:398 +0x4f
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:477 +0x30
  github.com/inspektor-gadget/inspektor-gadget/cmd/common.buildCommandFromGadget.func2()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/cmd/common/registry.go:394 +0x657
  github.com/spf13/cobra.(*Command).execute()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xf2f
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x604
  github.com/spf13/cobra.(*Command).Execute()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x567
  main.main()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/cmd/ig/main.go:82 +0x568

Previous read at 0x00c0001433e0 by goroutine 48:
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).watchRuntimeBinary()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:611 +0xcf
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install.func2()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:315 +0x33

Goroutine 48 (running) created at:
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.(*ContainerNotifier).install()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:315 +0x474
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook.NewContainerNotifier()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-hook/tracer.go:186 +0x1c8
  github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.NewManager.WithContainerFanotifyEbpf.func7()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-collection/options.go:610 +0xaa
  github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection.(*ContainerCollection).Initialize()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/container-collection/container-collection.go:103 +0x112
  github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.NewManager()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/ig-manager/ig-manager.go:110 +0x909
  github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.NewManager()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/ig-manager/ig-manager.go:90 +0x1d6
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*LocalManager).Init()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/localmanager/localmanager.go:211 +0xa26
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators.(*operatorWrapper).Init.func1()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/operators.go:130 +0x5b
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:65 +0x44
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators.(*operatorWrapper).Init()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/operators.go:129 +0x74
  github.com/inspektor-gadget/inspektor-gadget/pkg/operators.Operators.Init()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/pkg/operators/operators.go:188 +0xe6
  github.com/inspektor-gadget/inspektor-gadget/cmd/common.buildCommandFromGadget.func2()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/cmd/common/registry.go:394 +0x657
  github.com/spf13/cobra.(*Command).execute()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xf2f
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x604
  github.com/spf13/cobra.(*Command).Execute()
      /home/mvb/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x567
  main.main()
      /home/mvb/kinvolk/ebpf/inspektor-gadget/cmd/ig/main.go:82 +0x568
==================
```

Related to https://github.com/inspektor-gadget/inspektor-gadget/issues/2337







