### PR TITLE
re-add support for jsonpretty + yaml to image based gadgets

### DIFF
--- a/pkg/datasource/formatters/json/json.go
+++ b/pkg/datasource/formatters/json/json.go
@@ -17,7 +17,9 @@ package json
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 	_ "unsafe"
 
@@ -115,6 +117,12 @@ func (f *Formatter) addSubFields(accessors []datasource.FieldAccessor, prefix st
 	}
 
 	ctr := -1
+
+	// sort lexicographically
+	slices.SortFunc(accessors, func(i datasource.FieldAccessor, j datasource.FieldAccessor) int {
+		return strings.Compare(i.Name(), j.Name())
+	})
+
 	for _, acc := range accessors {
 		accessor := acc
 

--- a/pkg/datasource/formatters/json/options.go
+++ b/pkg/datasource/formatters/json/options.go
@@ -37,3 +37,10 @@ func WithShowAll(val bool) Option {
 		formatter.useDefault = true
 	}
 }
+
+func WithPretty(val bool, indent string) Option {
+	return func(formatter *Formatter) {
+		formatter.pretty = val
+		formatter.indent = indent
+	}
+}


### PR DESCRIPTION
This adds the missing `jsonpretty` and `yaml` output modes to the cli operator. Currently (as was with the previous
run gadget), YAML is handled by first marshaling to JSON and then converting, which is quite slow. We can later
on add an optimized YAML formatter that will handle marshaling directly.

This also sorts fields alphabetically.

```
$ ./ig run "ghcr.io/inspektor-gadget/gadget/trace_exec:latest" -o jsonpretty
INFO[0000] Experimental features enabled
{
  "args": "/opt/cni/bin/bridge",
  "args_count": 1,
  "args_size": 20,
  "comm": "bridge",
  "gid": 0,
  "k8s": {
    "container": "",
    "hostnetwork": false,
    "namespace": "",
    "node": "",
    "pod": ""
  },
  "loginuid": 4294967295,
  "mntns_id": 4026532263,
  "pid": 1475846,
  "ppid": 8590,
  "retval": 0,
  "runtime": {
    "containerId": "e127eea07a1ecd3d8a75515486c31fa6f685fd0ad7d98a598ac3ea70db0d4ed4",
    "containerImageDigest": "",
    "containerImageName": "gcr.io/k8s-minikube/kicbase:v0.0.40",
    "containerName": "minikube",
    "runtimeName": "docker"
  },
  "sessionid": 4294967295,
  "timestamp": "2024-03-27T23:41:35.264215823+01:00",
  "uid": 0,
  "upper_layer": false
}
...
```