### PR TITLE
ci: Add workflow to clean eks resources

### DIFF
--- a/.github/workflows/cloud-cleanup.yml
+++ b/.github/workflows/cloud-cleanup.yml
@@ -1,0 +1,31 @@
+name: Cleanup Cloud Resources
+env:
+  GO_VERSION: 1.22.0
+on:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  eks-cleanup:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    env:
+        AWS_REGION: us-east-2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Cleanup EKS resources
+        run: |
+          cd ./tools/eks-cleanup && go run .

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1603,7 +1603,7 @@ jobs:
         if [ ${{ matrix.arch }} = 'arm64' ]; then
           node_type='a1.xlarge'
         fi
-        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags ig-ci=true --node-type $node_type
+        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags ig-ci=true,ig-ci-timestamp=$(date -u --rfc-3339=seconds) --node-type $node_type
     - name: Run integration tests
       uses: ./.github/actions/run-integration-tests
       with:

--- a/tools/eks-cleanup/.gitignore
+++ b/tools/eks-cleanup/.gitignore
@@ -1,0 +1,1 @@
+eks-cleanup

--- a/tools/eks-cleanup/go.mod
+++ b/tools/eks-cleanup/go.mod
@@ -1,0 +1,7 @@
+module eks-cleanup
+
+go 1.21.4
+
+require github.com/aws/aws-sdk-go v1.50.32
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/tools/eks-cleanup/go.sum
+++ b/tools/eks-cleanup/go.sum
@@ -1,0 +1,14 @@
+github.com/aws/aws-sdk-go v1.50.32 h1:POt81DvegnpQKM4DMDLlHz1CO6OBnEoQ1gRhYFd7QRY=
+github.com/aws/aws-sdk-go v1.50.32/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/eks-cleanup/main.go
+++ b/tools/eks-cleanup/main.go
@@ -1,0 +1,389 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program is used to cleanup some resources that are leaked by the CI when running on EKS: See
+// - https://github.com/inspektor-gadget/inspektor-gadget/issues/2533
+// - https://github.com/eksctl-io/eksctl/issues/7589
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	region              = "us-east-2"
+	igCiTagKey          = "ig-ci"
+	igCiTimestampTagKey = "ig-ci-timestamp"
+	stackNameTagKey     = "aws:cloudformation:stack-name"
+	lifetime            = 3 * time.Hour
+)
+
+var dryRun = flag.Bool("dryrun", false, "don't remove anything")
+
+func hasCloudFormationIgCiTag(tags []*cloudformation.Tag) bool {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == igCiTagKey {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getCloudFormationIgCiTimestampTag(tags []*cloudformation.Tag) string {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == igCiTimestampTagKey {
+			return aws.StringValue(tag.Value)
+		}
+	}
+
+	return ""
+}
+
+// getOldStacks returns all stacks created by the CI that are older than 3 hours
+func getOldStacks(svc *cloudformation.CloudFormation) (map[string]*cloudformation.Stack, error) {
+	result, err := svc.DescribeStacks(&cloudformation.DescribeStacksInput{})
+	if err != nil {
+		return nil, fmt.Errorf("describing stacks: %w", err)
+	}
+
+	ret := map[string]*cloudformation.Stack{}
+	for _, stack := range result.Stacks {
+		// Only include stacks with the ig-ci tag
+		if !hasCloudFormationIgCiTag(stack.Tags) {
+			continue
+		}
+
+		timestamp := getCloudFormationIgCiTimestampTag(stack.Tags)
+		if timestamp == "" {
+			continue
+		}
+
+		// Only include stacks that are older than 3 hours
+		createdAt, err := time.Parse(time.RFC3339, timestamp)
+		if err != nil {
+
+			return nil, fmt.Errorf("parsing timestamp for stack %s: %v", aws.StringValue(stack.StackName), err)
+		}
+		if createdAt.After(time.Now().Add(-1 * lifetime)) {
+			fmt.Printf("skipping stack %s\n", aws.StringValue(stack.StackName))
+			continue
+		}
+
+		ret[aws.StringValue(stack.StackName)] = stack
+	}
+
+	return ret, nil
+}
+
+func hasIgciTag(tags []*ec2.Tag) bool {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == igCiTagKey {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getOldVpcs(svc *ec2.EC2) (map[string]*ec2.Vpc, error) {
+	input := &ec2.DescribeVpcsInput{}
+
+	ret := map[string]*ec2.Vpc{}
+	result, err := svc.DescribeVpcs(input)
+	if err != nil {
+		return nil, fmt.Errorf("describing VPCs: %w", err)
+	}
+
+	for _, vpc := range result.Vpcs {
+		if !hasIgciTag(vpc.Tags) {
+			continue
+		}
+
+		tag := getTagValue(vpc.Tags, stackNameTagKey)
+		// extra safe mechanism
+		if tag == "" {
+			continue
+		}
+
+		timestamp := getTagValue(vpc.Tags, igCiTimestampTagKey)
+		if timestamp == "" {
+			continue
+		}
+
+		// Only include stacks that are older than 3 hours
+		createdAt, err := time.Parse(time.RFC3339, timestamp)
+		if err != nil {
+			continue
+		}
+		if createdAt.After(time.Now().Add(-1 * lifetime)) {
+			fmt.Printf("skipping VPC %s\n", aws.StringValue(vpc.VpcId))
+			continue
+		}
+
+		ret[aws.StringValue(vpc.VpcId)] = vpc
+	}
+
+	return ret, nil
+}
+
+func getTagValue(tags []*ec2.Tag, key string) string {
+	for _, tag := range tags {
+		if aws.StringValue(tag.Key) == key {
+			return aws.StringValue(tag.Value)
+		}
+	}
+
+	return ""
+}
+
+func detachAndDeleteInternetGateways(svc *ec2.EC2, vpcId string) error {
+	gateways, err := svc.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{})
+	if err != nil {
+		return fmt.Errorf("describing internet gateways: %w", err)
+	}
+	for _, gateway := range gateways.InternetGateways {
+		if !hasIgciTag(gateway.Tags) {
+			continue
+		}
+
+		for _, attachment := range gateway.Attachments {
+			if aws.StringValue(attachment.VpcId) != vpcId {
+				// not attached to this vpc
+				return nil
+			}
+			fmt.Printf("detaching internet gateway: %s\n", aws.StringValue(gateway.InternetGatewayId))
+			input := &ec2.DetachInternetGatewayInput{
+				InternetGatewayId: gateway.InternetGatewayId,
+				VpcId:             aws.String(vpcId),
+				DryRun:            dryRun,
+			}
+			if _, err := svc.DetachInternetGateway(input); err != nil {
+				return fmt.Errorf("detaching internet gateway: %w", err)
+			}
+		}
+
+		fmt.Printf("deleting internet gateway: %s\n", aws.StringValue(gateway.InternetGatewayId))
+		input := &ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: gateway.InternetGatewayId,
+			DryRun:            dryRun,
+		}
+		if _, err := svc.DeleteInternetGateway(input); err != nil {
+			return fmt.Errorf("deleting internet gateway: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deleteNetworkInterfaces(svc *ec2.EC2, subnetId *string) error {
+	networkInterfaces, err := svc.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("subnet-id"),
+				Values: []*string{subnetId},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("describing network interfaces: %w", err)
+	}
+
+	for _, networkInterface := range networkInterfaces.NetworkInterfaces {
+		fmt.Printf("deleting network interface: %s\n", aws.StringValue(networkInterface.NetworkInterfaceId))
+		input := &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: networkInterface.NetworkInterfaceId,
+			DryRun:             dryRun,
+		}
+		if _, err := svc.DeleteNetworkInterface(input); err != nil {
+			return fmt.Errorf("deleting network interface: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deleteSubnets(svc *ec2.EC2, vpcId string) error {
+	subnets, err := svc.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(vpcId)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("describing subnets: %w", err)
+	}
+
+	for _, subnet := range subnets.Subnets {
+		if !hasIgciTag(subnet.Tags) {
+			continue
+		}
+
+		if err := deleteNetworkInterfaces(svc, subnet.SubnetId); err != nil {
+			return fmt.Errorf("deleting network interfaces: %w", err)
+		}
+
+		fmt.Printf("deleting subnet: %s\n", aws.StringValue(subnet.SubnetId))
+		input := &ec2.DeleteSubnetInput{
+			SubnetId: subnet.SubnetId,
+			DryRun:   dryRun,
+		}
+		if _, err = svc.DeleteSubnet(input); err != nil {
+			return fmt.Errorf("deleting subnet: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deleteSecurityGroups(svc *ec2.EC2, vpcId string) error {
+	securityGroups, err := svc.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(vpcId)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("describing security groups: %w", err)
+	}
+
+	for _, securityGroup := range securityGroups.SecurityGroups {
+		// TODO: security groups don't have the ig-ci tag
+		//if !hasIgciTag(securityGroup.Tags) {
+		//	continue
+		//}
+
+		if aws.StringValue(securityGroup.GroupName) == "default" {
+			continue
+		}
+
+		fmt.Printf("deleting security group: %s\n", aws.StringValue(securityGroup.GroupId))
+		input := &ec2.DeleteSecurityGroupInput{
+			GroupId: securityGroup.GroupId,
+			DryRun:  dryRun,
+		}
+		if _, err := svc.DeleteSecurityGroup(input); err != nil {
+			return fmt.Errorf("deleting security group: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deleteVpc(svc *ec2.EC2, vpcId string) error {
+	if err := detachAndDeleteInternetGateways(svc, vpcId); err != nil {
+		return fmt.Errorf("deleting internet gateway: %w", err)
+	}
+
+	if err := deleteSubnets(svc, vpcId); err != nil {
+		return fmt.Errorf("deleting subnets: %w", err)
+	}
+
+	if err := deleteSecurityGroups(svc, vpcId); err != nil {
+		return fmt.Errorf("deleting security groups: %w", err)
+	}
+
+	input := &ec2.DeleteVpcInput{
+		VpcId:  aws.String(vpcId),
+		DryRun: dryRun,
+	}
+	if _, err := svc.DeleteVpc(input); err != nil {
+		return fmt.Errorf("deleting VPC: %w", err)
+	}
+
+	return nil
+}
+
+func do() error {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            aws.Config{Region: aws.String(region)},
+	}))
+
+	ec2Svc := ec2.New(sess)
+	cloudformationSvc := cloudformation.New(sess)
+
+	stacks, err := getOldStacks(cloudformationSvc)
+	if err != nil {
+		return fmt.Errorf("describing stacks: %w", err)
+	}
+
+	// Start deleting stacks
+	for name := range stacks {
+		fmt.Printf("deleting stack: %s\n", name)
+		if *dryRun {
+			continue
+		}
+
+		input := &cloudformation.DeleteStackInput{
+			StackName: aws.String(name),
+		}
+		if _, err := cloudformationSvc.DeleteStack(input); err != nil {
+			return fmt.Errorf("deleting stack: %w", err)
+		}
+	}
+
+	// Wait for the deletions to go through
+	for name := range stacks {
+		fmt.Printf("waiting for stack to be deleted: %s\n", name)
+
+		context, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		if err := cloudformationSvc.WaitUntilStackDeleteCompleteWithContext(context,
+			&cloudformation.DescribeStacksInput{
+				StackName: aws.String(name),
+			}); err != nil {
+			cancel()
+			return fmt.Errorf("waiting for stack to be deleted: %w", err)
+		}
+		cancel()
+	}
+
+	vpcs, err := getOldVpcs(ec2Svc)
+	if err != nil {
+		return fmt.Errorf("describing VPCs: %w", err)
+	}
+
+	// Delete vpcs
+	for _, vpc := range vpcs {
+		fmt.Printf("deleting VPC: %s\n", aws.StringValue(vpc.VpcId))
+		if err := deleteVpc(ec2Svc, aws.StringValue(vpc.VpcId)); err != nil {
+			return fmt.Errorf("deleting VPC: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if err := do(); err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
# ci: Add workflow to clean eks resources

This adds a script to find and delete resources which are older than 3 hours. Unfortunately, the VPCs do not have a creation timestamp and therefore a custom tag is needed.

Additionally when deleting a cloudformation stack there is no option to wait until it actually got deleted. Therefore we need to poll it until it is gone.
Or else deleting the VPCs for that specific stack will fail.

Please take a look at the script and mark everything which seems wrong. I am not the best bash script writer

EKS version of https://github.com/inspektor-gadget/inspektor-gadget/pull/2682
Script is a modified version from @mauriciovasquezbernal (https://github.com/inspektor-gadget/inspektor-gadget/issues/2533#issuecomment-1961456214) 


```
Checking Cloudformation stacks...
Deleting Cloudformation Stack arn:aws:cloudformation:us-east-2:637423639163:stack/eksctl-burak-test-final-cluster/b1d4eb60-f2a9-11ee-82e5-06198267272f
Waiting for stacks to be deleted...
....
Checking VPCs...
Deleting network interfgaces in subnet subnet-066c49c0a844a11c1
Deleting network interface eni-0fab72bfd57b666cd
Deleting security group sg-05a676e98dcbd0cd7
Deleting subnet subnet-066c49c0a844a11c1
Deleting VPC vpc-087f72c6b2fe3455b
Deleting network interfgaces in subnet subnet-08a5bedb8c96ffe4a
Deleting network interface eni-03bcdaee766f8fef8
Deleting security group sg-01b5ede96df2bbc17
Deleting subnet subnet-08a5bedb8c96ffe4a
Deleting VPC vpc-00a7d989fac4c65f5
Deleting network interfgaces in subnet subnet-07ec7d6e33513e072
Deleting network interface eni-0d7d27f7e669bba26
Deleting security group sg-0647ec59ceb3a3378
Deleting subnet subnet-07ec7d6e33513e072
Deleting VPC vpc-00a4562ffa488ca29
```