### PR TITLE
image based gadgets: fix hostNetwork info

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,4 +213,16 @@ func GetColumns() *columns.Columns[Container] {
 	})
 
 	return cols
+}
+
+func (c *Container) K8sMetadata() *types.BasicK8sMetadata {
+	return &c.K8s.BasicK8sMetadata
+}
+
+func (c *Container) RuntimeMetadata() *types.BasicRuntimeMetadata {
+	return &c.Runtime.BasicRuntimeMetadata
+}
+
+func (c *Container) UsesHostNetwork() bool {
+	return c.HostNetwork
 }

--- a/pkg/container-collection/operator.go
+++ b/pkg/container-collection/operator.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ func (cc *ContainerCollection) EnrichEventByMntNs(event operators.ContainerInfoF
 		container = lookupContainerByMntns(cc.cachedContainers, mountNsId)
 	}
 	if container != nil {
-		event.SetContainerMetadata(&container.K8s.BasicK8sMetadata, &container.Runtime.BasicRuntimeMetadata)
+		event.SetContainerMetadata(container)
 	}
 }
 
@@ -43,12 +43,12 @@ func (cc *ContainerCollection) EnrichEventByNetNs(event operators.ContainerInfoF
 		return
 	}
 	if len(containers) == 1 {
-		event.SetContainerMetadata(&containers[0].K8s.BasicK8sMetadata, &containers[0].Runtime.BasicRuntimeMetadata)
+		event.SetContainerMetadata(containers[0])
 		return
 	}
 	if containers[0].K8s.PodName != "" && containers[0].K8s.Namespace != "" {
 		// Kubernetes containers within the same pod.
-		event.SetPodMetadata(&containers[0].K8s.BasicK8sMetadata, &containers[0].Runtime.BasicRuntimeMetadata)
+		event.SetPodMetadata(containers[0])
 	}
 	// else {
 	// 	TODO: Non-Kubernetes containers sharing the same network namespace.

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -265,7 +265,9 @@ func (ev *EventWrapper) SetPodMetadata(container types.Container) {
 		}
 		if ev.hostNetworkAccessor.IsRequested() {
 			ev.hostNetworkAccessor.Set(ev.Data, make([]byte, 1))
-			ev.hostNetworkAccessor.PutInt8(ev.Data, 0) // TODO
+			if container.UsesHostNetwork() {
+				ev.hostNetworkAccessor.PutInt8(ev.Data, 1)
+			}
 		}
 	}
 	rt := container.RuntimeMetadata()

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -251,7 +251,8 @@ func (ev *EventWrapper) GetNetNSID() uint64 {
 	return getUint64(ev.NetnsidAccessor, ev.Data)
 }
 
-func (ev *EventWrapper) SetPodMetadata(k8s *types.BasicK8sMetadata, rt *types.BasicRuntimeMetadata) {
+func (ev *EventWrapper) SetPodMetadata(container types.Container) {
+	k8s := container.K8sMetadata()
 	if k8s != nil {
 		if ev.namespaceAccessor.IsRequested() {
 			ev.namespaceAccessor.Set(ev.Data, []byte(k8s.Namespace))
@@ -267,6 +268,7 @@ func (ev *EventWrapper) SetPodMetadata(k8s *types.BasicK8sMetadata, rt *types.Ba
 			ev.hostNetworkAccessor.PutInt8(ev.Data, 0) // TODO
 		}
 	}
+	rt := container.RuntimeMetadata()
 	if rt != nil {
 		if ev.containernameAccessor.IsRequested() {
 			ev.containernameAccessor.Set(ev.Data, []byte(rt.ContainerName))
@@ -286,8 +288,8 @@ func (ev *EventWrapper) SetPodMetadata(k8s *types.BasicK8sMetadata, rt *types.Ba
 	}
 }
 
-func (ev *EventWrapper) SetContainerMetadata(k8s *types.BasicK8sMetadata, rt *types.BasicRuntimeMetadata) {
-	ev.SetPodMetadata(k8s, rt)
+func (ev *EventWrapper) SetContainerMetadata(container types.Container) {
+	ev.SetPodMetadata(container)
 }
 
 func (ev *EventWrapper) SetNode(node string) {

--- a/pkg/gadgets/traceloop/tracer/tracer.go
+++ b/pkg/gadgets/traceloop/tracer/tracer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Inspektor Gadget authors
+// Copyright 2019-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -711,7 +711,7 @@ func (t *Tracer) AttachContainer(container *containercollection.Container) error
 			return
 		}
 		for _, ev := range evs {
-			ev.SetContainerMetadata(&container.K8s.BasicK8sMetadata, &container.Runtime.BasicRuntimeMetadata)
+			ev.SetContainerMetadata(container)
 			t.eventCallback(ev)
 		}
 	}()

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -172,8 +172,8 @@ type ContainerInfoFromNetNSID interface {
 
 type ContainerInfoSetters interface {
 	NodeSetter
-	SetPodMetadata(*types.BasicK8sMetadata, *types.BasicRuntimeMetadata)
-	SetContainerMetadata(*types.BasicK8sMetadata, *types.BasicRuntimeMetadata)
+	SetPodMetadata(types.Container)
+	SetContainerMetadata(types.Container)
 }
 
 type NodeSetter interface {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Inspektor Gadget authors
+// Copyright 2019-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,6 +105,12 @@ func String2RuntimeName(name string) RuntimeName {
 	return RuntimeNameUnknown
 }
 
+type Container interface {
+	K8sMetadata() *BasicK8sMetadata
+	RuntimeMetadata() *BasicRuntimeMetadata
+	UsesHostNetwork() bool
+}
+
 type BasicRuntimeMetadata struct {
 	// RuntimeName is the name of the container runtime. It is useful to distinguish
 	// who is the "owner" of each container in a list of containers collected
@@ -172,7 +178,10 @@ func (c *CommonData) SetNode(node string) {
 	c.K8s.Node = node
 }
 
-func (c *CommonData) SetPodMetadata(k8s *BasicK8sMetadata, runtime *BasicRuntimeMetadata) {
+func (c *CommonData) SetPodMetadata(container Container) {
+	k8s := container.K8sMetadata()
+	runtime := container.RuntimeMetadata()
+
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace
 	c.K8s.PodLabels = k8s.PodLabels
@@ -181,7 +190,10 @@ func (c *CommonData) SetPodMetadata(k8s *BasicK8sMetadata, runtime *BasicRuntime
 	c.Runtime.RuntimeName = runtime.RuntimeName
 }
 
-func (c *CommonData) SetContainerMetadata(k8s *BasicK8sMetadata, runtime *BasicRuntimeMetadata) {
+func (c *CommonData) SetContainerMetadata(container Container) {
+	k8s := container.K8sMetadata()
+	runtime := container.RuntimeMetadata()
+
 	c.K8s.ContainerName = k8s.ContainerName
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace


### PR DESCRIPTION
This fixes an open issue with the hostNetwork information not being set correctly after the refactoring of the image based gadgets. This was mainly due to the enricher interfaces not providing that info, so I've changed those interfaces now to use yet another interface type (`Container`) that can be more easily extended without changing much code.