### PR TITLE
README.md: update artifacthub badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Inspektor Gadget Test Reports](https://img.shields.io/badge/Link-Test%20Reports-blue)](https://inspektor-gadget.github.io/ig-test-reports)
 [![Inspektor Gadget Benchmarks](https://img.shields.io/badge/Link-Benchmarks-blue)](https://inspektor-gadget.github.io/ig-benchmarks/dev/bench)
 [![Release](https://img.shields.io/github/v/release/inspektor-gadget/inspektor-gadget)](https://github.com/inspektor-gadget/inspektor-gadget/releases)
-[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)
+[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=gadgets)
 [![Artifact Hub: Helm charts](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helm-charts)](https://artifacthub.io/packages/helm/gadget/gadget)
 [![Slack](https://img.shields.io/badge/slack-%23inspektor--gadget-brightgreen.svg?logo=slack)](https://kubernetes.slack.com/messages/inspektor-gadget/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Inspektor Gadget Benchmarks](https://img.shields.io/badge/Link-Benchmarks-blue)](https://inspektor-gadget.github.io/ig-benchmarks/dev/bench)
 [![Release](https://img.shields.io/github/v/release/inspektor-gadget/inspektor-gadget)](https://github.com/inspektor-gadget/inspektor-gadget/releases)
 [![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadget)](https://artifacthub.io/packages/search?repo=gadget)
+[![Artifact Hub: Helm charts](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helm-charts)](https://artifacthub.io/packages/helm/gadget/gadget)
 [![Slack](https://img.shields.io/badge/slack-%23inspektor--gadget-brightgreen.svg?logo=slack)](https://kubernetes.slack.com/messages/inspektor-gadget/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/LICENSE)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/LICENSE-bpf.txt)

--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -23,7 +23,7 @@ repository](https://github.com/inspektor-gadget/gadget-template). This is a
 
 You can also look for examples in gadgets published on Artifact Hub:
 
-[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=inspektor-gadgets)
+[![Artifact Hub: Gadgets](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gadgets)](https://artifacthub.io/packages/search?repo=gadgets)
 
 ## Starting from scratch
 


### PR DESCRIPTION
Two changes:
1. Update the label to: "Helm charts"
2. Update the link to the URL of the Helm chart instead of the search webpage.

Note that the URL still contains "gadget". We are looking to change it to "inspektor-gadget" but at the moment it is linked to the chart name and renaming it would break the updates for users.

See related discussion in:
* https://github.com/inspektor-gadget/inspektor-gadget/pull/2586#discussion_r1526560343

Before this patch:

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/27575/ff891b4d-4627-429d-b994-b2583eba2261)

After this patch:

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/27575/148ded7d-04d4-467e-bf00-5407e72315bb)



cc @mqasimsarfraz @eiffel-fl 
