### PR TITLE
gha/stale: Update operations-per-run to 500

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          operations-per-run: 500
+
           days-before-issue-stale: 60
           days-before-issue-close: 14
           stale-issue-message: |


### PR DESCRIPTION
In [0] we hit the limit, hence better to increase it.

[0]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8165699333
