### PR TITLE
integration: Test uncompressed DNS messages 

### DIFF
--- a/integration/ig/k8s/trace_dns_test.go
+++ b/integration/ig/k8s/trace_dns_test.go
@@ -24,13 +24,10 @@ import (
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-func TestTraceDns(t *testing.T) {
-	t.Parallel()
-	ns := GenerateTestNamespaceName("test-trace-dns")
-
+func newTraceDnsCmd(t *testing.T, ns string, dnsServerArgs string) *Command {
 	commandsPreTest := []*Command{
 		CreateTestNamespaceCommand(ns),
-		PodCommand("dnstester", *dnsTesterImage, ns, "", ""),
+		PodCommand("dnstester", *dnsTesterImage, ns, `["/dnstester"]`, dnsServerArgs),
 		WaitUntilPodReadyCommand(ns, "dnstester"),
 	}
 
@@ -229,9 +226,27 @@ func TestTraceDns(t *testing.T) {
 		},
 	}
 
+	return traceDNSCmd
+}
+
+func TestTraceDns(t *testing.T) {
+	t.Parallel()
+	ns := GenerateTestNamespaceName("test-trace-dns")
+
 	// Start the trace gadget and verify the output.
-	commands = []*Command{
-		traceDNSCmd,
+	commands := []*Command{
+		newTraceDnsCmd(t, ns, ""),
+	}
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+}
+
+func TestTraceDnsUncompress(t *testing.T) {
+	t.Parallel()
+	ns := GenerateTestNamespaceName("test-trace-dns-uncompress")
+
+	// Start the trace gadget and verify the output.
+	commands := []*Command{
+		newTraceDnsCmd(t, ns, "-uncompress"),
 	}
 	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }

--- a/tools/dnstester/dnstester.go
+++ b/tools/dnstester/dnstester.go
@@ -15,15 +15,21 @@
 package main
 
 import (
+	"flag"
 	"log"
 
 	"github.com/miekg/dns"
 )
 
+var uncompress = flag.Bool("uncompress", false, "Uncompress DNS messages")
+
 func main() {
+	flag.Parse()
+	log.Printf("Starting dns server with uncompress=%v\n", *uncompress)
+
 	dns.Handle(".", dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)
-		m.Compress = true
+		m.Compress = !*uncompress
 		m.SetReply(r)
 
 		var rr dns.RR


### PR DESCRIPTION
This change adds tests to support testing uncompressed DNS messages.

Related: #2591 
