### PR TITLE
ci: Run integration test on GKE

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1107,6 +1107,7 @@ jobs:
     outputs:
       aro: ${{ steps.set_output.outputs.aro }}
       aks: ${{ steps.set_output.outputs.aks }}
+      gke: ${{ steps.set_output.outputs.gke }}
       cosign: ${{ steps.set_output.outputs.cosign }}
     steps:
       # Secrets cannot be used as if condition, use job output as workaround.
@@ -1122,6 +1123,9 @@ jobs:
           AZURE_AKS_RESOURCE_GROUP: '${{ secrets.AZURE_AKS_RESOURCE_GROUP }}'
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
+          GKE_PROJECT: '${{ secrets.GKE_PROJECT }}'
+          GKE_SERVICE_ACCOUNT: '${{ secrets.GKE_SERVICE_ACCOUNT }}'
+          GKE_WORKLOAD_IDENTITY_PROVIDER: '${{ secrets.GKE_WORKLOAD_IDENTITY_PROVIDER }}'
         run: |
           if [[ "${OPENSHIFT_SERVER}" != "" && \
                 "${OPENSHIFT_USER}" != "" && \
@@ -1154,6 +1158,17 @@ jobs:
           else
             echo "Secrets to use cosign were not configured in the repo"
             echo "cosign=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "${GKE_PROJECT}" != "" && \
+                "${GKE_SERVICE_ACCOUNT}" != "" && \
+                "${GKE_WORKLOAD_IDENTITY_PROVIDER}" != "" ]]; \
+          then
+            echo "Secrets to use a GKE cluster were configured in the repo"
+            echo "gke=true" >> $GITHUB_OUTPUT
+          else
+            echo "Secrets to use a GKE cluster were not configured in the repo"
+            echo "gke=false" >> $GITHUB_OUTPUT
           fi
 
   public-key-check:
@@ -1551,6 +1566,95 @@ jobs:
       run: |
         eksctl delete cluster --name ${{ env.CLUSTER_NAME }} --wait=false
 
+  test-integration-gke:
+    name: Integration tests on GKE
+    # level: 4
+    if: needs.check-secrets.outputs.gke == 'true'
+    needs:
+      - check-secrets
+      - test-unit
+      - build-clients
+      - build-gadget-container-images
+      - publish-gadget-images-manifest
+      - build-and-push-gadgets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - arch: amd64
+            region: us-east1
+            machine_type: e2-standard-2
+          - arch: arm64
+            region: us-central1
+            machine_type: t2a-standard-2
+    # Following permissions are needed to use OIDC authentication with GKE.
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      GKE_CLUSTER_PREFIX: 'ig-ci-gke-'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Set container repository and determine image tag
+        id: set-repo-determine-image-tag
+        uses: ./.github/actions/set-container-repo-and-determine-image-tag
+        with:
+          registry: ${{ env.REGISTRY }}
+          container-image: ${{ env.CONTAINER_REPO }}
+      - name: Authenticate with GKE
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.GKE_PROJECT }}
+          service_account: ${{ secrets.GKE_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GKE_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Craft cluster name
+        shell: bash
+        run: |
+            echo "CLUSTER_NAME=${{ env.GKE_CLUSTER_PREFIX }}${{ matrix.flavor.arch }}-${RANDOM}" >> $GITHUB_ENV
+      - name: Create GKE cluster
+        run: |
+          # arm64 machine types are only available in zones (us-central1-a, us-central1-b, us-central1-f, us-central1-d) in us-central1 region
+          extra_args=""
+          if [ ${{ matrix.flavor.arch }} = "arm64" ]; then
+                extra_args="--node-locations us-central1-a,us-central1-b,us-central1-f"
+          fi
+
+          gcloud container clusters create ${{ env.CLUSTER_NAME }} --project ${{ secrets.GKE_PROJECT }} \
+            --region ${{ matrix.flavor.region }} --machine-type ${{ matrix.flavor.machine_type }} --num-nodes 1 --disk-size 50 $extra_args
+      - name: Set GKE cluster ${{ env.CLUSTER_NAME }} context
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.CLUSTER_NAME }}
+          location: ${{ matrix.flavor.region }}
+      # ARM nodes come with a taint that prevents pods from being scheduled on them.
+      # https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment
+      - name: Remove taint for arm64 nodes
+        if: ${{ matrix.flavor.arch == 'arm64' }}
+        run: |
+          kubectl taint nodes --all kubernetes.io/arch=arm64:NoSchedule-
+      - name: Run integration tests
+        uses: ./.github/actions/run-integration-tests
+        with:
+          kubernetes_distribution: "gke-COS_containerd"
+          kubernetes_architecture: ${{ matrix.flavor.arch }}
+          container_repo: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}
+          image_tag: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+          gadget_repository: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
+          gadget_tag: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+          test_summary_suffix: "GKE-${{ matrix.flavor.arch }}"
+      - name: Delete GKE cluster
+        if: always()
+        run: |
+          gcloud container clusters delete --project ${{ secrets.GKE_PROJECT }} --region ${{ matrix.flavor.region }} ${{ env.CLUSTER_NAME }} --async --quiet
+
   test-integration-minikube:
     name: Integr. tests
     # level: 3
@@ -1622,6 +1726,7 @@ jobs:
       - test-integration-aks
       - test-integration-aro
       - test-integration-eks
