### PR TITLE
pkg/oci: make fixMetadataOwner more generic

### DIFF
--- a/pkg/oci/build_metadata.go
+++ b/pkg/oci/build_metadata.go
@@ -129,7 +129,7 @@ func createOrUpdateMetadataFile(ctx context.Context, opts *BuildGadgetImageOpts)
 
 	// fix owner of created metadata file
 	if !update {
-		if err := fixMetadataOwner(opts); err != nil {
+		if err := fixOwner(opts.MetadataPath, opts.EBPFSourcePath); err != nil {
 			log.Warnf("Failed to fix metadata file owner: %v", err)
 		}
 	}

--- a/pkg/oci/fix_owner_linux.go
+++ b/pkg/oci/fix_owner_linux.go
@@ -12,12 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux
+//go:build linux
 
 package oci
 
-import "fmt"
+import (
+	"os"
+	"syscall"
+)
 
-func fixMetadataOwner(opts *BuildGadgetImageOpts) error {
-	return fmt.Errorf("fixMetadataOwner not implemented on this platform")
+func fixOwner(targetFile, modelFile string) error {
+	info, err := os.Stat(modelFile)
+	if err != nil {
+		return err
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		err := os.Chown(targetFile, int(stat.Uid), int(stat.Gid))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/oci/fix_owner_others.go
+++ b/pkg/oci/fix_owner_others.go
@@ -12,26 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
+//go:build !linux
 
 package oci
 
-import (
-	"os"
-	"syscall"
-)
+import "fmt"
 
-func fixMetadataOwner(opts *BuildGadgetImageOpts) error {
-	info, err := os.Stat(opts.EBPFSourcePath)
-	if err != nil {
-		return err
-	}
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		err := os.Chown(opts.MetadataPath, int(stat.Uid), int(stat.Gid))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func fixOwner(_, _ string) error {
+	return fmt.Errorf("fixOwner not implemented on this platform")
 }


### PR DESCRIPTION
fixMetadataOwner() was previously added for the following reason:

'ig image build --update-metadata' overwrites gadget.yaml but since ig runs as root, the file gadget.yaml initially ends up belonging to root. The function fixMetadataOwner() fixes this with a chown.

In order to reuse fixMetadataOwner() for a different file, this patch makes it more generic.

This commit was initially part of #2586.