### PR TITLE
cmd: Do not truncate output when listing image-based gadgets.

### DIFF
--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -64,7 +64,7 @@ func NewListCmd() *cobra.Command {
 					return ""
 				})
 			}
-			formatter := textcolumns.NewFormatter(cols.GetColumnMap(), textcolumns.WithShouldTruncate(isTerm))
+			formatter := textcolumns.NewFormatter(cols.GetColumnMap(), textcolumns.WithShouldTruncate(!noTrunc && isTerm))
 			formatter.WriteTable(cmd.OutOrStdout(), images)
 			return nil
 		},


### PR DESCRIPTION
Hi.


With this PR, the digest are not truncated:

```bash
$ sudo -E ./ig image list --no-trunc                    francis/list-img-no-trunc % u=
INFO[0000] Experimental features enabled                
REPOSITORY TAG DIGEST CREATED
ghcr.io/eiffel-fl/gadget/trace_exec latest sha256:3bba250435a88c734b180e59b7750d082133ba4d58812ddfdf358c97050626d1 2024-04-10T11:17:26Z
ghcr.io/eiffel-fl/gadget/trace_oomkill latest sha256:87c76803b0be10ada9b2544056183344f480f87a8dd4e47fc4fa0a1a695b077c 2024-04-10T11:17:29Z
ghcr.io/eiffel-fl/gadget/trace_open latest sha256:3b07ed93eb3a5704d50d5c4d7f57235c042bf6df9328fd851bc34c979c5ccdb2 2024-04-10T11:17:30Z
```


Best regards.