### PR TITLE
ci: Use correct helper image even if both are built simultaneously

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -788,8 +788,8 @@ jobs:
     name: helper images
     runs-on: ubuntu-latest
     outputs:
-      dnstester_image: ${{ steps.image-tag.outputs.dnstester || env.DEFAULT_DNSTESTER_IMAGE }}
-      ebpf_builder_image: ${{ steps.image-tag.outputs.ebpf-builder || env.DEFAULT_EBPF_BUILDER_IMAGE }}
+      dnstester_image: ${{ steps.image-tag.outputs.dnstester }}
+      ebpf_builder_image: ${{ steps.image-tag.outputs.ebpf-builder }}
     permissions:
       # allow publishing container image
       # in case of public fork repo/packages permissions will always be read
@@ -855,9 +855,21 @@ jobs:
         platforms: ${{ matrix.image.platform }}
     - name: Save ${{ matrix.image.name }} image tag output
       id: image-tag
-      if: steps.build-image.outputs.digest != ''
       run: |
-        echo "${{ matrix.image.name }}=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}" >> $GITHUB_OUTPUT
+        if [ -n "${{ steps.build-image.outputs.digest }}" ]; then
+          image="${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}"
+        else
+          if [ ${{ matrix.image.name }} == "dnstester" ]; then
+            image=${{ env.DEFAULT_DNSTESTER_IMAGE }}
+          elif [ ${{ matrix.image.name }} == "ebpf-builder" ]; then
+            image=${{ env.DEFAULT_EBPF_BUILDER_IMAGE }}
+          else
+            >&2 echo "No default image for ${{ matrix.image.name }}!"
+            exit 1
+          fi
+        fi
+
+        echo "${{ matrix.image.name }}=${image}" >> $GITHUB_OUTPUT
 
   build-examples:
     name: example


### PR DESCRIPTION
Currently, if both helper images are built together one of the images will have a default value since we set tag for both the images in each matric run. This change ensures we only set the default value when needed and not in each matric run.

I mainly hit it when doing some testing on the fork as mentioned below. Also, it was always the `dnstester` which is affected since it is done building before `ebpf-builder`. Perhaps something that will happen rarely in main repo but still a weird issue.

Fixes: 5ddb3fb2f173e7873e1d9ce52c416fe055b8e74a

## Testing done

### w/o the change

- Run with both images built together can be found [here](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8232021327). You can see the integration test are still using [default dnstester image](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8232021327/job/22509446240#step:6:5) even if it was expected to use [custom built image](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8232021327/job/22508552634#step:9:1). The ebpf-builder still uses the [correct custom image](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8232021327/job/22508765636#step:4:1).

### with the change

-  Run with both images built together can be found [here](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8246624264). You can see it is using custom image for both ([ebpf-builder](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8246624264/job/22553503768#step:4:18), [dnstester](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/8246624264/job/22554130050#step:6:5) the cases correctly.