### PR TITLE
image based gadgets: return error if no valid gadget layers are found

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -60,7 +60,7 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 
 		opInst, err := op.InstantiateDataOperator(c, opParamValues)
 		if err != nil {
-			log.Errorf("instantiating operator %q: %v", op.Name(), err)
+			return nil, fmt.Errorf("instantiating operator %q: %w", op.Name(), err)
 		}
 		if opInst == nil {
 			log.Debugf("> skipped %s", op.Name())

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -222,6 +222,10 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		o.imageOperatorInstances = append(o.imageOperatorInstances, opInst)
 	}
 
+	if len(o.imageOperatorInstances) == 0 {
+		return fmt.Errorf("image doesn't contain valid gadget layers")
+	}
+
 	extraParams := make([]*api.Param, 0)
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Prepare(o.gadgetCtx)


### PR DESCRIPTION
Fixes #2677

After:
```
$ sudo -E ./ig run ghcr.io/inspektor-gadget/inspektor-gadget:latest
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": image doesn't contain valid gadget layers
```