### PR TITLE
test-integration-eks: Fix missing quotes + define explicit timeformat

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1656,7 +1656,7 @@ jobs:
         if [ ${{ matrix.arch }} = 'arm64' ]; then
           node_type='a1.xlarge'
         fi
-        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags "ig-ci=true,ig-ci-timestamp=$(date -u --rfc-3339=seconds)" --node-type $node_type
+        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags "ig-ci=true,ig-ci-timestamp=$(date -u +'%Y-%m-%dT%H:%M:%S%:z')" --node-type $node_type
     - name: Run integration tests
       uses: ./.github/actions/run-integration-tests
       with:

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1656,7 +1656,7 @@ jobs:
         if [ ${{ matrix.arch }} = 'arm64' ]; then
           node_type='a1.xlarge'
         fi
-        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags ig-ci=true,ig-ci-timestamp=$(date -u --rfc-3339=seconds) --node-type $node_type
+        eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags "ig-ci=true,ig-ci-timestamp=$(date -u --rfc-3339=seconds)" --node-type $node_type
     - name: Run integration tests
       uses: ./.github/actions/run-integration-tests
       with:


### PR DESCRIPTION
# test-integration-eks: Fix missing quotes + define explicit timeformat

Fixes: PR https://github.com/inspektor-gadget/inspektor-gadget/pull/2686 commit 410cb4904f2c400d6191028da8c5e041c8757a2b

Working citest run: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/8849861291/job/24303110950

Apparently RFC3339 is not always compatible with each implementation