+      - test-integration-gke
       - test-integration-k8s-ig
       - test-integration-non-k8s-ig
     runs-on: ubuntu-latest

--- a/docs/devel/ci.md
+++ b/docs/devel/ci.md
@@ -241,7 +241,7 @@ Finally, the clusters are deleted, whatsoever is the result of the tests.
 
 ## Run integration tests on EKS
 
-We use OpenID Connect to authenticate Github Actions against AWS. If you want to run the integration
+We use OpenID Connect to authenticate GitHub Actions against AWS. If you want to run the integration
 tests on your fork, follow
 [this](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 to configure your AWS account.
@@ -251,6 +251,25 @@ policies](https://eksctl.io/usage/minimum-iam-policies/) needed by eksctl. Save 
 role (including the rull `arn:aws..` prefix). in a [repository
 variable](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository)
 named `AWS_ROLE`.
+
+## Run integration tests on GKE
+
+In order to run the integration tests on GKE on a fork, you need to set the following secrets:
+
+- `GKE_PROJECT`: The GCP project where the GKE cluster is located.
+- `GKE_SERVICE_ACCOUNT`: The service account used to authenticate to GCP.
+- `GKE_WORKLOAD_IDENTITY_PROVIDER`: The workload identity provider used to authenticate to GCP.
+
+these secrets use OpenID Connect to authenticate GitHub Actions against GCP for more information on how it works
+you can check the GitHub documentation [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform#adding-a-google-cloud-workload-identity-provider).
+The steps to create a service account and a workload identity provider can be found in the [google-github-actions/auth](https://github.com/google-github-actions/auth?tab=readme-ov-file#workload-identity-federation-through-a-service-account) repository till step 6.
+In terms of permissions, the service account needs to have the following roles:
+
+- `roles/container.admin`
+- `roles/container.clusterAdmin`
+- `roles/iam.serviceAccountUser`
+
+You can see the guide [here](https://cloud.google.com/kubernetes-engine/docs/how-to/iam#assigning_roles_to_service_accounts) to see how these roles can be assigned to the service account.
 
 ## Benchmarks
 

--- a/integration/inspektor-gadget/advise_networkpolicy_test.go
+++ b/integration/inspektor-gadget/advise_networkpolicy_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestAdviseNetworkpolicy(t *testing.T) {
+	if *k8sDistro == K8sDistroGKECOS {
+		t.Skip("Skip running advise network policy on GKE COS: see pull request #2280")
+	}
+
 	nsServer := GenerateTestNamespaceName("test-advise-networkpolicy-server")
 	nsClient := GenerateTestNamespaceName("test-advise-networkpolicy-client")
 

--- a/integration/inspektor-gadget/integration_test.go
+++ b/integration/inspektor-gadget/integration_test.go
@@ -33,6 +33,7 @@ const (
 	K8sDistroARO            = "aro"
 	K8sDistroMinikubeGH     = "minikube-github"
 	K8sDistroEKSAmazonLinux = "eks-AmazonLinux"
+	K8sDistroGKECOS         = "gke-COS_containerd"
 )
 
 const securityProfileOperatorNamespace = "security-profiles-operator"
@@ -46,6 +47,7 @@ var (
 		K8sDistroARO,
 		K8sDistroMinikubeGH,
 		K8sDistroEKSAmazonLinux,
+		K8sDistroGKECOS,
 	}
 	cleaningUp = uint32(0)
 )

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -69,6 +69,10 @@ func TestTopEbpf(t *testing.T) {
 		t.Skip("Skip running top ebpf gadget on AKS Ubuntu amd64: see issue #931")
 	}
 
+	if *k8sDistro == K8sDistroGKECOS {
+		t.Skip("Skip running top ebpf gadget on GKE COS: see pull_request #2280")
+	}
+
 	t.Parallel()
 
 	t.Run("StartAndStop", func(t *testing.T) {

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -70,7 +70,7 @@ func TestTopEbpf(t *testing.T) {
 	}
 
 	if *k8sDistro == K8sDistroGKECOS {
-		t.Skip("Skip running top ebpf gadget on GKE COS: see pull_request #2280")
+		t.Skip("Skip running top ebpf gadget on GKE COS: see pull request #2280")
 	}
 
 	t.Parallel()

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestTraceNetwork(t *testing.T) {
 	if *k8sDistro == K8sDistroGKECOS {
-		t.Skip("Skip running top ebpf gadget on GKE COS: see pull_request #2280")
+		t.Skip("Skip running trace network on GKE COS: see pull request #2280")
 	}
 
 	ns := GenerateTestNamespaceName("test-trace-network")

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestTraceNetwork(t *testing.T) {
+	if *k8sDistro == K8sDistroGKECOS {
+		t.Skip("Skip running top ebpf gadget on GKE COS: see pull_request #2280")
+	}
+
 	ns := GenerateTestNamespaceName("test-trace-network")
 
 	t.Parallel()


### PR DESCRIPTION
This change allows running integration tests on GKE. It uses OIDC to authenticate with GCP similar to other cloud providers. Following are the successful runs:
- (amd64): https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7901941522/job/21566707127
- (arm64): https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7901941522/job/21566707426

In case you want to see logs for the tests that I have skipped (happy to have more feedback on this, also [potential fix](https://github.com/inspektor-gadget/inspektor-gadget/pull/2280#issuecomment-1939672769)):
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7900722522/attempts/1#summary-21563030071
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7887098920/attempts/2#summary-21523122919

Fixes #784 