### PR TITLE
pkg/uprobetracer: add support for USDT tracepoints

### DIFF
--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -53,10 +53,15 @@ Programs must return `TC_ACT_UNSPEC` in order to allow the packet to be processe
 The order of execution of the programs is not deterministic, this is something we could visit later
 on.
 
-### Uprobes / Uretprobes (experimental)
+### Uprobes / Uretprobes
 
 The section name must use the `<prog_type>/<file_path>:<symbol>` format.
 `<prog_type>` must be either `uprobe` or `uretprobe`.
 `<file_path>` is the absolute path of an executable or a library, that the uprobe will be attached to.
 For common libraries, `<file_path>` can also be the library's name, such as `libc`.
 `<symbol>` is a debugging symbol that can be found in the file mentioned above.
+
+### User-Level Statically Defined Tracing (USDT)
+The section name must use the `usdt/<file_path>:<providerName>:<probeName>` format.
+`<file_path>` can be either an absolute path or a library name, same as the field in Uprobe.
+`<providerName>` and `<probeName>` are two fields that can jointly identify a USDT trace point.

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -45,13 +45,16 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 			i.logger.Debugf("Attaching kretprobe %q to %q", p.Name, p.AttachTo)
 			return link.Kretprobe(p.AttachTo, prog, nil)
 		case strings.HasPrefix(p.SectionName, "uprobe/") ||
