### PR TITLE
pkg/{runcfanotify, container-hook}: Refactor code to use notify package.

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -1,0 +1,72 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finder
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/s3rj1k/go-fanotify/fanotify"
+	"golang.org/x/sys/unix"
+)
+
+// RuntimePaths is the list of paths where the container runtime runc or crun
+// could be installed. Depending on the Linux distribution, it could be in
+// different locations.
+//
+// When this package is executed in a container, it prepends the HOST_ROOT env
+// variable to the path.
+var RuntimePaths = []string{
+	"/bin/runc",
+	"/usr/bin/runc",
+	"/usr/sbin/runc",
+	"/usr/local/bin/runc",
+	"/usr/local/sbin/runc",
+	"/usr/lib/cri-o-runc/sbin/runc",
+	"/run/torcx/unpack/docker/bin/runc", // Used in Flatcar Container Linux
+	"/usr/bin/crun",
+	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
+}
+
+// Notify marks the runtime path given as argument if it exists.
+// The host root is prepend is not already present in runtime path.
+// If prepend runtime path is a symbolic link, it will be resolved.
+// The resulting runtime path is then marked using the corresponding NotifyFD.
+func Notify(runtimePath string, hostRoot string, notifyFD *fanotify.NotifyFD) (string, error) {
+	path := runtimePath
+	var err error
+
+	// Check if we have to prepend the host root to the runtime path
+	if !strings.HasPrefix(runtimePath, hostRoot) {
+		// SecureJoin will resolve symlinks according to the host root
+		path, err = securejoin.SecureJoin(hostRoot, path)
+		if err != nil {
+			return "", fmt.Errorf("securejoining of %s: %w", path, err)
+		}
+	}
+
+	if _, err = os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	if err = notifyFD.Mark(unix.FAN_MARK_ADD, unix.FAN_OPEN_EXEC_PERM, unix.AT_FDCWD, path); err != nil {
+		return "", fmt.Errorf("marking of %s: %w", path, err)
+	}
+
+	return path, nil
+}

--- a/pkg/runcfanotify/runcfanotify.go
+++ b/pkg/runcfanotify/runcfanotify.go
@@ -29,12 +29,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	securejoin "github.com/cyphar/filepath-securejoin"
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/s3rj1k/go-fanotify/fanotify"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	runtimefinder "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook/runtime-finder"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
@@ -114,23 +114,6 @@ type RuncNotifier struct {
 	wg sync.WaitGroup
 }
 
