### PR TITLE
trace/network: Close Operators after closing the tracer

### DIFF
--- a/pkg/gadget-collection/gadgets/trace/network/gadget.go
+++ b/pkg/gadget-collection/gadgets/trace/network/gadget.go
@@ -198,6 +198,11 @@ func (t *Trace) stop() {
 	if t.conn != nil {
 		t.conn.Close()
 	}
+
+	t.tracer.Close()
+	t.tracer = nil
+	t.started = false
+
 	if t.kubeIPInst != nil {
 		t.kubeIPInst.PostGadgetRun()
 		t.kubeIPInst = nil
@@ -210,8 +215,4 @@ func (t *Trace) stop() {
 		t.socketEnricherInst.PostGadgetRun()
 		t.socketEnricherInst = nil
 	}
-
-	t.tracer.Close()
-	t.tracer = nil
-	t.started = false
 }


### PR DESCRIPTION
# trace/network: Close Operators after closing the tracer

The `eventCallback` is still called multiple times after (some) operators were closed.

It might finally solve our flaky `TestAdviseNetworkpolicy` test in our CI.

Testing was done through calling the command 15-25 times manually :) I reproduced the issue on an AKS cluster. With minikube it always seemed to work before this PR. Now everything looks like it works