### PR TITLE
image-based gadgets: Implement btfgen support

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -72,3 +72,4 @@ WORKDIR /work
 # Add files used to build containerized gadgets
 ADD include /usr/include
 ADD cmd/common/image/Makefile.build /Makefile
+ADD cmd/common/image/Makefile.build.btfgen /Makefile.build.btfgen

--- a/cmd/common/image/Makefile.build
+++ b/cmd/common/image/Makefile.build
@@ -7,10 +7,8 @@ CFLAGS ?=
 OUTPUTDIR ?= /tmp
 EBPFSOURCE ?= program.bpf.c
 
-TARGETS = \
-	$(OUTPUTDIR)/amd64.bpf.o \
-	$(OUTPUTDIR)/arm64.bpf.o \
-	#
+ARCHS = amd64 arm64
+TARGETS = $(foreach ARCH,$(ARCHS),$(OUTPUTDIR)/$(ARCH).bpf.o)
 
 .PHONY: all
 all: $(TARGETS) wasm
@@ -34,3 +32,13 @@ else
 wasm:
 	$(error Unsupported wasm file type: $(notdir $(WASM)))
 endif
+
+# Get value of -f parameter
+ALT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+MAKEFILE_DIR := $(dir $(ALT_MAKEFILE))
+
+.PHONY: btfgen
+btfgen: $(foreach ARCH,$(ARCHS),btfgen-$(ARCH))
+
+btfgen-%: $(OUTPUTDIR)/%.bpf.o
+	$(MAKE) -f $(MAKEFILE_DIR)/Makefile.build.btfgen BPF_OBJECT=$^ ARCH=$(subst amd64,x86_64,$*) btfs; \

--- a/cmd/common/image/Makefile.build
+++ b/cmd/common/image/Makefile.build
@@ -1,7 +1,7 @@
 # This makefile is used by the build command, don't execute it manually
 
 CLANG ?= clang
-LLVM-STRIP ?= llvm-strip
+LLVM_STRIP ?= llvm-strip
 BASECFLAGS = -target bpf -Wall -g -O2
 CFLAGS ?=
 OUTPUTDIR ?= /tmp
@@ -18,7 +18,7 @@ all: $(TARGETS) wasm
 $(OUTPUTDIR)/%.bpf.o: $(EBPFSOURCE)
 	$(CLANG) $(BASECFLAGS) $(CFLAGS) -D __TARGET_ARCH_$(subst amd64,x86,$*) \
 		-c $< -I /usr/include/gadget/$*/ -o $@
-	$(LLVM-STRIP) -g $@
+	$(LLVM_STRIP) -g $@
 
 .PHONY: wasm
 ifeq ($(WASM),)

--- a/cmd/common/image/Makefile.build.btfgen
+++ b/cmd/common/image/Makefile.build.btfgen
@@ -1,0 +1,32 @@
+# This makefile is used by the build command, don't execute it manually
+
+BPFTOOL ?= bpftool
+
+ifndef BTFHUB_ARCHIVE
+$(error BTFHUB_ARCHIVE is undefined)
+endif
+
+ifndef BPF_OBJECT
+$(error BPF_OBJECT is undefined)
+endif
+
+SOURCE_BTF_FILES = $(shell find $(BTFHUB_ARCHIVE)/ -iregex ".*$(ARCH).*" -type f -name '*.btf.tar.xz')
+MIN_CORE_BTF_FILES = $(patsubst $(BTFHUB_ARCHIVE)/%.btf.tar.xz, $(OUTPUTDIR)/btfs/$(ARCH)/%.btf, $(SOURCE_BTF_FILES))
+
+.PHONY: btfs
+btfs: $(OUTPUTDIR)/btfs-$(ARCH).tar.gz
+
+$(MIN_CORE_BTF_FILES): $(BPF_OBJECT)
+
+$(OUTPUTDIR)/btfs/$(ARCH)/%.btf: BTF_FILE = $(<:.tar.xz=)
+$(OUTPUTDIR)/btfs/$(ARCH)/%.btf: $(BTFHUB_ARCHIVE)/%.btf.tar.xz
+	tar xvfJ $< -C "$(dir $<)" --touch > /dev/null
+	mkdir -p "$(@D)"
+	if [ -f $(BTF_FILE) ]; then \
+		$(BPFTOOL) gen min_core_btf $(BTF_FILE) $@ $(BPF_OBJECT) && rm -fr $(BTF_FILE); \
+	else \
+		echo "$(BTF_FILE) does not exist!" >&2; \
+	fi
+
+$(OUTPUTDIR)/btfs-$(ARCH).tar.gz: $(MIN_CORE_BTF_FILES)
+	cd $(OUTPUTDIR)/btfs/$(ARCH)/ && tar c --gz -f $@ *

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer"
 
 	// Another blank import for the used operator
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager"

