### PR TITLE
Artifact Hub: publish gadgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Inspektor Gadget Test Reports](https://img.shields.io/badge/Link-Test%20Reports-blue)](https://inspektor-gadget.github.io/ig-test-reports)
 [![Inspektor Gadget Benchmarks](https://img.shields.io/badge/Link-Benchmarks-blue)](https://inspektor-gadget.github.io/ig-benchmarks/dev/bench)
 [![Release](https://img.shields.io/github/v/release/inspektor-gadget/inspektor-gadget)](https://github.com/inspektor-gadget/inspektor-gadget/releases)
+[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadget)](https://artifacthub.io/packages/search?repo=gadget)
 [![Slack](https://img.shields.io/badge/slack-%23inspektor--gadget-brightgreen.svg?logo=slack)](https://kubernetes.slack.com/messages/inspektor-gadget/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/LICENSE)

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+# Artifact Hub repository metadata file
+# https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml
+
+repositoryID: a4a4aff7-52f0-43f9-93a5-0749f53bc898
+owners:
+  - name: The Inspektor Gadget authors
+    email: hello@inspektor-gadget.io

--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -21,6 +21,10 @@ If you want to create a new repository for your gadget, you can use the [gadget-
 repository](https://github.com/inspektor-gadget/gadget-template). This is a
 [GitHub tempate repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
+You can also look for examples in gadgets published on Artifact Hub:
+
+[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)
+
 ## Starting from scratch
 
 If you already have a git repository for your project and want to add a gadget

--- a/gadgets/ci/sched_cls_drop/artifacthub-pkg.yml
+++ b/gadgets/ci/sched_cls_drop/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "sched_cls_drop"
+category: monitoring-logging
+displayName: "sched_cls_drop"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "gadget used by the CI"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/sched_cls_drop:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/sched_cls_drop:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/snapshot_process/artifacthub-pkg.yml
+++ b/gadgets/snapshot_process/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "snapshot process"
+category: monitoring-logging
+displayName: "snapshot process"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "Show running processes"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/snapshot_process:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/snapshot_process:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/snapshot_socket/artifacthub-pkg.yml
+++ b/gadgets/snapshot_socket/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "snapshot socket"
+category: monitoring-logging
+displayName: "snapshot socket"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "Show TCP and UDP sockets"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/top_file/artifacthub-pkg.yml
+++ b/gadgets/top_file/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "top file"
+category: monitoring-logging
+displayName: "top file"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "Periodically report read/write activity by file"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/top_file:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/top_file:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_dns/artifacthub-pkg.yml
+++ b/gadgets/trace_dns/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace dns"
+category: monitoring-logging
+displayName: "trace dns"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace dns requests and responses"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_dns:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_dns:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_exec/artifacthub-pkg.yml
+++ b/gadgets/trace_exec/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace exec"
+category: monitoring-logging
+displayName: "trace exec"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace process executions"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_exec:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_malloc/artifacthub-pkg.yml
+++ b/gadgets/trace_malloc/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace malloc"
+category: monitoring-logging
+displayName: "trace malloc"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "use uprobe to trace malloc and free in libc.so"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_malloc:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_malloc:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_mount/artifacthub-pkg.yml
+++ b/gadgets/trace_mount/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace mount"
+category: monitoring-logging
+displayName: "trace mount"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace mount syscalls"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_mount:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_mount:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_oomkill/artifacthub-pkg.yml
+++ b/gadgets/trace_oomkill/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace oomkill"
+category: monitoring-logging
+displayName: "trace oomkill"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace OOM killer"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_open/artifacthub-pkg.yml
+++ b/gadgets/trace_open/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace open"
+category: monitoring-logging
+displayName: "trace open"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace open files"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_open:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_open:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_signal/artifacthub-pkg.yml
+++ b/gadgets/trace_signal/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace signal"
+category: monitoring-logging
+displayName: "trace signal"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace signal"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_signal:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_signal:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_sni/artifacthub-pkg.yml
+++ b/gadgets/trace_sni/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace sni"
+category: monitoring-logging
+displayName: "trace sni"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace sni"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_sni:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_sni:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_tcp/artifacthub-pkg.yml
+++ b/gadgets/trace_tcp/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace tcp"
+category: monitoring-logging
+displayName: "trace tcp"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "monitor connect, accept and close events of TCP connections"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_tcp:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_tcpconnect/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpconnect/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace tcpconnect"
+category: monitoring-logging
+displayName: "trace tcpconnect"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace tcp connections"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_tcpdrop/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpdrop/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace tcpdrop"
+category: monitoring-logging
+displayName: "trace tcpdrop"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace TCP packets dropped by the kernel"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_tcpretrans/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpretrans/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.26.0
+name: "trace tcpretrans"
+category: monitoring-logging
+displayName: "trace tcpretrans"
+createdAt: "2024-03-25T14:32:05+01:00"
+description: "trace TCP retransmissions"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/"
+install: |
+    # Run
+    ```bash
+    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest
+    ```
+provider:
+    name: Inspektor Gadget


### PR DESCRIPTION
Since #2586 will take some time to address the comments, I'm splitting it in two. This PR is the first part and focuses on adding the metadata to get the gadgets published on Artifact Hub. Once this is merged, I will continue with the helper tools.

---

# Artifact Hub: publish gadgets

Artifact Hub now supports Gadgets: https://github.com/artifacthub/hub/issues/3665

You can see the list of all gadgets is published on Artifact Hub:
https://artifacthub.io/packages/search?kind=22

Gadget authors can publish their gadgets on Artifact Hub by adding two files on their repositories:
* artifacthub-repo.yml
* artifacthub-pkg.yml

This PR does that for the official gadgets. For now, artifacthub-pkg.yml is written manually. Helpers to automate this will be done in #2586.

The gadgets from the main IG repository are published on this page:
[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/Gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)

## How to use

Visit the Artifact Hub links:
- https://artifacthub.io/packages/search?kind=22
- https://artifacthub.io/packages/search?repo=inspektor-gadgets

## Testing done


In the Artifact Hub dashboard, the official inspektor gadgets are currently configured to use my branch (alban_hub), so we can see the gadgets, even though this PR is not merged yet.

Once merged, I will change the setting to use the main branch.