### PR TITLE
docs: fix for release buffer error

### DIFF
--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -427,8 +427,10 @@ Inspektor Gadget to get the current mount namespace.
 Finally, we need to discard events we're not interested in:
 
 ```c
-	if (gadget_should_discard_mntns_id(event.mntns_id))
+	if (gadget_should_discard_mntns_id(event.mntns_id)) {
+		gadget_discard_buf(event);
 		return 0;
+	}
 ```
 
 The `gadget_should_discard_mntns_id` function is provided to determine if a given event should be


### PR DESCRIPTION
# Added call for gadget_discard_buf()

`gadget_discard_buf()` wasn't called for `if (gadget_should_discard_mntns_id(event.mntns_id)) return 0;`.
Giving error:
```
Error: running gadget: running gadget: install tracer: loading eBPF objects: create BPF collection: program enter_openat: load program: invalid argument: Unreleased reference id=2 alloc_insn=8 (63 line(s) omitted)
```