### PR TITLE
gadgets/trace_malloc: support more memory operations 

### DIFF
--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -13,6 +13,9 @@ structs:
     - name: pid
       attributes:
         template: pid
+    - name: tid
+      attributes:
+        template: pid
     - name: comm
       description: command
       attributes:
@@ -24,7 +27,7 @@ structs:
         alignment: left
         ellipsis: end
     - name: addr
-      description: address of malloc/free
+      description: address of malloc/free operations
       attributes:
         width: 20
         alignment: left
@@ -33,3 +36,12 @@ structs:
       description: Mount namespace inode id
       attributes:
         template: ns
+    - name: size
+      description: size of malloc operations
+      attributes:
+        width: 20
+        alignment: left
+        ellipsis: end
+    - name: timestamp_ns
+      attributes:
+        template: timestamp

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -9,28 +9,126 @@
 #include <gadget/macros.h>
 #include <gadget/mntns_filter.h>
 
+#define MAX_ENTRIES 10240
+
 enum memop {
-	MALLOC,
-	FREE,
+	malloc,
+	free,
+	calloc,
+	realloc,
+	realloc_free,
+	mmap,
+	munmap,
+	posix_memalign,
+	aligned_alloc,
+	valloc,
+	memalign,
+	pvalloc,
 };
 
 struct event {
 	gadget_mntns_id mntns_id;
 	__u32 pid;
+	__u32 tid;
 	char comm[TASK_COMM_LEN];
 	enum memop operation;
 	__u64 addr;
+	__u64 size;
+	__u64 timestamp_ns;
 };
 
-GADGET_TRACER_MAP(events, 1024 * 256);
+/* used for context between uprobes and uretprobes of allocations */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u32); // tid
+	__type(value, u64);
+} sizes SEC(".maps");
 
+/* used by posix_memalign */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u32); // tid
+	__type(value, u64);
+} memptrs SEC(".maps");
+
+/**
+ * clean up the maps when a thread terminates,
+ * because there may be residual data in the map
+ * if a userspace thread is killed between a uprobe and a uretprobe
+ */
+SEC("tracepoint/sched/sched_process_exit")
+int trace_sched_process_exit(void *ctx)
+{
+	u32 tid;
+
+	tid = (u32)bpf_get_current_pid_tgid();
+	bpf_map_delete_elem(&sizes, &tid);
+	bpf_map_delete_elem(&memptrs, &tid);
+	return 0;
+}
+
+GADGET_TRACER_MAP(events, 1024 * 256);
 GADGET_TRACER(malloc, events, event);
 
