### PR TITLE
kubeinvcache: Create the cachedmaps on demand

### DIFF
--- a/pkg/cachedmap/cachedmap.go
+++ b/pkg/cachedmap/cachedmap.go
@@ -62,6 +62,7 @@ func NewCachedMap[Key comparable, T any](oldEntryTTL time.Duration) CachedMap[Ke
 
 func (c *cachedMap[Key, T]) Close() {
 	close(c.exit)
+	c.Clear()
 }
 
 func (c *cachedMap[Key, T]) Clear() {


### PR DESCRIPTION
# kubeinvcache: Create the cachedmaps on demand

https://github.com/inspektor-gadget/inspektor-gadget/pull/2751 made the resource cache more general and modified it so that pruning old objects is done periodically in the background with the help of a timer.
That means if the `CachedMap` is allocated, there is a goroutine running in the background for it.

We do not need that if the `KubeInventoryCache` is not running. Therefore this PR creates these maps on demand and closes them accordingly