### PR TITLE
[Backport]: trace/dns + trace/exec + trace/open: fix unsafe typecasting

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
     - main
+    - 'release-*'
     - 'citest/**'
     tags:
     - 'v*'

--- a/pkg/gadgets/trace/dns/tracer/bpf/dns-common.h
+++ b/pkg/gadgets/trace/dns/tracer/bpf/dns-common.h
@@ -12,6 +12,7 @@
 // answers won't be sent to userspace.
 #define MAX_ADDR_ANSWERS 8
 
+// this needs to be manually kept in sync with dnsEventTAbbrev in tracer.go (without the anaddr field)
 struct event_t {
 	// Keep netns at the top: networktracer depends on it
 	__u32 netns;

--- a/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
+++ b/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
@@ -12,6 +12,7 @@
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)
 
+// this needs to be manually kept in sync with execsnoopEventAbbrev in tracer.go (without the args field)
 struct event {
 	__u64 mntns_id;
 	__u64 timestamp;

--- a/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
+++ b/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
@@ -13,6 +13,7 @@ struct start_t {
 	__u8 fname[NAME_MAX];
 };
 
+// this needs to be manually kept in sync with opensnoopEventAbbrev in tracer.go (without the full_fname field)
 struct event {
 	__u64 timestamp;
 	/* user terminology for pid: */


### PR DESCRIPTION
Backporting d841b4238a6d ("trace/dns + trace/exec + trace/open: fix unsafe typecasting") since it's affecting one of our users: https://kubernetes.slack.com/archives/CSYL75LF6/p1707355332239829. 

Upstream PR: https://github.com/inspektor-gadget/inspektor-gadget/pull/2443
