### PR TITLE
Introduce `uprobetracer` for auto attach/detach

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,6 +79,7 @@
 /pkg/standardgadgets/ @mauriciovasquezbernal
 /pkg/tracer-collection/ @alban
 /pkg/types/ @blanquicet
+/pkg/uprobetracer/ @i-Pear
 /pkg/utils/bpf-iter-ns/ @alban
 /pkg/utils/host/ @alban
 /tools/ @mqasimsarfraz

--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -55,6 +55,8 @@ on.
 
 ### Uprobes / Uretprobes (experimental)
 
-The section name must use the `uprobe/<file_path>:<symbol>` or `uretprobe/<file_path>:<symbol>` formats.
+The section name must use the `<prog_type>/<file_path>:<symbol>` format.
+`<prog_type>` must be either `uprobe` or `uretprobe`.
 `<file_path>` is the absolute path of an executable or a library, that the uprobe will be attached to.
+For common libraries, `<file_path>` can also be the library's name, such as `libc`.
 `<symbol>` is a debugging symbol that can be found in the file mentioned above.

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -1,7 +1,7 @@
 name: trace malloc
 description: use uprobe to trace malloc and free in libc.so
 tracers:
-  events:
+  malloc:
     mapName: events
     structName: event
 structs:

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -24,7 +24,7 @@ struct event {
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 
-GADGET_TRACER(open, events, event);
+GADGET_TRACER(malloc, events, event);
 
 static __always_inline int submit_memop_event(struct pt_regs *ctx,
 					      enum memop operation, __u64 addr)

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -49,13 +49,13 @@ static __always_inline int submit_memop_event(struct pt_regs *ctx,
 	return 0;
 }
 
-SEC("uretprobe//usr/lib/libc.so.6:malloc")
+SEC("uretprobe/libc:malloc")
 int trace_uprobe_malloc(struct pt_regs *ctx)
 {
 	return submit_memop_event(ctx, MALLOC, PT_REGS_RC(ctx));
 }
 
-SEC("uprobe//usr/lib/libc.so.6:free")
+SEC("uprobe/libc:free")
 int trace_uprobe_free(struct pt_regs *ctx)
 {
 	return submit_memop_event(ctx, FREE, PT_REGS_PARM1(ctx));

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/common v0.58.0
 	github.com/containers/image/v5 v5.30.0
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.5.0
 	github.com/docker/cli v25.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
+github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/pkg/uprobetracer/ldcache_parser.go
+++ b/pkg/uprobetracer/ldcache_parser.go
@@ -1,0 +1,199 @@
+package uprobetracer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+)
+
+const (
+	cache1Header    string = "ld.so-1.7.0"
+	cache1HeaderLen int    = 11
+
+	cache2Header    string = "glibc-ld.so.cache"
+	cache2HeaderLen int    = 17
+	cache2Version   string = "1.1"
+
+	ldCache1EntrySize uint32 = 12
+	ldCache1Size      uint32 = 16
+	ldCache2EntrySize uint32 = 24
+	ldCache2Size      uint32 = 48
+)
+
+type ldCache1Entry struct {
+	Flags int32
+	Key   uint32
+	Value uint32
+}
+
+type ldCache1 struct {
+	Header     [11]int8
+	EntryCount uint32
+}
+
+type ldCache2Entry struct {
+	Flags int32
+	Key   uint32
+	Value uint32
+	Pad1_ uint32
+	Pad2_ uint64
+}
+
+type ldCache2 struct {
+	Header         [17]int8
+	Version        [3]int8
+	EntryCount     uint32
+	StringTableLen uint32
+	Pad_           [5]uint32
+}
+
+type ldEntry struct {
+	Key   string
+	Value string
+}
+
+func readFromBytes[T any](obj *T, rawData []byte) error {
+	if int(unsafe.Sizeof(*obj)) != len(rawData) {
+		return fmt.Errorf("reading from bytes: length mismatched")
+	}
+	buffer := bytes.NewBuffer(rawData)
+	err := binary.Read(buffer, binary.NativeEndian, obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func readStringFromBytes(data []byte, startPos uint32) string {
+	res := ""
+	for i := startPos; i < uint32(len(data)); i++ {
+		if data[i] == 0 {
+			return res
+		}
+		res += string(data[i])
+	}
+	return ""
+}
+
+func readCacheFormat1(data []byte) []ldEntry {
+	var ldEntries []ldEntry
+
+	ldCache := ldCache1{}
+	if uint32(len(data)) <= ldCache1Size {
+		return nil
+	}
+	err := readFromBytes(&ldCache, data[:ldCache1Size])
+	if err != nil {
+		return nil
+	}
+	ldEntriesOffset := ldCache1Size
+	ldStringsOffset := ldCache1Size + ldCache1EntrySize*ldCache.EntryCount
+	for i := uint32(0); i < ldCache.EntryCount; i++ {
+		entryOffset := ldEntriesOffset + i*ldCache1EntrySize
+		entry := ldCache1Entry{}
+		if uint32(len(data)) <= entryOffset+ldCache1EntrySize {
+			return nil
+		}
+		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache1EntrySize])
+		if err != nil {
+			return nil
+		}
+		keyOffset := ldStringsOffset + entry.Key
+		valueOffset := ldStringsOffset + entry.Value
+		key := readStringFromBytes(data, keyOffset)
+		value := readStringFromBytes(data, valueOffset)
+		ldEntries = append(ldEntries, ldEntry{key, value})
+	}
+	return ldEntries
+}
+
+func readCacheFormat2(data []byte) []ldEntry {
+	var ldEntries []ldEntry
+
+	if !bytes.Equal([]byte(cache2Header), data[:cache2HeaderLen]) {
+		return nil
+	}
+	ldCache := ldCache2{}
+	if uint32(len(data)) <= ldCache2Size {
+		return nil
+	}
+	err := readFromBytes(&ldCache, data[:ldCache2Size])
+	if err != nil {
+		return nil
+	}
+	ldEntriesOffset := ldCache2Size
+	for i := uint32(0); i < ldCache.EntryCount; i++ {
+		entryOffset := ldEntriesOffset + i*ldCache2EntrySize
+		entry := ldCache2Entry{}
+		if uint32(len(data)) <= entryOffset+ldCache2EntrySize {
+			return nil
+		}
+		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache2EntrySize])
+		if err != nil {
+			return nil
+		}
+		keyOffset := entry.Key
+		valueOffset := entry.Value
+		key := readStringFromBytes(data, keyOffset)
+		value := readStringFromBytes(data, valueOffset)
+		ldEntries = append(ldEntries, ldEntry{key, value})
+	}
+	return ldEntries
+}
+
+// simulate the loader's behaviour, find library path in containers' `/etc/ld.so.cache`.
+// see https://github.com/bminor/glibc/blob/master/elf/cache.c#L292, the `print_cache` func
+// see https://github.com/iovisor/bcc/blob/master/src/cc/bcc_proc.c#L508, the `bcc_procutils_which_so` func
+func parseLdCache(ldCachePath string, libraryName string) []string {
+	fileInfo, err := os.Stat(ldCachePath)
+	if err != nil {
+		return nil
+	}
+	if fileInfo.Mode()&os.ModeNamedPipe != 0 {
+		return nil
+	}
+	ldCacheFile, err := os.ReadFile(ldCachePath)
+	if err != nil {
+		return nil
+	}
+	ldCacheFileSize := uint32(len(ldCacheFile))
+
+	var ldEntries []ldEntry
+	var filteredLibraries []string
+
+	if bytes.Equal([]byte(cache1Header), ldCacheFile[:cache1HeaderLen]) {
+		cache1 := ldCache1{}
+		if uint32(len(ldCacheFile)) <= ldCache1Size {
+			return nil
+		}
+		err := readFromBytes(&cache1, ldCacheFile[:ldCache1Size])
+		if err != nil {
+			return nil
+		}
+		cache1Len := ldCache1Size + cache1.EntryCount*ldCache1EntrySize
+		cache1Len = (cache1Len + 7) / 8 * 8
+		if ldCacheFileSize > (cache1Len + ldCache2Size) {
+			ldEntries = readCacheFormat2(ldCacheFile)
+		} else {
+			ldEntries = readCacheFormat1(ldCacheFile)
+		}
+	} else {
+		ldEntries = readCacheFormat2(ldCacheFile)
+	}
+
+	if ldEntries == nil {
+		return nil
+	}
+
+	// filter library entries with given library name
+	for _, entry := range ldEntries {
+		if strings.HasPrefix(entry.Key, libraryName+".so") {
+			filteredLibraries = append(filteredLibraries, entry.Value)
+		}
+	}
+
+	return filteredLibraries
+}

