### PR TITLE
integration: Separate and simplify container-related stuff

### DIFF
--- a/integration/containers/container_interface.go
+++ b/integration/containers/container_interface.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package containers
 
 import (
 	"fmt"
 
+	"github.com/inspektor-gadget/inspektor-gadget/integration"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type ContainerFactory interface {
-	NewContainer(name, cmd string, opts ...containerOption) TestStep
+	NewContainer(name, cmd string, opts ...containerOption) integration.TestStep
 }
 
 func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {

--- a/integration/containers/containerd.go
+++ b/integration/containers/containerd.go
@@ -17,14 +17,13 @@ package containers
 import (
 	"context"
 
-	"github.com/inspektor-gadget/inspektor-gadget/integration"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
 
 type ContainerdManager struct{}
 
-func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) integration.TestStep {
-	c := &ContainerdContainer{}
+func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) *TestContainer {
+	c := &TestContainer{}
 
 	for _, o := range opts {
 		o(&c.cOptions)
@@ -33,10 +32,4 @@ func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOpt
 
 	c.Container = testutils.NewContainerdContainer(name, cmd, c.options...)
 	return c
-}
-
-// ContainerdContainer implements TestStep for containerd containers
-type ContainerdContainer struct {
-	testutils.Container
-	cOptions
 }

--- a/integration/containers/containerd.go
+++ b/integration/containers/containerd.go
@@ -40,11 +40,3 @@ type ContainerdContainer struct {
 	testutils.Container
 	cOptions
 }
-
-func (c *ContainerdContainer) IsCleanup() bool {
-	return c.cleanup
-}
-
-func (c *ContainerdContainer) IsStartAndStop() bool {
-	return c.startAndStop
-}

--- a/integration/containers/containerd.go
+++ b/integration/containers/containerd.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package containers
 
 import (
 	"context"
 
+	"github.com/inspektor-gadget/inspektor-gadget/integration"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
 
 type ContainerdManager struct{}
 
-func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) TestStep {
+func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) integration.TestStep {
 	c := &ContainerdContainer{}
 
 	for _, o := range opts {

--- a/integration/containers/docker.go
+++ b/integration/containers/docker.go
@@ -40,11 +40,3 @@ type DockerContainer struct {
 	testutils.Container
 	cOptions
 }
-
-func (d *DockerContainer) IsCleanup() bool {
-	return d.cleanup
-}
-
-func (d *DockerContainer) IsStartAndStop() bool {
-	return d.startAndStop
-}

--- a/integration/containers/docker.go
+++ b/integration/containers/docker.go
@@ -17,14 +17,13 @@ package containers
 import (
 	"context"
 
-	"github.com/inspektor-gadget/inspektor-gadget/integration"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
 
 type DockerManager struct{}
 
-func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) integration.TestStep {
-	c := &DockerContainer{}
+func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) *TestContainer {
+	c := &TestContainer{}
 
 	for _, o := range opts {
 		o(&c.cOptions)
@@ -33,10 +32,4 @@ func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption)
 
 	c.Container = testutils.NewDockerContainer(name, cmd, c.options...)
 	return c
-}
-
-// DockerContainer implements TestStep for docker containers
-type DockerContainer struct {
-	testutils.Container
-	cOptions
 }

--- a/integration/containers/docker.go
+++ b/integration/containers/docker.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package containers
 
 import (
 	"context"
 
+	"github.com/inspektor-gadget/inspektor-gadget/integration"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
 
 type DockerManager struct{}
 
-func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) TestStep {
+func (dm *DockerManager) NewContainer(name, cmd string, opts ...containerOption) integration.TestStep {
 	c := &DockerContainer{}
 
 	for _, o := range opts {

--- a/integration/containers/factory.go
+++ b/integration/containers/factory.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/inspektor-gadget/inspektor-gadget/integration"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -34,39 +33,5 @@ func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 		return &ContainerdManager{}, nil
 	default:
 		return nil, fmt.Errorf("unknown container runtime %q", containerRuntime)
-	}
-}
-
-type cOptions struct {
-	options      []testutils.Option
-	cleanup      bool
-	startAndStop bool
-}
-
-// containerOption is a function that modifies a ContainerSpec and exposes only
-// few options from testutils.Option to the user.
-type containerOption func(opts *cOptions)
-
-func WithContainerImage(image string) containerOption {
-	return func(opts *cOptions) {
-		opts.options = append(opts.options, testutils.WithImage(image))
-	}
-}
-
-func WithContainerSeccompProfile(profile string) containerOption {
-	return func(opts *cOptions) {
-		opts.options = append(opts.options, testutils.WithSeccompProfile(profile))
-	}
-}
-
-func WithCleanup() containerOption {
-	return func(opts *cOptions) {
-		opts.cleanup = true
-	}
-}
-
-func WithStartAndStop() containerOption {
-	return func(opts *cOptions) {
-		opts.startAndStop = true
 	}
 }

--- a/integration/containers/factory.go
+++ b/integration/containers/factory.go
@@ -17,14 +17,17 @@ package containers
 import (
 	"fmt"
 
-	"github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type ContainerFactory interface {
-	NewContainer(name, cmd string, opts ...containerOption) integration.TestStep
+	NewContainer(name, cmd string, opts ...containerOption) *TestContainer
 }
 
+// NewContainerFactory returns a new instance of a ContainerFactory based on the
+// container runtime. The returned factory can be used to create new container
+// instances which can be used in tests.
 func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 	switch types.String2RuntimeName(containerRuntime) {
 	case types.RuntimeNameDocker:
@@ -34,4 +37,12 @@ func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 	default:
 		return nil, fmt.Errorf("unknown container runtime %q", containerRuntime)
 	}
+}
+
+// TestContainer is a wrapper around testutils.Container that implements the
+// missing functions from the TestStep interface. This allows to use the
+// container as a step in a test.
+type TestContainer struct {
+	testutils.Container
+	cOptions
 }

--- a/integration/containers/options.go
+++ b/integration/containers/options.go
@@ -28,6 +28,14 @@ type cOptions struct {
 // few options from testutils.Option to the user.
 type containerOption func(opts *cOptions)
 
+func (o *cOptions) IsCleanup() bool {
+	return o.cleanup
+}
+
+func (o *cOptions) IsStartAndStop() bool {
+	return o.startAndStop
+}
+
 func WithContainerImage(image string) containerOption {
 	return func(opts *cOptions) {
 		opts.options = append(opts.options, testutils.WithImage(image))

--- a/integration/containers/options.go
+++ b/integration/containers/options.go
@@ -1,0 +1,53 @@
+// Copyright 2023-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containers
+
+import (
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+)
+
+type cOptions struct {
+	options      []testutils.Option
+	cleanup      bool
+	startAndStop bool
+}
+
+// containerOption is a function that modifies a ContainerSpec and exposes only
+// few options from testutils.Option to the user.
+type containerOption func(opts *cOptions)
+
+func WithContainerImage(image string) containerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithImage(image))
+	}
+}
+
+func WithContainerSeccompProfile(profile string) containerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithSeccompProfile(profile))
+	}
+}
+
+func WithCleanup() containerOption {
+	return func(opts *cOptions) {
+		opts.cleanup = true
+	}
+}
+
+func WithStartAndStop() containerOption {
+	return func(opts *cOptions) {
+		opts.startAndStop = true
+	}
+}

--- a/integration/ig/non-k8s/integration_test.go
+++ b/integration/ig/non-k8s/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@ import (
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/integration/containers"
 )
 
 var (
-	containerFactory ContainerFactory
+	containerFactory containers.ContainerFactory
 	// flags
 	integration    = flag.Bool("integration", false, "run integration tests")
 	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	containerFactory, err = NewContainerFactory(*runtime)
+	containerFactory, err = containers.NewContainerFactory(*runtime)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/integration/containers"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -64,7 +65,7 @@ func TestFilterByContainerName(t *testing.T) {
 	}
 
 	testSteps := []TestStep{
-		containerFactory.NewContainer(cn, "sleep inf", WithStartAndStop()),
+		containerFactory.NewContainer(cn, "sleep inf", containers.WithStartAndStop()),
 		SleepForSecondsCommand(2),
 		listContainersCmd,
 	}

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/integration/containers"
 	snapshotprocessTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/process/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -61,7 +62,7 @@ func TestSnapshotProcess(t *testing.T) {
 	}
 
 	testSteps := []TestStep{
-		containerFactory.NewContainer(cn, "nc -l -p 9090", WithStartAndStop()),
+		containerFactory.NewContainer(cn, "nc -l -p 9090", containers.WithStartAndStop()),
 		snapshotProcessCmd,
 	}
 

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/integration/containers"
 	dnsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -158,7 +159,7 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 	testSteps := []TestStep{
 		traceDNSCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		containerFactory.NewContainer(cn, strings.Join(dnsCmds, " ; "), WithContainerImage(*dnsTesterImage)),
+		containerFactory.NewContainer(cn, strings.Join(dnsCmds, " ; "), containers.WithContainerImage(*dnsTesterImage)),
 	}
 
 	return testSteps

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+	"github.com/inspektor-gadget/inspektor-gadget/integration/containers"
 	networkTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/network/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -99,7 +100,7 @@ func TestTraceNetwork(t *testing.T) {
 	testSteps := []TestStep{
 		traceNetworkCmd,
 		SleepForSecondsCommand(2), // wait to ensure ig has started
-		containerFactory.NewContainer(cn, "nginx && curl 127.0.0.1", WithContainerImage("docker.io/library/nginx")),
+		containerFactory.NewContainer(cn, "nginx && curl 127.0.0.1", containers.WithContainerImage("docker.io/library/nginx")),
 	}
 
 	RunTestSteps(testSteps, t)


### PR DESCRIPTION
# Separate and simplify container-related stuff for testing

This PR aims to organize all the container-related stuff into a separate package. This way, only the tests interested in running containers will import it. In our case, the tests within `ig/non-k8s`. Furthermore, this PR removes some duplicated code we had for each runtime, consolidating everything into one structure.

Notice this PR prepares things to be easily moved to the `testing` pkg that https://github.com/inspektor-gadget/inspektor-gadget/pull/2607 is creating.