### PR TITLE
image list: add creation date

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -171,6 +172,7 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 		MetadataPath:     conf.Metadata,
 		UpdateMetadata:   opts.updateMetadata,
 		ValidateMetadata: opts.validateMetadata,
+		CreatedDate:      time.Now().Format(time.RFC3339),
 	}
 
 	if strings.HasSuffix(conf.Wasm, ".wasm") {

--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
@@ -53,6 +55,13 @@ func NewListCmd() *cobra.Command {
 					}
 					// Return the shortened digest and remove the sha256: prefix
 					return strings.TrimPrefix(i.Digest, "sha256:")[:12]
+				})
+				now := time.Now()
+				cols.MustSetExtractor("created", func(i *oci.GadgetImageDesc) any {
+					if t, err := time.Parse(time.RFC3339, i.Created); err == nil {
+						return fmt.Sprintf("%s ago", strings.ToLower(units.HumanDuration(now.Sub(t))))
+					}
+					return ""
 				})
 			}
 			formatter := textcolumns.NewFormatter(cols.GetColumnMap(), textcolumns.WithShouldTruncate(isTerm))


### PR DESCRIPTION
# image list: add creation date

The OCI image spec defines the creation date annotation: https://github.com/opencontainers/image-spec/blob/main/annotations.md

> `org.opencontainers.image.created` date and time on which the image was built, conforming to RFC 3339.

This patch ensures that the annotation is set with the same value for both amd64 and arm64.

Then, the date is printed in the image list command:

Note: the creation date will also be useful for the future Artifact Hub patch because the 'createdAt' field is mandatory in artifacthub-pkg.yml:

https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
```
createdAt: The date this package was created (RFC3339 layout) (required)
```

## How to use

```
$ sudo -E ig image list
INFO[0000] Experimental features enabled
REPOSITORY  TAG     DIGEST       CREATED
trace_dns   latest  d98eea3ede9e 2024-03-06T16:50:41+01:00
```

## Testing done

```bash
go run -exec 'sudo -E' ./cmd/ig/... image build -t mytest:mytest2 gadgets/trace_dns/
go run -exec 'sudo -E' ./cmd/ig/... image list|grep mytest
```

