### PR TITLE
integration: Publish aggregate test report summary

### DIFF
--- a/.github/actions/prepare-and-publish-test-reports/action.yml
+++ b/.github/actions/prepare-and-publish-test-reports/action.yml
@@ -8,6 +8,9 @@ inputs:
   test-step-conclusion:
     description: "Conclusion of the test step"
     required: true
+  test-summary-suffix:
+    description: "Suffix of the test summary file"
+    required: true
 
 runs:
   using: "composite"
@@ -23,6 +26,18 @@ runs:
         go tool test2json -t < ./${{ inputs.test-log-file }} > ./test-report.json
     - name: Publish test reports as markdown
       shell: bash
+      env:
+        PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+        PULL_REQUEST_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
       run: |
-        testjson2md -in ./test-report.json -out ./test-report.md -conclusion ${{ inputs.test-step-conclusion }}
+        testjson2md -in ./test-report.json \
+          -out ./test-report.md \
+          -out_summary ./test-report_${GITHUB_JOB}_${{ inputs.test-summary-suffix }}.json \
+          -conclusion ${{ inputs.test-step-conclusion }}
         cat test-report.md >> $GITHUB_STEP_SUMMARY
+    - name: Upload test reports summary as artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-reports
+        path: ./test-report_*_*.json

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -23,6 +23,9 @@ inputs:
   gadget_tag:
     description: 'Tag used for gadgets OCI images'
     required: true
+  test_summary_suffix:
+    description: 'Suffix of the test summary file'
+    required: true
 
 runs:
   using: "composite"
@@ -84,3 +87,4 @@ runs:
       with:
         test-log-file: integration.log
         test-step-conclusion: ${{ steps.integration-tests.conclusion }}
+        test-summary-suffix: ${{ inputs.test_summary_suffix }}

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1229,6 +1229,7 @@ jobs:
         with:
           test-log-file: integration.log
           test-step-conclusion: ${{ steps.integration-tests.conclusion }}
+          test-summary-suffix: ${{ matrix.runtime }}
 
   build-and-push-gadgets:
     name: Build and push gadgets
@@ -1316,6 +1317,7 @@ jobs:
         with:
           test-log-file: integration.log
           test-step-conclusion: ${{ steps.integration-tests.conclusion }}
+          test-summary-suffix: ${{ matrix.runtime }}
 
   test-integration-aks:
     name: Integration tests on AKS
@@ -1400,6 +1402,7 @@ jobs:
         image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         gadget_repository: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
         gadget_tag: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+        test_summary_suffix: "${{ matrix.os-sku }}-${{ matrix.arch }}"
     # This step ensures we get fresh credentials before removing the cluster
     - uses: azure/login@v1
       if: always()
@@ -1468,6 +1471,7 @@ jobs:
         image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         gadget_repository: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
         gadget_tag: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+        test_summary_suffix: "aro"
 
   test-integration-minikube:
     name: Integr. tests
@@ -1522,6 +1526,7 @@ jobs:
         dnstester_image: ${{ needs.build-helper-images.outputs.dnstester_image }}
         gadget_repository: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
         gadget_tag: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+        test_summary_suffix: ${{ matrix.runtime }}
     - if: ${{ matrix.runtime == 'docker' }}
       name: Check that README is up-to-date
       # We do this check here, as we need to run kubectl-gadget against a deployed installation to
@@ -1530,6 +1535,33 @@ jobs:
       shell: bash
       run: |
         perl tools/check-readme.pl ./kubectl-gadget README.md
+
+
+  publish-test-reports:
+    name: Publish test reports
+    # level: 5
+    needs:
+      - test-integration-minikube
+      - test-integration-aks
+      - test-integration-aro
+      - test-integration-k8s-ig
+      - test-integration-non-k8s-ig
+    runs-on: ubuntu-latest
+    # Skip this job when running on a fork or a PR from a fork.
+    if: always() && (
+      (github.event_name == 'push' && github.repository == 'inspektor-gadget/inspektor-gadget') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'inspektor-gadget/inspektor-gadget'))
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get all reports
+      uses: actions/download-artifact@v3
+      with:
+        name: "test-reports"
+    - name: Store test reports
+      shell: bash {0}
+      run: ./tools/store-test-reports.sh
+      env:
+        TEST_REPORTS_TOKEN: ${{ secrets.TEST_REPORTS_TOKEN }}
 
   release:
     name: Release

--- a/tools/store-test-reports.sh
+++ b/tools/store-test-reports.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set +x
+
+if [ -z "$GITHUB_ACTIONS" ]; then
+  echo "This script is expected to run in a GitHub Action"
+  exit 1
+fi
+
+function retry {
+  local n=1
+  local max=10
+  local delay=15
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $((RANDOM % delay))
+      else
+        echo "The command has failed after $n attempts."
+        return 1
+      fi
+    }
+  done
+}
+
+function store-reports {
+  local dir=$(mktemp -d -p . --suffix -ig-test-reports)
+  local repo="https://${TEST_REPORTS_TOKEN}@github.com/inspektor-gadget/ig-test-reports.git"
+
+  git clone $repo $dir
+  pushd $dir || exit 1
+  if [ ! -d data ]; then
+    mkdir -p data
+    echo '{}' > data/workflows.json
+  fi
+  for i in ../test-report_*_*.json; do
+      job_key=$(basename $i .json | sed 's/test-report_//')
+      jq --slurpfile obj $i \
+      --arg job_key ${job_key} \
+      '.[$job_key] = (.[$job_key][-99:] + $obj)' \
+      data/workflows.json > workflows.json.tmp
+      mv workflows.json.tmp data/workflows.json
+  done
+
+  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+  git config --global user.name "github-actions[bot]"
+  git add data
+  git commit -m "Add test reports for workflow ${GITHUB_RUN_NUMBER} and attempt ${GITHUB_RUN_ATTEMPT}"
+  git push
+  if [ $? -ne 0 ]; then
+    popd || exit 1
+    return 1
+  fi
+  popd || exit 1
+}
+
+retry store-reports
+rc=$?
+rm -rf *-ig-test-reports
+exit $rc


### PR DESCRIPTION
Currently, getting overview of test failures in the CI can be challenging. This change addresses that by extending the work we did for summaries and enhances that by storing them to a GitHub page. 

It took inspiration from the `ig-benchmarks` and commits the reports on each change. [Similarly](https://github.com/benchmark-action/github-action-benchmark/pull/216/files), uses `retry` to avoid running into multiple `git push` issue.

## Testing Done

Reports: https://inspektor-gadget.github.io/ig-test-reports/