--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -180,7 +180,7 @@ installed.
 In this case it's possible to control some of the tools used by setting some env variables:
 
 ```bash
-$ sudo CLANG=clang-15 LLVM-STRIP=llvm-strip-15 ig image build . -f mybuild.yaml --local
+$ sudo CLANG=clang-15 LLVM_STRIP=llvm-strip-15 ig image build . -f mybuild.yaml --local
 ```
 
 ##### Wasm module

--- a/docs/reference/btfgen.md
+++ b/docs/reference/btfgen.md
@@ -1,0 +1,36 @@
+---
+title: 'btfgen'
+weight: 100
+description: 'Using btfgen to enable the gadget in systems without BTF'
+---
+
+[btfgen][btfgen] enables running gadgets on system that don't provide BTF
+information. The `ig image build` command generates a new layer on the gadget
+image with the BTF information of the types used by the gadget for the most
+common kernels available in [btfhub][btfhub], this information is then used when
+running the gadget if the kernel doesn't have BTF enabled.
+
+## Enabling btfgen
+
+Given that generating the BTF information for a gadget takes a while, this
+support is disabled by default.
+
+The [btfhub-archive][btfhub-archive] repository needs to be present on the machine:
+
+```bash
+$ git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ $HOME/btfhub-archive/
+```
+
+Then, pass the `--btfgen` and the path of the btfhub-archive repository to the
+build command:
+
+```bash
+$ sudo -E ig image build . --btfgen --btfhub-archive $HOME/btfhub-archive -t myimage
+```
+
+The resulting image will contain the BTF information and can be pushed, run or
+tagged as any other gadget image.
+
+[btfgen]: https://kinvolk.io/blog/2022/03/btfgen-one-step-closer-to-truly-portable-ebpf-programs/
+[btfhub]: https://github.com/aquasecurity/btfhub
+[btfhub-archive]: https://github.com/aquasecurity/btfhub-archive/

--- a/docs/reference/oci.md
+++ b/docs/reference/oci.md
@@ -38,6 +38,7 @@ different media type among the following:
 
 - `application/vnd.gadget.ebpf.program.v1+binary`
 - `application/vnd.gadget.wasm.program.v1+binary`
+- `application/vnd.gadget.btfgen.v1+binary`
 
 ### The ebpf layer
 
@@ -48,6 +49,14 @@ Its content must be a valid ELF file.
 
 There must be at most one layer with the wasm media type. If present, it must
 not be empty and it must be a valid wasm file.
