### PR TITLE
ig: Pass host's GOPROXY to the build container

### DIFF
--- a/Dockerfiles/gadget.Dockerfile
+++ b/Dockerfiles/gadget.Dockerfile
@@ -13,6 +13,9 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 ARG TARGETARCH
 ARG BUILDARCH
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/
 RUN cd /gadget && go mod download

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -6,6 +6,9 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 ARG TARGETARCH
 ARG BUILDARCH
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 COPY go.mod go.sum /cache/
 RUN cd /cache && \
 	go mod download

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -9,6 +9,8 @@ ARG VERSION=undefined
 ENV VERSION=${VERSION}
 ARG EBPF_BUILDER=ghcr.io/inspektor-gadget/ebpf-builder:latest
 ENV EBPF_BUILDER=${EBPF_BUILDER}
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 
 COPY go.mod go.sum /cache/
 RUN cd /cache && go mod download

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -14,6 +14,9 @@ FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 ARG TARGETARCH
 ARG TARGETOS
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/
 RUN cd /gadget && go mod download

--- a/integration/ig/k8s/Makefile
+++ b/integration/ig/k8s/Makefile
@@ -1,6 +1,7 @@
 include $(shell pwd)/../../../minikube.mk
 
 DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+GOPROXY ?= $(shell go env GOPROXY)
 
 # make does not allow implicit rules (with '%') to be phony so let's use
 # the 'phony_explicit' dependency to make implicit rules inherit the phony
@@ -16,7 +17,8 @@ build:
 
 .PHONY: build-tests
 build-tests:
-	docker buildx build --load -t ig-tests -f ./../../../Dockerfiles/ig-tests.Dockerfile ../../../
+	docker buildx build --load -t ig-tests -f ./../../../Dockerfiles/ig-tests.Dockerfile \
+		--build-arg GOPROXY=$(GOPROXY) ../../../
 	docker create --name ig-tests-container ig-tests
 	docker cp ig-tests-container:/usr/bin/ig-integration.test ig-integration.test
 	docker rm ig-tests-container


### PR DESCRIPTION
# Pass host's GOPROXY to the build container

Users may need GOPROXY for faster download speed, passing the host's GOPROXY into the build container will improve the experience.

## Testing done

Tested by `make ig`.