-			strings.HasPrefix(p.SectionName, "uretprobe/"):
+			strings.HasPrefix(p.SectionName, "uretprobe/") ||
+			strings.HasPrefix(p.SectionName, "usdt/"):
 			uprobeTracer := i.uprobeTracers[p.Name]
 			switch strings.Split(p.SectionName, "/")[0] {
 			case "uprobe":
 				return nil, uprobeTracer.AttachProg(p.Name, uprobetracer.ProgUprobe, p.AttachTo, prog)
 			case "uretprobe":
 				return nil, uprobeTracer.AttachProg(p.Name, uprobetracer.ProgUretprobe, p.AttachTo, prog)
+			case "usdt":
+				return nil, uprobeTracer.AttachProg(p.Name, uprobetracer.ProgUSDT, p.AttachTo, prog)
 			}
 		}
 		return nil, fmt.Errorf("unsupported section name %q for program %q", p.SectionName, p.Name)

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -376,7 +376,8 @@ func (i *ebpfInstance) Prepare(gadgetCtx operators.GadgetContext) error {
 		switch p.Type {
 		case ebpf.Kprobe:
 			if strings.HasPrefix(p.SectionName, "uprobe/") ||
-				strings.HasPrefix(p.SectionName, "uretprobe/") {
+				strings.HasPrefix(p.SectionName, "uretprobe/") ||
+				strings.HasPrefix(p.SectionName, "usdt/") {
 				uprobeTracer, err := uprobetracer.NewTracer[api.GadgetData](gadgetCtx.Logger())
 				if err != nil {
 					i.Close()

--- a/pkg/uprobetracer/bytes.go
+++ b/pkg/uprobetracer/bytes.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package uprobetracer
 
 import (

--- a/pkg/uprobetracer/bytes.go
+++ b/pkg/uprobetracer/bytes.go
@@ -1,0 +1,31 @@
+package uprobetracer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"unsafe"
+)
+
+func readFromBytes[T any](obj *T, rawData []byte) error {
+	if int(unsafe.Sizeof(*obj)) != len(rawData) {
+		return errors.New("reading from bytes: length mismatched")
+	}
+	buffer := bytes.NewBuffer(rawData)
+	err := binary.Read(buffer, binary.NativeEndian, obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func readStringFromBytes(data []byte, startPos uint32) string {
+	res := ""
+	for i := startPos; i < uint32(len(data)); i++ {
+		if data[i] == 0 {
+			return res
+		}
+		res += string(data[i])
+	}
+	return ""
+}

--- a/pkg/uprobetracer/ldcache_parser.go
+++ b/pkg/uprobetracer/ldcache_parser.go
@@ -16,7 +16,6 @@ package uprobetracer
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -64,29 +63,6 @@ const (
 type ldEntry struct {
 	Key   string
 	Value string
-}
-
-func readFromBytes[T any](obj *T, rawData []byte) error {
-	if int(unsafe.Sizeof(*obj)) != len(rawData) {
-		return errors.New("reading from bytes: length mismatched")
-	}
-	buffer := bytes.NewBuffer(rawData)
-	err := binary.Read(buffer, binary.NativeEndian, obj)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func readStringFromBytes(data []byte, startPos uint32) string {
-	res := ""
-	for i := startPos; i < uint32(len(data)); i++ {
-		if data[i] == 0 {
-			return res
-		}
-		res += string(data[i])
-	}
-	return ""
 }
 
 func readCacheFormat1(data []byte) []ldEntry {

--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package uprobetracer handles how uprobe/uretprobe programs are attached
+// Package uprobetracer handles how uprobe/uretprobe/USDT programs are attached
 // to containers. It has two running modes: `pending` mode and `running` mode.
 //
 // Before `AttachProg` is called, uprobetracer runs in `pending` mode, only
@@ -55,6 +55,7 @@ type ProgType uint32
 const (
 	ProgUprobe ProgType = iota
 	ProgUretprobe
+	ProgUSDT
 )
 
 type inodeUUID struct {
@@ -118,7 +119,7 @@ func NewTracer[Event any](logger logger.Logger) (*Tracer[Event], error) {
 
 // AttachProg loads the ebpf program, and try attaching if there are pending containers
 func (t *Tracer[Event]) AttachProg(progName string, progType ProgType, attachTo string, prog *ebpf.Program) error {
-	if progType != ProgUprobe && progType != ProgUretprobe {
+	if progType != ProgUprobe && progType != ProgUretprobe && progType != ProgUSDT {
 		return fmt.Errorf("unsupported uprobe prog type: %q", progType)
 	}
 
@@ -129,12 +130,15 @@ func (t *Tracer[Event]) AttachProg(progName string, progType ProgType, attachTo 
 		return errors.New("loading uprobe program twice")
 	}
 
-	parts := strings.Split(attachTo, ":")
+	parts := strings.SplitN(attachTo, ":", 2)
 	if len(parts) < 2 {
 		return fmt.Errorf("invalid section name %q", attachTo)
 	}
 	if !filepath.IsAbs(parts[0]) && strings.Contains(parts[0], "/") {
 		return fmt.Errorf("section name must be either an absolute path or a library name: %q", parts[0])
+	}
+	if progType == ProgUSDT && len(strings.Split(parts[1], ":")) != 2 {
+		return fmt.Errorf("invalid USDT section name: %q", attachTo)
 	}
 
 	t.mu.Lock()
@@ -180,7 +184,7 @@ func (t *Tracer[Event]) searchForLibrary(containerPid uint32) ([]string, error) 
 	for _, targetPath := range targetPaths {
 		securedTargetPath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), targetPath)
 		if err != nil {
-			t.logger.Debugf("path %q in ld cache is not available: %q", filePath, err.Error())
+			t.logger.Debugf("path %q in ld cache is not available: %s", filePath, err.Error())
 			continue
 		}
 		securedTargetPaths = append(securedTargetPaths, securedTargetPath)
@@ -200,6 +204,16 @@ func (t *Tracer[Event]) attachUprobe(file *os.File) (link.Link, error) {
 		return ex.Uprobe(t.attachSymbol, t.prog, nil)
 	case ProgUretprobe:
 		return ex.Uretprobe(t.attachSymbol, t.prog, nil)
+	case ProgUSDT:
+		attachInfo, err := getUsdtInfo(attachPath, t.attachSymbol)
+		if err != nil {
+			return nil, fmt.Errorf("reading USDT metadata: %w", err)
+		}
+		return ex.Uprobe(t.attachSymbol, t.prog,
+			&link.UprobeOptions{
+				Address:      attachInfo.attachAddress,
+				RefCtrOffset: attachInfo.semaphoreAddress,
+			})
 	default:
 		return nil, fmt.Errorf("attaching to inode: unsupported prog type: %q", t.progType)
 	}
@@ -210,7 +224,7 @@ func (t *Tracer[Event]) attach(containerPid uint32) {
 	var attachedUUIDs []inodeUUID
 	attachFilePaths, err := t.searchForLibrary(containerPid)
 	if err != nil {
-		t.logger.Debugf("attaching to container %d: %q", containerPid, err.Error())
+		t.logger.Debugf("attaching to container %d: %s", containerPid, err.Error())
 	}
 
 	if len(attachFilePaths) == 0 {
@@ -220,22 +234,25 @@ func (t *Tracer[Event]) attach(containerPid uint32) {
 	for _, filePath := range attachFilePaths {
 		file, err := os.OpenFile(filePath, unix.O_PATH, 0)
 		if err != nil {
-			t.logger.Debugf("opening file '%q' for uprobe: %q", filePath, err.Error())
+			t.logger.Debugf("opening file '%q' for uprobe: %s", filePath, err.Error())
 			continue
 		}
 		fileUUID, err := getInodeUUID(file)
 		if err != nil {
-			t.logger.Debugf("getting inode info for '%q': %q", filePath, err.Error())
+			t.logger.Debugf("getting inode info for '%q': %s", filePath, err.Error())
 			file.Close()
 			continue
 		}
 
-		t.logger.Debugf("attaching uprobe %q to container %d: %q", t.attachSymbol, containerPid, filePath)
+		t.logger.Debugf("attaching uprobe %q to container %d: %q", t.progName, containerPid, filePath)
 		attachedUUIDs = append(attachedUUIDs, fileUUID)
 
 		inode, exists := t.inodeRefCount[fileUUID]
 		if !exists {
-			progLink, _ := t.attachUprobe(file)
+			progLink, err := t.attachUprobe(file)
+			if err != nil {
+				t.logger.Debugf("failed to attach uprobe %q: %s", t.progName, err.Error())
+			}
 			t.inodeRefCount[fileUUID] = &inodeKeeper{1, file, progLink}
 		} else {
 			inode.counter++

--- a/pkg/uprobetracer/usdt.go
+++ b/pkg/uprobetracer/usdt.go
@@ -1,0 +1,161 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uprobetracer
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// For details regarding the data format of USDT notes, please refer to:
+// https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation
+const (
+	sdtNoteSectionName = ".note.stapsdt"
+	sdtBaseSectionName = ".stapsdt.base"
+)
+
+type noteHeader struct {
+	NameSize uint32
+	DescSize uint32
+	Type     uint32
+}
+
+type usdtAttachInfo struct {
+	attachAddress    uint64
+	semaphoreAddress uint64
+}
+
+func vaddr2ElfOffset(f *elf.File, addr uint64) (uint64, error) {
+	for _, prog := range f.Progs {
+		if prog.Vaddr <= addr && addr < (prog.Vaddr+prog.Memsz) {
+			return addr - prog.Vaddr + prog.Off, nil
+		}
+	}
+	return 0, fmt.Errorf("malformed elf file: elf prog containing addr %x not found", addr)
+}
+
+func alignUp[T int | int32 | int64 | uint | uint32 | uint64](n T, align T) T {
+	return (n + align - 1) / align * align
+}
+
+func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) {
+	parts := strings.Split(attachSymbol, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid USDT section name: %q", attachSymbol)
+	}
+	providerName := parts[0]
+	probeName := parts[1]
+
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %q: %w", filepath, err)
+	}
+	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stating file %q: %w", filepath, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("ELF file %q is not regular", filepath)
+	}
+
+	elfReader, err := elf.NewFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("reading elf file %q: %w", filepath, err)
+	}
+	defer elfReader.Close()
+
+	noteSection := elfReader.Section(sdtNoteSectionName)
+	if noteSection == nil {
+		return nil, errors.New("USDT note section does not exist")
+	}
+	if noteSection.Type != elf.SHT_NOTE {
+		return nil, fmt.Errorf("section %q is not a note", sdtNoteSectionName)
+	}
+	notesReader := noteSection.Open()
+
+	baseSection := elfReader.Section(sdtBaseSectionName)
+	if baseSection == nil {
+		return nil, errors.New("USDT base section does not exist")
+	}
+	if baseSection.Type != elf.SHT_PROGBITS {
+		return nil, fmt.Errorf("%q is not a program defined section", sdtBaseSectionName)
+	}
+
+	wordSize := 4
+	if elfReader.Class == elf.ELFCLASS64 {
+		wordSize = 8
+	}
+
+	// walk through USDT notes, and match with providerName and probeName
+	// For details of the structure of ELF notes, please refer to
+	// https://man7.org/linux/man-pages/man5/elf.5.html, the `Notes (Nhdr)` section
+	for {
+		var header noteHeader
+		err = binary.Read(notesReader, elfReader.ByteOrder, &header)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("reading USDT note header: %w", err)
+		}
+
+		name := make([]byte, alignUp(uint64(header.NameSize), 4))
+		err = binary.Read(notesReader, elfReader.ByteOrder, &name)
+		if err != nil {
+			return nil, fmt.Errorf("reading USDT note name: %w", err)
+		}
+
+		desc := make([]byte, alignUp(uint64(header.DescSize), 4))
+		err = binary.Read(notesReader, elfReader.ByteOrder, &desc)
+		if err != nil {
+			return nil, fmt.Errorf("reading USDT note desc: %w", err)
+		}
+
+		if string(name) != "stapsdt\x00" || header.Type != 3 {
+			continue
+		}
+
+		elfLocation := elfReader.ByteOrder.Uint64(desc[:wordSize])
+		elfBase := elfReader.ByteOrder.Uint64(desc[wordSize : 2*wordSize])
+		elfSemaphore := elfReader.ByteOrder.Uint64(desc[2*wordSize : 3*wordSize])
+
+		diff := baseSection.Addr - elfBase
+		location, err := vaddr2ElfOffset(elfReader, elfLocation+diff)
+		if err != nil {
+			return nil, err
+		}
+
+		if elfSemaphore != 0 {
+			elfSemaphore, err = vaddr2ElfOffset(elfReader, elfSemaphore+diff)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		provider := readStringFromBytes(desc, uint32(3*wordSize))
+		probe := readStringFromBytes(desc, uint32(3*wordSize+len(provider)+1))
+		if provider == providerName && probe == probeName {
+			return &usdtAttachInfo{location, elfSemaphore}, nil
+		}
+	}
+	return nil, errors.New("no matching USDT metadata")
+}


### PR DESCRIPTION
# pkg/uprobetracer: add support for USDT tracepoints

Added USDT support for uprobe ebpf programs.
A parser for USDT elf notes is included.
Docs are updated.

## How to use

Use `usdt/<programPath or libraryName>:<providerName>:<probeName>` as the section name of ebpf file.

## Testing

Use `SEC("usdt//usr/bin/python3:python:function__entry")` and `SEC("usdt//usr/bin/python3:python:function__return")`.

Then run a python program inside the container:

```
from time import sleep

def f():
    print(123)

while True:
    f()
    sleep(1)
```
