### PR TITLE
eks-cleanup: Don't error when stack can't be deleted

### DIFF
--- a/tools/eks-cleanup/main.go
+++ b/tools/eks-cleanup/main.go
@@ -358,7 +358,7 @@ func do() error {
 				StackName: aws.String(name),
 			}); err != nil {
 			cancel()
-			return fmt.Errorf("waiting for stack to be deleted: %w", err)
+			fmt.Printf("waiting for stack to be deleted: %v", err)
 		}
 		cancel()
 	}
@@ -372,7 +372,7 @@ func do() error {
 	for _, vpc := range vpcs {
 		fmt.Printf("deleting VPC: %s\n", aws.StringValue(vpc.VpcId))
 		if err := deleteVpc(ec2Svc, aws.StringValue(vpc.VpcId)); err != nil {
-			return fmt.Errorf("deleting VPC: %w", err)
+			fmt.Printf("deleting VPC: %s", err)
 		}
 	}
 


### PR DESCRIPTION
This is probably the case when the VPCs are not deleted yet. Swapping the order to delete VPCs before the Cloudformation stacks is also not feasible since VPCs can't be deleted when the stack is still running.

So we just try to delete both and in the next run the corresponding stack or VPC will be deleted

Log from the deletion of stacks/VPCs where the previous version failed:


```
{8:56} tools/eks-cleanup:main ✗ ➭ go run .
deleting stack: eksctl-ig-ci-eks-amd64-3197-cluster
deleting stack: eksctl-ig-ci-eks-amd64-22224-cluster
deleting stack: eksctl-ig-ci-eks-arm64-30146-cluster
waiting for stack to be deleted: eksctl-ig-ci-eks-amd64-3197-cluster
waiting for stack to be deleted: RequestCanceled: waiter context canceled
caused by: context deadline exceededwaiting for stack to be deleted: eksctl-ig-ci-eks-amd64-22224-cluster
waiting for stack to be deleted: ResourceNotReady: failed waiting for successful resource statewaiting for stack to be deleted: eksctl-ig-ci-eks-arm64-30146-cluster
waiting for stack to be deleted: ResourceNotReady: failed waiting for successful resource stateskipping VPC vpc-04a519500116069e8
skipping VPC vpc-0fd83343a60249a87
deleting VPC: vpc-0dbfe91ad6a843ad7
deleting network interface: eni-0649122b0c816618a
deleting subnet: subnet-004f8f681eccd7e83
deleting security group: sg-0cd5b16a8d00d95da
deleting VPC: vpc-0a2e8cfe70385d7c5
deleting network interface: eni-064eca7ef64d2a706
deleting subnet: subnet-0d10317f39f221a6c
deleting security group: sg-09a400c4f715224b3
deleting VPC: vpc-03eaf0e15193fe9c3
deleting network interface: eni-0be27f72db828ab8c
deleting subnet: subnet-00a747d3a89686da5
deleting security group: sg-085bcba4688c91b81

{9:12} tools/eks-cleanup:main ✗ ➭ go run .
skipping stack eksctl-ig-ci-eks-amd64-9380-cluster
skipping stack eksctl-ig-ci-eks-arm64-20443-cluster
deleting stack: eksctl-ig-ci-eks-amd64-3197-cluster
deleting stack: eksctl-ig-ci-eks-amd64-22224-cluster
deleting stack: eksctl-ig-ci-eks-arm64-30146-cluster
waiting for stack to be deleted: eksctl-ig-ci-eks-amd64-3197-cluster
waiting for stack to be deleted: eksctl-ig-ci-eks-amd64-22224-cluster
waiting for stack to be deleted: eksctl-ig-ci-eks-arm64-30146-cluster
skipping VPC vpc-04a519500116069e8
skipping VPC vpc-0fd83343a60249a87
```