+
+### The btfgen layer
+
+[btfgen](https://www.inspektor-gadget.io//blog/2022/03/btfgen-one-step-closer-to-truly-portable-ebpf-programs/)
+is used to enable running eBPF programs on kernels that don't provide BTF information. A gadget
+image can contain at most one btfgen layer. This layer must contain the generated BTF files in a
+tarball following the same folder structure of
+[btfhub-archive](https://github.com/aquasecurity/btfhub-archive/).
 
 ## Image annotations
 

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/script"
 
 	// Blank import for some operators
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"

--- a/pkg/btfgen/btfgen.go
+++ b/pkg/btfgen/btfgen.go
@@ -47,7 +47,7 @@ func initialize() error {
 		return nil
 	}
 
-	info, err := getOSInfo()
+	info, err := GetOSInfo()
 	if err != nil {
 		return err
 	}
@@ -90,15 +90,15 @@ func GetBTFSpec() *btf.Spec {
 	return spec
 }
 
-type osInfo struct {
+type OsInfo struct {
 	ID        string
 	VersionID string
 	Arch      string
 	Kernel    string
 }
 
-func getOSInfo() (*osInfo, error) {
-	osInfo := &osInfo{}
+func GetOSInfo() (*OsInfo, error) {
+	osInfo := &OsInfo{}
 
 	file, err := os.Open(filepath.Join(host.HostRoot, "/etc/os-release"))
 	if err != nil {

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -43,6 +43,7 @@ const (
 const (
 	eBPFObjectMediaType = "application/vnd.gadget.ebpf.program.v1+binary"
 	wasmObjectMediaType = "application/vnd.gadget.wasm.program.v1+binary"
+	btfgenMediaType     = "application/vnd.gadget.btfgen.v1+binary"
 	metadataMediaType   = "application/vnd.gadget.config.v1+yaml"
 )
 
@@ -51,6 +52,8 @@ type ObjectPath struct {
 	EBPF string
 	// Optional path to the Wasm file
 	Wasm string
+	// Optional path to tarball containing BTF files generated with btfgen
+	Btfgen string
 }
 
 type BuildGadgetImageOpts struct {
@@ -212,11 +215,19 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 		layerDescs = append(layerDescs, wasmDesc)
 	}
 
+	if paths.Btfgen != "" {
+		btfDesc, err := createLayerDesc(ctx, target, paths.Btfgen, btfgenMediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating and pushing btfgen descriptor: %w", err)
+		}
+		layerDescs = append(layerDescs, btfDesc)
+	}
+
+	var defDesc ocispec.Descriptor
 	// artifactType must be only set when the config.mediaType is set to
 	// MediaTypeEmptyJSON. In our case, when the metadata file is not provided:
 	// https://github.com/opencontainers/image-spec/blob/f5f87016de46439ccf91b5381cf76faaae2bc28f/manifest.md?plain=1#L170
 	var artifactType string
-	var defDesc ocispec.Descriptor
 
 	if _, err := os.Stat(metadataFilePath); err == nil {
 		// Read the metadata file into a byte array

--- a/pkg/oci/fix_owner_linux.go
+++ b/pkg/oci/fix_owner_linux.go
@@ -49,7 +49,7 @@ func fixGeneratedFilesOwner(opts *BuildGadgetImageOpts) error {
 	allPaths := []string{}
 
 	for _, paths := range opts.ObjectPaths {
-		allPaths = append(allPaths, paths.EBPF, paths.Wasm)
+		allPaths = append(allPaths, paths.EBPF, paths.Wasm, paths.Btfgen)
 	}
 
 	for _, path := range allPaths {

--- a/pkg/operators/btfgen/btfgen.go
+++ b/pkg/operators/btfgen/btfgen.go
@@ -1,0 +1,148 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package btfgenoperator
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/cilium/ebpf/btf"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/btfgen"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+)
+
+const (
+	btfMediaType   = "application/vnd.gadget.btfgen.v1+binary"
+	kernelTypesVar = "kernelTypes"
+)
+
+var kernelHasBTF func() bool = sync.OnceValue(func() bool {
+	_, err := btf.LoadKernelSpec()
+	return err == nil
+})
+
+type btfgenOperator struct{}
+
+func (o *btfgenOperator) Name() string {
+	return "btfgen"
+}
+
+func (o *btfgenOperator) Description() string {
+	return "Enables to run gadget on kernels without BTF information by using BTF types generated with btfgen"
+}
+
+func (o *btfgenOperator) InstantiateImageOperator(
+	gadgetCtx operators.GadgetContext, desc ocispec.Descriptor, paramValues api.ParamValues,
+) (operators.ImageOperatorInstance, error) {
+	logger := gadgetCtx.Logger()
+
+	// If the kernel exposes BTF; nothing to do
+	if kernelHasBTF() {
+		logger.Debugf("kernel provides BTF, nothing to do on btfgen operator")
+		return nil, nil
+	}
+
+	return &btfgenOperatorInstance{
+		desc: desc,
+	}, nil
+}
+
+type btfgenOperatorInstance struct {
+	desc ocispec.Descriptor
+}
+
+func (i *btfgenOperatorInstance) Name() string {
+	return "btfgenInstance"
+}
+
+func (i *btfgenOperatorInstance) Prepare(gadgetCtx operators.GadgetContext) error {
+	info, err := btfgen.GetOSInfo()
+	if err != nil {
+		return fmt.Errorf("getting OS info: %w", err)
+	}
+
+	r, err := oci.GetContentFromDescriptor(gadgetCtx.Context(), i.desc)
+	if err != nil {
+		return fmt.Errorf("getting ebpf binary: %w", err)
+	}
+	defer r.Close()
+
+	btfFileName := fmt.Sprintf("%s/%s/%s/%s.btf", info.ID, info.VersionID, info.Arch, info.Kernel)
+	btfBytes, err := getBTFFile(r, btfFileName)
+	if err != nil {
+		return fmt.Errorf("getting BTF file: %w", err)
+	}
+
+	btfSpec, err := btf.LoadSpecFromReader(bytes.NewReader(btfBytes))
+	if err != nil {
+		return fmt.Errorf("loading BTF spec: %w", err)
+	}
+
+	// save the kernel types to be used by the ebpf operator when loading bpf the spec.
+	gadgetCtx.SetVar(kernelTypesVar, btfSpec)
+
+	return nil
+}
+
+func (i *btfgenOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (i *btfgenOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func getBTFFile(r io.Reader, filename string) ([]byte, error) {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("BTF file %q not found", filename)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar: %w", err)
+		}
+
+		if hdr.Name == filename {
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("reading BTF: %w", err)
+			}
+
+			return b, nil
+		}
+	}
+}
+
+func (i *btfgenOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params {
+	return nil
+}
+
+func init() {
+	operators.RegisterOperatorForMediaType(btfMediaType, &btfgenOperator{})
+}


### PR DESCRIPTION
This PR implements support for btfgen for image-based gadgets.

This is based on #2512, however only the last commit is really depending on that, other commits can already be reviewed. 

### How does it work?

btfgen is used to generate the BTF files with the types needed by the gadget, those are stored in a new layer on the gadget image. A new btfgen operator uses that layer to get the types for the current kernel, those are passed to the ebpf operator that uses them when loading the programs into the kernel.

### Testing 

#### Get btfhub-archive

> note: btfhub-archive need to be cloned into $HOME, otherwise a step below will fail. The following script already takes care of it

```bash
$ ./tools/getbtfhub.sh
```

#### Compiling a gadget with btf information 

Consider the following simple gadget that uses some CO-RE functions:

```c
#include <vmlinux.h>
#include <bpf/bpf_helpers.h>
#include <gadget/macros.h>
#include <bpf/bpf_core_read.h>

struct event {
	__u64 mntns_id;
	__u32 pid;
};

struct {
	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
	__uint(key_size, sizeof(__u32));
	__uint(value_size, sizeof(__u32));
} events SEC(".maps");

// [Optional] Define a tracer
GADGET_TRACER(open, events, event);

SEC("tracepoint/syscalls/sys_enter_openat")
int enter_openat(struct syscall_trace_enter *ctx)
{
	struct event event = {};
	struct task_struct *task;

	event.pid = bpf_get_current_pid_tgid() >> 32;
	task = (struct task_struct *)bpf_get_current_task();
	event.mntns_id = (u64)BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);

	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
			      sizeof(event));

	return 0;
}

char LICENSE[] SEC("license") = "GPL";
```

> Note: The fallback mechanism of the GADGET_TRACER macro isn't working for me right now, hence this gadget declares a perf event array directly. That will be investigated later on


```bash 
# [optional]: create path to store generated artifacts. Only needed to be able to inspect generated btf files
$ mkdir /tmp/foo 

# (remove the -o /tmp/foo option if you don't want to inspect generated btf files)
$ sudo -E ig image build . --local --btfgen --btfhub-archive $HOME/btfhub-archive -t <your-container-registry>/hello-world:btfgen -o /tmp/foo
...

# optional: inspect the generated btf files 
$ bpftool btf dump file /tmp/foo/btfs/x86_64/ubuntu/20.04/x86_64/5.4.0-91-generic.btf 
[1] INT 'unsigned int' size=4 bits_offset=0 nr_bits=32 encoding=(none)
[2] STRUCT 'task_struct' size=9216 vlen=1
	'nsproxy' type_id=3 bits_offset=22080
[3] PTR '(anon)' type_id=4
[4] STRUCT 'nsproxy' size=56 vlen=1
	'mnt_ns' type_id=5 bits_offset=192
[5] PTR '(anon)' type_id=7
[6] STRUCT 'ns_common' size=24 vlen=1
	'inum' type_id=1 bits_offset=128
[7] STRUCT 'mnt_namespace' size=120 vlen=1
	'ns' type_id=6 bits_offset=64

# only types used by the gadget are present on that file

$ sudo -E image push <your-container-registry>/hello-world:btfgen
```

### Getting a machine that doesn't provide information

Nowadays it's a bit difficult to get a machine without BTF support as most vendors have enabled it, the following vagrant file can be used to create a virtual machine without this support:

```vagrantfile
# -*- mode: ruby -*-
# vi: set ft=ruby :

$script = <<-SCRIPT
sudo apt-get update
sudo apt-get install linux-headers-5.4.0-91-generic linux-image-5.4.0-91-generic linux-modules-5.4.0-91-generic -y
sudo sed -i 's#GRUB_DEFAULT=0#GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux 5.4.0-91-generic"#g' /etc/default/grub
sudo update-grub

sudo apt-get install docker.io -y
SCRIPT

Vagrant.configure("2") do |config|
  config.vm.box = "ubuntu/focal64"
  # The following can be enabled to mount a local directory to the VM
  #config.vm.synced_folder "<path-to-inspektor-gadget>", "/inspektor-gadget", type: "sshfs"
  config.vm.provision "shell", inline: $script

  config.vm.provider "virtualbox" do |vb|
    # Display the VirtualBox GUI when booting the machine
    vb.gui = false

    vb.cpus = 8
    vb.memory = "8192"
  end
end
```

```$bash
$ vagrant up 

# reload to boot into new kernel
$ vagrant reload 

$ vagrant ssh -c "uname -r"
5.4.0-91-generic
```

### Compiling `ig` with btfgen support

`ig` also loads some ebpf programs into the kernel, hence it has to be compiled with btgen support for this testing

```bash
$ make ENABLE_BTFGEN=true BTFHUB_ARCHIVE=$(HOME)/btfhub-archive ig
```

### Running the gadget

```bash 
$ sudo -E ./ig run <your-container-registry>/hello-world:btfgen --pull always  
INFO[0000] Experimental features enabled                
MNTNS_ID                                                                                                  PID                                                 
4026531840                                                                                                106389                                              
4026531840                                                                                                106389                                   
```



### TODO
- [x] Documentation  (for gadget developers)
- [x] Print progress or message indicating btfgen could take a long time
- [x] How to implement d9c3119ebe82 ("btfgen: Process one archive at a time.") on this too?
- [ ] Tests? :worried: 
- [x] Enable and test it on kubernetes
- [ ] Enable it on official gadgets (future PR?)

Fixes  #2045