### PR TITLE
cri: check range before accessing imageRef

### DIFF
--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -288,6 +288,15 @@ type CRIContainer interface {
 	GetImageRef() string
 }
 
+func digestFromRef(imageRef string) string {
+	splitted := strings.Split(imageRef, "@")
+	if len(splitted) == 1 {
+		return imageRef
+	} else {
+		return splitted[1]
+	}
+}
+
 func CRIContainerToContainerData(runtimeName types.RuntimeName, container CRIContainer) *runtimeclient.ContainerData {
 	containerMetadata := container.GetMetadata()
 	image := container.GetImage()
@@ -303,7 +312,7 @@ func CRIContainerToContainerData(runtimeName types.RuntimeName, container CRICon
 				ContainerName:        strings.TrimPrefix(containerMetadata.GetName(), "/"),
 				RuntimeName:          runtimeName,
 				ContainerImageName:   image.GetImage(),
-				ContainerImageDigest: strings.Split(imageRef, "@")[1],
+				ContainerImageDigest: digestFromRef(imageRef),
 			},
 			State: containerStatusStateToRuntimeClientState(container.GetState()),
 		},


### PR DESCRIPTION
panic on enriching some imageRef fields:
panic: runtime error: index out of range [1] with length 1

Based on work from: @burak-ok 

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/2413

The patch originally comes from #2398