### PR TITLE
Add runc symlink for rancher rke2

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -41,6 +41,7 @@ var RuntimePaths = []string{
 	"/run/torcx/unpack/docker/bin/runc", // Used in Flatcar Container Linux
 	"/usr/bin/crun",
 	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
+	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2
 }
 
 // Notify marks the runtime path given as argument if it exists.


### PR DESCRIPTION
# Add runc symlink for rancher rke2

Now that we support symlink resolution in runtime path, we can support Rancher rke2 out of the box (similar to what we have for k3s).

## How to use

Install rancher https://docs.rke2.io/install/quickstart and try tracing without specifying any runc path.

## Testing done

Compiled `ig` and successfully ran some tracers on rke2.