--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -1,0 +1,256 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uprobetracer handles how uprobe/uretprobe/USDT programs are attached
+// to containers. It has two running modes: `pending` mode and `running` mode.
+//
+// Before `AttachProg` is called, uprobetracer runs in `pending` mode, only
+// maintaining the container PIDs ready to attach to.
+//
+// When `AttachProg` is called, uprobetracer enters the `running` mode and
+// attaches to all pending containers. After that, it will never get back to
+// the `pending` mode.
+//
+// Uprobetracer doesn't maintain ebpf.collection or perf-ring buffer by itself,
+// those are hold by the parent tracer.
+//
+// All interfaces should hold locks, while inner functions do not.
+package uprobetracer
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cyphar/filepath-securejoin"
+
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+)
+
+type ProgType uint32
+
+const (
+	ProgUprobe    ProgType = 1
+	ProgUretprobe ProgType = 2
+)
+
+type Tracer[Event any] struct {
+	progName       string
+	progType       ProgType
+	attachFilePath string
+	attachSymbol   string
+	prog           *ebpf.Program
+
+	// keeps the ebpf links for each attached container
+	// when users write library names in ebpf section names, it's possible to
+	// find multiple libraries of different archs within the same container,
+	// making this a one-to-many mapping
+	containerPid2Links map[uint32][]link.Link
+	// used as a set, keeps PIDs of the pending containers
+	pendingContainerPids map[uint32]bool
+
+	closed bool
+
+	mu sync.Mutex
+}
+
+func NewTracer[Event any]() (_ *Tracer[Event], err error) {
+	t := &Tracer[Event]{
+		containerPid2Links:   make(map[uint32][]link.Link),
+		pendingContainerPids: make(map[uint32]bool),
+		closed:               false,
+	}
+	return t, nil
+}
+
+// AttachProg loads the ebpf program, and try attaching if there are pending containers
+func (t *Tracer[Event]) AttachProg(progName string, progType ProgType, attachTo string, prog *ebpf.Program) error {
+	if progType != ProgUprobe && progType != ProgUretprobe {
+		return fmt.Errorf("unsupported uprobe prog type: %q", progType)
+	}
+
+	if prog == nil {
+		return fmt.Errorf("prog does not exist")
+	}
+	if t.prog != nil {
+		return fmt.Errorf("loading uprobe program twice")
+	}
+
+	parts := strings.Split(attachTo, ":")
+	if len(parts) < 2 {
+		return fmt.Errorf("invalid section name %q", attachTo)
+	}
+	if !filepath.IsAbs(parts[0]) && strings.Contains(parts[0], "/") {
+		return fmt.Errorf("section name must be either an absolute path or a library name: %q", parts[0])
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return fmt.Errorf("uprobetracer has been closed")
+	}
+
+	t.progName = progName
+	t.progType = progType
+	t.attachFilePath = parts[0]
+	t.attachSymbol = parts[1]
+	t.prog = prog
+
+	// attach to pending containers, then release the pending list
+	for pid := range t.pendingContainerPids {
+		t.attach(pid)
+	}
+	t.pendingContainerPids = nil
+
+	return nil
+}
+
+func searchForLibrary(containerPid uint32, filePath string) []string {
+	var libraryPaths []string
+	var securedLibraryPaths []string
+
+	if !filepath.IsAbs(filePath) {
+		containerLdCachePath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), "etc/ld.so.cache")
+		if err == nil {
+			ldCachePaths := parseLdCache(containerLdCachePath, filePath)
+			if ldCachePaths != nil {
+				libraryPaths = ldCachePaths
+			}
+		}
+	} else {
+		libraryPaths = append(libraryPaths, filePath)
+	}
+	for _, libraryPath := range libraryPaths {
+		securedLibraryPath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), libraryPath)
+		if err == nil {
+			securedLibraryPaths = append(securedLibraryPaths, securedLibraryPath)
+		}
+	}
+	return securedLibraryPaths
+}
+
+// attach ebpf program to a self-hosted inode
+func (t *Tracer[Event]) attachEbpf(attachPath string, containerPid uint32) (link.Link, error) {
+	ex, err := link.OpenExecutable(attachPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening executable %q", attachPath)
+	}
+
+	option := &link.UprobeOptions{
+		PID: int(containerPid),
+	}
+
+	switch t.progType {
+	case ProgUprobe:
+		return ex.Uprobe(t.attachSymbol, t.prog, option)
+	case ProgUretprobe:
+		return ex.Uretprobe(t.attachSymbol, t.prog, option)
+	default:
+		return nil, fmt.Errorf("internal error: unsupported prog type: %q", t.progType)
+	}
+}
+
+// try attaching to a container, will update `containerPid2Links`
+func (t *Tracer[Event]) attach(containerPid uint32) {
+	var attachedLinks []link.Link
+	attachFilePaths := searchForLibrary(containerPid, t.attachFilePath)
+
+	for _, attachPath := range attachFilePaths {
+		l, err := t.attachEbpf(attachPath, containerPid)
+		if err == nil {
+			attachedLinks = append(attachedLinks, l)
+		}
+	}
+
+	t.containerPid2Links[containerPid] = attachedLinks
+}
+
+// AttachContainer will attach now if the prog is ready, otherwise it will add container into the pending list
+func (t *Tracer[Event]) AttachContainer(container *containercollection.Container) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return fmt.Errorf("uprobetracer has been closed")
+	}
+
+	if t.prog == nil {
+		_, exist := t.pendingContainerPids[container.Pid]
+		if exist {
+			return fmt.Errorf("container PID already exists: %d", container.Pid)
+		}
+		t.pendingContainerPids[container.Pid] = true
+	} else {
+		_, exist := t.containerPid2Links[container.Pid]
+		if exist {
+			return fmt.Errorf("container PID already exists: %d", container.Pid)
+		}
+		t.attach(container.Pid)
+	}
+	return nil
+}
+
+func (t *Tracer[Event]) DetachContainer(container *containercollection.Container) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return nil
+	}
+
+	if t.prog == nil {
+		// remove from pending list
+		_, exist := t.pendingContainerPids[container.Pid]
+		if !exist {
+			return fmt.Errorf("container has not been attached")
+		}
+		delete(t.pendingContainerPids, container.Pid)
+	} else {
+		// detach from container if attached
+		attachedLinks, exist := t.containerPid2Links[container.Pid]
+		if !exist {
+			return fmt.Errorf("container has not been attached")
+		}
+		delete(t.containerPid2Links, container.Pid)
+
+		for _, l := range attachedLinks {
+			l.Close()
+		}
+	}
+
+	return nil
+}
+
+func (t *Tracer[Event]) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return
+	}
+
+	for _, links := range t.containerPid2Links {
+		for _, l := range links {
+			l.Close()
+		}
+	}
+
+	t.containerPid2Links = nil
+	t.closed = true
+}


### PR DESCRIPTION
# Description
Part of #1912.
This patch introduces a new package `uprobetracer` for auto attaching/detaching.

# Testing
a. Two containers sharing the same image, make sure the target file is only probed once.
b. Starting/stopping/restarting the containers, and see if it works well.
