### PR TITLE
gadget-context: Don't add op instance's params if op is not requested

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -53,8 +53,6 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
-		params = append(params, instanceParams...)
-
 		err = apihelpers.Validate(instanceParams, opParamValues)
 		if err != nil {
 			return nil, fmt.Errorf("validating params for operator %q: %w", op.Name(), err)
@@ -69,6 +67,9 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 			continue
 		}
 		dataOperatorInstances = append(dataOperatorInstances, opInst)
+
+		// Add instance params only if operator was actually instantiated (i.e., activated)
+		params = append(params, instanceParams...)
 	}
 
 	for _, opInst := range dataOperatorInstances {


### PR DESCRIPTION
# Don't add op instance's params if op is not requested

Data operators will be instantiated (activated) only if the gadget requests a feature the operator provides. If a given operator is not instantiated, then we shouldn't add its parameters.

## Testing done

The struct generated by the `open` tracer defined in the following gadget doesn't meet any of the requirements to activate the LocalManager data operator (All this is also valid for KubeManager):

1. The gadget declares a map named `gadget_mntns_filter_map` (This is automatically done if `mntns_filter.h` is included). Notice this allows gadgets to filter by container.
2. The gadget contains a tc program (`BPF_PROG_TYPE_SCHED_CLS`). It's necessary because the tc programs need to get notifications about the creation and deletion of containers.
3. The struct generated by the gadget containers a field of type `gadget_mntns_id`, or `gadget_netns_id` (fallback `netns`). This allows gadgets' event to get enriched with k8s and runtime metadata.

As I said, none of these is the case of our example gadget. However, the `containername` and `host` flags are added to the gadget (they are present in the `--help`).

This is the gadget used for the tests:

```c
// Kernel types definitions
// Check https://blog.aquasec.com/vmlinux.h-ebpf-programs for more details
#include <vmlinux.h>

// eBPF helpers signatures
// Check https://man7.org/linux/man-pages/man7/bpf-helpers.7.html to learn
// more about different available helpers
#include <bpf/bpf_helpers.h>

// Inspektor Gadget buffer
#include <gadget/buffer.h>

// Inspektor Gadget macros
#include <gadget/macros.h>

struct event {
	__u32 pid;
};

// events is the name of the buffer map and 1024 * 256 is its size.
GADGET_TRACER_MAP(events, 1024 * 256);

// [Optional] Define a tracer
GADGET_TRACER(open, events, event);

SEC("tracepoint/syscalls/sys_enter_openat")
int enter_openat(struct syscall_trace_enter *ctx)
{
	struct event *event;

	event = gadget_reserve_buf(&events, sizeof(*event));
	if (!event)
		return 0;

	event->pid = bpf_get_current_pid_tgid() >> 32;

	gadget_submit_buf(ctx, &events, event, sizeof(*event));

	return 0;
}

char LICENSE[] SEC("license") = "GPL";
```

### Before this PR

Operator' flags are incorrectly added:

```bash
$ IG_EXPERIMENTAL=true go run --exec "sudo -E" ./cmd/ig/... run mygadget --help | grep containername
INFO[0000] Experimental features enabled
  -c, --containername string            Show only data from containers with that name (default "")
```

Of course, setting the flag has no effect at all.

### After this PR

As expected, operator's flag are not added:

```bash
$ IG_EXPERIMENTAL=true go run --exec "sudo -E" ./cmd/ig/... run mygadget --help | grep containername
INFO[0000] Experimental features enabled
```
