### PR TITLE
UserGroupCache: Move OnceValue to global scope

### DIFF
--- a/pkg/operators/uidgidresolver/usergroupcache.go
+++ b/pkg/operators/uidgidresolver/usergroupcache.go
@@ -57,15 +57,12 @@ const (
 )
 
 var (
-	fullPasswdPath = filepath.Join(host.HostRoot, baseDirPath, passwdFileName)
-	fullGroupPath  = filepath.Join(host.HostRoot, baseDirPath, groupFileName)
-)
-
-func GetUserGroupCache() UserGroupCache {
-	return sync.OnceValue(func() *userGroupCache {
+	fullPasswdPath    = filepath.Join(host.HostRoot, baseDirPath, passwdFileName)
+	fullGroupPath     = filepath.Join(host.HostRoot, baseDirPath, groupFileName)
+	GetUserGroupCache = sync.OnceValue(func() *userGroupCache {
 		return &userGroupCache{}
-	})()
-}
+	})
+)
 
 func (cache *userGroupCache) Start() error {
 	cache.useCountMutex.Lock()


### PR DESCRIPTION
Creating the OnceValue inside the function and then calling it doesn't create the desired effect. It just creates new caches all the time.

Therefore move the creation of the `OnceValue` to the global scope.