### PR TITLE
container-utils: docker: enrich container meta with container image digest

### DIFF
--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -84,7 +84,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedContainer.Runtime.ContainerImageName = ""
 			}
@@ -104,7 +104,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 				c.Runtime.ContainerID = ""
 				c.Runtime.ContainerImageDigest = ""
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if isDockerRuntime {
 					c.Runtime.ContainerImageName = ""
 				}
@@ -156,7 +156,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -188,7 +188,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 					e.Container.Runtime.ContainerName = cn
 				}
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if isDockerRuntime {
 					e.Container.Runtime.ContainerImageName = ""
 				}

--- a/integration/k8s/integration_test.go
+++ b/integration/k8s/integration_test.go
@@ -72,7 +72,7 @@ func normalizeCommonData(e *eventtypes.CommonData, ns string) {
 			strings.HasPrefix(e.Runtime.ContainerName, prefixContainerName) {
 			e.Runtime.ContainerName = cn
 		}
-		// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+		// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 		if isDockerRuntime {
 			e.Runtime.ContainerImageName = ""
 		}

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -60,7 +60,7 @@ func newListContainerTestStep(
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedContainer.Runtime.ContainerImageName = ""
 			}
@@ -81,7 +81,7 @@ func newListContainerTestStep(
 				c.Runtime.ContainerID = ""
 				c.Runtime.ContainerImageDigest = ""
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if isDockerRuntime {
 					c.Runtime.ContainerImageName = ""
 				}
@@ -192,7 +192,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -226,7 +226,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 					e.Container.Runtime.ContainerName = cn
 				}
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
 					e.Container.Runtime.ContainerImageName = ""
 				}
@@ -287,7 +287,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -321,7 +321,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 					e.Container.Runtime.ContainerName = cn
 				}
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
 					e.Container.Runtime.ContainerImageName = ""
 				}
@@ -385,7 +385,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 				},
 			}
 
-			// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+			// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 			if isDockerRuntime {
 				expectedEvent.Container.Runtime.ContainerImageName = ""
 			}
@@ -419,7 +419,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 					e.Container.Runtime.ContainerName = cn
 				}
 
-				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+				// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 				if e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
 					e.Container.Runtime.ContainerImageName = ""
 				}

--- a/integration/k8s/trace_network_test.go
+++ b/integration/k8s/trace_network_test.go
@@ -160,7 +160,7 @@ func TestTraceNetwork(t *testing.T) {
 							e.Runtime.ContainerName = cn
 						}
 					}
-					// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
+					// Docker can provide different values for ContainerImageName. See `getContainerImageInfoFromImage`
 					if isDockerRuntime {
 						e.Runtime.ContainerImageName = ""
 					}

--- a/pkg/container-utils/docker/docker_test.go
+++ b/pkg/container-utils/docker/docker_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetContainerImageInfoFromImage(t *testing.T) {
+	tests := []struct {
+		name                string
+		fullImageName       string
+		expectedImageName   string
+		expectedImageDigest string
+	}{
+		{
+			name:                "canonical image name with tag and digest",
+			fullImageName:       "gcr.io/k8s-minikube/kicbase:v0.0.37@sha256:8bf7a0e8a062bc5e2b71d28b35bfa9cc862d9220e234e86176b3785f685d8b15",
+			expectedImageName:   "gcr.io/k8s-minikube/kicbase:v0.0.37",
+			expectedImageDigest: "sha256:8bf7a0e8a062bc5e2b71d28b35bfa9cc862d9220e234e86176b3785f685d8b15",
+		},
+		{
+			name:                "image name with tag and digest",
+			fullImageName:       "busybox@sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
+			expectedImageName:   "busybox",
+			expectedImageDigest: "sha256:3fbc632167424a6d997e74f52b878d7cc478225cffac6bc977eedfe51c7f4e79",
+		},
+		{
+			name:                "image name with tag",
+			fullImageName:       "docker.io/library/busybox:latest",
+			expectedImageName:   "docker.io/library/busybox:latest",
+			expectedImageDigest: "",
+		},
+		{
+			name:                "simple image name without tag/digest",
+			fullImageName:       "busybox",
+			expectedImageName:   "busybox",
+			expectedImageDigest: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageName, imageDigest := getContainerImageInfoFromImage(tt.fullImageName)
+			assert.Equal(t, tt.expectedImageName, imageName)
+			assert.Equal(t, tt.expectedImageDigest, imageDigest)
+		})
+	}
+}

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -254,7 +254,7 @@ func (c *ContainerdContainer) stop(t *testing.T) {
 }
 
 func getFullImage(options *containerOptions) string {
-	if strings.Contains(options.image, ":") {
+	if strings.Contains(options.image, ":") || strings.Contains(options.image, "@") {
 		return options.image
 	}
 	return options.image + ":" + options.imageTag


### PR DESCRIPTION
## Description

Add container image digest to container meta when using docker runtime

## Testing done

- [x] Unit tests
- [x] Manual test

before:

```
"containerMeta":{
    "runtimeName":"docker",
    "containerID":"24878827d73c97435ad1ceee6fc5fc26f402723065e557bb4d1934b61a7fd8ab",
    "containerName":"competent_swanson",
    "containerImageName":"ubuntu:noble-20240429",
    "containerImageDigest":""
}
```

after:

```
"containerMeta":{
    "runtimeName":"docker",
    "containerID":"aaeaa9cc31a183c42c6762bb32aef883ecbfb48e4f13320292bfd3ff8cd16d94",
    "containerName":"funny_goldwasser",
    "containerImageName":"ubuntu:noble-20240429",
    "containerImageDigest":"sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15"
}
```

