### PR TITLE
kubectl-gadget: Multiple fixes around skipInfo logic 

### DIFF
--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
@@ -76,8 +75,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		runtime.InitDeployInfo()
-		info, err := deployinfo.Load()
+		info, err := runtime.InitDeployInfo()
 		if err != nil {
 			log.Warnf("Failed to load deploy info: %s", err)
 		} else if err := commonutils.CheckServerVersionSkew(info.ServerVersion); err != nil {

--- a/pkg/runtime/grpc/info.go
+++ b/pkg/runtime/grpc/info.go
@@ -21,8 +21,6 @@ import (
 	"math"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/inspektor-gadget/inspektor-gadget/internal/deployinfo"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 )
@@ -30,26 +28,27 @@ import (
 // InitDeployInfo loads the locally stored deploy info. If no deploy info is stored locally,
 // it will try to fetch it from one of the remotes and store it locally. It will issue warnings on
 // failures.
-func (r *Runtime) InitDeployInfo() {
+func (r *Runtime) InitDeployInfo() (*deployinfo.DeployInfo, error) {
 	// Initialize info
 	info, err := deployinfo.Load()
 	if err == nil {
 		r.info = info
-		return
+		return info, nil
 	}
 
 	info, err = r.loadRemoteDeployInfo()
 	if err != nil {
-		log.Warnf("could not load gadget info from remote: %v", err)
-		return
+		return nil, fmt.Errorf("loading gadget info from remote: %w", err)
 	}
 
 	r.info = info
 
 	err = deployinfo.Store(info)
 	if err != nil {
-		log.Warnf("could not store gadget info: %v", err)
+		return nil, fmt.Errorf("storing gadget info: %w", err)
 	}
+
+	return info, nil
 }
 
 func (r *Runtime) UpdateDeployInfo() error {


### PR DESCRIPTION
Add the completion command to the list of commands we need to skip getting the deploy info for.

Fix the following issues:
- kubectl-gadget completion not working when IG is not deployed
- kubectl-gadget version not showing the client version when k8s is not reacheable

Fixes #2773

### Testing

I performed the following:


```bash 
$ mkdir /tmp/config

$ minikube start -p ig
$ cp $HOME/.kube/config /tmp/config/ig

$ minikube start -p non-ig
$ cp $HOME/.kube/config /tmp/config/non-ig


$ KUBECONFIG=/tmp/config/ig kubectl get nodes
NAME   STATUS   ROLES           AGE     VERSION
ig     Ready    control-plane   2m14s   v1.28.3

$ KUBECONFIG=/tmp/config/non-ig kubectl get nodes
NAME     STATUS   ROLES           AGE   VERSION
non-ig   Ready    control-plane   23s   v1.28.3

# Deploy ig to one of the clusters
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget deploy

$ KUBECONFIG=/tmp/config/ig kubectl get namespaces
NAME              STATUS   AGE
default           Active   3m54s
gadget            Active   58s
kube-node-lease   Active   3m54s
kube-public       Active   3m54s
kube-system       Active   3m55s


# kubectl-gadget

## without k8s 
$ KUBECONFIG=/dev/null ./kubectl-gadget
Collection of gadgets for Kubernetes developers
...

## without IG deployed 
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget
Collection of gadgets for Kubernetes developers
...

## with IG deployed 
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget
Collection of gadgets for Kubernetes developers
...

# kubectl-gadget -h 

## without k8s 
$ KUBECONFIG=/dev/null ./kubectl-gadget -h
WARN[0000] Failed to contact Inspektor Gadget. Help text could be incomplete.
WARN[0000] No running Inspektor Gadget instances found. Help text could be incomplete.
Collection of gadgets for Kubernetes developers
...

## without IG deployed 
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget -h
WARN[0000] No running Inspektor Gadget instances found. Help text could be incomplete.
Collection of gadgets for Kubernetes developers
...

## with IG deployed 
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget -h
Collection of gadgets for Kubernetes developers
...

# kubectl-gadget version 

## without k8s 
$ KUBECONFIG=/dev/null ./kubectl-gadget version
Client version: v0.27.0-200-gea640ffa8-dirty
Error: searching for running Inspektor Gadget instances: Get "http://localhost:8080/apis/apps/v1/daemonsets?fieldSelector=metadata.name%3Dgadget&labelSelector=k8s-app%3Dgadget": dial tcp 127.0.0.1:8080: connect: connection refused

## without IG deployed
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget version
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget version
Client version: v0.27.0-200-gea640ffa8-dirty
Server version: not installed

## with IG deployed
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget version
Client version: v0.27.0-200-gea640ffa8-dirty
Server version: v0.27.0-190-gb69483053-dirty

# kubectl-gadget completion bash 

## without k8s
$ KUBECONFIG=/dev/null ./kubectl-gadget completion bash
... (works)

## without IG deployed
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget completion bash
... (works as well)

## with IG deployed
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget completion bash
... (works as well)


# kubectl-gadget trace exec 

## without k8s
$ KUBECONFIG=/dev/null ./kubectl-gadget trace exec
FATA[0000] Searching for running Inspektor Gadget instances.Get "http://localhost:8080/apis/apps/v1/daemonsets?fieldSelector=metadata.name%3Dgadget&labelSelector=k8s-app%3Dgadget": dial tcp 127.0.0.1:8080: connect: connection refused

## without IG deployed
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget trace exec
FATA[0000] No running Inspektor Gadget instances found.

## with IG deployed
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget trace exec
K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID       PPID     COMM     PCOMM    RET ARGS
(works...)


# kubectl-gadget trace exec -h

## without k8s
$ KUBECONFIG=/dev/null ./kubectl-gadget trace exec -h
WARN[0000] Failed to contact Inspektor Gadget. Help text could be incomplete.
WARN[0000] No running Inspektor Gadget instances found. Help text could be incomplete.
... 

## without IG deployed
$ KUBECONFIG=/tmp/config/non-ig ./kubectl-gadget trace exec -h
WARN[0000] No running Inspektor Gadget instances found. Help text could be incomplete.
... 

## with IG deployed
$ KUBECONFIG=/tmp/config/ig ./kubectl-gadget trace exec -h
Trace new processes
...

```