### PR TITLE
integration: Use interface type instead of type parameter

### DIFF
--- a/integration/common/profile_tcprtt.go
+++ b/integration/common/profile_tcprtt.go
@@ -75,7 +75,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 	clientPodName := "test-pod"
 	ns := integration.GenerateTestNamespaceName("test-profile-tcprtt")
 
-	startServerCommands := []*integration.Command{
+	startServerCommands := []integration.TestStep{
 		integration.CreateTestNamespaceCommand(ns),
 		integration.PodCommand(serverPodName, "nginx", ns, "", ""),
 		integration.WaitUntilPodReadyCommand(ns, serverPodName),
@@ -83,7 +83,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 	integration.RunTestSteps(startServerCommands, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		cleanupCommands := []*integration.Command{
+		cleanupCommands := []integration.TestStep{
 			integration.DeleteTestNamespaceCommand(ns),
 		}
 		integration.RunTestSteps(cleanupCommands, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
@@ -91,7 +91,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 
 	serverIP := integration.GetTestPodIP(t, ns, serverPodName)
 
-	generateTrafficCommands := []*integration.Command{
+	generateTrafficCommands := []integration.TestStep{
 		integration.BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", serverIP)),
 		integration.WaitUntilTestPodReadyCommand(ns),
 	}
@@ -118,7 +118,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	// TODO: Why without timeout the topTCPCmd command doesn't generate any output?
@@ -134,7 +134,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 	// 		tcprttProfileTypes.AddressTypeAll,
 	// 		tcprttProfileTypes.WildcardAddress,
 	// 	)
-	// 	integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+	// 	integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	// })
 
 	t.Run("FilterRemotePort", func(t *testing.T) {
@@ -151,7 +151,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			80,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	t.Run("FilterRemoteAddr", func(t *testing.T) {
@@ -168,7 +168,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	t.Run("FilterLocalAddr", func(t *testing.T) {
@@ -185,7 +185,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	t.Run("ByRemoteAndFilterLocalAddr", func(t *testing.T) {
@@ -202,7 +202,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	t.Run("ByLocalAndFilterRemoteAddr", func(t *testing.T) {
@@ -219,7 +219,7 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 
 	t.Run("MillisecondsAndFilterRemoteAndLocalAddr", func(t *testing.T) {
@@ -236,6 +236,6 @@ func RunTestProfileTCPRTT(t *testing.T) {
 			0,
 			0,
 		)
-		integration.RunTestSteps([]*integration.Command{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
+		integration.RunTestSteps([]integration.TestStep{topTCPCmd}, t, integration.WithCbBeforeCleanup(integration.PrintLogsFn(ns)))
 	})
 }

--- a/integration/ig/k8s/enrichment_pod_label_test.go
+++ b/integration/ig/k8s/enrichment_pod_label_test.go
@@ -31,13 +31,13 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 	ns := GenerateTestNamespaceName(pod)
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand(cn, "busybox", ns, `["sleep", "inf"]`, ""),
 		WaitUntilPodReadyCommand(ns, pod),
@@ -110,7 +110,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 		},
 	}
 
-	RunTestSteps([]*Command{listContainersCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	RunTestSteps([]TestStep{listContainersCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 }
 
 func TestEnrichmentPodLabelNewPod(t *testing.T) {
@@ -194,7 +194,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		listContainersCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/list_containers_test.go
+++ b/integration/ig/k8s/list_containers_test.go
@@ -100,13 +100,13 @@ func TestListContainers(t *testing.T) {
 	ns := GenerateTestNamespaceName(pod)
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand(cn, "busybox", ns, `["sleep", "inf"]`, ""),
 		WaitUntilPodReadyCommand(ns, pod),
@@ -133,7 +133,7 @@ func TestListContainers(t *testing.T) {
 				ExpectEntriesInArrayToMatch(t, o, f, c)
 			},
 		)
-		RunTestSteps([]*Command{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("FilteredList", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestListContainers(t *testing.T) {
 				ExpectAllInArrayToMatch(t, o, f, c)
 			},
 		)
-		RunTestSteps([]*Command{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }
 
@@ -232,7 +232,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		watchContainersCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
@@ -324,12 +324,12 @@ func TestWatchDeletedContainers(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand(pod, "busybox", ns, `["sleep", "inf"]`, ""),
 		WaitUntilPodReadyCommand(ns, pod),
 		watchContainersCmd,
-		{
+		&Command{
 			Name: "DeletePod",
 			Cmd:  fmt.Sprintf("kubectl delete pod %s -n %s", pod, ns),
 		},
@@ -440,11 +440,11 @@ spec:
     command: ["sleep", "inf"]
 `, po, ns, po, cn)
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		watchContainersCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		{
+		&Command{
 			Name:           "RunTestPodWithSecurityContext",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", securityContextPodYaml),
 			ExpectedRegexp: fmt.Sprintf("pod/%s created", po),

--- a/integration/ig/k8s/profile_bio_test.go
+++ b/integration/ig/k8s/profile_bio_test.go
@@ -39,7 +39,7 @@ func TestProfileBio(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		profileBioCmd,
 	}
 

--- a/integration/ig/k8s/profile_cpu_test.go
+++ b/integration/ig/k8s/profile_cpu_test.go
@@ -70,7 +70,7 @@ func TestProfileCpu(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "while true; do echo foo > /dev/null; done"),
 		WaitUntilTestPodReadyCommand(ns),

--- a/integration/ig/k8s/snapshot_process_test.go
+++ b/integration/ig/k8s/snapshot_process_test.go
@@ -71,7 +71,7 @@ func TestSnapshotProcess(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "nc -l -p 9090"),
 		WaitUntilTestPodReadyCommand(ns),

--- a/integration/ig/k8s/top_block_io_test.go
+++ b/integration/ig/k8s/top_block_io_test.go
@@ -89,7 +89,7 @@ func TestTopBlockIO(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-top-block-io")
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		// Adding an additional sleep time to generate less events and avoid
 		// interference with other tests. See TestTopFile for more details.
@@ -99,7 +99,7 @@ func TestTopBlockIO(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -110,7 +110,7 @@ func TestTopBlockIO(t *testing.T) {
 
 		cmd := fmt.Sprintf("ig top block-io -o json -m 999 --runtimes=%s", *containerRuntime)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, true)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestTopBlockIO(t *testing.T) {
 		cmd := fmt.Sprintf("ig top block-io -o json -m 999 --runtimes=%s --timeout %d",
 			*containerRuntime, timeout)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -128,6 +128,6 @@ func TestTopBlockIO(t *testing.T) {
 		cmd := fmt.Sprintf("ig top block-io -o json -m 999 --runtimes=%s --timeout %d --interval %d",
 			*containerRuntime, timeout, timeout)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/ig/k8s/top_ebpf_test.go
+++ b/integration/ig/k8s/top_ebpf_test.go
@@ -65,7 +65,7 @@ func TestTopEbpf(t *testing.T) {
 
 		cmd := fmt.Sprintf("ig top ebpf -o json --runtimes=%s -m 100", *containerRuntime)
 		topEbpfCmd := newTopEbpfCmd(cmd, true)
-		RunTestSteps([]*Command{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
+		RunTestSteps([]TestStep{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestTopEbpf(t *testing.T) {
 		cmd := fmt.Sprintf("ig top ebpf -o json --runtimes=%s -m 100 --timeout %d",
 			*containerRuntime, timeout)
 		topEbpfCmd := newTopEbpfCmd(cmd, false)
-		RunTestSteps([]*Command{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
+		RunTestSteps([]TestStep{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -83,6 +83,6 @@ func TestTopEbpf(t *testing.T) {
 		cmd := fmt.Sprintf("ig top ebpf -o json --runtimes=%s -m 100 --timeout %d --interval %d",
 			*containerRuntime, timeout, timeout)
 		topEbpfCmd := newTopEbpfCmd(cmd, false)
-		RunTestSteps([]*Command{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
+		RunTestSteps([]TestStep{topEbpfCmd}, t, WithCbBeforeCleanup(PrintLogsFn()))
 	})
 }

--- a/integration/ig/k8s/top_file_test.go
+++ b/integration/ig/k8s/top_file_test.go
@@ -80,7 +80,7 @@ func TestTopFile(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-top-file")
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodRepeatCommand(ns, "echo foo > bar"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -88,7 +88,7 @@ func TestTopFile(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -105,7 +105,7 @@ func TestTopFile(t *testing.T) {
 
 		cmd := fmt.Sprintf("ig top file -o json --sort -writes,-wbytes -m 999 --runtimes=%s", *containerRuntime)
 		topFileCmd := newTopFileCmd(ns, cmd, true)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestTopFile(t *testing.T) {
 		cmd := fmt.Sprintf("ig top file -o json --sort -writes,-wbytes -m 999 --runtimes=%s --timeout %d",
 			*containerRuntime, timeout)
 		topFileCmd := newTopFileCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -123,6 +123,6 @@ func TestTopFile(t *testing.T) {
 		cmd := fmt.Sprintf("ig top file -o json --sort -writes,-wbytes -m 999 --runtimes=%s --timeout %d --interval %d",
 			*containerRuntime, timeout, timeout)
 		topFileCmd := newTopFileCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/ig/k8s/top_tcp_test.go
+++ b/integration/ig/k8s/top_tcp_test.go
@@ -91,7 +91,7 @@ func TestTopTCP(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-top-tcp")
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -99,7 +99,7 @@ func TestTopTCP(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -110,7 +110,7 @@ func TestTopTCP(t *testing.T) {
 
 		cmd := fmt.Sprintf("ig top tcp -o json -m 999 --runtimes=%s", *containerRuntime)
 		topTCPCmd := newTopTCPCmd(ns, cmd, true)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestTopTCP(t *testing.T) {
 		cmd := fmt.Sprintf("ig top tcp -o json -m 999 --runtimes=%s --timeout %d",
 			*containerRuntime, timeout)
 		topTCPCmd := newTopTCPCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -128,6 +128,6 @@ func TestTopTCP(t *testing.T) {
 		cmd := fmt.Sprintf("ig top tcp -o json -m 999 --runtimes=%s --timeout %d --interval %d",
 			*containerRuntime, timeout, timeout)
 		topTCPCmd := newTopTCPCmd(ns, cmd, false)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/ig/k8s/trace_bind_test.go
+++ b/integration/ig/k8s/trace_bind_test.go
@@ -76,7 +76,7 @@ func TestTraceBind(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceBindCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_capabilities_test.go
+++ b/integration/ig/k8s/trace_capabilities_test.go
@@ -95,7 +95,7 @@ func TestTraceCapabilities(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		capabilitiesCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_exec_test.go
+++ b/integration/ig/k8s/trace_exec_test.go
@@ -122,7 +122,7 @@ func TestTraceExec(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceExecCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
@@ -179,10 +179,10 @@ func TestTraceExecHost(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceExecCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		{
+		&Command{
 			Name:           cmd,
 			Cmd:            cmd,
 			ExpectedRegexp: fmt.Sprintf("%d", time.Now().Year()),

--- a/integration/ig/k8s/trace_fsslower_test.go
+++ b/integration/ig/k8s/trace_fsslower_test.go
@@ -78,7 +78,7 @@ func TestTraceFsslower(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceFsslowerCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_mount_test.go
+++ b/integration/ig/k8s/trace_mount_test.go
@@ -80,7 +80,7 @@ func TestTraceMount(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceMountCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_network_test.go
+++ b/integration/ig/k8s/trace_network_test.go
@@ -28,7 +28,7 @@ func TestTraceNetwork(t *testing.T) {
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-network")
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("nginx-pod", "nginx", ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "nginx-pod"),
@@ -142,7 +142,7 @@ func TestTraceNetwork(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceNetworkCmd,
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", nginxIP)),
 		WaitUntilTestPodReadyCommand(ns),

--- a/integration/ig/k8s/trace_oomkill_test.go
+++ b/integration/ig/k8s/trace_oomkill_test.go
@@ -97,11 +97,11 @@ spec:
     - while true; do tail /dev/zero; done
 `, ns)
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceOOMKillCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		{
+		&Command{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),
 			ExpectedRegexp: "pod/test-pod created",

--- a/integration/ig/k8s/trace_open_test.go
+++ b/integration/ig/k8s/trace_open_test.go
@@ -79,7 +79,7 @@ func TestTraceOpen(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceOpenCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_signal_test.go
+++ b/integration/ig/k8s/trace_signal_test.go
@@ -73,7 +73,7 @@ func TestTraceSignal(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceSignalCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_sni_test.go
+++ b/integration/ig/k8s/trace_sni_test.go
@@ -73,7 +73,7 @@ func TestTraceSni(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceSNICmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_tcp_test.go
+++ b/integration/ig/k8s/trace_tcp_test.go
@@ -87,7 +87,7 @@ func TestTraceTCP(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceTCPCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/k8s/trace_tcpconnect_test.go
+++ b/integration/ig/k8s/trace_tcpconnect_test.go
@@ -86,7 +86,7 @@ func TestTraceTcpconnect(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		tcpconnectCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
@@ -166,7 +166,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		tcpconnectCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started

--- a/integration/ig/non-k8s/top_ebpf_test.go
+++ b/integration/ig/non-k8s/top_ebpf_test.go
@@ -55,7 +55,7 @@ func TestTopEbpf(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		topebpfCmd,
 	}
 

--- a/integration/inspektor-gadget/advise_seccompprofile_test.go
+++ b/integration/inspektor-gadget/advise_seccompprofile_test.go
@@ -26,11 +26,11 @@ func TestAdviseSeccompProfile(t *testing.T) {
 
 	t.Parallel()
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodRepeatCommand(ns, "echo foo"),
 		WaitUntilTestPodReadyCommand(ns),
-		{
+		&Command{
 			Name:           "RunAdviseSeccompProfileGadget",
 			Cmd:            fmt.Sprintf("id=$($KUBECTL_GADGET advise seccomp-profile start -n %s -p test-pod); sleep 30; $KUBECTL_GADGET advise seccomp-profile stop $id", ns),
 			ExpectedRegexp: `write`,

--- a/integration/inspektor-gadget/audit_seccomp_test.go
+++ b/integration/inspektor-gadget/audit_seccomp_test.go
@@ -139,18 +139,18 @@ spec:
           name: myseccompprofile
 `, ns)
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
-		{
+		&Command{
 			Name:           "CreateSeccompProfile",
 			Cmd:            fmt.Sprintf("kubectl apply -f - <<EOF%sEOF", seccompInstallerYaml),
 			ExpectedRegexp: "daemonset.apps/seccomp-installer created",
 		},
-		{
+		&Command{
 			Name: "WaitForDaemonSet",
 			Cmd:  fmt.Sprintf("kubectl rollout -n %s status daemonset/seccomp-installer --timeout=120s", ns),
 		},
-		{
+		&Command{
 			Name: "RunSeccompAuditTestPod",
 			Cmd: fmt.Sprintf(`
 				kubectl apply -f - <<EOF
@@ -178,7 +178,7 @@ EOF
 			ExpectedRegexp: "pod/test-pod created",
 		},
 		WaitUntilTestPodReadyCommand(ns),
-		{
+		&Command{
 			Name: "RunAuditSeccompGadget",
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET audit seccomp -n %s --timeout 15 -o json", ns),
 			ValidateOutput: func(t *testing.T, output string) {
@@ -205,7 +205,7 @@ EOF
 				ExpectEntriesToMatch(t, output, normalize, expectedEntry)
 			},
 		},
-		{
+		&Command{
 			Name:    "RemoveSeccompProfile",
 			Cmd:     fmt.Sprintf("kubectl delete -f - <<EOF%sEOF", seccompInstallerYaml),
 			Cleanup: true,

--- a/integration/inspektor-gadget/profile_blockio_test.go
+++ b/integration/inspektor-gadget/profile_blockio_test.go
@@ -26,8 +26,8 @@ import (
 func TestProfileBlockIO(t *testing.T) {
 	t.Parallel()
 
-	commands := []*Command{
-		{
+	commands := []TestStep{
+		&Command{
 			Name: "RunProfileBlockIOGadget",
 			Cmd:  "$KUBECTL_GADGET profile block-io --node $(kubectl get node --no-headers | cut -d' ' -f1 | head -1) --timeout 15 -o json",
 			ValidateOutput: func(t *testing.T, output string) {

--- a/integration/inspektor-gadget/profile_cpu_test.go
+++ b/integration/inspektor-gadget/profile_cpu_test.go
@@ -31,11 +31,11 @@ func TestProfileCpu(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "while true; do echo foo > /dev/null; done"),
 		WaitUntilTestPodReadyCommand(ns),
-		{
+		&Command{
 			Name: "RunProfileCpuGadget",
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET profile cpu -n %s -p test-pod -K --timeout 15 -o json", ns),
 			ValidateOutput: func(t *testing.T, output string) {

--- a/integration/inspektor-gadget/run_insecure_test.go
+++ b/integration/inspektor-gadget/run_insecure_test.go
@@ -26,7 +26,7 @@ func TestRunInsecure(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("registry", "docker.io/library/registry:2", ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "registry"),
@@ -35,7 +35,7 @@ func TestRunInsecure(t *testing.T) {
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -44,7 +44,7 @@ func TestRunInsecure(t *testing.T) {
 	registryIP := GetTestPodIP(t, ns, "registry")
 
 	// copy gadget image to insecure registry
-	orasCpCmds := []*Command{
+	orasCpCmds := []TestStep{
 		JobCommand("copier", "ghcr.io/oras-project/oras:v1.1.0", ns,
 			"oras",
 			"copy",

--- a/integration/inspektor-gadget/run_schedcls_test.go
+++ b/integration/inspektor-gadget/run_schedcls_test.go
@@ -31,13 +31,13 @@ func TestRunSchedCLS(t *testing.T) {
 	ns := GenerateTestNamespaceName("test-run-schedcls")
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("nginx-pod", "nginx", ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "nginx-pod"),
@@ -52,13 +52,13 @@ func TestRunSchedCLS(t *testing.T) {
 		StartAndStop: true,
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		runSchedCLSCmd,
 		// Wait until program is attached. TODO: How to avoid hardcoding a delay here?
 		SleepForSecondsCommand(5),
 		JobCommand("wget", "busybox", ns, "sh", "-c", fmt.Sprintf("wget -T 5 %s || true", nginxIP)),
 		WaitUntilJobCompleteCommand(ns, "wget"),
-		{
+		&Command{
 			Name: "ValidateOutput",
 			Cmd:  fmt.Sprintf("kubectl logs job.batch/wget -n %s", ns),
 			ValidateOutput: func(t *testing.T, output string) {

--- a/integration/inspektor-gadget/run_snapshot_process_test.go
+++ b/integration/inspektor-gadget/run_snapshot_process_test.go
@@ -31,7 +31,7 @@ func TestRunSnapshotProcess(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "nc -l -p 9090"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -39,14 +39,14 @@ func TestRunSnapshotProcess(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	commands := []*Command{
-		{
+	commands := []TestStep{
+		&Command{
 			Name:         "StartRunSnapshotProcessGadget",
 			Cmd:          fmt.Sprintf("$KUBECTL_GADGET run %s/snapshot_process:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns),
 			StartAndStop: true,

--- a/integration/inspektor-gadget/run_top_file_test.go
+++ b/integration/inspektor-gadget/run_top_file_test.go
@@ -74,7 +74,7 @@ func runTopFile(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		topFileCmd,
 		BusyboxPodRepeatCommand(ns, "echo date >> /tmp/date.txt"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -88,14 +88,14 @@ func TestRunTopFile(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_mount_test.go
+++ b/integration/inspektor-gadget/run_trace_mount_test.go
@@ -79,7 +79,7 @@ func runTraceMount(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceMountCmd,
 		BusyboxPodRepeatCommand(ns, "mount /foo /bar"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -93,14 +93,14 @@ func TestRunTraceMount(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_oomkill_test.go
+++ b/integration/inspektor-gadget/run_trace_oomkill_test.go
@@ -92,9 +92,9 @@ spec:
     - while true; do tail /dev/zero; done
 `, ns)
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceOOMKillCmd,
-		{
+		&Command{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),
 			ExpectedRegexp: "pod/test-pod created",
@@ -110,14 +110,14 @@ func TestRunTraceOOMKill(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_open_test.go
+++ b/integration/inspektor-gadget/run_trace_open_test.go
@@ -68,7 +68,7 @@ func runTraceOpen(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceOpenCmd,
 		BusyboxPodRepeatCommand(ns, "setuidgid 1000:1111 cat /dev/null"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -82,14 +82,14 @@ func TestRunTraceOpen(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_signal_test.go
+++ b/integration/inspektor-gadget/run_trace_signal_test.go
@@ -68,7 +68,7 @@ func runTraceSignal(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceSignalCmd,
 		BusyboxPodRepeatCommand(ns, "sleep 3 & kill $!"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -82,14 +82,14 @@ func TestRunTraceSignal(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_sni_test.go
+++ b/integration/inspektor-gadget/run_trace_sni_test.go
@@ -70,7 +70,7 @@ func runTraceSni(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceSniCmd,
 		BusyboxPodRepeatCommand(ns, "setuidgid 1000:1111 wget --no-check-certificate -T 2 -q -O /dev/null https://inspektor-gadget.io"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -84,14 +84,14 @@ func TestRunTraceSni(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/run_trace_tcp_test.go
+++ b/integration/inspektor-gadget/run_trace_tcp_test.go
@@ -73,7 +73,7 @@ func runTraceTcp(t *testing.T, ns string, cmd string) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceTcpCmd,
 		// TODO: can't use setuidgid because it's not available on the nginx image
 		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
@@ -88,14 +88,14 @@ func TestRunTraceTcp(t *testing.T) {
 
 	t.Parallel()
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 	}
 
 	RunTestSteps(commandsPreTest, t)
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))

--- a/integration/inspektor-gadget/script_test.go
+++ b/integration/inspektor-gadget/script_test.go
@@ -39,7 +39,7 @@ func TestScript(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceOpenCmd,
 		BusyboxPodRepeatCommand(ns, "nc -l 127.0.0.1 -p 9090 -w 1"),

--- a/integration/inspektor-gadget/snapshot_process_test.go
+++ b/integration/inspektor-gadget/snapshot_process_test.go
@@ -31,7 +31,7 @@ func TestSnapshotProcess(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "nc -l -p 9090"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -39,7 +39,7 @@ func TestSnapshotProcess(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -47,8 +47,8 @@ func TestSnapshotProcess(t *testing.T) {
 
 	nodeName := GetPodNode(t, ns, "test-pod")
 
-	commands := []*Command{
-		{
+	commands := []TestStep{
+		&Command{
 			Name: "RunProcessCollectorGadget",
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET snapshot process -n %s -o json --node %s", ns, nodeName),
 			ValidateOutput: func(t *testing.T, output string) {

--- a/integration/inspektor-gadget/snapshot_socket_test.go
+++ b/integration/inspektor-gadget/snapshot_socket_test.go
@@ -35,7 +35,7 @@ func TestSnapshotSocket(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodCommand(ns, "nc -l 0.0.0.0 -p 9090"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -43,7 +43,7 @@ func TestSnapshotSocket(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -51,8 +51,8 @@ func TestSnapshotSocket(t *testing.T) {
 
 	nodeName := GetPodNode(t, ns, "test-pod")
 
-	commands := []*Command{
-		{
+	commands := []TestStep{
+		&Command{
 			Name: "RunSnapshotSocketGadget",
 			Cmd:  fmt.Sprintf("$KUBECTL_GADGET snapshot socket -n %s -o json --node %s", ns, nodeName),
 			ValidateOutput: func(t *testing.T, output string) {

--- a/integration/inspektor-gadget/top_blockio_test.go
+++ b/integration/inspektor-gadget/top_blockio_test.go
@@ -82,7 +82,7 @@ func TestTopBlockIO(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodRepeatCommand(ns, "dd if=/dev/zero of=/tmp/test count=4096"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -90,7 +90,7 @@ func TestTopBlockIO(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -101,7 +101,7 @@ func TestTopBlockIO(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top block-io -n %s -o json", ns)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, true, isDockerRuntime)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestTopBlockIO(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top block-io -n %s -o json --timeout %d", ns, topTimeoutInSeconds)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -117,6 +117,6 @@ func TestTopBlockIO(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top block-io -n %s -o json --timeout %d --interval %d", ns, topTimeoutInSeconds, topTimeoutInSeconds)
 		topBlockIOCmd := newTopBlockIOCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topBlockIOCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/inspektor-gadget/top_ebpf_test.go
+++ b/integration/inspektor-gadget/top_ebpf_test.go
@@ -80,7 +80,7 @@ func TestTopEbpf(t *testing.T) {
 
 		cmd := "$KUBECTL_GADGET top ebpf -o json -m 100"
 		topEbpfCmd := newTopEbpfCmd(cmd, true)
-		RunTestSteps([]*Command{topEbpfCmd}, t)
+		RunTestSteps([]TestStep{topEbpfCmd}, t)
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestTopEbpf(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top ebpf -o json -m 999 --timeout %d", topTimeoutInSeconds)
 		topEbpfCmd := newTopEbpfCmd(cmd, false)
-		RunTestSteps([]*Command{topEbpfCmd}, t)
+		RunTestSteps([]TestStep{topEbpfCmd}, t)
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -96,6 +96,6 @@ func TestTopEbpf(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top ebpf -o json -m 999 --timeout %d --interval %d", topTimeoutInSeconds, topTimeoutInSeconds)
 		topEbpfCmd := newTopEbpfCmd(cmd, false)
-		RunTestSteps([]*Command{topEbpfCmd}, t)
+		RunTestSteps([]TestStep{topEbpfCmd}, t)
 	})
 }

--- a/integration/inspektor-gadget/top_file_test.go
+++ b/integration/inspektor-gadget/top_file_test.go
@@ -65,7 +65,7 @@ func TestTopFile(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		BusyboxPodRepeatCommand(ns, "echo date >> /tmp/date.txt"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -73,7 +73,7 @@ func TestTopFile(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -84,7 +84,7 @@ func TestTopFile(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top file -n %s --sort \"-writes\" -o json", ns)
 		topFileCmd := newTopFileCmd(ns, cmd, true, isDockerRuntime)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestTopFile(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top file -n %s --sort \"-writes\" -o json --timeout %d", ns, topTimeoutInSeconds)
 		topFileCmd := newTopFileCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -100,6 +100,6 @@ func TestTopFile(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top file -n %s --sort \"-writes\" -o json --timeout %d --interval %d", ns, topTimeoutInSeconds, topTimeoutInSeconds)
 		topFileCmd := newTopFileCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topFileCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/inspektor-gadget/top_tcp_test.go
+++ b/integration/inspektor-gadget/top_tcp_test.go
@@ -79,7 +79,7 @@ func TestTopTcp(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
 		WaitUntilTestPodReadyCommand(ns),
@@ -87,7 +87,7 @@ func TestTopTcp(t *testing.T) {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commandsPostTest := []*Command{
+		commandsPostTest := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commandsPostTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -98,7 +98,7 @@ func TestTopTcp(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s -o json", ns)
 		topTCPCmd := newTopTCPCmd(ns, cmd, true, isDockerRuntime)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestTopTcp(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s -o json -m 100 --timeout %d", ns, topTimeoutInSeconds)
 		topTCPCmd := newTopTCPCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
 	t.Run("Interval=Timeout", func(t *testing.T) {
@@ -114,6 +114,6 @@ func TestTopTcp(t *testing.T) {
 
 		cmd := fmt.Sprintf("$KUBECTL_GADGET top tcp -n %s -o json -m 100 --timeout %d --interval %d", ns, topTimeoutInSeconds, topTimeoutInSeconds)
 		topTCPCmd := newTopTCPCmd(ns, cmd, false, isDockerRuntime)
-		RunTestSteps([]*Command{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+		RunTestSteps([]TestStep{topTCPCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 }

--- a/integration/inspektor-gadget/trace_bind_test.go
+++ b/integration/inspektor-gadget/trace_bind_test.go
@@ -65,7 +65,7 @@ func TestTraceBind(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceBindCmd,
 		BusyboxPodRepeatCommand(ns, "setuidgid 1000:1111 nc -l -p 9090 -w 1"),

--- a/integration/inspektor-gadget/trace_capabilities_test.go
+++ b/integration/inspektor-gadget/trace_capabilities_test.go
@@ -87,7 +87,7 @@ func TestTraceCapabilities(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceCapabilitiesCmd,
 		BusyboxPodRepeatCommand(ns, "nice -n -20 echo"),

--- a/integration/inspektor-gadget/trace_dns_test.go
+++ b/integration/inspektor-gadget/trace_dns_test.go
@@ -28,7 +28,7 @@ func newTraceDnsCmd(t *testing.T, ns string, dnsServerArgs string) *Command {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("dnstester", *dnsTesterImage, ns, `["/dnstester"]`, dnsServerArgs),
 		WaitUntilPodReadyCommand(ns, "dnstester"),
@@ -36,7 +36,7 @@ func newTraceDnsCmd(t *testing.T, ns string, dnsServerArgs string) *Command {
 	RunTestSteps(commandsPreTest, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 
 	t.Cleanup(func() {
-		commands := []*Command{
+		commands := []TestStep{
 			DeleteTestNamespaceCommand(ns),
 		}
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
@@ -49,7 +49,7 @@ func newTraceDnsCmd(t *testing.T, ns string, dnsServerArgs string) *Command {
 	}
 
 	// Start the busybox pod so that we can get the IP address of the pod.
-	commands := []*Command{
+	commands := []TestStep{
 		BusyboxPodRepeatCommand(ns, strings.Join(nslookupCmds, " ; ")),
 		WaitUntilTestPodReadyCommand(ns),
 	}
@@ -172,7 +172,7 @@ func TestTraceDns(t *testing.T) {
 	traceDNSCmd := newTraceDnsCmd(t, ns, "")
 
 	// Start the trace gadget and verify the output.
-	commands := []*Command{
+	commands := []TestStep{
 		traceDNSCmd,
 	}
 
@@ -187,7 +187,7 @@ func TestTraceDnsUncompress(t *testing.T) {
 	traceDNSCmd := newTraceDnsCmd(t, ns, "-uncompress")
 
 	// Start the trace gadget and verify the output.
-	commands := []*Command{
+	commands := []TestStep{
 		traceDNSCmd,
 	}
 

--- a/integration/inspektor-gadget/trace_exec_test.go
+++ b/integration/inspektor-gadget/trace_exec_test.go
@@ -100,7 +100,7 @@ func TestTraceExec(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceExecCmd,
 		// Give time to kubectl-gadget to start the tracer

--- a/integration/inspektor-gadget/trace_fsslower_test.go
+++ b/integration/inspektor-gadget/trace_fsslower_test.go
@@ -68,7 +68,7 @@ func TestTraceFsslower(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		fsslowerCmd,
 		BusyboxPodCommand(ns, "echo 'this is foo' > foo && while true; do cat foo && sleep 0.1; done"),

--- a/integration/inspektor-gadget/trace_mount_test.go
+++ b/integration/inspektor-gadget/trace_mount_test.go
@@ -68,7 +68,7 @@ func TestTraceMount(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceMountCmd,
 		BusyboxPodRepeatCommand(ns, "mount /mnt /mnt"),

--- a/integration/inspektor-gadget/trace_network_test.go
+++ b/integration/inspektor-gadget/trace_network_test.go
@@ -36,7 +36,7 @@ func TestTraceNetwork(t *testing.T) {
 	// TODO: Handle it once we support getting container image name from docker
 	isDockerRuntime := IsDockerRuntime(t)
 
-	commandsPreTest := []*Command{
+	commandsPreTest := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		PodCommand("nginx-pod", "nginx", ns, "", ""),
 		WaitUntilPodReadyCommand(ns, "nginx-pod"),
@@ -136,7 +136,7 @@ func TestTraceNetwork(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		traceNetworkCmd,
 		BusyboxPodRepeatCommand(ns, fmt.Sprintf("wget -q -O /dev/null %s:80", nginxIP)),
 		WaitUntilTestPodReadyCommand(ns),

--- a/integration/inspektor-gadget/trace_oomkill_test.go
+++ b/integration/inspektor-gadget/trace_oomkill_test.go
@@ -86,10 +86,10 @@ spec:
     - while true; do tail /dev/zero; done
 `, ns)
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceOomkillCmd,
-		{
+		&Command{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),
 			ExpectedRegexp: "pod/test-pod created",

--- a/integration/inspektor-gadget/trace_open_test.go
+++ b/integration/inspektor-gadget/trace_open_test.go
@@ -67,7 +67,7 @@ func TestTraceOpen(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceOpenCmd,
 		BusyboxPodRepeatCommand(ns, "setuidgid 1000:1111 cat /dev/null"),

--- a/integration/inspektor-gadget/trace_signal_test.go
+++ b/integration/inspektor-gadget/trace_signal_test.go
@@ -61,7 +61,7 @@ func TestTraceSignal(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceSignalCmd,
 		BusyboxPodRepeatCommand(ns, "sleep 3 & kill $!"),

--- a/integration/inspektor-gadget/trace_sni_test.go
+++ b/integration/inspektor-gadget/trace_sni_test.go
@@ -63,7 +63,7 @@ func TestTraceSni(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceSniCmd,
 		BusyboxPodRepeatCommand(ns, "setuidgid 1000:1111 wget --no-check-certificate -T 2 -q -O /dev/null https://inspektor-gadget.io"),

--- a/integration/inspektor-gadget/trace_tcp_test.go
+++ b/integration/inspektor-gadget/trace_tcp_test.go
@@ -79,7 +79,7 @@ func TestTraceTcp(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceTCPCmd,
 		// TODO: can't use setuidgid because it's not available on the nginx image

--- a/integration/inspektor-gadget/trace_tcpconnect_test.go
+++ b/integration/inspektor-gadget/trace_tcpconnect_test.go
@@ -75,7 +75,7 @@ func TestTraceTcpconnect(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceTcpconnectCmd,
 		PodCommand("test-pod", "nginx", ns, "[sh, -c]", "nginx && while true; do curl 127.0.0.1; sleep 0.1; done"),
@@ -143,7 +143,7 @@ func TestTraceTcpconnect_latency(t *testing.T) {
 		},
 	}
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
 		traceTcpconnectCmd,
 		// TODO: can't use setuidgid because it's not available on the nginx image

--- a/integration/inspektor-gadget/traceloop_test.go
+++ b/integration/inspektor-gadget/traceloop_test.go
@@ -26,45 +26,45 @@ func TestTraceloop(t *testing.T) {
 
 	t.Parallel()
 
-	commands := []*Command{
+	commands := []TestStep{
 		CreateTestNamespaceCommand(ns),
-		{
+		&Command{
 			Name: "StartTraceloopGadget",
 			Cmd:  "$KUBECTL_GADGET traceloop start",
 		},
-		{
+		&Command{
 			Name: "WaitForTraceloopStarted",
 			Cmd:  "sleep 15",
 		},
-		{
+		&Command{
 			Name: "RunTraceloopTestPod",
 			Cmd:  fmt.Sprintf("kubectl run --restart=Never -n %s --image=busybox multiplication -- sh -c 'RANDOM=output ; echo \"3*7*2\" | bc > /tmp/file-$RANDOM ; sleep infinity'", ns),
 		},
-		{
+		&Command{
 			Name: "WaitForTraceloopTestPod",
 			Cmd:  fmt.Sprintf("sleep 5 ; kubectl wait -n %s --for=condition=ready pod/multiplication ; kubectl get pod -n %s ; sleep 2", ns, ns),
 		},
-		{
+		&Command{
 			Name:           "CheckTraceloopList",
 			Cmd:            "sleep 20; $KUBECTL_GADGET traceloop list | grep multiplication",
 			ExpectedRegexp: "multiplication",
 		},
-		{
+		&Command{
 			Name:           "CheckTraceloopShow",
 			Cmd:            "CONTAINER_ID=$($KUBECTL_GADGET traceloop list | grep multiplication | awk '{ print $5 }'); $KUBECTL_GADGET traceloop show $CONTAINER_ID | grep -C 5 write",
 			ExpectedRegexp: `bc\s+write\s+fd=\d+,\s+buf="42`,
 		},
-		{
+		&Command{
 			Name:    "PrintTraceloopList",
 			Cmd:     "$KUBECTL_GADGET traceloop list",
 			Cleanup: true,
 		},
-		{
+		&Command{
 			Name:    "StopTraceloopGadget",
 			Cmd:     "$KUBECTL_GADGET traceloop stop",
 			Cleanup: true,
 		},
-		{
+		&Command{
 			Name:    "WaitForTraceloopStopped",
 			Cmd:     "sleep 15",
 			Cleanup: true,

--- a/integration/teststeps.go
+++ b/integration/teststeps.go
@@ -61,7 +61,7 @@ func WithCbBeforeCleanup(f func(t *testing.T)) func(opts *runTestStepsOpts) {
 // RunTestSteps is used to run a list of test steps with stopping/clean up logic.
 // executeBeforeCleanup is executed before calling the cleanup functions, it can be use for instance
 // to print extra logs when the test fails.
-func RunTestSteps[S TestStep](steps []S, t *testing.T, options ...Option) {
+func RunTestSteps(steps []TestStep, t *testing.T, options ...Option) {
 	opts := &runTestStepsOpts{}
 
 	for _, option := range options {


### PR DESCRIPTION
# Use interface type instead of type parameter in integration tests

The `RunTestSteps()` can perfectly work using interfaces instead of type parameters. This change makes the code more readable and easier to understand. Additionally, as suggested by the official Go blog post [1]: "_Don’t use type parameters if method implementations differ_", and in this case, the implementation of `TestStep`'s methods is completely different between `integration.Command` and `testutils.ContainerdContainer` or `testutils.DockerContainer`. The blog post also states "_using a type parameter will generally not be faster than using an interface type_". So, another reason to not use type parameters in this case.

[1] https://blog.golang.org/generics-next-step

## Testing done

Integration tests continue working 🙂 