### PR TITLE
Introduce uprobetracer for auto attach/detach

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,6 +79,7 @@
 /pkg/standardgadgets/ @mauriciovasquezbernal
 /pkg/tracer-collection/ @alban
 /pkg/types/ @blanquicet
+/pkg/uprobetracer/ @alban @i-Pear
 /pkg/utils/bpf-iter-ns/ @alban
 /pkg/utils/host/ @alban
 /tools/ @mqasimsarfraz

--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -55,6 +55,8 @@ on.
 
 ### Uprobes / Uretprobes (experimental)
 
-The section name must use the `uprobe/<file_path>:<symbol>` or `uretprobe/<file_path>:<symbol>` formats.
+The section name must use the `<prog_type>/<file_path>:<symbol>` format.
+`<prog_type>` must be either `uprobe` or `uretprobe`.
 `<file_path>` is the absolute path of an executable or a library, that the uprobe will be attached to.
+For common libraries, `<file_path>` can also be the library's name, such as `libc`.
 `<symbol>` is a debugging symbol that can be found in the file mentioned above.

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -29,3 +29,7 @@ structs:
         width: 20
         alignment: left
         ellipsis: end
+    - name: mntns_id
+      description: Mount namespace inode id
+      attributes:
+        template: ns

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -46,13 +46,13 @@ static __always_inline int submit_memop_event(struct pt_regs *ctx,
 	return 0;
 }
 
-SEC("uretprobe//usr/lib/libc.so.6:malloc")
+SEC("uretprobe/libc:malloc")
 int trace_uprobe_malloc(struct pt_regs *ctx)
 {
 	return submit_memop_event(ctx, MALLOC, PT_REGS_RC(ctx));
 }
 
