### PR TITLE
KubeInventoryCache: Keep old pods/svcs in a cached for enrichment

### DIFF
--- a/pkg/operators/common/resource_cache_test.go
+++ b/pkg/operators/common/resource_cache_test.go
@@ -1,0 +1,209 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewResourceCache(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+	assert.Equal(t, 0, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	locked := cache.TryLock()
+	assert.True(t, locked)
+	if locked {
+		cache.Unlock()
+	}
+}
+
+func TestResourceCacheAdd(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+}
+
+func TestResourceCacheOverwrite(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	obj2 := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj2)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj2, *cache.current[key])
+}
+
+func TestResourceCacheRemove(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	cache.Remove(obj)
+	assert.Equal(t, 0, len(cache.current))
+	assert.Equal(t, 1, len(cache.old))
+	assert.Equal(t, *obj, *cache.old[key].obj)
+}
+
+func TestResourceCachePruneOldObjects(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	cache.Remove(obj)
+	assert.Equal(t, 0, len(cache.current))
+	assert.Equal(t, 1, len(cache.old))
+	assert.Equal(t, *obj, *cache.old[key].obj)
+
+	// Manually subtract the TTL from the timestamp
+	temp := cache.old[key]
+	temp.deletionTimestamp = temp.deletionTimestamp.Add(-oldObjectTTL)
+	cache.old[key] = temp
+	cache.PruneOldObjects()
+	assert.Equal(t, 0, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+}
+
+func TestResourceCacheToSlice(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	sliceFromCurrent := cache.ToSlice()
+	cache.Remove(obj)
+	sliceFromOld := cache.ToSlice()
+
+	// Manually subtract the TTL from the timestamp
+	temp := cache.old[key]
+	temp.deletionTimestamp = temp.deletionTimestamp.Add(-oldObjectTTL)
+	cache.old[key] = temp
+	cache.PruneOldObjects()
+
+	sliceAfterPrune := cache.ToSlice()
+
+	require.Equal(t, 1, len(sliceFromCurrent))
+	require.Equal(t, 1, len(sliceFromOld))
+	assert.Equal(t, *obj, *sliceFromCurrent[0])
+	assert.Equal(t, *obj, *sliceFromOld[0])
+	assert.Equal(t, 0, len(sliceAfterPrune))
+}
+
+func TestResourceCacheGet(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	objFromCache := cache.Get(key)
+	require.NotNil(t, objFromCache)
+	assert.Equal(t, *obj, *objFromCache)
+}
+
+func TestResourceCacheGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	obj := &metav1.ObjectMeta{Name: key}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	objFromCache := cache.Get("notfound")
+	assert.Nil(t, objFromCache)
+}
+
+func TestResourceCacheGetCmp(t *testing.T) {
+	t.Parallel()
+
+	cache := newResourceCache[metav1.ObjectMeta]()
+	require.NotNil(t, cache)
+
+	key := "key"
+	labelKey := "foo"
+	labelValue := "bar"
+	obj := &metav1.ObjectMeta{Name: key, Labels: map[string]string{labelKey: labelValue}}
+	cache.Add(obj)
+	assert.Equal(t, 1, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj, *cache.current[key])
+
+	key2 := "key2"
+	labelKey2 := "foo2"
+	labelValue2 := "bar2"
+	obj2 := &metav1.ObjectMeta{Name: key2, Labels: map[string]string{labelKey2: labelValue2}}
+	cache.Add(obj2)
+	assert.Equal(t, 2, len(cache.current))
+	assert.Equal(t, 0, len(cache.old))
+	assert.Equal(t, *obj2, *cache.current[key2])
+
+	objFromCache := cache.GetCmp(func(obj *metav1.ObjectMeta) bool {
+		return obj.Labels[labelKey] == labelValue
+	})
+	require.NotNil(t, objFromCache)
+	assert.Equal(t, *obj, *objFromCache)
+}

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -113,21 +113,19 @@ func (m *KubeNameResolverInstance) enrich(ev any) {
 	kubeNameResolver, _ := ev.(KubeNameResolverInterface)
 	containerInfo, _ := ev.(operators.ContainerInfoGetters)
 
-	for _, pod := range m.k8sInventory.GetPods() {
-		if pod.Namespace == containerInfo.GetNamespace() && pod.Name == containerInfo.GetPod() {
-			owner := ""
-			// When the pod belongs to Deployment, ReplicaSet or DaemonSet, find the
-			// shorter name without the random suffix. That will be used to
-			// generate the network policy name.
-			if pod.OwnerReferences != nil {
-				nameItems := strings.Split(pod.Name, "-")
-				if len(nameItems) > 2 {
-					owner = strings.Join(nameItems[:len(nameItems)-2], "-")
-				}
+	pod := m.k8sInventory.GetPodByName(containerInfo.GetNamespace(), containerInfo.GetPod())
+	if pod != nil {
+		owner := ""
+		// When the pod belongs to Deployment, ReplicaSet or DaemonSet, find the
+		// shorter name without the random suffix. That will be used to
+		// generate the network policy name.
+		if pod.OwnerReferences != nil {
+			nameItems := strings.Split(pod.Name, "-")
+			if len(nameItems) > 2 {
+				owner = strings.Join(nameItems[:len(nameItems)-2], "-")
 			}
-			kubeNameResolver.SetLocalPodDetails(owner, pod.Status.HostIP, pod.Status.PodIP, pod.Labels)
-			return
 		}
+		kubeNameResolver.SetLocalPodDetails(owner, pod.Status.HostIP, pod.Status.PodIP, pod.Labels)
 	}
 }
 

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
@@ -93,7 +91,7 @@ func (k *KubeNameResolver) Instantiate(gadgetCtx operators.GadgetContext, gadget
 
 type KubeNameResolverInstance struct {
 	gadgetCtx      operators.GadgetContext
-	k8sInventory   *common.K8sInventoryCache
+	k8sInventory   common.K8sInventoryCache
 	gadgetInstance any
 }
 
@@ -115,12 +113,7 @@ func (m *KubeNameResolverInstance) enrich(ev any) {
 	kubeNameResolver, _ := ev.(KubeNameResolverInterface)
 	containerInfo, _ := ev.(operators.ContainerInfoGetters)
 
-	pods, err := m.k8sInventory.GetPods()
-	if err != nil {
-		log.Warnf("getting pods from k8s inventory: %v", err)
-		return
-	}
-	for _, pod := range pods {
+	for _, pod := range m.k8sInventory.GetPods() {
 		if pod.Namespace == containerInfo.GetNamespace() && pod.Name == containerInfo.GetPod() {
 			owner := ""
 			// When the pod belongs to Deployment, ReplicaSet or DaemonSet, find the


### PR DESCRIPTION
# KubeInventoryCache: Keep old pods/svcs in a cached for enrichment

In order to always correctly enrich events we need to keep just deleted pods and services in a separate list.

1. The first commit introduces this mechanism with the disadvantage that for every event a copy of the pods list needs to be made
1. The second commit adds functions so the enricher query for specific pods directly. This solves the problem with the copy

## CI failure reasons
This PR should also solve quite a few of sporadic CI failures. The problem was with `TestAdviseNetworkpolicy`. Sometimes the last events were not enriched, but `advices network-policy report` expects it to be.
```
panic: unknown event

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/networkpolicy/advisor.(*NetworkPolicyAdvisor).eventToRule(_, {{{{{...}, {...}, {...}, {...}, {...}}, {{...}, {...}, 0x0}}, 0x17bebc30e004e04c, ...}, ...})
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/networkpolicy/advisor/advisor.go:218 +0x467
github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/networkpolicy/advisor.(*NetworkPolicyAdvisor).GeneratePolicies(0xc000621ab8)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/gadgets/advise/networkpolicy/advisor/advisor.go:338 +0x1145
github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise.runNetworkPolicyReport(0xc000138500?, {0x25d4669?, 0x4?, 0x25d4615?})
	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise/network-policy.go:134 +0xa5
github.com/spf13/cobra.(*Command).execute(0x441db40, {0xc000605320, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0x441be80)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
	/home/runner/work/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/main.go:143 +0xa78
```

## Reference to CI failures
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8435525185/job/23141683215
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8417172133/job/23045382049#step:6:1118
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8417172133/job/23045380018#step:9:1484
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8372146616/job/22922756710#step:11:2158
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8359069409/job/22881938033#step:9:1606
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8326739119/job/22783291719#step:11:1128