### PR TITLE
run: Support basic uprobe and uretprobe

### DIFF
--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -52,3 +52,9 @@ Inspektor Gadget supports running multiple gadgets that use SchedCLS programs at
 Programs must return `TC_ACT_UNSPEC` in order to allow the packet to be processed by other gadgets.
 The order of execution of the programs is not deterministic, this is something we could visit later
 on.
+
+### Uprobes / Uretprobes (experimental)
+
+The section name must use the `uprobe/<file_path>:<symbol>` or `uretprobe/<file_path>:<symbol>` formats.
+`<file_path>` is the absolute path of an executable or a library, that the uprobe will be attached to.
+`<symbol>` is a debugging symbol that can be found in the file mentioned above.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -7,6 +7,7 @@ IG ?= ig
 GADGETS = \
 	trace_dns \
 	trace_exec \
+	trace_malloc \
 	trace_mount \
 	trace_oomkill \
 	trace_open \

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -1,0 +1,28 @@
+name: trace malloc
+description: use uprobe to trace malloc and free in libc.so
+tracers:
+  events:
+    mapName: events
+    structName: event
+structs:
+  event:
+    fields:
+    - name: pid
+      attributes:
+        template: pid
+    - name: comm
+      description: command
+      attributes:
+        template: comm
+    - name: operation
+      description: memory operation type
+      attributes:
+        width: 16
+        alignment: left
+        ellipsis: end
+    - name: addr
+      description: address of malloc/free
+      attributes:
+        width: 20
+        alignment: left
+        ellipsis: end

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2024 The Inspektor Gadget authors */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+
+enum memop {
+	MALLOC,
+	FREE,
+};
+
+struct event {
+	__u32 pid;
+	__u8 comm[TASK_COMM_LEN];
+	enum memop operation;
+	__u64 addr;
+};
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+GADGET_TRACER(open, events, event);
+
+static __always_inline int submit_memop_event(struct pt_regs *ctx,
+					      enum memop operation, __u64 addr)
+{
+	struct event *event;
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	event->pid = bpf_get_current_pid_tgid() >> 32;
+	bpf_get_current_comm(event->comm, sizeof(event->comm));
+	event->operation = operation;
+	event->addr = addr;
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+	return 0;
+}
+
+SEC("uretprobe//usr/lib/libc.so.6:malloc")
+int trace_uprobe_malloc(struct pt_regs *ctx)
+{
+	return submit_memop_event(ctx, MALLOC, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe//usr/lib/libc.so.6:free")
+int trace_uprobe_free(struct pt_regs *ctx)
+{
+	return submit_memop_event(ctx, FREE, PT_REGS_PARM1(ctx));
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
# run: Support basic uprobe and uretprobe
This patch introduces basic support for uprobe and uretprobe.
Filtering as well as auto attach/detach will be supported in the future.

Also, a simple gadget `trace_malloc` is added as demo.

## Testing done
`ig image build -t trace_malloc:latest .`
`ig run trace_malloc:latest --host`
