### PR TITLE
cmd: Implement image import and export commands

### DIFF
--- a/cmd/common/image/export.go
+++ b/cmd/common/image/export.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,24 +15,33 @@
 package image
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
-func NewImageCmd() *cobra.Command {
+func NewExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "image",
-		Short: "Manage gadget images",
+		Use:          "export SRC_IMAGE [SRC_IMAGE n] DST_FILE",
+		Short:        "Export the SRC_IMAGE images to DST_FILE",
+		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l := len(args)
+			srcImages := args[:l-1]
+			dstFile := args[l-1]
+			err := oci.ExportGadgetImages(context.TODO(), dstFile, srcImages...)
+			if err != nil {
+				return fmt.Errorf("exporting images: %w", err)
+			}
+			cmd.Printf("Successfully exported images to %s\n", dstFile)
+			return nil
+		},
 	}
-
-	cmd.AddCommand(NewBuildCmd())
-	cmd.AddCommand(NewExportCmd())
-	cmd.AddCommand(NewPushCmd())
-	cmd.AddCommand(NewPullCmd())
-	cmd.AddCommand(NewTagCmd())
-	cmd.AddCommand(NewListCmd())
-	cmd.AddCommand(NewRemoveCmd())
 
 	return utils.MarkExperimental(cmd)
 }

--- a/cmd/common/image/import.go
+++ b/cmd/common/image/import.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,25 +15,34 @@
 package image
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
-func NewImageCmd() *cobra.Command {
+func NewImportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "image",
-		Short: "Manage gadget images",
+		Use:          "import SRC_FILE",
+		Short:        "Import images from SRC_FILE",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcFile := args[0]
+			tags, err := oci.ImportGadgetImages(context.TODO(), srcFile)
+			if err != nil {
+				return fmt.Errorf("importing images: %w", err)
+			}
+			cmd.Printf("Successfully imported images:\n")
+			for _, tag := range tags {
+				cmd.Printf("  %s\n", tag)
+			}
+			return nil
+		},
 	}
-
-	cmd.AddCommand(NewBuildCmd())
-	cmd.AddCommand(NewExportCmd())
-	cmd.AddCommand(NewImportCmd())
-	cmd.AddCommand(NewPushCmd())
-	cmd.AddCommand(NewPullCmd())
-	cmd.AddCommand(NewTagCmd())
-	cmd.AddCommand(NewListCmd())
-	cmd.AddCommand(NewRemoveCmd())
 
 	return utils.MarkExperimental(cmd)
 }

--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -304,11 +304,41 @@ Usage:
   ig image tag SRC_IMAGE DST_IMAGE [flags]
 
 Flags:
-  -h, --help   help for ta
+  -h, --help   help for tag
 ```
 
 ```bash
 $ sudo ig image tag mygadget:latest ghcr.io/mauriciovasquezbernal/mygadget:latest
 INFO[0000] Experimental features enabled
 Successfully tagged with ghcr.io/mauriciovasquezbernal/mygadget:latest@sha256:adf9a4c636421d09e038eefa15623176195b0de482b25972e09b8bb3390bd3e9
+```
+
+#### `export`
+
+Export the SRC_IMAGE images to DST_FILE.
+
+```bash
+$ sudo ig image export -h
+INFO[0000] Experimental features enabled
+Export the SRC_IMAGE images to DST_FILE (experimental)
+
+Usage:
+  ig image export SRC_IMAGE [SRC_IMAGE n] DST_FILE [flags]
+
+Flags:
+  -h, --help   help for export
+```
+
+```bash
+# Pull an image
+$ sudo -E ig image pull ghcr.io/inspektor-gadget/gadget/trace_open
+INFO[0000] Experimental features enabled
+
+# Export it to a file
+$ sudo -E ig image export ghcr.io/inspektor-gadget/gadget/trace_open trace_open.tar
+INFO[0000] Experimental features enabled
+Successfully exported images to trace_open.tar
+
+$ ls -lnh trace_open.tar
+-rw-r--r-- 1 0 0 181K abr 24 17:35 trace_open.tar
 ```

--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -342,3 +342,39 @@ Successfully exported images to trace_open.tar
 $ ls -lnh trace_open.tar
 -rw-r--r-- 1 0 0 181K abr 24 17:35 trace_open.tar
 ```
+
+#### `import`
+
+```bash
+$ sudo -E ig image import -h
+INFO[0000] Experimental features enabled
+Import images from SRC_FILE (experimental)
+
+Usage:
+  ig image import SRC_FILE [flags]
+
+Flags:
+  -h, --help   help for import
+```
+
+```bash
+# Remove image if existing
+$ sudo -E ig image remove trace_open
+INFO[0000] Experimental features enabled
+Successfully removed trace_open
+
+$ sudo -E ig image list
+INFO[0000] Experimental features enabled
+REPOSITORY                     TAG                           DIGEST       CREATED
+
+# Import image exported above
+$ sudo -E ig image import trace_open.tar
+INFO[0000] Experimental features enabled
+Successfully imported images:
+  ghcr.io/inspektor-gadget/gadget/trace_open:latest
+
+$ sudo -E ig image list
+INFO[0000] Experimental features enabled
+REPOSITORY                     TAG                           DIGEST       CREATED
+trace_open                     latest                        19ea8377298f 30 minutes ago
+```


### PR DESCRIPTION
Implement commands to export / import gadget images to / from a file.

### Why 

Being able to export and export images from files is useful for the following cases:
- It's possible to distribute images by just using files. Airgapped environments. Cases where reaching the internet is not an option
- Integrate gadget images directly into the application binary. #2021. (I already have a POC of this working, but it's still missing a lot of things)

### Testing

```bash 
# let's start with an empty image store
$ sudo rm -rf /var/lib/ig/oci-store
$ sudo -E ig image list
INFO[0000] Experimental features enabled
REPOSITORY             TAG                    DIGEST       CREATED


# pull one image (build will work as well)
$ sudo -E ig image pull trace_open
INFO[0000] Experimental features enabled
Pulling trace_open...
Successfully pulled ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:1ef0b57afaafe4e7d1befffc902cdda56a3d51936b9301710047b722f8018145

# export image
$ sudo -E ig image export trace_open /tmp/images.tar 
INFO[0000] Experimental features enabled
Successfully exported images to /tmp/images.tar

# clean the image store (or copy tar file to another machine...)
$ sudo rm -rf /var/lib/ig/oci-store
$ sudo -E ig image list
INFO[0000] Experimental features enabled
REPOSITORY             TAG                    DIGEST       CREATED

# import the image
$ sudo -E ig image import /tmp/images.tar
INFO[0000] Experimental features enabled
Successfully imported images:
  ghcr.io/inspektor-gadget/gadget/trace_open:latest

#  image is there and can be run
$ sudo -E ig image list
INFO[0000] Experimental features enabled
REPOSITORY             TAG                    DIGEST       CREATED
trace_open             latest                 1ef0b57afaaf 56 minutes ago

$ sudo -E ig run trace_open --pull never
INFO[0000] Experimental features enabled
RUNTIME.C… PID     UID      GID      MNT… … FD     … MODE  COMM  FNAME      TIME

```


