### PR TITLE
gadgettracermanager: Explictly import kubemanager operator

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script"
 
 	// Blank import for some operators
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"
 
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"


### PR DESCRIPTION
# Explictly import kubemanager operator

Currently, the kubemanager operator is implicitly registered (its `init()` is called) because it's imported by the kubenameresolver operator, which is imported by the gadget-collection trace network gadget. It means that if we decide to remove such a gadget, the kubemanager operator won't be registered anymore.

This PR adds the kubemanager operator to the gadgettracermanager to avoid dependence on other operators or gadgets.

## Testing done

After removing the gadget trace network from gadget-collection:

- **Before this PR**: kubemanager won't be registered. It means we won't be able to filter by k8s metadata, events won't be enriched with k8s metadata, etc.
- **After this PR**: Everything will continue working as expected.