### PR TITLE
docs: Add requirements to tcpdrop gadget

### DIFF
--- a/docs/builtin-gadgets/trace/tcpdrop.md
+++ b/docs/builtin-gadgets/trace/tcpdrop.md
@@ -203,6 +203,9 @@ This table can be generated with:
 ```bash
 $ go run ./pkg/gadgets/trace/tcpdrop/tracer/dropreasongen/...
 ```
+### Requirements
+
+The gadget currently needs Linux Kernel version >= 5.17
 
 ### Other tools showing dropped packets
 


### PR DESCRIPTION
# Add requirements to tcpdrop gadget

Tcpdrop gadget is currently working with Linux kernel >= 5.17.  See https://github.com/inspektor-gadget/inspektor-gadget/pull/1469 and https://github.com/inspektor-gadget/inspektor-gadget/issues/1199#issuecomment-1419079293
This PR adds a requirements section to the gadget documentation.
