### PR TITLE
gha: Automatically mark and close stale issues / PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,37 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            If you believe this was closed in error, please feel free to reopen it.
+          stale-issue-label: lifecycle/stale
+          exempt-issue-labels: good-first-issue,lifecycle/staleproof
+          exempt-all-issue-assignees: true # do not close issues with assignees
+
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs. Thank you for your contributions.
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            If you believe this was closed in error, please feel free to reopen it.
+          stale-pr-label:  lifecycle/stale
+          exempt-pr-labels: lifecycle/staleproof


### PR DESCRIPTION
Issues and PRs will be marked as stale after 60 days of inactivity, and will be closed 14 days after is there is not new activity.

This is used to avoid a lot of old issues / PRs piling up on the repository.

