### PR TITLE
gadgets/ci/sched_cls_drop: add missing gadget.yaml

### DIFF
--- a/gadgets/ci/sched_cls_drop/gadget.yaml
+++ b/gadgets/ci/sched_cls_drop/gadget.yaml
@@ -1,0 +1,10 @@
+name: sched_cls_drop
+description: gadget used by the CI
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://inspektor-gadget.io/docs/latest/
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget
+gadgetParams:
+  iface:
+    key: iface
+    defaultValue: ""
+    description: Network interface to attach to


### PR DESCRIPTION
Although the gadget.yaml metadata file is not mandatory, it is best practice to have one. This patch adds it. It will make it easier for the next PRs.

This commit was initially part of #2586.