### PR TITLE
Cleanup custom-columns CLI flag

### DIFF
--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -40,13 +40,6 @@ import (
 )
 
 const (
-	OutputModeColumns    = "columns"
-	OutputModeJSON       = "json"
-	OutputModeJSONPretty = "jsonpretty"
-	OutputModeYAML       = "yaml"
-)
-
-const (
 	kubernetesColumnPrefix = "k8s"
 	runtimeColumnPrefix    = "runtime"
 )
@@ -153,7 +146,7 @@ func buildColumnsOutputFormat(gadgetParams *params.Params, parser parser.Parser,
 
 	of.Description += out.String()
 
-	return gadgets.OutputFormats{OutputModeColumns: of}
+	return gadgets.OutputFormats{utils.OutputModeColumns: of}
 }
 
 func buildOutputFormatsHelp(outputFormats gadgets.OutputFormats) []string {
@@ -264,28 +257,28 @@ func buildCommandFromGadget(
 			AddFlags(cmd, &extraGadgetParams, skipParams, runtime)
 
 			outputFormats.Append(gadgets.OutputFormats{
-				OutputModeJSON: {
+				utils.OutputModeJSON: {
 					Name:        "JSON",
 					Description: "The output of the gadget is returned as raw JSON",
 					Transform:   nil,
 				},
-				OutputModeJSONPretty: {
+				utils.OutputModeJSONPretty: {
 					Name:        "JSON Prettified",
 					Description: "The output of the gadget is returned as prettified JSON",
 					Transform:   nil,
 				},
-				OutputModeYAML: {
+				utils.OutputModeYAML: {
 					Name:        "YAML",
 					Description: "The output of the gadget is returned as YAML",
 					Transform:   nil,
 				},
 			})
-			defaultOutputFormat = OutputModeJSON
+			defaultOutputFormat = utils.OutputModeJSON
 
 			// Add parser output flags
 			if parser != nil {
 				outputFormats.Append(buildColumnsOutputFormat(gadgetParams, parser, hiddenColumnTags))
-				defaultOutputFormat = "columns"
+				defaultOutputFormat = utils.OutputModeColumns
 
 				cmd.PersistentFlags().StringSliceVarP(
 					&filters,
@@ -411,12 +404,12 @@ func buildCommandFromGadget(
 					}
 
 					transformResult = formats[outputModeName].Transform
-				case OutputModeJSON:
+				case utils.OutputModeJSON:
 					transformResult = func(result any) ([]byte, error) {
 						r, _ := result.([]byte)
 						return r, nil
 					}
-				case OutputModeJSONPretty:
+				case utils.OutputModeJSONPretty:
 					transformResult = func(result any) ([]byte, error) {
 						var out bytes.Buffer
 
@@ -427,7 +420,7 @@ func buildCommandFromGadget(
 
 						return out.Bytes(), nil
 					}
-				case OutputModeYAML:
+				case utils.OutputModeYAML:
 					transformResult = func(result any) ([]byte, error) {
 						d, err := k8syaml.JSONToYAML(result.([]byte))
 						if err != nil {
@@ -617,7 +610,7 @@ func buildCommandFromGadget(
 					}
 					fe.Output(string(transformed))
 				})
-			case OutputModeColumns:
+			case utils.OutputModeColumns:
 				formatter.SetEventCallback(fe.Output)
 
 				// Enable additional output, if the gadget supports it (e.g. profile/cpu)
@@ -644,13 +637,13 @@ func buildCommandFromGadget(
 				}
 				fe.Output(formatter.FormatHeader())
 				parser.SetEventCallback(formatter.EventHandlerFuncArray())
-			case OutputModeJSON:
+			case utils.OutputModeJSON:
 				jsonCallback := printEventAsJSONFn(fe)
 				parser.SetEventCallback(jsonCallback)
-			case OutputModeJSONPretty:
+			case utils.OutputModeJSONPretty:
 				jsonPrettyCallback := printEventAsJSONPrettyFn(fe)
 				parser.SetEventCallback(jsonPrettyCallback)
-			case OutputModeYAML:
+			case utils.OutputModeYAML:
 				yamlCallback := printEventAsYAMLFn(fe)
 				parser.SetEventCallback(yamlCallback)
 			}

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -29,11 +29,13 @@ import (
 )
 
 const (
-	OutputModeJSON          = "json"
-	OutputModeCustomColumns = "custom-columns"
+	OutputModeColumns    = "columns"
+	OutputModeJSON       = "json"
+	OutputModeJSONPretty = "jsonpretty"
+	OutputModeYAML       = "yaml"
 )
 
-var SupportedOutputModes = []string{OutputModeJSON, OutputModeCustomColumns}
+var SupportedOutputModes = []string{OutputModeJSON, OutputModeColumns}
 
 // OutputConfig contains the flags that describes how to print the gadget's output
 type OutputConfig struct {
@@ -71,27 +73,27 @@ func (config *OutputConfig) ParseOutputConfig() error {
 
 	switch {
 	case len(config.OutputMode) == 0:
-		config.OutputMode = OutputModeCustomColumns
+		config.OutputMode = OutputModeColumns
 		return nil
 	case config.OutputMode == OutputModeJSON:
 		return nil
-	case strings.HasPrefix(config.OutputMode, OutputModeCustomColumns):
+	case strings.HasPrefix(config.OutputMode, OutputModeColumns):
 		parts := strings.Split(config.OutputMode, "=")
 		if len(parts) != 2 {
-			return WrapInErrInvalidArg(OutputModeCustomColumns,
+			return WrapInErrInvalidArg(OutputModeColumns,
 				errors.New("expects a comma separated list of columns to use"))
 		}
 
 		cols := strings.Split(strings.ToLower(parts[1]), ",")
 		for _, col := range cols {
 			if len(col) == 0 {
-				return WrapInErrInvalidArg(OutputModeCustomColumns,
+				return WrapInErrInvalidArg(OutputModeColumns,
 					errors.New("column can't be empty"))
 			}
 		}
 
 		config.CustomColumns = cols
-		config.OutputMode = OutputModeCustomColumns
+		config.OutputMode = OutputModeColumns
 		return nil
 	default:
 		return WrapInErrOutputModeNotSupported(config.OutputMode)

--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -108,7 +108,7 @@ func (p *BaseParser[E]) Transform(element *E, toColumns func(*E) string) string 
 		}
 
 		return string(b)
-	case OutputModeCustomColumns:
+	case OutputModeColumns:
 		return toColumns(element)
 	}
 

--- a/cmd/common/utils/parser_test.go
+++ b/cmd/common/utils/parser_test.go
@@ -54,7 +54,7 @@ func TestBaseParser(t *testing.T) {
 			description: "none valid column using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			columnsWidth: map[string]int{
 				"pid":  0,
@@ -66,7 +66,7 @@ func TestBaseParser(t *testing.T) {
 			description: "none valid column using tabs",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			availableColumns: []string{
 				"pid",
@@ -79,7 +79,7 @@ func TestBaseParser(t *testing.T) {
 			description: "ignore invalid column using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			columnsWidth: map[string]int{
 				"pid":  -7,
@@ -94,7 +94,7 @@ func TestBaseParser(t *testing.T) {
 			description: "ignore invalid column using tabs",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			availableColumns: []string{
 				"pid",
@@ -109,7 +109,7 @@ func TestBaseParser(t *testing.T) {
 			description: "ignore multiple invalid columns using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "invalid-col", "comm", "another-invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			columnsWidth: map[string]int{
 				"pid":  -7,
@@ -124,7 +124,7 @@ func TestBaseParser(t *testing.T) {
 			description: "ignore multiple invalid column using tabs",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "invalid-col", "comm", "another-invalid-col"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			availableColumns: []string{
 				"pid",
@@ -139,7 +139,7 @@ func TestBaseParser(t *testing.T) {
 			description: "normal case using width",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "comm"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			columnsWidth: map[string]int{
 				"pid":  -7,
@@ -154,7 +154,7 @@ func TestBaseParser(t *testing.T) {
 			description: "normal case using tabs",
 			outputConfig: &OutputConfig{
 				CustomColumns: []string{"pid", "comm"},
-				OutputMode:    OutputModeCustomColumns,
+				OutputMode:    OutputModeColumns,
 			},
 			availableColumns: []string{
 				"pid",

--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -144,7 +144,7 @@ func printContainers(parser *commonutils.GadgetParser[containercollection.Contai
 		}
 
 		fmt.Printf("%s\n", b)
-	case commonutils.OutputModeCustomColumns:
+	case commonutils.OutputModeColumns:
 		fmt.Println(parser.TransformIntoTable(containers))
 	}
 
@@ -159,7 +159,7 @@ func printPubSubEvent(parser *commonutils.GadgetParser[containercollection.PubSu
 			return commonutils.WrapInErrMarshalOutput(err)
 		}
 		fmt.Printf("%s\n", b)
-	case commonutils.OutputModeCustomColumns:
+	case commonutils.OutputModeColumns:
 		fmt.Println(parser.TransformIntoColumns(event))
 	}
 

--- a/cmd/kubectl-gadget/traceloop.go
+++ b/cmd/kubectl-gadget/traceloop.go
@@ -217,7 +217,7 @@ func runTraceloopList(cmd *cobra.Command, args []string) error {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeCustomColumns:
+			case commonutils.OutputModeColumns:
 				fmt.Println(parser.TransformIntoColumns(&info))
 			}
 		}
@@ -276,7 +276,7 @@ func runTraceloopShow(cmd *cobra.Command, args []string) error {
 				}
 
 				fmt.Println(string(b))
-			case commonutils.OutputModeCustomColumns:
+			case commonutils.OutputModeColumns:
 				fmt.Println(parser.TransformIntoColumns(&event))
 			}
 		}

--- a/docs/builtin-gadgets/top/ebpf.md
+++ b/docs/builtin-gadgets/top/ebpf.md
@@ -56,7 +56,7 @@ So in this case for example, in the past second `vfs_write_entry` has been calle
 The program references 4 maps that have a total maximum size of 40.953 MB (see below for more information on MapMemory).
 
 If you want to get the cumulative runtime and run count of the eBPF programs starting from the beginning of the trace,
-you can call the gadget with the custom-columns option and specify the cumulruntime and cumulruncount columns.
+you can call the gadget with the columns option and specify the cumulruntime and cumulruncount columns.
 Combined with the `--sort cumulruntime` and `--timeout 60` parameters, you can for example measure the time spent
 over a minute:
 

--- a/docs/ig.md
+++ b/docs/ig.md
@@ -109,7 +109,7 @@ docker              b72558e589cb95e835c4840de19f0306d4081091c34045246d62b6efed35
 Notice that most of the commands support the following features even if, for
 simplicity, they are not demonstrated in each command guide:
 
-- JSON format and `custom-columns` output mode are supported through the
+- JSON format and `columns` output mode are supported through the
   `--output` flag.
 - It is possible to filter events by container name using the `--containername`
   flag.

--- a/pkg/columns/doc.go
+++ b/pkg/columns/doc.go
@@ -56,7 +56,7 @@ The parameter could be used for specific options, passing nil will use the defau
 	| ellipsis  | none,left,right,middle | defines how situations of content exceeding the given space should be handled, eg: where to place the ellipsis ("…") |
 	| fixed     | none                   | defines that this column will have a fixed width, even when auto-scaling is enabled                                  |
 	| group     | sum                    | defines what should happen with the field whenever entries are grouped (see grouping)                                |
-	| hide      | none                   | specifies that this column is not to be considered by default (see custom columns)                                   |
+	| hide      | none                   | specifies that this column is not to be considered by default                                                        |
 	| precision | int                    | specifies the precision of floats (number of decimals)                                                               |
 	| width     | int                    | defines the space allocated for the column                                                                           |
 

--- a/tools/demos/trace-dns/demo.sh
+++ b/tools/demos/trace-dns/demo.sh
@@ -21,6 +21,6 @@ run "kubectl run -n demo test-pod --image busybox -- sh -c 'while true ; do wget
 run "kubectl wait -n demo --for=condition=ready pod/test-pod"
 
 desc "Let's trace"
-run "kubectl gadget trace dns -n demo --timeout 3 -o custom-columns=pod,comm,qr,qtype,name"
+run "kubectl gadget trace dns -n demo --timeout 3 -o columns=pod,comm,qr,qtype,name"
 
 sleep 5

--- a/tools/demos/trace-exec/demo.sh
+++ b/tools/demos/trace-exec/demo.sh
@@ -18,6 +18,6 @@
 
 desc "Let's trace new processes"
 run "kubectl get pod -n demo"
-run "kubectl gadget trace exec -n demo --timeout 4 -o custom-columns=pod,pid,comm,args"
+run "kubectl gadget trace exec -n demo --timeout 4 -o columns=pod,pid,comm,args"
 
 sleep 5


### PR DESCRIPTION
# Cleanup custom-columns CLI flag

This PR fixes #1526 as the `custom-columns` flag has been changed to `columns`, the changes in this PR will replace all the `custom-columns` flag from documentation and code with `columns`
