### PR TITLE
add filter operator

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -42,6 +42,7 @@ import (
 	// Another blank import for the used operator
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/prometheus"

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -46,6 +46,7 @@ import (
 	// Blank import for some operators
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"
@@ -310,7 +311,6 @@ func main() {
 			HookMode:            hookMode,
 			FallbackPodInformer: fallbackPodInformer,
 		})
-
 		if err != nil {
 			log.Fatalf("failed to create Gadget Tracer Manager server: %v", err)
 		}

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -33,6 +33,18 @@ const (
 	TypeMetrics
 )
 
+type dsError string
+
+func (err dsError) Error() string {
+	return string(err)
+}
+
+const (
+	// ErrDiscard can be returned on subscription callbacks to tell the datasource to discard the entity (packet, array
+	// or single event, depending on the subscription)
+	ErrDiscard = dsError("discarded")
+)
+
 type Data interface {
 	private()
 	payload() [][]byte

--- a/pkg/operators/filter/filter.go
+++ b/pkg/operators/filter/filter.go
@@ -1,0 +1,428 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/exp/constraints"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+type comparisonType int
+
+const (
+	name        = "filter"
+	ParamFilter = "filter"
+	Priority    = 9000
+)
+
+const (
+	comparisonTypeUnknown comparisonType = iota
+	comparisonTypeMatch
+	comparisonTypeRegex
+	comparisonTypeLt
+	comparisonTypeLte
+	comparisonTypeGt
+	comparisonTypeGte
+)
+
+type filterOperator struct{}
+
+func (f *filterOperator) Name() string {
+	return name
+}
+
+func (f *filterOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (f *filterOperator) GlobalParams() api.Params {
+	return nil
+}
+
+func (f *filterOperator) InstanceParams() api.Params {
+	return api.Params{&api.Param{
+		Key: ParamFilter,
+		Description: `Filter rules
+  A filter can match any column using the following syntax
+    columnName==value     - matches, if the content of columnName equals exactly value
+    columnName!=value     - matches, if the content of columnName does not equal exactly value
+    columnName>=value     - matches, if the content of columnName is greater than or equal to the value
+    columnName>value      - matches, if the content of columnName is greater than the value
+    columnName<=value     - matches, if the content of columnName is less than or equal to the value
+    columnName<value      - matches, if the content of columnName is less than the value
+    columnName~value      - matches, if the content of columnName matches the regular expression 'value'
+                 see [https://github.com/google/re2/wiki/Syntax] for more information on the syntax
+        `,
+		Alias: "F",
+	}}
+}
+
+func (f *filterOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	filterCfg, _ := instanceParamValues[ParamFilter]
+
+	fop := &filterOperatorInstance{
+		ffns: map[datasource.DataSource][]func(datasource.DataSource, datasource.Data) bool{},
+	}
+
+	filters := strings.Split(filterCfg, ",")
+	for _, filter := range filters {
+		if filter == "" {
+			continue
+		}
+		gadgetCtx.Logger().Debugf("adding filter %q", filter)
+		err := fop.addFilter(gadgetCtx, filter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fop, nil
+}
+
+func (f *filterOperator) Priority() int {
+	return Priority
+}
+
+type filterOperatorInstance struct {
+	ffns map[datasource.DataSource][]func(datasource.DataSource, datasource.Data) bool
+}
+
+func (f *filterOperatorInstance) Name() string {
+	return name
+}
+
+func (f *filterOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, funcs := range f.ffns {
+		funcs := funcs
+		ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+			for _, fn := range funcs {
+				if !fn(ds, data) {
+					return datasource.ErrDiscard
+				}
+			}
+			return nil
+		}, Priority) // TODO: need some predefined & sane values
+	}
+	return nil
+}
+
+func (f *filterOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (f *filterOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func getCompareFunc[T constraints.Ordered](op comparisonType) func(a, b T) bool {
+	switch op {
+	default:
+		return func(a, b T) bool {
+			return false
+		}
+	case comparisonTypeMatch:
+		return func(a, b T) bool {
+			return a == b
+		}
+	case comparisonTypeLt:
+		return func(a, b T) bool {
+			return a < b
+		}
+	case comparisonTypeGt:
+		return func(a, b T) bool {
+			return a > b
+		}
+	case comparisonTypeLte:
+		return func(a, b T) bool {
+			return a <= b
+		}
+	case comparisonTypeGte:
+		return func(a, b T) bool {
+			return a >= b
+		}
+	}
+}
+
+func extractFilter(filter string) (dsName string, fieldName string, op comparisonType, negate bool, value string, err error) {
+	// State machine to get filter
+	var opString string
+
+	stage := 0
+	pos := 0
+nextChar:
+	for {
+		if pos >= len(filter) {
+			break
+		}
+		switch stage {
+		case 0:
+			switch filter[pos] {
+			case ':':
+				dsName = fieldName
+				fieldName = ""
+				pos++
+				continue nextChar
+			case '!', '~', '>', '<', '=':
+				stage = 1
+				continue nextChar
+			}
+			fieldName += string(filter[pos])
+			pos++
+		case 1:
+			switch filter[pos] {
+			case '!', '~', '>', '<', '=':
+				opString += string(filter[pos])
+				pos++
+			default:
+				switch opString {
+				case "=", "==":
+					op = comparisonTypeMatch
+				case "!=":
+					op = comparisonTypeMatch
+					negate = true
+				case "<=":
+					op = comparisonTypeLte
+				case "<":
+					op = comparisonTypeLt
+				case ">=":
+					op = comparisonTypeGte
+				case ">":
+					op = comparisonTypeGt
+				case "~":
+					op = comparisonTypeRegex
+				case "!~":
+					op = comparisonTypeRegex
+					negate = true
+				default:
+					return "", "", comparisonTypeUnknown, false, "",
+						fmt.Errorf("invalid operation: %q", opString)
+				}
+				stage = 2
+			}
+		case 2:
+			value = filter[pos:]
+			return
+		}
+	}
+	return "", "", comparisonTypeUnknown, false, "", fmt.Errorf("incomplete filter rule")
+}
+
+func (f *filterOperatorInstance) addFilter(gadgetCtx operators.GadgetContext, filter string) error {
+	dsName, fieldName, op, negate, value, err := extractFilter(filter)
+	if err != nil {
+		return fmt.Errorf("extracting filter rule %q: %w", filter, err)
+	}
+
+	var filterds datasource.DataSource
+	var field datasource.FieldAccessor
+	for _, ds := range gadgetCtx.GetDataSources() {
+		if dsName != "" && ds.Name() != dsName {
+			continue
+		}
+		nf := ds.GetField(fieldName)
+		if nf == nil {
+			continue
+		}
+		if field != nil {
+			return fmt.Errorf("ambiguous field name, please specify the datasource")
+		}
+		field = nf
+		filterds = ds
+	}
+
+	if field == nil {
+		return fmt.Errorf("field %q not found", fieldName)
+	}
+
+	ff, err := getFilterFunc(field, op, negate, value)
+	if err != nil {
+		return err
+	}
+
+	f.ffns[filterds] = append(f.ffns[filterds], ff)
+	return nil
+}
+
+func getFilterFunc(f datasource.FieldAccessor, op comparisonType, negate bool, stringVal string) (
+	func(datasource.DataSource, datasource.Data) bool, error,
+) {
+	var intVal int64
+	var uintVal uint64
+	var floatVal float64
+	var boolVal bool
+	var err error
+
+	fieldType := f.Type()
+
+	if (fieldType == api.Kind_String || fieldType == api.Kind_CString) && op == comparisonTypeRegex {
+		re, err := regexp.Compile(stringVal)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regular expression: %q", stringVal)
+		}
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			val, _ := f.String(data)
+			return re.MatchString(val) != negate
+		}, nil
+	}
+	if op == comparisonTypeRegex {
+		return nil, fmt.Errorf("regex based filtering can only be used on strings")
+	}
+
+	if fieldType == api.Kind_Bool && op != comparisonTypeMatch {
+		return nil, fmt.Errorf("boolean values can only be filtered by exact match")
+	}
+
+	bitSize := 64
+	switch f.Type() {
+	case api.Kind_Int8, api.Kind_Uint8:
+		bitSize = 8
+	case api.Kind_Int16, api.Kind_Uint16:
+		bitSize = 16
+	case api.Kind_Int32, api.Kind_Uint32, api.Kind_Float32:
+		bitSize = 32
+	}
+
+	switch f.Type() {
+	default:
+		return nil, fmt.Errorf("unsupported field type for comparison: %s", f.Type())
+	case api.Kind_Int8, api.Kind_Int16, api.Kind_Int32, api.Kind_Int64:
+		intVal, err = strconv.ParseInt(stringVal, 10, bitSize)
+		if err != nil {
+			return nil, fmt.Errorf("parsing comparison value as int: %w", err)
+		}
+	case api.Kind_Uint8, api.Kind_Uint16, api.Kind_Uint32, api.Kind_Uint64:
+		uintVal, err = strconv.ParseUint(stringVal, 10, bitSize)
+		if err != nil {
+			return nil, fmt.Errorf("parsing comparison value as uint: %w", err)
+		}
+	case api.Kind_Float32, api.Kind_Float64:
+		floatVal, err = strconv.ParseFloat(stringVal, bitSize)
+		if err != nil {
+			return nil, fmt.Errorf("parsing comparison value as float: %w", err)
+		}
+	case api.Kind_String, api.Kind_CString, api.Kind_Invalid:
+	// Nothing to be done in this case
+	case api.Kind_Bool:
+		switch stringVal {
+		default:
+			return nil, fmt.Errorf("parsing comparison value %q as bool", stringVal)
+		case "true", "1":
+			boolVal = true
+		case "false", "0":
+		}
+	}
+
+	switch f.Type() {
+	case api.Kind_String, api.Kind_CString:
+		cmp := getCompareFunc[string](op)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.String(data)
+			return cmp(v, stringVal) != negate
+		}, nil
+	case api.Kind_Int8:
+		cmp := getCompareFunc[int8](op)
+		val := int8(intVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Int8(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Int16:
+		cmp := getCompareFunc[int16](op)
+		val := int16(intVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Int16(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Int32:
+		cmp := getCompareFunc[int32](op)
+		val := int32(intVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Int32(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Int64:
+		cmp := getCompareFunc[int64](op)
+		val := intVal
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Int64(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Uint8:
+		cmp := getCompareFunc[uint8](op)
+		val := uint8(uintVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Uint8(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Uint16:
+		cmp := getCompareFunc[uint16](op)
+		val := uint16(uintVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Uint16(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Uint32:
+		cmp := getCompareFunc[uint32](op)
+		val := uint32(uintVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Uint32(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Uint64:
+		cmp := getCompareFunc[uint64](op)
+		val := uintVal
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Uint64(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Float32:
+		cmp := getCompareFunc[float32](op)
+		val := float32(floatVal)
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Float32(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Float64:
+		cmp := getCompareFunc[float64](op)
+		val := floatVal
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Float64(data)
+			return cmp(v, val) != negate
+		}, nil
+	case api.Kind_Bool:
+		if op != comparisonTypeMatch {
+			return nil, fmt.Errorf("invalid comparison value for bool field %s", f.Name())
+		}
+		return func(ds datasource.DataSource, data datasource.Data) bool {
+			v, _ := f.Bool(data)
+			return (v == boolVal) != negate
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unsupported type: %s", f.Type())
+}
+
+func init() {
+	operators.RegisterDataOperator(&filterOperator{})
+}

--- a/pkg/operators/filter/filter_test.go
+++ b/pkg/operators/filter/filter_test.go
@@ -1,0 +1,511 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+)
+
+func TestFilterRuleExtractor(t *testing.T) {
+	type testCase struct {
+		filter    string
+		dsName    string
+		fieldName string
+		op        comparisonType
+		negate    bool
+		value     string
+		error     bool
+	}
+	testCases := []testCase{
+		{
+			filter:    "abc==def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeMatch,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc!=def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeMatch,
+			negate:    true,
+			value:     "def",
+		},
+		{
+			filter:    "abc<=def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeLte,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc<def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeLt,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc>=def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeGte,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc>def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeGt,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc~def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeRegex,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter:    "abc!~def",
+			dsName:    "",
+			fieldName: "abc",
+			op:        comparisonTypeRegex,
+			negate:    true,
+			value:     "def",
+		},
+		{
+			filter:    "dsname:abc==def",
+			dsName:    "dsname",
+			fieldName: "abc",
+			op:        comparisonTypeMatch,
+			negate:    false,
+			value:     "def",
+		},
+		{
+			filter: "incomplete",
+			error:  true,
+		},
+		{
+			filter: "abc==",
+			error:  true,
+		},
+		{
+			filter: "abc===def",
+			error:  true,
+		},
+		{
+			filter: "abc!==def",
+			error:  true,
+		},
+		{
+			filter: "abc!def",
+			error:  true,
+		},
+		{
+			filter: "abc!",
+			error:  true,
+		},
+		{
+			filter: "abc:",
+			error:  true,
+		},
+		{
+			filter: ":",
+			error:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filter, func(t *testing.T) {
+			dsName, fieldName, op, negate, value, err := extractFilter(tc.filter)
+			if tc.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.dsName, dsName)
+			assert.Equal(t, tc.fieldName, fieldName)
+			assert.Equal(t, tc.op, op)
+			assert.Equal(t, tc.negate, negate)
+			assert.Equal(t, tc.value, value)
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	testCaseData := struct {
+		stringValue  string
+		int64Value   int64
+		float64Value float64
+		boolValue    bool
+	}{
+		stringValue:  "abc",
+		int64Value:   123,
+		float64Value: 456.0,
+		boolValue:    true,
+	}
+	type testCase struct {
+		name         string
+		filterString string
+		match        bool
+		error        bool
+	}
+	testCases := []testCase{
+		{
+			name:         "incomplete filter",
+			filterString: "abc",
+			error:        true,
+		},
+		{
+			name:         "string match positive",
+			filterString: "stringValue==abc",
+			match:        true,
+		},
+		{
+			name:         "string match negative",
+			filterString: "stringValue==def",
+			match:        false,
+		},
+		{
+			name:         "string not match positive",
+			filterString: "stringValue!=def",
+			match:        true,
+		},
+		{
+			name:         "string not match negative",
+			filterString: "stringValue!=abc",
+			match:        false,
+		},
+		{
+			name:         "string lte positive",
+			filterString: "stringValue<=def",
+			match:        true,
+		},
+		{
+			name:         "string gte negative",
+			filterString: "stringValue>=def",
+			match:        false,
+		},
+		{
+			name:         "string regex match positive",
+			filterString: "stringValue~a..",
+			match:        true,
+		},
+		{
+			name:         "string regex match negative",
+			filterString: "stringValue~b..",
+			match:        false,
+		},
+		{
+			name:         "string regex not match positive",
+			filterString: "stringValue!~b..",
+			match:        true,
+		},
+		{
+			name:         "string regex not match negative",
+			filterString: "stringValue!~a..",
+			match:        false,
+		},
+		{
+			name:         "string regex invalid",
+			filterString: "stringValue~???a..",
+			error:        true,
+		},
+
+		{
+			name:         "int match positive",
+			filterString: "int64Value==123",
+			match:        true,
+		},
+		{
+			name:         "int match negative",
+			filterString: "int64Value==345",
+			match:        false,
+		},
+		{
+			name:         "int gte positive",
+			filterString: "int64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "int gte positive",
+			filterString: "int64Value>=123",
+			match:        true,
+		},
+		{
+			name:         "int gte negative",
+			filterString: "int64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "int lte positive",
+			filterString: "int64Value<=1000",
+			match:        true,
+		},
+		{
+			name:         "int lte positive",
+			filterString: "int64Value<=123",
+			match:        true,
+		},
+		{
+			name:         "int lte negative",
+			filterString: "int64Value<=1",
+			match:        false,
+		},
+		{
+			name:         "int gt positive",
+			filterString: "int64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "int gt negative",
+			filterString: "int64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "int lt positive",
+			filterString: "int64Value>1",
+			match:        true,
+		},
+		{
+			name:         "int lt negative",
+			filterString: "int64Value>1000",
+			match:        false,
+		},
+		{
+			name:         "int no int",
+			filterString: "int64Value>abc",
+			error:        true,
+		},
+
+		{
+			name:         "float match positive",
+			filterString: "float64Value==456",
+			match:        true,
+		},
+		{
+			name:         "float match positive",
+			filterString: "float64Value==456.0",
+			match:        true,
+		},
+		{
+			name:         "float match negative",
+			filterString: "float64Value==345",
+			match:        false,
+		},
+		{
+			name:         "float match negative",
+			filterString: "float64Value==456.8",
+			match:        false,
+		},
+		{
+			name:         "float gte positive",
+			filterString: "float64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "float gte positive",
+			filterString: "float64Value>=456",
+			match:        true,
+		},
+		{
+			name:         "float gte negative",
+			filterString: "float64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "float lte positive",
+			filterString: "float64Value<=1000",
+			match:        true,
+		},
+		{
+			name:         "float lte positive",
+			filterString: "float64Value<=456",
+			match:        true,
+		},
+		{
+			name:         "float lte negative",
+			filterString: "float64Value<=1",
+			match:        false,
+		},
+		{
+			name:         "float gt positive",
+			filterString: "float64Value>=1.0",
+			match:        true,
+		},
+		{
+			name:         "float gt negative",
+			filterString: "float64Value>=1000.0",
+			match:        false,
+		},
+		{
+			name:         "float lt positive",
+			filterString: "float64Value>1.0",
+			match:        true,
+		},
+		{
+			name:         "float lt negative",
+			filterString: "float64Value>1000.0",
+			match:        false,
+		},
+		{
+			name:         "float no float",
+			filterString: "float64Value>abc",
+			error:        true,
+		},
+
+		{
+			name:         "bool match positive",
+			filterString: "boolValue==true",
+			match:        true,
+		},
+		{
+			name:         "bool match negative",
+			filterString: "boolValue==false",
+			match:        false,
+		},
+		{
+			name:         "bool not match positive",
+			filterString: "boolValue!=false",
+			match:        true,
+		},
+		{
+			name:         "bool not match negative",
+			filterString: "boolValue!=true",
+			match:        false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ds datasource.DataSource
+			var stringField datasource.FieldAccessor
+			var int64Field datasource.FieldAccessor
+			var float64Field datasource.FieldAccessor
+			var boolField datasource.FieldAccessor
+			rows := 0
+			err := Tester(
+				t,
+				&filterOperator{},
+				api.ParamValues{
+					"operator.filter.filter": tc.filterString,
+				},
+				func(gadgetCtx operators.GadgetContext) error {
+					var err error
+					ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "filter")
+					require.NoError(t, err)
+					stringField, err = ds.AddField("stringValue", api.Kind_String)
+					require.NoError(t, err)
+					int64Field, err = ds.AddField("int64Value", api.Kind_Int64)
+					require.NoError(t, err)
+					float64Field, err = ds.AddField("float64Value", api.Kind_Float64)
+					require.NoError(t, err)
+					boolField, err = ds.AddField("boolValue", api.Kind_Bool)
+					require.NoError(t, err)
+					return nil
+				},
+				func(gadgetCtx operators.GadgetContext) error {
+					data, err := ds.NewPacketSingle()
+					require.NoError(t, err)
+					err = stringField.PutString(data, testCaseData.stringValue)
+					require.NoError(t, err)
+					err = int64Field.PutInt64(data, testCaseData.int64Value)
+					require.NoError(t, err)
+					err = float64Field.PutFloat64(data, testCaseData.float64Value)
+					require.NoError(t, err)
+					err = boolField.PutBool(data, testCaseData.boolValue)
+					require.NoError(t, err)
+					err = ds.EmitAndRelease(data)
+					require.NoError(t, err)
+					return nil
+				},
+				func(gadgetCtx operators.GadgetContext) error {
+					err := ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+						// t.Logf("received %+v", data)
+						rows++
+						return nil
+					}, Priority+1)
+					require.NoError(t, err)
+					return nil
+				},
+			)
+			if tc.error {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tc.match {
+					assert.Equal(t, rows, 1)
+				} else {
+					assert.Equal(t, rows, 0)
+				}
+			}
+		})
+	}
+}
+
+func Tester(
+	t *testing.T,
+	operator operators.DataOperator,
+	paramValues api.ParamValues,
+	prepare func(operators.GadgetContext) error,
+	produce func(operators.GadgetContext) error,
+	verify func(operators.GadgetContext) error,
+) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+
+	verifier := simple.New("verifier",
+		simple.WithPriority(Priority+1),
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			defer wg.Done()
+			defer cancel()
+			return verify(gadgetCtx)
+		}),
+	)
+
+	gadgetCtx := gadgetcontext.New(ctx, "",
+		gadgetcontext.WithDataOperators(operator, producer, verifier),
+	)
+
+	return gadgetCtx.Run(paramValues)
+}


### PR DESCRIPTION
This re-adds filter functionality to the image-based gadgets.

I've slightly changed the syntax to be a bit clearer now:

Before:
`--filter ... field:abc ... field2:>=123`

After:
`--filter ... field==abc ... field2>=123`

Also, now the colon `:` is used to target specific DataSources:

`--filter ds:field==abc`

Several things should be fixed/cleaned up before merging this (already in discussion / being worked on):

* [x] add method `fieldAccessor.Bool()` #2823
* [x] clean up `fieldAccessor.String()` / `fieldAccessor.CString()` handling #2823 
* [x] add drop mechanism for events (using a specific `Drop` error that can be returned by DataSource subscribers) (done in this PR)
* [x] add unit tests

Later on this should be extended to also expose the filters to eBPF programs so that they can adopt filtering inside eBPF already if possilbe.