### PR TITLE
trace/{dns,sni}: Split NewTracer() logic

### DIFF
--- a/pkg/gadget-collection/gadgets/trace/dns/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/dns/gadget.go
@@ -130,6 +130,12 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		trace.Status.OperationError = fmt.Sprintf("Failed to start dns tracer: %s", err)
 		return
 	}
+
+	if err := t.tracer.RunWorkaround(); err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to start dns tracer: %s", err)
+		return
+	}
+
 	t.started = true
 
 	trace.Status.State = gadgetv1alpha1.TraceStateStarted

--- a/pkg/gadget-collection/gadgets/trace/sni/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/sni/gadget.go
@@ -130,6 +130,11 @@ func (t *Trace) Start(trace *gadgetv1alpha1.Trace) {
 		return
 	}
 
+	if err := t.tracer.RunWorkaround(); err != nil {
+		trace.Status.OperationError = fmt.Sprintf("Failed to start sni tracer: %s", err)
+		return
+	}
+
 	t.started = true
 
 	trace.Status.State = gadgetv1alpha1.TraceStateStarted

--- a/pkg/gadgets/trace/dns/tracer/tracer.go
+++ b/pkg/gadgets/trace/dns/tracer/tracer.go
@@ -57,13 +57,18 @@ func NewTracer() (*Tracer, error) {
 		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
 
+	return t, nil
+}
+
+// RunWorkaround is used by pkg/gadget-collection/gadgets/trace/dns/gadget.go to run the gadget
+// after calling NewTracer()
+func (t *Tracer) RunWorkaround() error {
 	// timeout nor ports configurable in this case
 	if err := t.run(context.TODO(), log.StandardLogger(), time.Minute, []uint16{53, 5353}); err != nil {
 		t.Close()
-		return nil, fmt.Errorf("running tracer: %w", err)
+		return fmt.Errorf("running tracer: %w", err)
 	}
-
-	return t, nil
+	return nil
 }
 
 // pkt_type definitions:

--- a/pkg/gadgets/trace/sni/tracer/tracer.go
+++ b/pkg/gadgets/trace/sni/tracer/tracer.go
@@ -50,12 +50,19 @@ func NewTracer() (*Tracer, error) {
 		return nil, fmt.Errorf("installing tracer: %w", err)
 	}
 
+	return t, nil
+}
+
+// RunWorkaround is used by pkg/gadget-collection/gadgets/trace/sni/gadget.go to run the gadget
+// after calling NewTracer()
+func (t *Tracer) RunWorkaround() error {
 	if err := t.run(); err != nil {
 		t.Close()
-		return nil, fmt.Errorf("running tracer: %w", err)
+
+		return fmt.Errorf("running tracer: %w", err)
 	}
 
-	return t, nil
+	return nil
 }
 
 func parseSNIEvent(sample []byte, netns uint64) (*types.Event, error) {


### PR DESCRIPTION
# Split NewTracer() logic in dns and sni tracers

Before this change NewTracer() installed and run the tracer.
Now calling NewTracer() only installs the tracer, and Run() or RunWorkaround() runs it.
This change is needed so that the socket enricher could be set before loading the eBPF programs.

A similar solution was implemented in the network tracer.

Discussion: https://kubernetes.slack.com/archives/CSYL75LF6/p1713707118485529

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

Before this change, `MountNsID` was empty even when setting the socket enricher. I have run the DNS tracer with this change implemented and I could see that mount namespace was filled successfully and so enrichment of events is working.