### PR TITLE
ci: unpin docker buildx version

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -695,9 +695,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # TODO: Remove once buildx v0.12.0 is released with https://github.com/docker/buildx/pull/1965
-          version: https://github.com/docker/buildx.git#e5cee892ed4fa2e0af53c54c09131c96c68383ff
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -756,9 +753,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # TODO: Remove once buildx v0.12.0 is released with https://github.com/docker/buildx/pull/1965
-          version: https://github.com/docker/buildx.git#e5cee892ed4fa2e0af53c54c09131c96c68383ff
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
We were using a specific version for docker buildx to have support for adding annotaions ( https://github.com/docker/buildx/pull/1965). But it has been released into stable already so removing workaround. You can confirm that `docker/setup-buildx-action@v3` uses [`v0.12.0+` by default now.](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/7903715108/job/21572292303#step:4:109)
