### PR TITLE
eks: Add timestamp tag

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1603,7 +1603,7 @@ jobs:
         if [ ${{ matrix.arch }} = 'arm64' ]; then
           node_type='a1.xlarge'
         fi
-        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags ig-ci=true --node-type $node_type
+        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags ig-ci=true,ig-ci-timestamp=$(date +%s) --node-type $node_type
     - name: Run integration tests
       uses: ./.github/actions/run-integration-tests
       with:


### PR DESCRIPTION
# eks: Add timestamp tag

In a future PR  a periodic script to delete all cloudformation stacks and vpcs older than a day will be added. For that a timestamp is needed