### PR TITLE
Add readmes for image-basde and built-in gadgets

### DIFF
--- a/gadgets/README.md
+++ b/gadgets/README.md
@@ -1,0 +1,10 @@
+# Gadgets
+
+This folder contains the
+[image-based](https://github.com/inspektor-gadget/inspektor-gadget/issues/1929) gadgets provided by
+Inspektor Gadget. We're in the [process of
+converting](https://github.com/inspektor-gadget/inspektor-gadget/issues/2032) the
+[built-in](../pkg/gadgets/) gadgets to use this approach. Hence, not all gadgets are available here
+and the ones available could be [missing some
+features](https://github.com/inspektor-gadget/inspektor-gadget/issues/2316) comparared to their
+built-in counterparts.

--- a/pkg/gadgets/README.md
+++ b/pkg/gadgets/README.md
@@ -1,0 +1,6 @@
+# Built-in Gadgets
+
+This folder contains the code for the built-in gadgets. We're
+[converting](https://github.com/inspektor-gadget/inspektor-gadget/issues/2032) these gadgets to be
+[image-based](../../gadgets/), once the conversion is completed, these will be deprecated and
+removed.


### PR DESCRIPTION
I've received the "what's the difference between these two folders" question few times. Let's add a small readme to clarify it.

