### PR TITLE
TestRunTraceOOMKill: Add sleep after starting ig/kubectl-gadget

### DIFF
--- a/integration/k8s/run_trace_oomkill_test.go
+++ b/integration/k8s/run_trace_oomkill_test.go
@@ -91,6 +91,9 @@ spec:
 
 	commands := []TestStep{
 		traceOOMKillCmd,
+		// Wait to ensure ig or kubectl-gadget has downloaded the image and started it
+		// before we start the test pod, which only gives us 1 event to trace (oneshot)
+		SleepForSecondsCommand(10),
 		&Command{
 			Name:           "RunOomkillTestPod",
 			Cmd:            fmt.Sprintf("echo '%s' | kubectl apply -f -", limitPodYaml),


### PR DESCRIPTION
This waits for 10 seconds for ig or kubectl-gadget to finished downloading the gadget from the OCI registry and starting it

Reference: For the OOMKill test from the builtin legacy gadget we even have a 2 second sleep there. With image based gadget we need a little bit more time to additionally download the image