### PR TITLE
image build: add annotations in OCI image

### DIFF
--- a/docs/reference/oci.md
+++ b/docs/reference/oci.md
@@ -49,6 +49,19 @@ Its content must be a valid ELF file.
 There must be at most one layer with the wasm media type. If present, it must
 not be empty and it must be a valid wasm file.
 
-## Image labels
+## Image annotations
 
-TODO
+OCI images can have annotations at different levels:
+- index
+- manifest
+- config
+- layer
+
+Inspektor Gadget automatically adds the following annotations at the manifest and config levels:
+- `org.opencontainers.image.*`: defined by [OCI Image Format](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)
+  - title
+  - description
+  - url
+  - documentation
+  - source
+  - created

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -152,6 +152,15 @@ type GadgetMetadata struct {
 	Name string `yaml:"name"`
 	// Gadget description
 	Description string `yaml:"description,omitempty"`
+	// HomepageURL is the URL to the gadget's homepage
+	HomepageURL string `yaml:"homepageURL,omitempty"`
+	// DocumentationURL is the URL to the gadget's documentation
+	DocumentationURL string `yaml:"documentationURL,omitempty"`
+	// SourceURL is the URL to the gadget's source code repository
+	SourceURL string `yaml:"sourceURL,omitempty"`
+	// Annotations is a map of key-value pairs that provide additional information about the gadget
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+
 	// Tracers implemented by the gadget
 	// TODO: Rename this field to something that doesn't collide with the opentelemetry concept
 	Tracers map[string]Tracer `yaml:"tracers,omitempty"`

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -346,6 +346,18 @@ func (m *GadgetMetadata) Populate(spec *ebpf.CollectionSpec) error {
 		m.Description = "TODO: Fill the gadget description"
 	}
 
+	if m.HomepageURL == "" {
+		m.HomepageURL = "TODO: Fill the gadget homepage URL"
+	}
+
+	if m.DocumentationURL == "" {
+		m.DocumentationURL = "TODO: Fill the gadget documentation URL"
+	}
+
+	if m.SourceURL == "" {
+		m.SourceURL = "TODO: Fill the gadget source code URL"
+	}
+
 	if err := m.populateTracers(spec); err != nil {
 		return fmt.Errorf("handling trace maps: %w", err)
 	}

--- a/pkg/gadgets/run/types/metadata_test.go
+++ b/pkg/gadgets/run/types/metadata_test.go
@@ -18,8 +18,9 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
 
 func TestValidate(t *testing.T) {
@@ -330,8 +331,11 @@ func TestPopulate(t *testing.T) {
 		"1_tracer_1_struct_from_scratch": {
 			objectPath: "../../../../testdata/populate_metadata_1_tracer_1_struct_from_scratch.o",
 			expectedMetadata: &GadgetMetadata{
-				Name:        "TODO: Fill the gadget name",
-				Description: "TODO: Fill the gadget description",
+				Name:             "TODO: Fill the gadget name",
+				Description:      "TODO: Fill the gadget description",
+				HomepageURL:      "TODO: Fill the gadget homepage URL",
+				DocumentationURL: "TODO: Fill the gadget documentation URL",
+				SourceURL:        "TODO: Fill the gadget source code URL",
 				Tracers: map[string]Tracer{
 					"test": {
 						MapName:    "events",
@@ -376,8 +380,14 @@ func TestPopulate(t *testing.T) {
 		"tracer_add_missing_field": {
 			objectPath: "../../../../testdata/populate_metadata_tracer_add_missing_field.o",
 			initialMetadata: &GadgetMetadata{
-				Name:        "foo",
-				Description: "bar",
+				Name:             "foo",
+				Description:      "bar",
+				HomepageURL:      "url1",
+				DocumentationURL: "url2",
+				SourceURL:        "url3",
+				Annotations: map[string]string{
+					"io.inspektor-gadget.test": "test",
+				},
 				Tracers: map[string]Tracer{
 					"test": {
 						MapName:    "events",
@@ -412,8 +422,14 @@ func TestPopulate(t *testing.T) {
 				},
 			},
 			expectedMetadata: &GadgetMetadata{
-				Name:        "foo",
-				Description: "bar",
+				Name:             "foo",
+				Description:      "bar",
+				HomepageURL:      "url1",
+				DocumentationURL: "url2",
+				SourceURL:        "url3",
+				Annotations: map[string]string{
+					"io.inspektor-gadget.test": "test",
+				},
 				Tracers: map[string]Tracer{
 					"test": {
 						MapName:    "events",
@@ -458,8 +474,11 @@ func TestPopulate(t *testing.T) {
 		"no_tracers_from_scratch": {
 			objectPath: "../../../../testdata/populate_metadata_no_tracers_from_scratch.o",
 			expectedMetadata: &GadgetMetadata{
-				Name:        "TODO: Fill the gadget name",
-				Description: "TODO: Fill the gadget description",
+				Name:             "TODO: Fill the gadget name",
+				Description:      "TODO: Fill the gadget description",
+				HomepageURL:      "TODO: Fill the gadget homepage URL",
+				DocumentationURL: "TODO: Fill the gadget documentation URL",
+				SourceURL:        "TODO: Fill the gadget source code URL",
 			},
 		},
 		"tracer_wrong_map_type": {
@@ -473,8 +492,11 @@ func TestPopulate(t *testing.T) {
 		"tracer_map_without_btf": {
 			objectPath: "../../../../testdata/populate_metadata_tracer_map_without_btf.o",
 			expectedMetadata: &GadgetMetadata{
-				Name:        "TODO: Fill the gadget name",
-				Description: "TODO: Fill the gadget description",
+				Name:             "TODO: Fill the gadget name",
+				Description:      "TODO: Fill the gadget description",
+				HomepageURL:      "TODO: Fill the gadget homepage URL",
+				DocumentationURL: "TODO: Fill the gadget documentation URL",
+				SourceURL:        "TODO: Fill the gadget source code URL",
 				Tracers: map[string]Tracer{
 					"test": {
 						MapName:    "events",
@@ -519,8 +541,11 @@ func TestPopulate(t *testing.T) {
 		"param_populate_from_scratch": {
 			objectPath: "../../../../testdata/populate_metadata_1_param_from_scratch.o",
 			expectedMetadata: &GadgetMetadata{
-				Name:        "TODO: Fill the gadget name",
-				Description: "TODO: Fill the gadget description",
+				Name:             "TODO: Fill the gadget name",
+				Description:      "TODO: Fill the gadget description",
+				HomepageURL:      "TODO: Fill the gadget homepage URL",
+				DocumentationURL: "TODO: Fill the gadget documentation URL",
+				SourceURL:        "TODO: Fill the gadget source code URL",
 				EBPFParams: map[string]EBPFParam{
 					// This also makes sure that param2 won't get picked up
 					// since GADGET_PARAM(param2) is missing
@@ -536,8 +561,14 @@ func TestPopulate(t *testing.T) {
 		"param_dont_modify_values": {
 			objectPath: "../../../../testdata/populate_metadata_1_param_from_scratch.o",
 			initialMetadata: &GadgetMetadata{
-				Name:        "foo",
-				Description: "bar",
+				Name:             "foo",
+				Description:      "bar",
+				HomepageURL:      "url1",
+				DocumentationURL: "url2",
+				SourceURL:        "url3",
+				Annotations: map[string]string{
+					"io.inspektor-gadget.test": "test",
+				},
 				EBPFParams: map[string]EBPFParam{
 					"param": {
 						// Set desc and some attributes to be sure they aren't overwritten
@@ -550,8 +581,14 @@ func TestPopulate(t *testing.T) {
 				},
 			},
 			expectedMetadata: &GadgetMetadata{
-				Name:        "foo",
-				Description: "bar",
+				Name:             "foo",
+				Description:      "bar",
+				HomepageURL:      "url1",
+				DocumentationURL: "url2",
+				SourceURL:        "url3",
+				Annotations: map[string]string{
+					"io.inspektor-gadget.test": "test",
+				},
 				EBPFParams: map[string]EBPFParam{
 					// This also makes sure that param2 won't get picked up
 					// since GADGET_PARAM(param2) is missing
@@ -569,8 +606,11 @@ func TestPopulate(t *testing.T) {
 		"snapshotter_struct": {
 			objectPath: "../../../../testdata/populate_metadata_snapshotter_struct.o",
 			expectedMetadata: &GadgetMetadata{
-				Name:        "TODO: Fill the gadget name",
-				Description: "TODO: Fill the gadget description",
+				Name:             "TODO: Fill the gadget name",
+				Description:      "TODO: Fill the gadget description",
+				HomepageURL:      "TODO: Fill the gadget homepage URL",
+				DocumentationURL: "TODO: Fill the gadget documentation URL",
+				SourceURL:        "TODO: Fill the gadget source code URL",
 				Snapshotters: map[string]Snapshotter{
 					"events": {
 						StructName: "event",


### PR DESCRIPTION
OCI images can have annotations at different levels:
- index
- manifest
- config
- layer

This patch adds annotations in the index, manifest and config levels.

artifacthub reads annotations at the manifest level. The 3 required annotations from artifacthub are defined:
- io.artifacthub.package.readme-url
- org.opencontainers.image.created
- org.opencontainers.image.description

Users can add custom images with the `annotations` field in gadget.yaml.

https://github.com/inspektor-gadget/inspektor-gadget/issues/2175