### PR TITLE
charts: Add '/host/var' to volumeMounts

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -184,6 +184,9 @@ spec:
             - mountPath: /host/run
               name: run
               readOnly: true
+            - mountPath: /host/var
+              name: var
+              readOnly: true
             # WARNING Despite mounting host proc as readonly, it is possible to
             # write host file system using symlinks under /host/proc. The
             # following command, ran from gadget pod, will result in writing to
@@ -248,6 +251,11 @@ spec:
         - name: run
           hostPath:
             path: /run
+        # /var is needed by container-hook to fanoitfy mark certain directories
+        # e.g. needed in case of docker runtime on minikube (driver=kvm2)
+        - name: var
+          hostPath:
+            path: /var
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -261,6 +261,9 @@ spec:
             - mountPath: /host/run
               name: run
               readOnly: true
+            - mountPath: /host/var
+              name: var
+              readOnly: true
             # WARNING Despite mounting host proc as readonly, it is possible to
             # write host file system using symlinks under /host/proc. The
             # following command, ran from gadget pod, will result in writing to
@@ -317,6 +320,11 @@ spec:
         - name: run
           hostPath:
             path: /run
+        # /var is needed by container-hook to fanoitfy mark certain directories
+        # e.g. needed in case of docker runtime on minikube (driver=kvm2)
+        - name: var
+          hostPath:
+            path: /var
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup


### PR DESCRIPTION
While reducing coverage for '/host' we dropped '/host/var' as well but it turns out when running docker runtime in minikube with kvm2 driver we need this path. This change fixes it by mounting only the needed path.

Fixes: 2b437e17f4e94bd8fff48f3ec2226dadf6bf7a4e

## Testing done

### before

```
$ MINIKUBE_DRIVER=kvm2 make minikube-deploy
$ kubectl logs -n gadget -l k8s-app=gadget -f
$ kubectl create deploy test --image nginx
time="2024-03-28T11:43:01Z" level=error msg="error monitoring runtime instance: marking /host/var/run/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/5b4194d99b44c5298002e334c1b48ad814428262931e57a6e1983618e9b8de5e: fanotify: mark error, no such file or directory\n"
time="2024-03-28T11:43:17Z" level=error msg="error monitoring runtime instance: marking /host/var/run/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/9f1d1538ad6d2ebdbe4e789d33cd23cc7354035c8829682b1a646ebcf172af13: fanotify: mark error, no such file or directory\n"
time="2024-03-28T11:43:18Z" level=warning msg="container default/test-764c85dd84-lxd4k/nginx wasn't detected by the main hook! The fallback pod informer will add it."
```

### after

```
$ MINIKUBE_DRIVER=kvm2 make minikube-deploy
$ kubectl logs -n gadget -l k8s-app=gadget -f
$ kubectl create deploy test --image nginx
time="2024-03-28T17:10:39Z" level=info msg="gadget tracermgr set in kubemanager"
time="2024-03-28T17:10:39Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2024-03-28T17:10:40Z" level=info msg="Starting trace controller manager"
...
```