### PR TITLE
docs: trace network title

### DIFF
--- a/docs/builtin-gadgets/trace/network.md
+++ b/docs/builtin-gadgets/trace/network.md
@@ -1,5 +1,5 @@
 ---
-title: 'The "network" gadget'
+title: 'Using trace network'
 weight: 10
 ---
 


### PR DESCRIPTION
For consistency, use the same title for this gadget as all other gadgets in the same category.

See:
https://inspektor-gadget.io/docs/v0.26.0/builtin-gadgets/trace/network/

Before this patch:

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/27575/d7f18f6b-a9dc-4560-87e2-56a5dbe83469)
