### PR TITLE
pkg/columns: Do not elide output when redirected.

### DIFF
--- a/pkg/columns/formatter/textcolumns/options.go
+++ b/pkg/columns/formatter/textcolumns/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	DefaultColumns []string    // defines which columns to show by default; will be set to all visible columns if nil
 	HeaderStyle    HeaderStyle // defines how column headers are decorated (e.g. uppercase/lowercase)
 	RowDivider     string      // defines the (to be repeated) string that should be used below the header
+	ShouldTruncate bool        // defines whether to truncate strings or not
 }
 
 func DefaultOptions() *Options {
@@ -46,6 +47,7 @@ func DefaultOptions() *Options {
 		DefaultColumns: nil,
 		HeaderStyle:    HeaderStyleUppercase,
 		RowDivider:     DividerNone,
+		ShouldTruncate: true,
 	}
 }
 
@@ -81,5 +83,12 @@ func WithHeaderStyle(headerStyle HeaderStyle) Option {
 func WithRowDivider(divider string) Option {
 	return func(opts *Options) {
 		opts.RowDivider = divider
+	}
+}
+
+// WithShouldTruncate sets whether strings should be truncated.
+func WithShouldTruncate(ellipsis bool) Option {
+	return func(opts *Options) {
+		opts.ShouldTruncate = ellipsis
 	}
 }

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -35,6 +35,11 @@ func (tf *TextColumnsFormatter[T]) buildFixedString(s string, length int, ellips
 	if length <= 0 {
 		return ""
 	}
+
+	if !tf.options.ShouldTruncate {
+		return s
+	}
+
 	rs := []rune(s)
 
 	shortened := ellipsis.Shorten(rs, length, ellipsisType)
@@ -110,7 +115,7 @@ func (tf *TextColumnsFormatter[T]) FormatTable(entries []*T) string {
 	return string(out[:len(out)-1])
 }
 
-// WriteTable writes header, divider nd the formatted entries with the current settings to writer
+// WriteTable writes header, divider and the formatted entries with the current settings to writer
 func (tf *TextColumnsFormatter[T]) WriteTable(writer io.Writer, entries []*T) error {
 	_, err := writer.Write([]byte(tf.FormatHeader()))
 	if err != nil {


### PR DESCRIPTION
Hi.


This PR removes ellipsis when the output is not a terminal:

```bash
$ sudo -E ./ig image list | awk '{ printf "%s:%s\n", $1, $2 }' | tail -2
INFO[0000] Experimental features enabled                
blocks:latest
ghcr.io/inspektor-gadget/gadgets/blocks:latest
```

Best regards.