### PR TITLE
pkg/run: Don't rely on GADGET_TRACER as it is optional

### DIFF
--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -274,8 +274,6 @@ func (t *Tracer) handleTracerMapDefinition(tracerMapName string) error {
 			bufMap.KeySize = 4
 			bufMap.ValueSize = 4
 
-			t.spec.Maps[tracerMapName] = bufMap
-
 			if heapMapPresent {
 				_, tracer := getAnyMapElem(t.config.Metadata.Tracers)
 
@@ -286,8 +284,6 @@ func (t *Tracer) handleTracerMapDefinition(tracerMapName string) error {
 
 				// Replace MAX_EVENT_SIZE by the actual event size.
 				heapMap.ValueSize = eventStruct.Size
-
-				t.spec.Maps[types.GadgetHeapMapName] = heapMap
 			}
 		}
 	} else {

--- a/pkg/gadgets/run/tracer/tracer.go
+++ b/pkg/gadgets/run/tracer/tracer.go
@@ -277,14 +277,11 @@ func (t *Tracer) handleTracerMapDefinition(tracerMapName string) error {
 			t.spec.Maps[tracerMapName] = bufMap
 
 			if heapMapPresent {
-				infos, err := types.GetTracerInfo(t.spec)
-				if err != nil {
-					return fmt.Errorf("getting tracer information: %w", err)
-				}
+				_, tracer := getAnyMapElem(t.config.Metadata.Tracers)
 
 				var eventStruct *btf.Struct
-				if err := t.spec.Types.TypeByName(infos.EventType, &eventStruct); err != nil {
-					return fmt.Errorf("finding event type %q: %w", infos.EventType, err)
+				if err := t.spec.Types.TypeByName(tracer.StructName, &eventStruct); err != nil {
+					return fmt.Errorf("finding event type %q: %w", tracer.StructName, err)
 				}
 
 				// Replace MAX_EVENT_SIZE by the actual event size.


### PR DESCRIPTION
# Don't rely on GADGET_TRACER as it is optional

```
GetTracerInfo gets the tracer information from what was defined by
the GADGET_TRACER macro. However, such macro is optional, so we
must not rely on it. Additionally, by the time
handleTracerMapDefinition() is called, the metadata was already
built (either from the metadata file or from the eBPF code), so we
can get the tracer information from there.
```