-SEC("uprobe//usr/lib/libc.so.6:free")
+SEC("uprobe/libc:free")
 int trace_uprobe_free(struct pt_regs *ctx)
 {
 	return submit_memop_event(ctx, FREE, PT_REGS_PARM1(ctx));

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -4,8 +4,10 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+
 #include <gadget/buffer.h>
 #include <gadget/macros.h>
+#include <gadget/mntns.h>
 
 enum memop {
 	MALLOC,
@@ -13,6 +15,7 @@ enum memop {
 };
 
 struct event {
+	gadget_mntns_id mntns_id;
 	__u32 pid;
 	__u8 comm[TASK_COMM_LEN];
 	enum memop operation;
@@ -32,6 +35,7 @@ static __always_inline int submit_memop_event(struct pt_regs *ctx,
 	if (!event)
 		return 0;
 
+	event->mntns_id = gadget_get_mntns_id();
 	event->pid = bpf_get_current_pid_tgid() >> 32;
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
 	event->operation = operation;

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/common v0.58.0
 	github.com/containers/image/v5 v5.30.0
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v26.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
+github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -17,14 +17,13 @@ package ebpfoperator
 import (
 	"fmt"
 	"net"
-	"path/filepath"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/uprobetracer"
 )
 
 const (
@@ -45,37 +44,14 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 		case strings.HasPrefix(p.SectionName, kretprobePrefix):
 			i.logger.Debugf("Attaching kretprobe %q to %q", p.Name, p.AttachTo)
 			return link.Kretprobe(p.AttachTo, prog, nil)
-
-		case strings.HasPrefix(p.SectionName, "uprobe/") || strings.HasPrefix(p.SectionName, "uretprobe/"):
-			captureHost := false
-			for _, container := range i.containers {
-				if container.Pid == 1 {
-					captureHost = true
-				}
-			}
-			if !captureHost {
-				return nil, fmt.Errorf("uprobe can only be used with --host at this moment")
-			}
-
-			parts := strings.Split(p.AttachTo, ":")
-			if len(parts) < 2 {
-				return nil, fmt.Errorf("invalid section name %q", p.AttachTo)
-			}
-			if !filepath.IsAbs(parts[0]) {
-				return nil, fmt.Errorf("section name is not an absolute path: %q", parts[0])
-			}
-			executablePath := filepath.Join(host.HostProcFs, "1/root", parts[0])
-			ex, err := link.OpenExecutable(executablePath)
-			if err != nil {
-				return nil, fmt.Errorf("opening executable: %q", executablePath)
-			}
-
-			i.logger.Debugf("Attaching uprobe %q to %q", p.Name, p.AttachTo)
+		case strings.HasPrefix(p.SectionName, "uprobe/") ||
+			strings.HasPrefix(p.SectionName, "uretprobe/"):
+			uprobeTracer := i.uprobeTracers[p.Name]
 			switch strings.Split(p.SectionName, "/")[0] {
 			case "uprobe":
-				return ex.Uprobe(parts[1], prog, nil)
+				return nil, uprobeTracer.AttachProg(p.Name, uprobetracer.ProgUprobe, p.AttachTo, prog)
 			case "uretprobe":
-				return ex.Uretprobe(parts[1], prog, nil)
+				return nil, uprobeTracer.AttachProg(p.Name, uprobetracer.ProgUretprobe, p.AttachTo, prog)
 			}
 		}
 		return nil, fmt.Errorf("unsupported section name %q for program %q", p.SectionName, p.Name)

--- a/pkg/uprobetracer/ldcache_parser.go
+++ b/pkg/uprobetracer/ldcache_parser.go
@@ -1,0 +1,210 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uprobetracer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+)
+
+type ldCache1Entry struct {
+	Flags int32
+	Key   uint32
+	Value uint32
+}
+
+type ldCache1 struct {
+	Header     [11]int8
+	EntryCount uint32
+}
+
+type ldCache2Entry struct {
+	Flags int32
+	Key   uint32
+	Value uint32
+	Pad1_ uint32
+	Pad2_ uint64
+}
+
+type ldCache2 struct {
+	Header         [17]int8
+	Version        [3]int8
+	EntryCount     uint32
+	StringTableLen uint32
+	Pad_           [5]uint32
+}
+
+const (
+	cache1Header string = "ld.so-1.7.0"
+	cache2Header string = "glibc-ld.so.cache1.1"
+
+	ldCache1EntrySize = uint32(unsafe.Sizeof(ldCache1Entry{}))
+	ldCache1Size      = uint32(unsafe.Sizeof(ldCache1{}))
+	ldCache2EntrySize = uint32(unsafe.Sizeof(ldCache2Entry{}))
+	ldCache2Size      = uint32(unsafe.Sizeof(ldCache2{}))
+)
+
+type ldEntry struct {
+	Key   string
+	Value string
+}
+
+func readFromBytes[T any](obj *T, rawData []byte) error {
+	if int(unsafe.Sizeof(*obj)) != len(rawData) {
+		return errors.New("reading from bytes: length mismatched")
+	}
+	buffer := bytes.NewBuffer(rawData)
+	err := binary.Read(buffer, binary.NativeEndian, obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func readStringFromBytes(data []byte, startPos uint32) string {
+	res := ""
+	for i := startPos; i < uint32(len(data)); i++ {
+		if data[i] == 0 {
+			return res
+		}
+		res += string(data[i])
+	}
+	return ""
+}
+
+func readCacheFormat1(data []byte) []ldEntry {
+	var ldEntries []ldEntry
+
+	ldCache := ldCache1{}
+	if uint32(len(data)) <= ldCache1Size {
+		return nil
+	}
+	err := readFromBytes(&ldCache, data[:ldCache1Size])
+	if err != nil {
+		return nil
+	}
+	ldEntriesOffset := ldCache1Size
+	ldStringsOffset := ldCache1Size + ldCache1EntrySize*ldCache.EntryCount
+	for i := uint32(0); i < ldCache.EntryCount; i++ {
+		entryOffset := ldEntriesOffset + i*ldCache1EntrySize
+		entry := ldCache1Entry{}
+		if uint32(len(data)) <= entryOffset+ldCache1EntrySize {
+			return nil
+		}
+		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache1EntrySize])
+		if err != nil {
+			return nil
+		}
+		keyOffset := ldStringsOffset + entry.Key
+		valueOffset := ldStringsOffset + entry.Value
+		key := readStringFromBytes(data, keyOffset)
+		value := readStringFromBytes(data, valueOffset)
+		ldEntries = append(ldEntries, ldEntry{key, value})
+	}
+	return ldEntries
+}
+
+func readCacheFormat2(data []byte) []ldEntry {
+	var ldEntries []ldEntry
+
+	if !bytes.Equal([]byte(cache2Header), data[:len(cache2Header)]) {
+		return nil
+	}
+	ldCache := ldCache2{}
+	if uint32(len(data)) <= ldCache2Size {
+		return nil
+	}
+	err := readFromBytes(&ldCache, data[:ldCache2Size])
+	if err != nil {
+		return nil
+	}
+	ldEntriesOffset := ldCache2Size
+	for i := uint32(0); i < ldCache.EntryCount; i++ {
+		entryOffset := ldEntriesOffset + i*ldCache2EntrySize
+		entry := ldCache2Entry{}
+		if uint32(len(data)) <= entryOffset+ldCache2EntrySize {
+			return nil
+		}
+		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache2EntrySize])
+		if err != nil {
+			return nil
+		}
+		keyOffset := entry.Key
+		valueOffset := entry.Value
+		key := readStringFromBytes(data, keyOffset)
+		value := readStringFromBytes(data, valueOffset)
+		ldEntries = append(ldEntries, ldEntry{key, value})
+	}
+	return ldEntries
+}
+
+// simulate the loader's behaviour, find library path in containers' `/etc/ld.so.cache`.
+// see https://github.com/bminor/glibc/blob/master/elf/cache.c#L292, the `print_cache` func
+// see https://github.com/iovisor/bcc/blob/master/src/cc/bcc_proc.c#L508, the `bcc_procutils_which_so` func
+func parseLdCache(ldCachePath string, libraryName string) ([]string, error) {
+	fileInfo, err := os.Stat(ldCachePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat file %q: %w", ldCachePath, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("ldCache file %q is not regular", ldCachePath)
+	}
+	ldCacheFile, err := os.ReadFile(ldCachePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %w", ldCachePath, err)
+	}
+	ldCacheFileSize := uint32(len(ldCacheFile))
+
+	var ldEntries []ldEntry
+	var filteredLibraries []string
+
+	if bytes.Equal([]byte(cache1Header), ldCacheFile[:len(cache1Header)]) {
+		cache1 := ldCache1{}
+		if uint32(len(ldCacheFile)) <= ldCache1Size {
+			return nil, errors.New("ldCache format error")
+		}
+		err := readFromBytes(&cache1, ldCacheFile[:ldCache1Size])
+		if err != nil {
+			return nil, errors.New("ldCache format error")
+		}
+		cache1Len := ldCache1Size + cache1.EntryCount*ldCache1EntrySize
+		cache1Len = (cache1Len + 7) / 8 * 8
+		if ldCacheFileSize > (cache1Len + ldCache2Size) {
+			ldEntries = readCacheFormat2(ldCacheFile)
+		} else {
+			ldEntries = readCacheFormat1(ldCacheFile)
+		}
+	} else {
+		ldEntries = readCacheFormat2(ldCacheFile)
+	}
+
+	if ldEntries == nil {
+		return nil, errors.New("ldCache format error")
+	}
+
+	// filter library entries with given library name
+	for _, entry := range ldEntries {
+		if strings.HasPrefix(entry.Key, libraryName+".so") {
+			filteredLibraries = append(filteredLibraries, entry.Value)
+		}
+	}
+
+	return filteredLibraries, nil
+}

--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -1,0 +1,328 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uprobetracer handles how uprobe/uretprobe programs are attached
+// to containers. It has two running modes: `pending` mode and `running` mode.
+//
+// Before `AttachProg` is called, uprobetracer runs in `pending` mode, only
+// maintaining the container PIDs ready to attach to.
+//
+// When `AttachProg` is called, uprobetracer enters the `running` mode and
+// attaches to all pending containers. After that, it will never get back to
+// the `pending` mode.
+//
+// In `running` mode, uprobetracer holds fd(s) of the executables, so we can
+// use `/proc/self/fd/$fd` for attaching, it is used to avoid fd-reusing.
+//
+// Uprobetracer doesn't maintain ebpf.collection or perf-ring buffer by itself,
+// those are hold by the parent tracer.
+//
+// All interfaces should hold locks, while inner functions do not.
+package uprobetracer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"golang.org/x/sys/unix"
+
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+)
+
+type ProgType uint32
+
+const (
+	ProgUprobe ProgType = iota
+	ProgUretprobe
+)
+
+type inodeUUID struct {
+	token uint64
+}
+
+func getInodeUUID(file *os.File) (inodeUUID, error) {
+	// TODO: use `kfilefields` to get a unique token for each inode,
+	// here we just use `fd` as token, making each file has a distinct token.
+	return inodeUUID{uint64(file.Fd())}, nil
+}
+
+// inodeKeeper holds a file object, with the counter representing its
+// reference count. The link is not nil only when the file is attached.
+type inodeKeeper struct {
+	counter int
+	file    *os.File
+	link    link.Link
+}
+
+func (t *inodeKeeper) close() {
+	if t.link != nil {
+		t.link.Close()
+	}
+	t.file.Close()
+}
+
+type Tracer[Event any] struct {
+	progName       string
+	progType       ProgType
+	attachFilePath string
+	attachSymbol   string
+	prog           *ebpf.Program
+
+	// keeps the inodes for each attached container
+	// when users write library names in ebpf section names, it's possible to
+	// find multiple libraries of different archs within the same container,
+	// making this a one-to-many mapping
+	containerPid2Inodes map[uint32][]inodeUUID
+	// keeps the fd and refCount for each inodeUUID
+	inodeRefCount map[inodeUUID]*inodeKeeper
+	// used as a set, keeps PIDs of the pending containers
+	pendingContainerPids map[uint32]bool
+
+	logger logger.Logger
+
+	closed bool
+	mu     sync.Mutex
+}
+
+func NewTracer[Event any](logger logger.Logger) (*Tracer[Event], error) {
+	t := &Tracer[Event]{
+		containerPid2Inodes:  make(map[uint32][]inodeUUID),
+		inodeRefCount:        make(map[inodeUUID]*inodeKeeper),
+		pendingContainerPids: make(map[uint32]bool),
+		logger:               logger,
+		closed:               false,
+	}
+	return t, nil
+}
+
+// AttachProg loads the ebpf program, and try attaching if there are pending containers
+func (t *Tracer[Event]) AttachProg(progName string, progType ProgType, attachTo string, prog *ebpf.Program) error {
+	if progType != ProgUprobe && progType != ProgUretprobe {
+		return fmt.Errorf("unsupported uprobe prog type: %q", progType)
+	}
+
+	if prog == nil {
+		return errors.New("prog does not exist")
+	}
+	if t.prog != nil {
+		return errors.New("loading uprobe program twice")
+	}
+
+	parts := strings.Split(attachTo, ":")
+	if len(parts) < 2 {
+		return fmt.Errorf("invalid section name %q", attachTo)
+	}
+	if !filepath.IsAbs(parts[0]) && strings.Contains(parts[0], "/") {
+		return fmt.Errorf("section name must be either an absolute path or a library name: %q", parts[0])
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return errors.New("uprobetracer has been closed")
+	}
+
+	t.progName = progName
+	t.progType = progType
+	t.attachFilePath = parts[0]
+	t.attachSymbol = parts[1]
+	t.prog = prog
+
+	// attach to pending containers, then release the pending list
+	for pid := range t.pendingContainerPids {
+		t.attach(pid)
+	}
+	t.pendingContainerPids = nil
+
+	return nil
+}
+
+func (t *Tracer[Event]) searchForLibrary(containerPid uint32) ([]string, error) {
+	var targetPaths []string
+	var securedTargetPaths []string
+
+	filePath := t.attachFilePath
+	if !filepath.IsAbs(filePath) {
+		containerLdCachePath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), "etc/ld.so.cache")
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", filePath, err)
+		}
+		ldCachePaths, err := parseLdCache(containerLdCachePath, filePath)
+		if err != nil {
+			return nil, fmt.Errorf("parsing ld cache: %w", err)
+		}
+		targetPaths = ldCachePaths
+	} else {
+		targetPaths = append(targetPaths, filePath)
+	}
+	for _, targetPath := range targetPaths {
+		securedTargetPath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), targetPath)
+		if err != nil {
+			t.logger.Debugf("path %q in ld cache is not available: %q", filePath, err.Error())
+			continue
+		}
+		securedTargetPaths = append(securedTargetPaths, securedTargetPath)
+	}
+	return securedTargetPaths, nil
+}
+
+// attach uprobe program to the inode of the file passed in parameter
+func (t *Tracer[Event]) attachUprobe(file *os.File) (link.Link, error) {
+	attachPath := path.Join(host.HostProcFs, "self/fd/", fmt.Sprint(file.Fd()))
+	ex, err := link.OpenExecutable(attachPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening %q: %w", attachPath, err)
+	}
+	switch t.progType {
+	case ProgUprobe:
+		return ex.Uprobe(t.attachSymbol, t.prog, nil)
+	case ProgUretprobe:
+		return ex.Uretprobe(t.attachSymbol, t.prog, nil)
+	default:
+		return nil, fmt.Errorf("attaching to inode: unsupported prog type: %q", t.progType)
+	}
+}
+
+// try attaching to a container, will update `containerPid2Inodes`
+func (t *Tracer[Event]) attach(containerPid uint32) {
+	var attachedUUIDs []inodeUUID
+	attachFilePaths, err := t.searchForLibrary(containerPid)
+	if err != nil {
+		t.logger.Debugf("attaching to container %d: %q", containerPid, err.Error())
+	}
+
+	if len(attachFilePaths) == 0 {
+		t.logger.Debugf("cannot find file to attach in container %d for symbol %q", containerPid, t.attachSymbol)
+	}
+
+	for _, filePath := range attachFilePaths {
+		file, err := os.OpenFile(filePath, unix.O_PATH, 0)
+		if err != nil {
+			t.logger.Debugf("opening file '%q' for uprobe: %q", filePath, err.Error())
+			continue
+		}
+		fileUUID, err := getInodeUUID(file)
+		if err != nil {
+			t.logger.Debugf("getting inode info for '%q': %q", filePath, err.Error())
+			file.Close()
+			continue
+		}
+
+		t.logger.Debugf("attaching uprobe %q to container %d: %q", t.attachSymbol, containerPid, filePath)
+		attachedUUIDs = append(attachedUUIDs, fileUUID)
+
+		inode, exists := t.inodeRefCount[fileUUID]
+		if !exists {
+			progLink, _ := t.attachUprobe(file)
+			t.inodeRefCount[fileUUID] = &inodeKeeper{1, file, progLink}
+		} else {
+			inode.counter++
+			file.Close()
+		}
+	}
+
+	t.containerPid2Inodes[containerPid] = attachedUUIDs
+}
+
+// AttachContainer will attach now if the prog is ready, otherwise it will add container into the pending list
+func (t *Tracer[Event]) AttachContainer(container *containercollection.Container) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return errors.New("uprobetracer has been closed")
+	}
+
+	if t.prog == nil {
+		_, exist := t.pendingContainerPids[container.Pid]
+		if exist {
+			return fmt.Errorf("container PID already exists: %d", container.Pid)
+		}
+		t.pendingContainerPids[container.Pid] = true
+	} else {
+		_, exist := t.containerPid2Inodes[container.Pid]
+		if exist {
+			return fmt.Errorf("container PID already exists: %d", container.Pid)
+		}
+		t.attach(container.Pid)
+	}
+	return nil
+}
+
+func (t *Tracer[Event]) DetachContainer(container *containercollection.Container) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return nil
+	}
+
+	if t.prog == nil {
+		// remove from pending list
+		_, exist := t.pendingContainerPids[container.Pid]
+		if !exist {
+			return errors.New("container has not been attached")
+		}
+		delete(t.pendingContainerPids, container.Pid)
+	} else {
+		// detach from container if attached
+		attachedUUIDs, exist := t.containerPid2Inodes[container.Pid]
+		if !exist {
+			return errors.New("container has not been attached")
+		}
+		delete(t.containerPid2Inodes, container.Pid)
+
+		for _, attachedUUID := range attachedUUIDs {
+			keeper, exist := t.inodeRefCount[attachedUUID]
+			if !exist {
+				return errors.New("internal error: finding inodeKeeper with inodeUUID")
+			}
+			keeper.counter--
+			if keeper.counter == 0 {
+				keeper.close()
+				delete(t.inodeRefCount, attachedUUID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *Tracer[Event]) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return
+	}
+
+	for _, keeper := range t.inodeRefCount {
+		keeper.close()
+	}
+
+	t.containerPid2Inodes = nil
+	t.inodeRefCount = nil
+	t.closed = true
+}


### PR DESCRIPTION
# Introduce uprobetracer for auto attach/detach

## Description
Part of #1912.
This patch introduces a new package `uprobetracer` for auto attaching/detaching.
There will be duplicate records with current implementation.

## Testing
- Starting/stopping/restarting the containers, and see if it works well.
- Use `--pod` and `--containername` to test the filter
