### PR TITLE
ci/lint: Skip package cache

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -106,6 +106,7 @@ jobs:
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648
         args: "--out-${NO_FUTURE}format colored-line-number"
+        skip-pkg-cache: true
 
   semgrep:
     name: semgrep


### PR DESCRIPTION
# ci/lint: Skip package cache

We always have 20k+ error lines regarding already existing files in `go/pkg/mod/`. So if its complaining it that its already there, we can tell it to skip this step

https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8567294294/job/23491730887?pr=2680#step:4:28