### PR TITLE
integration: IntegrationTestsContainer interface is not necessary

### DIFF
--- a/integration/container_interface.go
+++ b/integration/container_interface.go
@@ -16,23 +16,13 @@ package integration
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type ContainerFactory interface {
-	NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer
-}
-
-type IntegrationTestsContainer interface {
-	Run(t *testing.T)
-	Start(t *testing.T)
-	Stop(t *testing.T)
-	IsCleanup() bool
-	IsStartAndStop() bool
-	Running() bool
+	NewContainer(name, cmd string, opts ...containerOption) TestStep
 }
 
 func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {

--- a/integration/containerd.go
+++ b/integration/containerd.go
@@ -22,7 +22,7 @@ import (
 
 type ContainerdManager struct{}
 
-func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer {
+func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) TestStep {
 	c := &ContainerdContainer{}
 
 	for _, o := range opts {

--- a/integration/docker.go
+++ b/integration/docker.go
@@ -22,7 +22,7 @@ import (
 
 type DockerManager struct{}
 
-func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) IntegrationTestsContainer {
+func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) TestStep {
 	c := &DockerContainer{}
 
 	for _, o := range opts {


### PR DESCRIPTION
# IntegrationTestsContainer interface is not necessary

`IntegrationTestsContainer` defines what a container struct must implement so that it can be run by `RunTestSteps`. However, it's exactly what `TestStep` also does.
