### PR TITLE
Mount filesystems by default when running in a container

### DIFF
--- a/docs/examples/pod-ig.yaml
+++ b/docs/examples/pod-ig.yaml
@@ -18,7 +18,6 @@ spec:
       command:
         # CHANGEME: run the gadget of your choice
         - "ig"
-        - "--auto-mount-filesystems"
         - "trace"
         - "exec"
         - "--host"
@@ -30,8 +29,6 @@ spec:
           name: host
         - mountPath: /run
           name: run
-        - mountPath: /sys/kernel/debug
-          name: debugfs
   # CHANGEME: where do you want to run this pod?
   nodeName: minikube-containerd
   volumes:
@@ -41,6 +38,3 @@ spec:
     - name: run
       hostPath:
         path: /run
-    - name: debugfs
-      hostPath:
-        path: /sys/kernel/debug

--- a/docs/ig.md
+++ b/docs/ig.md
@@ -308,9 +308,6 @@ $ docker run -ti --rm \
     --privileged \
     -v /run:/run \
     -v /:/host \
-    -v /sys/kernel/debug:/sys/kernel/debug \
-    -v /sys/kernel/tracing:/sys/kernel/tracing \
-    -v /sys/fs/bpf:/sys/fs/bpf \
     --pid=host \
     ghcr.io/inspektor-gadget/ig \
     trace exec
@@ -323,8 +320,6 @@ List of flags:
 - `-v /run:/run` gives access to the container runtimes sockets (docker, containerd, CRI-O).
 - `-v /:/host` gives access to the host filesystem. This is used to access the host processes via /host/proc, and access
   container runtime hooks (rootfs and config.json).
-- `-v` volumes for debugfs, tracefs and bpf filesystems. Alternatively, it is possible to pass the flag
-  `--auto-mount-filesystems` to ig to automatically mount those filesystems.
 - `--pid=host` runs in the host PID namespace. Optional on Linux. This is necessary on Docker Desktop on Windows because
   /host/proc does not give access to the host processes.
 

--- a/pkg/utils/host/host.go
+++ b/pkg/utils/host/host.go
@@ -142,11 +142,17 @@ func AddFlags(command *cobra.Command) {
 		false,
 		"Automatically run in a privileged systemd unit if lacking enough capabilities",
 	)
+
+	// Enable the mount workaround by default when running inside a container.
+	automountFilesystemsDefault := false
+	if HostRoot != "" && HostRoot != "/" {
+		automountFilesystemsDefault = true
+	}
 	command.PersistentFlags().BoolVarP(
 		&autoMountFilesystemsFlag,
 		"auto-mount-filesystems",
 		"",
-		false,
+		automountFilesystemsDefault,
 		"Automatically mount bpffs, debugfs and tracefs if they are not already mounted",
 	)
 	command.PersistentFlags().BoolVarP(


### PR DESCRIPTION
Inspektor Gadget requires some filesystems to be mounted in order to work (bpffs, tracefs and debugfs). a65dbbc6bcfd ("host package: workarounds for kubectl-debug and Windows") introduced a way to mount those filesystems automatically, however the logic wasn't enable by default on ig.

This commit enables that logic by default when running inside a container (HOST_ROOT is passed). This helps users to run ig inside a container without having to worry about passing all the mounts from the host.

After this commit, ig can be run as:

docker run --privileged -it --rm -v /:/host -e HOST_ROOT=/host -v /run:/run ig_image trace exec

The logic is still disabled by default when running in the host because we don't want to change the system configuration without making the user aware.

--- 

@alban  what do you think about this approach?