-// runcPaths is the list of paths where runc could be installed. Depending on
-// the Linux distribution, it could be in different locations.
-//
-// When this package is executed in a container, it prepends the
-// HOST_ROOT env variable to the path.
-var runcPaths = []string{
-	"/bin/runc",
-	"/usr/bin/runc",
-	"/usr/sbin/runc",
-	"/usr/local/bin/runc",
-	"/usr/local/sbin/runc",
-	"/usr/lib/cri-o-runc/sbin/runc",
-	"/run/torcx/unpack/docker/bin/runc",
-	"/usr/bin/crun",
-	"/var/lib/rancher/k3s/data/current/bin/runc",
-}
-
 // initFanotify initializes the fanotify API with the flags we need
 func initFanotify() (*fanotify.NotifyFD, error) {
 	fanotifyFlags := uint(unix.FAN_CLOEXEC | unix.FAN_CLASS_CONTENT | unix.FAN_UNLIMITED_QUEUE | unix.FAN_UNLIMITED_MARKS | unix.FAN_NONBLOCK)
@@ -163,7 +146,7 @@ func Supported() bool {
 // or terminated, and call the callback on such event.
 //
 // Limitations:
-// - runc must be installed in one of the paths listed by runcPaths
+// - runc must be installed in one of the paths listed by notify.RuntimePaths
 func NewRuncNotifier(callback RuncNotifyFunc) (*RuncNotifier, error) {
 	n := &RuncNotifier{
 		callback:         callback,
@@ -182,52 +165,33 @@ func NewRuncNotifier(callback RuncNotifyFunc) (*RuncNotifier, error) {
 
 	runcPath := os.Getenv("RUNC_PATH")
 	if runcPath != "" {
-		log.Debugf("Runcfanotify: trying runc from RUNC_PATH env variable at %s", runcPath)
+		log.Debugf("runc-fanotify: trying runtime from RUNC_PATH env variable at %s", runcPath)
 
-		// Check if we have to prepend the host root to the runtime path
-		if !strings.HasPrefix(runcPath, host.HostRoot) {
-			// SecureJoin will resolve symlinks according to the host root
-			runcPath, err = securejoin.SecureJoin(host.HostRoot, runcPath)
-			if err != nil {
-				return nil, fmt.Errorf("runcfanotify: securejoin failed: %w", err)
-			}
+		notifiedPath, err := runtimefinder.Notify(runcPath, host.HostRoot, runcBinaryNotify)
+		if err != nil {
+			return nil, fmt.Errorf("runc-fanotify: notifying %s: %w", runcPath, err)
 		}
 
-		if _, err := os.Stat(runcPath); errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
-
-		if err := runcBinaryNotify.Mark(unix.FAN_MARK_ADD, unix.FAN_OPEN_EXEC_PERM, unix.AT_FDCWD, runcPath); err != nil {
-			return nil, fmt.Errorf("fanotify marking of %s: %w", runcPath, err)
-		}
+		log.Debugf("runc-fanotify: monitoring runtime at %s (originally %s)", notifiedPath, runcPath)
 		runcMonitored = true
 	} else {
-		for _, r := range runcPaths {
-			// SecureJoin will resolve symlinks according to the host root
-			runcPath, err := securejoin.SecureJoin(host.HostRoot, r)
+		for _, r := range runtimefinder.RuntimePaths {
+			log.Debugf("runc-fanotify: trying runtime at %s", r)
+
+			notifiedPath, err := runtimefinder.Notify(r, host.HostRoot, runcBinaryNotify)
 			if err != nil {
-				log.Debugf("Runcfanotify: securejoin failed: %s", err)
+				log.Debugf("runc-fanotify: notifying %s: %v", r, err)
 				continue
 			}
 
-			log.Debugf("Runcfanotify: trying runc at %s", runcPath)
-
-			if _, err := os.Stat(runcPath); errors.Is(err, os.ErrNotExist) {
-				log.Debugf("Runcfanotify: runc at %s not found", runcPath)
-				continue
-			}
-
-			if err := runcBinaryNotify.Mark(unix.FAN_MARK_ADD, unix.FAN_OPEN_EXEC_PERM, unix.AT_FDCWD, runcPath); err != nil {
-				log.Warnf("Runcfanotify: failed to fanotify mark: %s", err)
-				continue
-			}
+			log.Debugf("runc-fanotify: monitoring runtime at %s (originally %s)", notifiedPath, r)
 			runcMonitored = true
 		}
 	}
 
 	if !runcMonitored {
 		runcBinaryNotify.File.Close()
-		return nil, fmt.Errorf("no runc instance can be monitored with fanotify. The following paths were tested: %s. You can use the RUNC_PATH env variable to specify a custom path. If you are successful doing so, please open a PR to add your custom path to runcPaths", strings.Join(runcPaths, ","))
+		return nil, fmt.Errorf("no runc instance can be monitored with fanotify. The following paths were tested: %s. You can use the RUNC_PATH env variable to specify a custom path. If you are successful doing so, please open a PR to add your custom path to runtimefinder.RuntimePaths", strings.Join(runtimefinder.RuntimePaths, ", "))
 	}
 
 	n.wg.Add(2)


### PR DESCRIPTION
Hi.

This PR refactors the common code between `runcfanotify` and `container-hook`.
I also unified the runtime paths array, so they now count the same number for both hooks and it is now easier to add a new hook.

Best regards.