### PR TITLE
integration: Disable installing Security Profile Operator

### DIFF
--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -51,7 +51,7 @@ var (
 	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
 
 	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")
-	doNotDeploySPO = flag.Bool("no-deploy-spo", false, "don't deploy the Security Profiles Operator (SPO)")
+	doNotDeploySPO = flag.Bool("no-deploy-spo", true, "don't deploy the Security Profiles Operator (SPO)")
 
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
 	k8sArch   = flag.String("k8s-arch", "amd64", "allows to skip tests that are not supported on a given CPU architecture")


### PR DESCRIPTION
The security profile operator is only used by TestAuditSeccomp to install a simple seccomp profile in the cluster. This is an overkill.

This commit uses a simpler approach by copying the profile by using a DaemonSet to the node and disables installing this by default. The code to deploy/undeploy the SPO isn't removed as it could be useful to test the "advise seccomp" gadget in the future.

Some reasons to avoid deploying the SPO are:
- It needs quite a lot of resources
- It takes a lot of time to be deployed
- Some times it fails to be deployed, and also to be cleanup, leaving it running on the cluster


