### PR TITLE
gadget-service: Improve address validation

### DIFF
--- a/pkg/gadget-service/api/helpers.go
+++ b/pkg/gadget-service/api/helpers.go
@@ -38,6 +38,9 @@ func ParseSocketAddress(addr string) (string, string, error) {
 	case "unix":
 		socketPath = socketURL.Path
 	case "tcp":
+		if socketURL.Host == "" {
+			return "", "", fmt.Errorf("invalid tcp socket address '%s'. Use something like 'tcp://127.0.0.1:1234'", addr)
+		}
 		socketPath = socketURL.Host
 	}
 	return socketType, socketPath, nil


### PR DESCRIPTION
Make logic fail on socket paths like tcp://foo:9000

---

The following command doesn't show any error: (notice the missing `//` after `tcp`)

```bash 
$ sudo ig daemon --host tcp:127.0.0.1:8888
INFO[0000] starting Inspektor Gadget daemon at "tcp:127.0.0.1:8888"
```

But also doesn't work as ig doesn't listen on that address. Make it print an explicit error in that case.