### PR TITLE
gha: Fix exempt issue label for action/stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,7 +24,7 @@ jobs:
             This issue has been automatically closed due to inactivity.
             If you believe this was closed in error, please feel free to reopen it.
           stale-issue-label: lifecycle/stale
-          exempt-issue-labels: good-first-issue,lifecycle/staleproof
+          exempt-issue-labels: 'good first issue,lifecycle/staleproof'
           exempt-all-issue-assignees: true # do not close issues with assignees
 
           days-before-pr-stale: 60


### PR DESCRIPTION
It seems we need to use `good first issue` vs `good-first-issue` for `action/stale` because some of the older issues with exception labels have been marked stale:
- https://github.com/inspektor-gadget/inspektor-gadget/issues/1526
- https://github.com/inspektor-gadget/inspektor-gadget/issues/967

Other projects also use ["good first issue"](https://github.com/dapr/dapr/blob/master/.github/workflows/dapr-bot-schedule.yml#L65). 

Fixes: 033664546e74d692e8c71b6c6222249d8e2de15a

