### PR TITLE
run: Populate tracers with the correct name

### DIFF
--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -434,8 +434,10 @@ func (m *GadgetMetadata) populateTracers(spec *ebpf.CollectionSpec) error {
 	}
 
 	if _, found := m.Tracers[tracerInfo.Name]; !found {
-		log.Debugf("Adding tracer %q", tracerMap.Name)
-		m.Tracers[tracerMap.Name] = Tracer{
+		log.Debugf("Adding tracer %q with map %q and struct %q",
+			tracerInfo.Name, tracerMap.Name, tracerMapStruct.Name)
+
+		m.Tracers[tracerInfo.Name] = Tracer{
 			MapName:    tracerMap.Name,
 			StructName: tracerMapStruct.Name,
 		}

--- a/pkg/gadgets/run/types/metadata_test.go
+++ b/pkg/gadgets/run/types/metadata_test.go
@@ -333,7 +333,7 @@ func TestPopulate(t *testing.T) {
 				Name:        "TODO: Fill the gadget name",
 				Description: "TODO: Fill the gadget description",
 				Tracers: map[string]Tracer{
-					"events": {
+					"test": {
 						MapName:    "events",
 						StructName: "event",
 					},
@@ -379,7 +379,7 @@ func TestPopulate(t *testing.T) {
 				Name:        "foo",
 				Description: "bar",
 				Tracers: map[string]Tracer{
-					"events": {
+					"test": {
 						MapName:    "events",
 						StructName: "event",
 					},
@@ -415,7 +415,7 @@ func TestPopulate(t *testing.T) {
 				Name:        "foo",
 				Description: "bar",
 				Tracers: map[string]Tracer{
-					"events": {
+					"test": {
 						MapName:    "events",
 						StructName: "event",
 					},
@@ -476,7 +476,7 @@ func TestPopulate(t *testing.T) {
 				Name:        "TODO: Fill the gadget name",
 				Description: "TODO: Fill the gadget description",
 				Tracers: map[string]Tracer{
-					"events": {
+					"test": {
 						MapName:    "events",
 						StructName: "event",
 					},


### PR DESCRIPTION
# run: Populate tracers with the correct name

When generating the metadata from the eBPF code, the tracer is wrongly created with the map name:

https://github.com/inspektor-gadget/inspektor-gadget/blob/dfaeb2992e1ab7ad7316b241e18845e573232e26/pkg/gadgets/run/types/metadata.go#L438

It is clear in the `TestPopulate/1_tracer_1_struct_from_scratch` unit tests as it expects an "events" tracer:

https://github.com/inspektor-gadget/inspektor-gadget/blob/dfaeb2992e1ab7ad7316b241e18845e573232e26/pkg/gadgets/run/types/metadata_test.go#L335-L340

When the eBPF code defines a "test" tracer:

https://github.com/inspektor-gadget/inspektor-gadget/blob/dfaeb2992e1ab7ad7316b241e18845e573232e26/testdata/populate_metadata_1_tracer_1_struct_from_scratch.bpf.c#L22

## How to use

Remove the metadata file of any of out image-based gadgets, build it with the `--update-metadata` flag and verify that the tracer is created with the name defined by the `GADGET_TRACER` macro.

## Testing done

The unit-tests are all green:

```bash
go test -test.v -exec sudo ./pkg/gadgets/run/...
```
