### PR TITLE
image/build: Implement option to keep built file

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -66,6 +66,7 @@ type cmdOpts struct {
 	fileChanged      bool
 	image            string
 	local            bool
+	outputDir        string
 	builderImage     string
 	updateMetadata   bool
 	validateMetadata bool
@@ -95,6 +96,7 @@ func NewBuildCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "build.yaml", "Path to build.yaml")
 	cmd.Flags().BoolVarP(&opts.local, "local", "l", false, "Build using local tools")
+	cmd.Flags().StringVarP(&opts.outputDir, "output", "o", "", "Path to a folder to store generated files while building")
 	cmd.Flags().StringVarP(&opts.image, "tag", "t", "", "Name for the built image (format name:tag)")
 	cmd.Flags().StringVar(&opts.builderImage, "builder-image", builderImage, "Builder image to use")
 	cmd.Flags().BoolVar(&opts.updateMetadata, "update-metadata", false, "Update the metadata according to the eBPF code")
@@ -130,12 +132,20 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 		return fmt.Errorf("unmarshaling build.yaml: %w", err)
 	}
 
-	// make a temp folder to store the build results
-	tmpDir, err := os.MkdirTemp("", "gadget-build-")
-	if err != nil {
-		return fmt.Errorf("creating temp dir: %w", err)
+	if opts.outputDir != "" {
+		if _, err := os.Stat(opts.outputDir); err != nil {
+			return err
+		}
+	} else {
+		// make a temp folder to store the build results
+		tmpDir, err := os.MkdirTemp("", "gadget-build-")
+		if err != nil {
+			return fmt.Errorf("creating temp dir: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		opts.outputDir = tmpDir
 	}
-	defer os.RemoveAll(tmpDir)
 
 	if opts.path != "." {
 		cwd, err := os.Getwd()
@@ -154,11 +164,11 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 	}
 
 	if opts.local {
-		if err := buildLocal(opts, conf, tmpDir); err != nil {
+		if err := buildLocal(opts, conf); err != nil {
 			return err
 		}
 	} else {
-		if err := buildInContainer(opts, conf, tmpDir); err != nil {
+		if err := buildInContainer(opts, conf); err != nil {
 			return err
 		}
 	}
@@ -169,7 +179,7 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 
 	for _, arch := range archs {
 		obj := &oci.ObjectPath{
-			EBPF: filepath.Join(tmpDir, arch+".bpf.o"),
+			EBPF: filepath.Join(opts.outputDir, arch+".bpf.o"),
 		}
 
 		// TODO: the same wasm file is provided for all architectures. Should we allow per-arch
@@ -179,7 +189,7 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 			obj.Wasm = conf.Wasm
 		} else if conf.Wasm != "" {
 			// User provided a source file to build wasm from
-			obj.Wasm = filepath.Join(tmpDir, "program.wasm")
+			obj.Wasm = filepath.Join(opts.outputDir, "program.wasm")
 		}
 
 		objectsPaths[arch] = obj
@@ -204,8 +214,8 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 	return nil
 }
 
-func buildLocal(opts *cmdOpts, conf *buildFile, output string) error {
-	makefilePath := filepath.Join(output, "Makefile")
+func buildLocal(opts *cmdOpts, conf *buildFile) error {
+	makefilePath := filepath.Join(opts.outputDir, "Makefile")
 	if err := os.WriteFile(makefilePath, makefile, 0o644); err != nil {
 		return fmt.Errorf("writing Makefile: %w", err)
 	}
@@ -215,7 +225,7 @@ func buildLocal(opts *cmdOpts, conf *buildFile, output string) error {
 		"-j", fmt.Sprintf("%d", runtime.NumCPU()),
 		"EBPFSOURCE="+conf.EBPFSource,
 		"WASM="+conf.Wasm,
-		"OUTPUTDIR="+output,
+		"OUTPUTDIR="+opts.outputDir,
 		"CFLAGS="+conf.CFlags,
 	)
 	if out, err := buildCmd.CombinedOutput(); err != nil {
@@ -225,7 +235,7 @@ func buildLocal(opts *cmdOpts, conf *buildFile, output string) error {
 	return nil
 }
 
-func buildInContainer(opts *cmdOpts, conf *buildFile, output string) error {
+func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting current directory: %w", err)
@@ -299,7 +309,7 @@ func buildInContainer(opts *cmdOpts, conf *buildFile, output string) error {
 				{
 					Type:   mount.TypeBind,
 					Target: "/out",
-					Source: output,
+					Source: opts.outputDir,
 				},
 			},
 		},

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -46,16 +46,21 @@ const (
 	metadataMediaType   = "application/vnd.gadget.config.v1+yaml"
 )
 
+type ObjectPath struct {
+	// Path to the EBPF object
+	EBPF string
+	// Optional path to the Wasm file
+	Wasm string
+}
+
 type BuildGadgetImageOpts struct {
 	// Source path of the eBPF program. Currently it's not used for compilation purposes
 	EBPFSourcePath string
 	// List of eBPF objects to include in the image. The key is the architecture and the value
-	// is the path to the eBPF object.
-	EBPFObjectPaths map[string]string
+	// are the paths to the objects.
+	ObjectPaths map[string]*ObjectPath
 	// Path to the metadata file.
 	MetadataPath string
-	// Optional path to the Wasm file
-	WasmObjectPath string
 	// If true, the metadata is updated to follow changes in the eBPF objects.
 	UpdateMetadata bool
 	// If true, the metadata is validated before creating the image.
@@ -186,10 +191,21 @@ func createEmptyDesc(ctx context.Context, target oras.Target) (ocispec.Descripto
 	return emptyDesc, nil
 }
 
-func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, progFilePath, wasmFilePath, arch, createdDate string) (ocispec.Descriptor, error) {
-	progDesc, err := createLayerDesc(ctx, target, progFilePath, eBPFObjectMediaType)
+func createManifestForTarget(ctx context.Context, target oras.Target, metadataFilePath, arch string, paths *ObjectPath, createdDate string) (ocispec.Descriptor, error) {
+	layerDescs := []ocispec.Descriptor{}
+
+	progDesc, err := createLayerDesc(ctx, target, paths.EBPF, eBPFObjectMediaType)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("creating and pushing eBPF descriptor: %w", err)
+	}
+	layerDescs = append(layerDescs, progDesc)
+
+	if paths.Wasm != "" {
+		wasmDesc, err := createLayerDesc(ctx, target, paths.Wasm, wasmObjectMediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating and pushing wasm descriptor: %w", err)
+		}
+		layerDescs = append(layerDescs, wasmDesc)
 	}
 
 	// artifactType must be only set when the config.mediaType is set to
@@ -225,17 +241,9 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 		},
 		Config:       defDesc,
-		Layers:       []ocispec.Descriptor{progDesc},
+		Layers:       layerDescs,
 		Annotations:  defDesc.Annotations,
 		ArtifactType: artifactType,
-	}
-
-	if wasmFilePath != "" {
-		wasmDesc, err := createLayerDesc(ctx, target, wasmFilePath, wasmObjectMediaType)
-		if err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("creating and pushing wasm descriptor: %w", err)
-		}
-		manifest.Layers = append(manifest.Layers, wasmDesc)
 	}
 
 	manifestJson, err := json.Marshal(manifest)
@@ -268,8 +276,8 @@ func createImageIndex(ctx context.Context, target oras.Target, o *BuildGadgetIma
 	// Read the eBPF program files and push them to the memory store
 	layers := []ocispec.Descriptor{}
 
-	for arch, path := range o.EBPFObjectPaths {
-		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, path, o.WasmObjectPath, arch, o.CreatedDate)
+	for arch, paths := range o.ObjectPaths {
+		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, arch, paths, o.CreatedDate)
 		if err != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", arch, err)
 		}

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -116,6 +116,10 @@ func BuildGadgetImage(ctx context.Context, opts *BuildGadgetImageOpts, image str
 		}
 	}
 
+	if err := fixGeneratedFilesOwner(opts); err != nil {
+		return nil, fmt.Errorf("fixing generated files owner: %w", err)
+	}
+
 	return imageDesc, nil
 }
 

--- a/pkg/oci/build_metadata.go
+++ b/pkg/oci/build_metadata.go
@@ -45,8 +45,8 @@ func getAnySpec(opts *BuildGadgetImageOpts) (*ebpf.CollectionSpec, error) {
 	// TODO: we could perform a sanity check to be sure different architectures generate the
 	// same metadata, but that's too much for now.
 	// We're validating the metadata at runtime, so a possible error will be caught there.
-	for _, path := range opts.EBPFObjectPaths {
-		progPath = path
+	for _, paths := range opts.ObjectPaths {
+		progPath = paths.EBPF
 		break
 	}
 

--- a/pkg/oci/fix_owner_linux.go
+++ b/pkg/oci/fix_owner_linux.go
@@ -35,3 +35,32 @@ func fixOwner(targetFile, modelFile string) error {
 
 	return nil
 }
+
+func fixGeneratedFilesOwner(opts *BuildGadgetImageOpts) error {
+	info, err := os.Stat(opts.EBPFSourcePath)
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	allPaths := []string{}
+
+	for _, paths := range opts.ObjectPaths {
+		allPaths = append(allPaths, paths.EBPF, paths.Wasm)
+	}
+
+	for _, path := range allPaths {
+		if path == "" {
+			continue
+		}
+		err := os.Chown(path, int(stat.Uid), int(stat.Gid))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/oci/fix_owner_others.go
+++ b/pkg/oci/fix_owner_others.go
@@ -21,3 +21,7 @@ import "fmt"
 func fixOwner(_, _ string) error {
 	return fmt.Errorf("fixOwner not implemented on this platform")
 }
+
+func fixGeneratedFilesOwner(opts *BuildGadgetImageOpts) error {
+	return fmt.Errorf("fixGeneratedFilesOwner not implemented on this platform")
+}


### PR DESCRIPTION
There are situations when keeping the built files is useful. Implement a -o/--output option for it

Taken from #2598

### Testing
```bash 
$ cd gadgets/trace_open
$ mkdir /tmp/build
$ sudo -E ig image build . -o /tmp/build/
INFO[0000] Experimental features enabled
Successfully built @sha256:8d3859d56a61db46c286c30e81417025b67c4668c9118b0c6f7c5f466e666f31
$ ls -la /tmp/build/
total 184
drwxrwxr-x  2 mauriciov mauriciov  4096 abr 18 12:51 .
drwxrwxrwt 27 root      root      12288 abr 18 12:51 ..
-rw-r--r--  1 mauriciov mauriciov 88784 abr 18 12:51 amd64.bpf.o
-rw-r--r--  1 mauriciov mauriciov 81704 abr 18 12:51 arm64.bpf.o
```


