### PR TITLE
fix: re-add timeout for image-based gadgets

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -17,6 +17,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -47,6 +48,8 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 
 	var info *api.GadgetInfo
 	paramLookup := map[string]*params.Param{}
+
+	var timeoutSeconds int
 
 	cmd := &cobra.Command{
 		Use:          "run",
@@ -155,10 +158,13 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			}
 			ops = append(ops, clioperator.CLIOperator)
 
+			timeoutDuration := time.Duration(timeoutSeconds) * time.Second
+
 			gadgetCtx := gadgetcontext.New(
 				ctx,
 				args[0],
 				gadgetcontext.WithDataOperators(ops...),
+				gadgetcontext.WithTimeout(timeoutDuration),
 			)
 
 			paramValueMap := make(map[string]string)
@@ -178,6 +184,14 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			return nil
 		},
 	}
+
+	cmd.PersistentFlags().IntVarP(
+		&timeoutSeconds,
+		"timeout",
+		"t",
+		0,
+		"Number of seconds that the gadget will run for, 0 to run indefinitely",
+	)
 
 	AddFlags(cmd, ociParams, nil, runtime)
 	AddFlags(cmd, runtimeGlobalParams, nil, runtime)

--- a/pkg/gadget-context/options.go
+++ b/pkg/gadget-context/options.go
@@ -16,6 +16,7 @@ package gadgetcontext
 
 import (
 	"slices"
+	"time"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
@@ -32,5 +33,11 @@ func WithLogger(logger logger.Logger) Option {
 func WithDataOperators(ops ...operators.DataOperator) Option {
 	return func(gadgetCtx *GadgetContext) {
 		gadgetCtx.dataOperators = slices.Clone(ops)
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.timeout = timeout
 	}
 }

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -15,6 +15,7 @@
 package gadgetcontext
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -106,6 +107,13 @@ func (c *GadgetContext) run(dataOperatorInstances []operators.DataOperatorInstan
 		}
 	}
 
+	ctx := c.Context()
+	if c.timeout > 0 {
+		newContext, cancel := context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+		ctx = newContext
+	}
+
 	for _, opInst := range dataOperatorInstances {
 		log.Debugf("starting op %q", opInst.Name())
 		err := opInst.Start(c)
@@ -117,7 +125,7 @@ func (c *GadgetContext) run(dataOperatorInstances []operators.DataOperatorInstan
 
 	log.Debugf("running...")
 
-	<-c.Context().Done()
+	<-ctx.Done()
 
 	// Stop/DeInit in reverse order
 	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {

--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -192,6 +193,7 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 		ociRequest.ImageName,
 		gadgetcontext.WithLogger(logger),
 		gadgetcontext.WithDataOperators(ops...),
+		gadgetcontext.WithTimeout(time.Duration(ociRequest.Timeout)),
 	)
 
 	runtimeParams := s.runtime.ParamDescs().ToParams()


### PR DESCRIPTION
This adds the parameter `-t` / `--timeout` back to image-based gadgets.

Task from #2653