### PR TITLE
gadgets: Add README.md for image-based gadgets

### DIFF
--- a/gadgets/snapshot_process/README.md
+++ b/gadgets/snapshot_process/README.md
@@ -1,0 +1,95 @@
+> ⚠️ This feature is experimental and could change without prior notification. Check the installation guide to enable [experimental features](../../docs/getting-started/install-linux.md#experimental-features).
+
+The snapshot process gadget gathers information about running processes.
+
+### On Kubernetes
+
+Let's start this demo by creating a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+There is not any running process in the `demo` namespace now:
+
+```bash
+$ kubectl gadget run snapshot_process -n demo
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       TID       PPID       UID       GID
+```
+
+Create a pod on the `demo` namespace using the `nginx` image:
+
+```bash
+$ kubectl -n demo run mypod --image=nginx
+pod/mypod created
+$ kubectl wait -n demo --for=condition=ready pod/mypod
+pod/mypod condition met
+```
+
+After the pod is running, we can try to get the list of running processes again:
+
+```bash
+$ kubectl gadget run snapshot_process -n demo
+INFO[0000] Experimental features enabled
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       TID       PPID      UID       GID
+ubuntu-hirsute      demo                mypod               mypod               nginx      411928    411928    411902    0         0
+ubuntu-hirsute      demo                mypod               mypod               nginx      411964    411964    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411965    411965    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411966    411966    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411967    411967    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411968    411968    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411969    411969    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411970    411970    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411971    411971    411928    101       101
+```
+
+We can see the different `nginx` process started within the container.
+
+Execute an instance of `sleep` on the pod:
+
+```bash
+$ kubectl -n demo exec mypod -- /bin/sh -c "sleep 1000 &"
+```
+
+Now there is an additional `sleep` processes running in `mypod`:
+
+```bash
+$ kubectl gadget run snapshot_process -n demo
+INFO[0000] Experimental features enabled
+K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       TID       PPID      UID       GID
+ubuntu-hirsute      demo                mypod               mypod               nginx      411928    411928    411902    0         0
+ubuntu-hirsute      demo                mypod               mypod               nginx      411964    411964    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411965    411965    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411966    411966    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411967    411967    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411968    411968    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411969    411969    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411970    411970    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               nginx      411971    411971    411928    101       101
+ubuntu-hirsute      demo                mypod               mypod               sleep      412000    412000    411928    0         0
+```
+
+Delete the demo test namespace:
+
+```bash
+$ kubectl delete ns demo
+namespace "demo" deleted
+```
+
+### With `ig`
+
+Create a container that runs sleep inside:
+
+```bash
+$ docker run --name test-snapshot-process -it --rm busybox /bin/sh -c 'sleep 100'
+```
+
+Run the snapshot process gadget, it'll print all process in the container:
+
+```bash
+$ sudo ig snapshot process -c test-snapshot-process
+INFO[0000] Experimental features enabled
+RUNTIME.CONTAINERNAME            MNTNS_ID           PID            TID             PPID           UID        GID      COMM     NETNS                  
+test-snapshot-process            4026533169         2666921        2666921         2666899        0          0        sh       0  
+```

--- a/gadgets/snapshot_socket/README.md
+++ b/gadgets/snapshot_socket/README.md
@@ -1,0 +1,81 @@
+---
+title: 'Using snapshot socket'
+weight: 20
+description: >
+  Gather information about TCP and UDP sockets.
+---
+
+The snapshot socket gadget gathers information about TCP and UDP sockets.
+
+### On Kubernetes
+
+We will start this demo by using nginx to create a web server on port 80:
+
+```bash
+$ kubectl create ns test-socketcollector
+namespace/test-socketcollector created
+$ kubectl run --restart=Never -n test-socketcollector --image=nginx nginx-app --port=80
+pod/nginx-app created
+```
+
+Wait for the pod to get ready:
+
+```bash
+$ kubectl wait --timeout=-1s -n test-socketcollector --for=condition=ready pod/nginx-app ; kubectl get pod -n test-socketcollector
+pod/nginx-app condition met
+NAME        READY   STATUS    RESTARTS   AGE
+nginx-app   1/1     Running   0          46s
+```
+
+We will now use the snapshot socket gadget to retrieve the TCP/UDP sockets information
+of the nginx-app pod. Notice we are filtering by namespace but we could have
+done it also using the podname or labels:
+
+```bash
+$ kubectl gadget run snapshot_socket -n test-socketcollector
+INFO[0000] Experimental features enabled
+K8S.NODE            K8S.NAMESPACE       K8S.POD        K8S.CONTAINER    SRC                      DST        
+minikube-docker     test-socketcollect… nginx-app      nginx-app        r/0.0.0.0:80             r/0.0.0.0:0
+```
+
+In the output, "SRC" is the local IP address and port number pair.
+If connected, "DST" is the remote IP address and port number pair,
+otherwise, it will be "0.0.0.0:0".
+
+Now, modify the nginx configuration to listen on port 8080 instead of 80 and reload the daemon:
+
+```bash
+$ kubectl exec -n test-socketcollector nginx-app -- /bin/bash -c "sed -i 's/listen \+80;/listen\t8080;/g' /etc/nginx/conf.d/default.conf && exec nginx -s reload"
+[...] signal process started
+```
+
+Now, we can check again with the snapshot socket gadget what the active socket is:
+
+```bash
+K8S.NODE            K8S.NAMESPACE       K8S.POD        K8S.CONTAINER    SRC                      DST        
+minikube-docker     test-socketcollect… nginx-app      nginx-app        r/0.0.0.0:8080           r/0.0.0.0:0
+```
+
+Delete test namespace:
+
+```bash
+$ kubectl delete ns test-socketcollector
+namespace "test-socketcollector" deleted
+```
+
+### With `ig`
+
+Create a container with the `nginx` image:
+
+```bash
+$ docker run --name test-socketcollector -it --rm nginx
+```
+
+Run the snapshot socket gadget:
+
+```bash
+$ sudo ig run snapshot_socket -c test-socketcollector
+INFO[0000] Experimental features enabled
+RUNTIME.CONTAINERNAME     SRC.PORT  SRC.PROTO DST.PORT  DST.PRO… STATE     INO               NETNS            SRC.ADDRESS        DST.ADDRESS                
+test-socketcollector      80        6         0         6        10        30977890          4026533194       :::20480           :::0                       
+test-socketcollector      80        6         0         6        10        30977889          4026533194       0.0.0.0:20480      0.0.0.0:0   

--- a/gadgets/trace_exec/README.md
+++ b/gadgets/trace_exec/README.md
@@ -1,0 +1,120 @@
+> ⚠️ This feature is experimental and could change without prior notification. Check the installation guide to enable [experimental features](../../docs/getting-started/install-linux.md#experimental-features).
+
+The trace exec gadget streams new processes creation events.
+
+### On Kubernetes
+
+Let's deploy an example application that will spawn few new processes:
+
+```bash
+$ kubectl apply -f docs/examples/ds-myapp.yaml
+daemonset.apps/myapp1-pod created
+daemonset.apps/myapp2-pod created
+
+$ kubectl get pod --show-labels -o wide
+NAME               READY   STATUS    RESTARTS   AGE   IP               NODE              NOMINATED NODE   READINESS GATES   LABELS
+myapp1-pod-sbtvw   1/1     Running   0          9s    10.244.192.133   minikube-docker   <none>           <none>            controller-revision-hash=865c886d8f,myapp=app-one,name=myapp1-pod,pod-template-generation=1,role=demo
+myapp2-pod-5pg4w   1/1     Running   0          9s    10.244.192.132   minikube-docker   <none>           <none>            controller-revision-hash=677d884fc,myapp=app-two,name=myapp2-pod,pod-template-generation=1,role=demo
+```
+
+Using the trace exec gadget, we can see which new processes are spawned on node
+minikube-docker where myapp1-pod-sbtvw and myapp2-pod-5pg4w are running:
+
+```bash
+$ kubectl gadget run trace_exec --selector role=demo --node minikube-docker --fields k8s,pid,ppid,comm,args
+INFO[0000] Experimental features enabled
+K8S.NODE        K8S.NAMESPACE K8S.POD          K8S.CONTAINER PID     PPID    COMM  ARGS
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226276 2221571 true  /bin/true
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226277 2221571 date  /bin/date
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226278 2221571 cat   /bin/cat /proc/version
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226279 2221571 true  /bin/true
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226280 2221571 date  /bin/date
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226281 2221571 cat   /bin/cat /proc/version
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226282 2221571 true  /bin/true
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226283 2221571 date  /bin/date
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226284 2221571 cat   /bin/cat /proc/version
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226286 2221571 true  /bin/true
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226287 2221571 date  /bin/date
+minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226288 2221571 cat   /bin/cat /proc/version
+minikube-docker default       myapp2-pod-5pg4w myapp2-pod    2226289 2221280 true  /bin/true
+minikube-docker default       myapp2-pod-5pg4w myapp2-pod    2226290 2221280 date  /bin/date
+minikube-docker default       myapp2-pod-5pg4w myapp2-pod    2226291 2221280 echo  /bin/echo sleep-10
+minikube-docker default       myapp2-pod-5pg4w myapp2-pod    2226292 2221280 sleep /bin/sleep 10
+^C
+```
+Processes of both pods are spawned: myapp1 spawns `cat /proc/version` and `sleep 1`,
+myapp2 spawns `echo sleep-10` and `sleep 10`, both spawn `true` and `date`.
+We can stop to trace again by hitting Ctrl-C.
+
+Finally, we clean up our demo app.
+
+```bash
+$ kubectl delete -f docs/examples/ds-myapp.yaml
+```
+
+### With `ig`
+
+Let's start the gadget in a terminal:
+
+```bash
+$ sudo ig run trace_exec -c test-trace-exec --fields runtime.containername,pid,ppid,comm,args
+INFO[0000] Experimental features enabled
+RUNTIME.CONTAINERNAME PID     PPID    COMM  ARGS
+```
+
+Run a container that executes some binaries:
+
+```bash
+$ docker run --name test-trace-exec -it --rm busybox /bin/sh -c 'while /bin/true ; do whoami ; sleep 3 ; done'
+```
+
+The tool will show the different processes executed by the container:
+
+```bash
+$ sudo ig run trace_exec -c test-trace-exec --fields runtime.containername,pid,ppid,comm,args
+RUNTIME.CONTAINERNAME PID     PPID    COMM   PCOMM           RET ARGS
+test-trace-exec       2233189 2233166 sh     containerd-shim 0   /bin/sh -c while /bin/true ; do whoami ; sleep 3 ; done
+test-trace-exec       2233214 2233189 true   sh              0   /bin/true
+test-trace-exec       2233215 2233189 whoami sh              0   /bin/whoami
+test-trace-exec       2233567 2233189 true   sh              0   /bin/true
+test-trace-exec       2233570 2233189 whoami sh              0   /bin/whoami
+test-trace-exec       2233642 2233189 true   sh              0   /bin/true
+test-trace-exec       2233643 2233189 whoami sh              0   /bin/whoami
+test-trace-exec       2233757 2233189 true   sh              0   /bin/true
+test-trace-exec       2233758 2233189 whoami sh              0   /bin/whoami
+test-trace-exec       2233931 2233189 true   sh              0   /bin/true
+test-trace-exec       2233932 2233189 whoami sh              0   /bin/whoami
+```
+
+
+### Overlay filesystem upper layer
+
+It can be useful to know if the executable in a container was modified or part
+of the original container image. If it was modified, it will be located in the
+upper layer of the overlay filesystem. For this reason, this gadget provides
+the upper layer field which is true if the executable is located in the upper
+layer of the overlay filesystem.
+
+```bash
+$ sudo ig run trace_exec -c test --fields comm,retval,upper_layer
+COMM             RET UPPERLAYER
+sh               0   false
+cp               0   false
+echo             0   false
+echo2            0   true
+```
+
+```bash
+$ docker run -ti --rm --name=test ubuntu \
+    sh -c 'cp /bin/echo /bin/echo2 ; /bin/echo lower ; /bin/echo2 upper'
+lower
+upper
+```
+
+Limitations:
+- The upper layer field is only available when the executable is executed
+  correctly (retval=0). For example, if the executable does not have the "execute"
+  permission, the execution will fail and the upper layer field will not be
+  defined.
+- In case of a shell script, the upper layer field will refer to the location
+  of the shell program (e.g. `/bin/sh`) and not the script file.

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -13,6 +13,7 @@ structs:
     - name: timestamp
       attributes:
         template: timestamp
+        hidden: true
     - name: pid
       attributes:
         template: pid
@@ -25,9 +26,11 @@ structs:
     - name: uid
       attributes:
         template: uid
+        hidden: true
     - name: gid
       attributes:
         template: uid
+        hidden: true
     - name: loginuid
       description: 'TODO: Fill field description'
       attributes:
@@ -47,6 +50,7 @@ structs:
       attributes:
         width: 3
         alignment: left
+        hidden: true
         ellipsis: end
     - name: args_count
       description: 'TODO: Fill field description'
@@ -73,11 +77,13 @@ structs:
       description: Mount namespace inode id
       attributes:
         template: ns
+        hidden: true
     - name: upper_layer
       description: Whether the executable is in the upper layer of the overlay filesystem
       attributes:
         width: 5
         alignment: left
+        hidden: true
         ellipsis: end
 ebpfParams:
   ignore_failed:

--- a/gadgets/trace_open/README.md
+++ b/gadgets/trace_open/README.md
@@ -1,0 +1,60 @@
+> ⚠️ This feature is experimental and could change without prior notification. Check the installation guide to enable [experimental features](../../docs/getting-started/install-linux.md#experimental-features).
+
+The trace open gadget streams events related to files opened inside pods.
+
+### On Kubernetes
+
+Here we deploy a small demo pod "mypod":
+
+```bash
+$ kubectl run --restart=Never -ti --image=busybox mypod -- sh -c 'while /bin/true ; do whoami ; sleep 3 ; done'
+```
+
+Using the trace open gadget, we can see which processes open what files.
+We can simply filter for the pod "mypod" and omit specifying the node,
+thus tracing on all nodes for a pod called "mypod":
+
+```bash
+$ kubectl gadget run trace_open --podname mypod
+K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER   PID    COMM               FD ERR PATH
+ip-10-0-30-247   default          mypod            mypod           18455  whoami              3   0 /etc/passwd
+ip-10-0-30-247   default          mypod            mypod           18521  whoami              3   0 /etc/passwd
+ip-10-0-30-247   default          mypod            mypod           18525  whoami              3   0 /etc/passwd
+ip-10-0-30-247   default          mypod            mypod           18530  whoami              3   0 /etc/passwd
+^
+Terminating!
+```
+
+Seems the whoami command opens "/etc/passwd" to map the user ID to a user name.
+We can leave trace open by hitting Ctrl-C.
+
+Finally, we need to clean up our pod:
+
+```bash
+$ kubectl delete pod mypod
+```
+
+
+### With `ig`
+
+Let's start the gadget in a terminal:
+
+```bash
+$ sudo ig run trace_open -c test-trace-open --fields runtime.containername,pid,comm,fd,err,fname
+RUNTIME.CONTAINERNAME                                      PID        COMM             FD    ERR FNAME
+```
+
+Run a container that opens some files:
+
+```bash
+$ docker run --name test-trace-open -it --rm busybox /bin/sh -c 'while /bin/true ; do whoami ; sleep 3 ; done'
+```
+
+The tool will show the different files opened by the container:
+
+```bash
+$ sudo ig trace open -c test-trace-open --fields runtime.containername,pid,comm,fd,err,fname
+RUNTIME.CONTAINERNAME                                      PID        COMM             FD    ERR PATH
+test-trace-open                                            630417     whoami           3     0   /etc/passwd
+test-trace-open                                            630954     whoami           3     0   /etc/passwd
+```


### PR DESCRIPTION
Add README.md for image-based gadgets. This should be used by artifacthub to show the documentation for individual gadgets as well! 

Related https://github.com/inspektor-gadget/inspektor-gadget/issues/2727

This PR only adds documentation for following gadgets:

- snapshot_process
- snapshot_socket
- trace_exec
- trace_open