### PR TITLE
pkg/gadgets/top/tcp: Align IP version field with other gadgets

### DIFF
--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"syscall"
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
@@ -36,7 +35,7 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool) *Command {
 				WithPodLabels("test-pod", ns, isCrioRuntime),
 			),
 			Comm:      "curl",
-			IPVersion: syscall.AF_INET,
+			IPVersion: 4,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
 					Addr:    "127.0.0.1",

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"syscall"
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
@@ -29,7 +28,7 @@ func newTopTCPCmd(ns string, cmd string, startAndStop bool, isDockerRuntime bool
 		expectedEntry := &toptcpTypes.Stats{
 			CommonData: BuildCommonDataK8s(ns, WithContainerImageName("docker.io/library/nginx:latest", isDockerRuntime)),
 			Comm:       "curl",
-			IPVersion:  syscall.AF_INET,
+			IPVersion:  4,
 			SrcEndpoint: eventtypes.L4Endpoint{
 				L3Endpoint: eventtypes.L3Endpoint{
 					Addr:    "127.0.0.1",

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -187,7 +187,7 @@ func (t *Tracer) nextStats() ([]*types.Stats, error) {
 				},
 				Port: key.Dport,
 			},
-			IPVersion: key.Family,
+			IPVersion: ipversion,
 			Sent:      val.Sent,
 			Received:  val.Received,
 		}

--- a/pkg/gadgets/top/tcp/types/types.go
+++ b/pkg/gadgets/top/tcp/types/types.go
@@ -49,7 +49,7 @@ type Stats struct {
 
 	Pid       int32  `json:"pid,omitempty" column:"pid,template:pid"`
 	Comm      string `json:"comm,omitempty" column:"comm,template:comm"`
-	IPVersion uint16 `json:"ipversion,omitempty" column:"ip,template:ipversion"`
+	IPVersion int    `json:"ipversion,omitempty" column:"ip,template:ipversion"`
 
 	SrcEndpoint eventtypes.L4Endpoint `json:"src,omitempty" column:"src"`
 	DstEndpoint eventtypes.L4Endpoint `json:"dst,omitempty" column:"dst"`
@@ -65,12 +65,6 @@ func (e *Stats) GetEndpoints() []*eventtypes.L3Endpoint {
 func GetColumns() *columns.Columns[Stats] {
 	cols := columns.MustCreateColumns[Stats]()
 
-	cols.MustSetExtractor("ip", func(stats *Stats) any {
-		if stats.IPVersion == syscall.AF_INET {
-			return "4"
-		}
-		return "6"
-	})
 	cols.MustSetExtractor("sent", func(stats *Stats) any {
 		return fmt.Sprint(units.BytesSize(float64(stats.Sent)))
 	})


### PR DESCRIPTION
# Align IP version field of top tcp with other gadgets

The top tcp gadget reports the IPVersion field as the address family `AF_INET` or `AF_INET6`. Instead, all other gadgets reporting such a field use `4` or `6` directly, which avoids further manipulation of output on CLI or third-party applications consuming the JSON. Gadgets using `4` and `6`:

- [Trace tcp](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/top-tcp-ipversion/pkg/gadgets/trace/tcp/tracer/tracer.go#L203)
- [Trace tcpconnect](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/top-tcp-ipversion/pkg/gadgets/trace/tcpconnect/tracer/tracer.go#L200)
- [Trace tcpdrop](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/top-tcp-ipversion/pkg/gadgets/trace/tcpdrop/tracer/tracer.go#L214)
- [Trace tcpretransmit](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/top-tcp-ipversion/pkg/gadgets/trace/tcpretrans/tracer/tracer.go#L161)

This change is beneficial for those folks consuming the JSON output from other applications:

### Before this commit ("ipversion":2)

```bash
$ ig top tcp -o json
[{"runtime":{...},"k8s":{},"mountnsid":4026534246,"pid":19366,"comm":"kubelet","ipversion":2,"src":{"addr":"192.168.49.2","version":4,"port":39304},"dst":{"addr":"192.168.49.2","version":4,"port":8443},"sent":566,"received":2056}]
```

### After this commit ("ipversion":4)

```bash
$ ig top tcp -o json
[{"runtime":{...},"k8s":{},"mountnsid":4026534246,"pid":19366,"comm":"kubelet","ipversion":4,"src":{"addr":"192.168.49.2","version":4,"port":35098},"dst":{"addr":"192.168.49.2","version":4,"port":8443},"sent":566,"received":2056}]
```
## NOTE 

Isn't the version inside the src and dst redundant? I think we could avoid it.