### PR TITLE
[CI] integration: Increase pod and job wait timeout to 45s

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -665,7 +665,7 @@ func DeleteRemainingNamespacesCommand() *Command {
 func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
 	return &Command{
 		Name:           fmt.Sprintf("WaitForJob: %s", jobname),
-		Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete -n %s %s", namespace, jobname),
+		Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete --timeout 45s -n %s %s", namespace, jobname),
 		ExpectedString: fmt.Sprintf("job.batch/%s condition met\n", jobname),
 	}
 }
@@ -675,7 +675,7 @@ func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
 func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 	return &Command{
 		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", namespace, podname),
+		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready --timeout 45s -n %s %s", namespace, podname),
 		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
 	}
 }


### PR DESCRIPTION
# integration: Increase pod and job ready timeout to 45s

We get CI test failures because of timeouts and therefore we could maybe wait an extra 15s ([The default timeout is 30s](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_wait/))

- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8448407680/job/23142053593#step:11:2168
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8448407680/job/23142052066 (Log too long for direct link to line
   ```
   2024-03-27T08:52:39.6903877Z === NAME  TestTraceOOMKill
   2024-03-27T08:52:39.6904729Z     command.go:483: Command returned(WaitForTestPod):
   2024-03-27T08:52:39.6905683Z         error: timed out waiting for the condition on pods/test-pod
   ```
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8359069409/job/22881852532#step:7:2759
