### PR TITLE
ci: Enable running tests on release branch

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
     - main
+    - 'release-*'
     - 'citest/**'
     tags:
     - 'v*'


### PR DESCRIPTION
Now that we're backporting fixes, we need to run the CI in the release branch too.

