### PR TITLE
integration: Logging timestamp before calling step.Stop

### DIFF
--- a/integration/teststeps.go
+++ b/integration/teststeps.go
@@ -92,8 +92,8 @@ func RunTestSteps(steps []TestStep, t *testing.T, options ...Option) {
 			if step.IsStartAndStop() && step.Running() {
 				// Wait a bit before stopping the step.
 				time.Sleep(stepWaitDuration)
+				t.Logf("[%s] Stopping %q\n", time.Now().UTC(), step.DisplayName())
 				step.Stop(t)
-				t.Logf("[%s] Stopped %q\n", time.Now().UTC(), step.DisplayName())
 			}
 		}()
 	}


### PR DESCRIPTION
# integration: Logging timestamp before calling step.Stop

When `step.Stop` uses `t.Fatalf` we will never get the timestamp. This way we know when we are initiating the stop at least