-static __always_inline int submit_memop_event(struct pt_regs *ctx,
-					      enum memop operation, __u64 addr)
+static __always_inline int gen_alloc_enter(size_t size)
+{
+	u32 tid;
+
+	tid = (u32)bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&sizes, &tid, &size, BPF_ANY);
+
+	return 0;
+}
+
+static __always_inline int gen_alloc_exit(struct pt_regs *ctx,
+					  enum memop operation, u64 addr)
 {
 	u64 mntns_id;
 	struct event *event;
+	u64 pid_tgid;
+	u32 tid;
+	u64 *size_ptr;
+	u64 size;
+
+	mntns_id = gadget_get_mntns_id();
+	if (gadget_should_discard_mntns_id(mntns_id))
+		return 0;
+
+	pid_tgid = bpf_get_current_pid_tgid();
+	tid = (u32)pid_tgid;
+	size_ptr = bpf_map_lookup_elem(&sizes, &tid);
+	if (!size_ptr)
+		return 0;
+	size = *size_ptr;
+	bpf_map_delete_elem(&sizes, &tid);
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	event->mntns_id = mntns_id;
+	event->pid = pid_tgid >> 32;
+	event->tid = tid;
+	bpf_get_current_comm(event->comm, sizeof(event->comm));
+	event->operation = operation;
+	event->addr = addr;
+	event->size = size;
+	event->timestamp_ns = bpf_ktime_get_ns();
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+	return 0;
+}
+
+static __always_inline int gen_free_enter(struct pt_regs *ctx,
+					  enum memop operation, u64 addr)
+{
+	u64 mntns_id;
+	struct event *event;
+	u64 pid_tgid;
+	u32 tid;
 
 	mntns_id = gadget_get_mntns_id();
 	if (gadget_should_discard_mntns_id(mntns_id))
@@ -40,27 +138,151 @@ static __always_inline int submit_memop_event(struct pt_regs *ctx,
 	if (!event)
 		return 0;
 
+	pid_tgid = bpf_get_current_pid_tgid();
+	tid = (u32)pid_tgid;
+
 	event->mntns_id = mntns_id;
-	event->pid = bpf_get_current_pid_tgid() >> 32;
+	event->pid = pid_tgid >> 32;
+	event->tid = tid;
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
 	event->operation = operation;
 	event->addr = addr;
+	event->size = 0;
+	event->timestamp_ns = bpf_ktime_get_ns();
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 
 	return 0;
 }
 
-SEC("uretprobe/libc:malloc")
-int trace_uprobe_malloc(struct pt_regs *ctx)
+/* common macros */
+#define PROBE_RET_VAL_FOR_ALLOC(func)                              \
+	SEC("uretprobe/libc:" #func)                               \
+	int trace_uretprobe_##func(struct pt_regs *ctx)            \
+	{                                                          \
+		return gen_alloc_exit(ctx, func, PT_REGS_RC(ctx)); \
+	}
+
+/* malloc */
+SEC("uprobe/libc:malloc")
+int BPF_UPROBE(trace_uprobe_malloc, size_t size)
 {
-	return submit_memop_event(ctx, MALLOC, PT_REGS_RC(ctx));
+	return gen_alloc_enter(size);
 }
 
+PROBE_RET_VAL_FOR_ALLOC(malloc)
+
+/* free */
 SEC("uprobe/libc:free")
-int trace_uprobe_free(struct pt_regs *ctx)
+int BPF_UPROBE(trace_uprobe_free, void *address)
 {
-	return submit_memop_event(ctx, FREE, PT_REGS_PARM1(ctx));
+	return gen_free_enter(ctx, free, (u64)address);
 }
+
+/* calloc */
+SEC("uprobe/libc:calloc")
+int BPF_UPROBE(trace_uprobe_calloc, size_t nmemb, size_t size)
+{
+	return gen_alloc_enter(nmemb * size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(calloc)
+
+/* realloc */
+SEC("uprobe/libc:realloc")
+int BPF_UPROBE(trace_uprobe_realloc, void *ptr, size_t size)
+{
+	gen_free_enter(ctx, realloc_free, (u64)ptr);
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(realloc)
+
+/* mmap */
+SEC("uprobe/libc:mmap")
+int BPF_UPROBE(trace_uprobe_mmap, void *address, size_t size)
+{
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(mmap)
+
+/* munmap */
+SEC("uprobe/libc:munmap")
+int BPF_UPROBE(trace_uprobe_munmap, void *address)
+{
+	return gen_free_enter(ctx, munmap, (u64)address);
+}
+
+/* posix_memalign */
+SEC("uprobe/libc:posix_memalign")
+int BPF_UPROBE(trace_uprobe_posix_memalign, void **memptr, size_t alignment,
+	       size_t size)
+{
+	u64 memptr64;
+	u32 tid;
+
+	tid = (u32)bpf_get_current_pid_tgid();
+	memptr64 = (u64)memptr;
+	bpf_map_update_elem(&memptrs, &tid, &memptr64, BPF_ANY);
+
+	return gen_alloc_enter(size);
+}
+
+SEC("uretprobe/libc:posix_memalign")
+int trace_uretprobe_posix_memalign(struct pt_regs *ctx)
+{
+	u64 *memptr64;
+	void *addr;
+	u32 tid;
+
+	tid = (u32)bpf_get_current_pid_tgid();
+
+	memptr64 = bpf_map_lookup_elem(&memptrs, &tid);
+	if (!memptr64)
+		return 0;
+	bpf_map_delete_elem(&memptrs, &tid);
+
+	if (bpf_probe_read_user(&addr, sizeof(void *), (void *)*memptr64))
+		return 0;
+
+	return gen_alloc_exit(ctx, posix_memalign, (u64)addr);
+}
+
+/* aligned_alloc */
+SEC("uprobe/libc:aligned_alloc")
+int BPF_UPROBE(trace_uprobe_aligned_alloc, size_t alignment, size_t size)
+{
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(aligned_alloc)
+
+/* valloc */
+SEC("uprobe/libc:valloc")
+int BPF_UPROBE(trace_uprobe_valloc, size_t size)
+{
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(valloc)
+
+/* memalign */
+SEC("uprobe/libc:memalign")
+int BPF_UPROBE(trace_uprobe_memalign, size_t alignment, size_t size)
+{
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(memalign)
+
+/* pvalloc */
+SEC("uprobe/libc:pvalloc")
+int BPF_UPROBE(trace_uprobe_pvalloc, size_t size)
+{
+	return gen_alloc_enter(size);
+}
+
+PROBE_RET_VAL_FOR_ALLOC(pvalloc)
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
# gadgets/trace_malloc: support more memory operations

Gadgets such as `memleak` and `deadlock` need userspace code to further interpret the data collected from kernel side. It needs WASM support, which is not currently available. So this pull request just send the events to ebpf map, and processing the events in userspace is future work.