### PR TITLE
Cleanup custom-columns CLI flag

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	OutputModeJSON          = "json"
-	OutputModeCustomColumns = "custom-columns"
+	OutputModeCustomColumns = "columns"
 )
 
 var SupportedOutputModes = []string{OutputModeJSON, OutputModeCustomColumns}

--- a/docs/builtin-gadgets/top/ebpf.md
+++ b/docs/builtin-gadgets/top/ebpf.md
@@ -56,7 +56,7 @@ So in this case for example, in the past second `vfs_write_entry` has been calle
 The program references 4 maps that have a total maximum size of 40.953 MB (see below for more information on MapMemory).
 
 If you want to get the cumulative runtime and run count of the eBPF programs starting from the beginning of the trace,
-you can call the gadget with the custom-columns option and specify the cumulruntime and cumulruncount columns.
+you can call the gadget with the columns option and specify the cumulruntime and cumulruncount columns.
 Combined with the `--sort cumulruntime` and `--timeout 60` parameters, you can for example measure the time spent
 over a minute:
 

--- a/docs/ig.md
+++ b/docs/ig.md
@@ -109,7 +109,7 @@ docker              b72558e589cb95e835c4840de19f0306d4081091c34045246d62b6efed35
 Notice that most of the commands support the following features even if, for
 simplicity, they are not demonstrated in each command guide:
 
-- JSON format and `custom-columns` output mode are supported through the
+- JSON format and `columns` output mode are supported through the
   `--output` flag.
 - It is possible to filter events by container name using the `--containername`
   flag.

--- a/integration/command.go
+++ b/integration/command.go
@@ -218,7 +218,7 @@ var CleanupSPO = []*Command{
 		Cmd: `
 		while true; do
 		  # Ensure we have profiles to clean, otherwise just exit.
-		  NAMESPACES=$(kubectl get seccompprofile --all-namespaces --no-headers --ignore-not-found -o custom-columns=":metadata.namespace" | uniq)
+		  NAMESPACES=$(kubectl get seccompprofile --all-namespaces --no-headers --ignore-not-found -o columns=":metadata.namespace" | uniq)
 		  if [ -z $NAMESPACES ]; then
 		    break
 		  fi

--- a/tools/demos/trace-dns/demo.sh
+++ b/tools/demos/trace-dns/demo.sh
@@ -21,6 +21,6 @@ run "kubectl run -n demo test-pod --image busybox -- sh -c 'while true ; do wget
 run "kubectl wait -n demo --for=condition=ready pod/test-pod"
 
 desc "Let's trace"
-run "kubectl gadget trace dns -n demo --timeout 3 -o custom-columns=pod,comm,qr,qtype,name"
+run "kubectl gadget trace dns -n demo --timeout 3 -o columns=pod,comm,qr,qtype,name"
 
 sleep 5

--- a/tools/demos/trace-exec/demo.sh
+++ b/tools/demos/trace-exec/demo.sh
@@ -18,6 +18,6 @@
 
 desc "Let's trace new processes"
 run "kubectl get pod -n demo"
-run "kubectl gadget trace exec -n demo --timeout 4 -o custom-columns=pod,pid,comm,args"
+run "kubectl gadget trace exec -n demo --timeout 4 -o columns=pod,pid,comm,args"
 
 sleep 5


### PR DESCRIPTION
# Cleanup custom-columns CLI flag

This PR fixes #1526 as the `custom-columns` flag has been changed to `columns`, the changes in this PR will replace all the `custom-columns` flag from documentation and code with `columns`
