### PR TITLE
kubernetes: cgroupfs: mount read-only

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -204,6 +204,7 @@ spec:
               name: debugfs
             - mountPath: /sys/fs/cgroup
               name: cgroup
+              readOnly: true
             - mountPath: /sys/fs/bpf
               name: bpffs
             {{- if .Values.config.mountPullSecret }}

--- a/examples/builtin-gadgets/withfilter/trace/network/deploy.yaml
+++ b/examples/builtin-gadgets/withfilter/trace/network/deploy.yaml
@@ -142,6 +142,7 @@ spec:
               mountPath: /sys/kernel/tracing
             - name: cgroup
               mountPath: /sys/fs/cgroup
+              readOnly: true
             - name: bpffs
               mountPath: /sys/fs/bpf
           securityContext:

--- a/examples/kube-container-collection/deploy.yaml
+++ b/examples/kube-container-collection/deploy.yaml
@@ -91,6 +91,7 @@ spec:
           mountPath: /sys/kernel/debug
         - name: cgroup
           mountPath: /sys/fs/cgroup
+          readOnly: true
         - name: bpffs
           mountPath: /sys/fs/bpf
       tolerations:

--- a/examples/runc-hook/deploy.yaml
+++ b/examples/runc-hook/deploy.yaml
@@ -94,6 +94,7 @@ spec:
           mountPath: /sys/kernel/debug
         - name: cgroup
           mountPath: /sys/fs/cgroup
+          readOnly: true
         - name: bpffs
           mountPath: /sys/fs/bpf
       tolerations:

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -281,6 +281,7 @@ spec:
               name: debugfs
             - mountPath: /sys/fs/cgroup
               name: cgroup
+              readOnly: true
             - mountPath: /sys/fs/bpf
               name: bpffs
       nodeSelector:


### PR DESCRIPTION
# kubernetes: cgroupfs: mount read-only

Inspektor Gadget needs access to the host volume /sys/fs/cgroup but does not need write access. Switch to readOnly=true.

## How to use

No changes.

## Testing done

None yet. Let's run the CI first.

Related PR: https://github.com/inspektor-gadget/inspektor-gadget/pull/2285