### PR TITLE
tests: Update fsslower to look for open event instead of read

### DIFF
--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -45,7 +45,7 @@ func TestTraceFsslower(t *testing.T) {
 				),
 				Comm: "cat",
 				File: "foo",
-				Op:   "R",
+				Op:   "O",
 			}
 
 			normalize := func(e *fsslowerTypes.Event) {

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -45,7 +45,7 @@ func TestTraceFsslower(t *testing.T) {
 				Event: BuildBaseEventK8s(ns, WithContainerImageName("docker.io/library/busybox:latest", isDockerRuntime)),
 				Comm:  "cat",
 				File:  "foo",
-				Op:    "R",
+				Op:    "O",
 			}
 
 			normalize := func(e *tracefsslowerType.Event) {


### PR DESCRIPTION
Look open event instead of read to avoid failing due to https://github.com/inspektor-gadget/inspektor-gadget/issues/2554.


