### PR TITLE
Fix tracer name in GADGET_TRACER(open, ...)

### DIFF
--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -298,7 +298,7 @@ It'll create a `gadget.yaml` file:
 name: 'TODO: Fill the gadget name'
 description: 'TODO: Fill the gadget description'
 tracers:
-  events:
+  open:
     mapName: events
     structName: event
 structs:
@@ -331,7 +331,7 @@ pid, comm, etc.
 name: mygadget
 description: Example gadget
 tracers:
-  events:
+  open:
     mapName: events
     structName: event
 structs:

--- a/docs/reference/gadget-helper-api.md
+++ b/docs/reference/gadget-helper-api.md
@@ -156,7 +156,7 @@ The following snippet demonstrates how to use the code available in `<gadget/buf
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 
-GADGET_TRACER(open, events, event);
+GADGET_TRACER(exit, events, event);
 
 /* ... */
 

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -1,7 +1,7 @@
 name: trace malloc
 description: use uprobe to trace malloc and free in libc.so
 tracers:
-  events:
+  malloc:
     mapName: events
     structName: event
 structs:

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -21,7 +21,7 @@ struct event {
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 
-GADGET_TRACER(open, events, event);
+GADGET_TRACER(malloc, events, event);
 
 static __always_inline int submit_memop_event(struct pt_regs *ctx,
 					      enum memop operation, __u64 addr)

--- a/gadgets/trace_oomkill/gadget.yaml
+++ b/gadgets/trace_oomkill/gadget.yaml
@@ -1,7 +1,7 @@
 name: oomkill
 description: trace OOM killer
 tracers:
-  events:
+  oomkill:
     mapName: events
     structName: event
 structs:

--- a/gadgets/trace_oomkill/program.bpf.c
+++ b/gadgets/trace_oomkill/program.bpf.c
@@ -27,7 +27,7 @@ struct event {
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 
-GADGET_TRACER(open, events, event);
+GADGET_TRACER(oomkill, events, event);
 
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(ig_oom_kill, struct oom_control *oc, const char *message)


### PR DESCRIPTION
The macro GADGET_TRACER defines the tracer name with "open" in several places due to copy and paste. This patch renames the tracers to suitable names.

This patch also updates gadget.yaml and the documentation accordingly.

One commit in this PR was picked up from #2634.

cc @eiffel-fl @i-Pear 