### PR TITLE
docs: Update image build documentation

### DIFF
--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -144,9 +144,11 @@ Successfully built sha256:adf9a4c636421d09e038eefa15623176195b0de482b25972e09b8b
 ##### Customizing your build
 
 The building process is controlled by the `build.yaml` file. The following parameters are available:
+
 - `ebpfsource`: eBPF source code file. It defaults to `program.bpf.c`.
 - `metadata`: File containing metadata about the gadget. It defaults to `gadget.yaml`.
 - `wasm`: Wasm module. It is unset by default.
+- `cflags`: The C flags used to compile the eBPF program. It is unset by default.
 
 By default, the build command looks for `build.yaml` in PATH. It can be changed with the `--file` flag:
 

--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -183,6 +183,10 @@ INFO[0000] Experimental features enabled
 Successfully built docker.io/library/mygadget:latest@sha256:dd3f5c357983bb863ef86942e36f4c851933eec4b32ba65ee375acb1c514f628
 ```
 
+Take into account that it is possible to customize the build process by defining a `build.yaml` file.
+Check the [Customizing your build](../../docs/core-concepts/images.md#customizing-your-build)
+section for more details.
+
 ## (Optional) Pushing the gadget image to a container registry
 
 You could push the gadget to a remote container registry. If you're using the same machine for


### PR DESCRIPTION
# Update image build documentation

This PR makes two changes to the build documentation:
1. Update fields that can be specified in the `build.yaml` file.
2. Add reference to the build customization in the hello-word-gadget file.
