### PR TITLE
Minor change in create pod 

### DIFF
--- a/docs/builtin-gadgets/top/block-io.md
+++ b/docs/builtin-gadgets/top/block-io.md
@@ -13,7 +13,7 @@ the most block device input/output.
 First, we need to create one pod for us to play with:
 
 ```bash
-$ kubectl run test-pod --image busybox:latest sleep inf
+$ kubectl run  --generator=run-pod/v1 test-pod --image busybox:latest sleep inf
 ```
 
 You can now use the gadget, but output will be empty:


### PR DESCRIPTION
changing the run command to use the API version. The current version doesn't create the right pod name
`kubectl run test-pod --image=busybox:latest -- sleep inf
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.`

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
