### PR TITLE
pkg/uprobetracer: support LSM trace points

### DIFF
--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -65,3 +65,7 @@ For common libraries, `<file_path>` can also be the library's name, such as `lib
 The section name must use the `usdt/<file_path>:<providerName>:<probeName>` format.
 `<file_path>` can be either an absolute path or a library name, same as the field in Uprobe.
 `<providerName>` and `<probeName>` are two fields that can jointly identify a USDT trace point.
+
+### Tracing with Linux Security Modules (LSM)
+The section name must use the `lsm/<hook>` format.
+The hook points could be found in [`<include/linux/lsm_hook_defs.h>`](https://elixir.bootlin.com/linux/latest/source/include/linux/lsm_hook_defs.h).

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -117,6 +117,11 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 
 		i.logger.Debugf("Attaching sched_cls %q", p.Name)
 		return nil, handler.AttachProg(prog)
+	case ebpf.LSM:
+		i.logger.Debugf("Attaching LSM %q to %q", p.Name, p.AttachTo)
+		return link.AttachLSM(link.LSMOptions{
+			Program: prog,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported program %q of type %q", p.Name, p.Type)
 	}

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -32,6 +32,9 @@ const (
 	iterPrefix      = "iter/"
 	fentryPrefix    = "fentry/"
 	fexitPrefix     = "fexit/"
+	uprobePrefix    = "uprobe/"
+	uretprobePrefix = "uretprobe/"
+	usdtPrefix      = "usdt/"
 )
 
 func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.ProgramSpec, prog *ebpf.Program) (link.Link, error) {
@@ -44,9 +47,9 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 		case strings.HasPrefix(p.SectionName, kretprobePrefix):
 			i.logger.Debugf("Attaching kretprobe %q to %q", p.Name, p.AttachTo)
 			return link.Kretprobe(p.AttachTo, prog, nil)
-		case strings.HasPrefix(p.SectionName, "uprobe/") ||
-			strings.HasPrefix(p.SectionName, "uretprobe/") ||
-			strings.HasPrefix(p.SectionName, "usdt/"):
+		case strings.HasPrefix(p.SectionName, uprobePrefix) ||
+			strings.HasPrefix(p.SectionName, uretprobePrefix) ||
+			strings.HasPrefix(p.SectionName, usdtPrefix):
 			uprobeTracer := i.uprobeTracers[p.Name]
 			switch strings.Split(p.SectionName, "/")[0] {
 			case "uprobe":


### PR DESCRIPTION
# pkg/uprobetracer: support LSM trace points

## How to use

Use `lsm/<hook>` as section names.
