### PR TITLE
fix gRPC timeout for image-based gadgets on GetGadgetInfo()

### DIFF
--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -375,6 +375,10 @@ func (r *Runtime) dialContext(dialCtx context.Context, target target, timeout ti
 			gadgetNamespace := r.globalParams.Get(ParamGadgetNamespace).AsString()
 			return NewK8SPortFwdConn(ctx, r.restConfig, gadgetNamespace, target, port, timeout)
 		}))
+	} else {
+		newCtx, cancel := context.WithTimeout(dialCtx, timeout)
+		defer cancel()
+		dialCtx = newCtx
 	}
 
 	conn, err := grpc.DialContext(dialCtx, "passthrough:///"+target.addressOrPod, opts...)

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -36,11 +36,7 @@ func (r *Runtime) GetGadgetInfo(gadgetCtx runtime.GadgetContext, runtimeParams *
 		runtimeParams = r.ParamDescs().ToParams()
 	}
 
-	timeout := time.Second * time.Duration(r.globalParams.Get(ParamConnectionTimeout).AsUint16())
-	ctx, cancelDial := context.WithTimeout(gadgetCtx.Context(), timeout)
-	defer cancelDial()
-
-	conn, err := r.getConnToRandomTarget(ctx, runtimeParams)
+	conn, err := r.getConnToRandomTarget(gadgetCtx.Context(), runtimeParams)
 	if err != nil {
 		return nil, fmt.Errorf("dialing random target: %w", err)
 	}
@@ -52,7 +48,7 @@ func (r *Runtime) GetGadgetInfo(gadgetCtx runtime.GadgetContext, runtimeParams *
 		ImageName:   gadgetCtx.ImageName(),
 		Version:     api.VersionGadgetInfo,
 	}
-	out, err := client.GetGadgetInfo(ctx, in)
+	out, err := client.GetGadgetInfo(gadgetCtx.Context(), in)
 	if err != nil {
 		return nil, fmt.Errorf("getting gadget info: %w", err)
 	}


### PR DESCRIPTION
The timeout could potentially happen if the server had to download a gadget image on a slow connection. This changes the timeout to be connection-related only and not a total time that the gRPC call may take (we don't set such a limit now.)

Discussed on [Slack](https://kubernetes.slack.com/archives/CSYL75LF6/p1712761766862949)