### PR TITLE
integration: Add timestamp to Run/Start/Stop

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -95,6 +95,10 @@ func GetSeed() int64 {
 	return seed
 }
 
+func (c *Command) DisplayName() string {
+	return c.Name
+}
+
 func (c *Command) IsCleanup() bool {
 	return c.Cleanup
 }

--- a/integration/teststeps.go
+++ b/integration/teststeps.go
@@ -24,6 +24,9 @@ const stepWaitDuration = 10 * time.Second
 // TestStep allows combining different steps (e.g command, container creation)
 // to allow simplified/consistent flow for tests via RunTestSteps
 type TestStep interface {
+	// DisplayName returns a short descriptive name for the step.
+	DisplayName() string
+
 	// Run runs the step and wait its completion.
 	Run(t *testing.T)
 
@@ -90,6 +93,7 @@ func RunTestSteps(steps []TestStep, t *testing.T, options ...Option) {
 				// Wait a bit before stopping the step.
 				time.Sleep(stepWaitDuration)
 				step.Stop(t)
+				t.Logf("[%s] Stopped %q\n", time.Now().UTC(), step.DisplayName())
 			}
 		}()
 	}
@@ -100,11 +104,13 @@ func RunTestSteps(steps []TestStep, t *testing.T, options ...Option) {
 			continue
 		}
 
+		t.Logf("[%s] Starting %q\n", time.Now().UTC(), step.DisplayName())
 		if step.IsStartAndStop() {
 			step.Start(t)
 			continue
 		}
 
 		step.Run(t)
+		t.Logf("[%s] Stopped %q\n", time.Now().UTC(), step.DisplayName())
 	}
 }

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -36,6 +36,7 @@ type containerSpec struct {
 }
 
 type Container interface {
+	DisplayName() string
 	Run(t *testing.T)
 	Start(t *testing.T)
 	Stop(t *testing.T)
@@ -59,6 +60,10 @@ func (c *containerSpec) Running() bool {
 
 func (c *containerSpec) PortBindings() nat.PortMap {
 	return c.portBindings
+}
+
+func (c *containerSpec) DisplayName() string {
+	return c.name + ": " + c.cmd
 }
 
 var SupportedContainerRuntimes = []types.RuntimeName{


### PR DESCRIPTION
# integration: Add timestamp to Run/Start/Stop

To better debug issues with the CI the timestamps of Run/Start/Stop could be useful. Any other suggestions is welcomed