### PR TITLE
tree-wide: Fix imports grouping and add lint target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
   - stylecheck
   - staticcheck
   - errorlint
+  - goimports
 
 linters-settings:
   gofumpt:
@@ -45,3 +46,8 @@ linters-settings:
     asserts: true
     # Check for plain error comparisons (errors.Is must be used)
     comparison: true
+  goimports:
+    # A comma-separated list of prefixes, which, if set, checks import paths
+    # with the given prefixes are grouped after 3rd-party packages.
+    # Default: ""
+    local-prefixes: github.com/inspektor-gadget/inspektor-gadget

--- a/cmd/kubectl-gadget/advise/seccomp-profile.go
+++ b/cmd/kubectl-gadget/advise/seccomp-profile.go
@@ -23,13 +23,14 @@ import (
 	"github.com/spf13/cobra"
 	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	commonadvise "github.com/inspektor-gadget/inspektor-gadget/cmd/common/advise"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var seccompAdvisorStartCmd = &cobra.Command{

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -20,14 +20,10 @@ import (
 	"strings"
 	"time"
 
-	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -36,8 +32,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 
+	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
 
 var undeployCmd = &cobra.Command{

--- a/gadget-container/entrypoint/entrypoint.go
+++ b/gadget-container/entrypoint/entrypoint.go
@@ -27,11 +27,12 @@ import (
 	"syscall"
 
 	nriv1 "github.com/containerd/nri/types/v1"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/gadgettracermanagerloglevel"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const gadgetPullSecretPath = "/var/run/secrets/gadget/pull-secret/config.json"

--- a/pkg/btfgen/btfgen.go
+++ b/pkg/btfgen/btfgen.go
@@ -29,9 +29,10 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf/btf"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
 var (

--- a/pkg/container-collection/networktracer/connect.go
+++ b/pkg/container-collection/networktracer/connect.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )

--- a/pkg/container-utils/cri/cri_test.go
+++ b/pkg/container-utils/cri/cri_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 

--- a/pkg/gadget-collection/gadgets/interface.go
+++ b/pkg/gadget-collection/gadgets/interface.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+
 	gadgetv1alpha1 "github.com/inspektor-gadget/inspektor-gadget/pkg/apis/gadget/v1alpha1"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"

--- a/pkg/gadgets/snapshot/socket/tracer/tracer_test.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer_test.go
@@ -22,10 +22,11 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSocketTracerCreate(t *testing.T) {


### PR DESCRIPTION
Add goimports linter to make sure all imports are grouped in the same way in all the repository.


