### PR TITLE
oci: Fail is start image operator fails

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -266,11 +266,20 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 }
 
 func (o *OciHandlerInstance) Start(gadgetCtx operators.GadgetContext) error {
+	started := []operators.ImageOperatorInstance{}
+
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Start(o.gadgetCtx)
 		if err != nil {
-			o.gadgetCtx.Logger().Errorf("starting operator %q: %v", opInst.Name(), err)
+			// Stop all started operators
+			for _, startedOp := range started {
+				startedOp.Stop(o.gadgetCtx)
+			}
+
+			return fmt.Errorf("starting operator %q: %w", opInst.Name(), err)
 		}
+
+		started = append(started, opInst)
 	}
 	return nil
 }


### PR DESCRIPTION
Make the whole operation fail is starting an image operator fails.

### Testing

Create a gadget that doesn't pass the verifier:

```c
#include <vmlinux.h>
#include <bpf/bpf_helpers.h>
#include <gadget/buffer.h>
#include <gadget/macros.h>
#include <gadget/mntns_filter.h>
#include <gadget/types.h>

#define NAME_MAX 255

struct event {
	gadget_mntns_id mntns_id;
	__u32 pid;
	char comm[TASK_COMM_LEN];
	char filename[NAME_MAX];
};

// events is the name of the buffer map and 1024 * 256 is its size.
GADGET_TRACER_MAP(events, 1024 * 256);

// [Optional] Define a tracer
GADGET_TRACER(open, events, event);

SEC("tracepoint/syscalls/sys_enter_openat")
int enter_openat(struct syscall_trace_enter *ctx)
{
	struct event *event;
	u64 mntns_id;

	mntns_id = gadget_get_mntns_id();
	if (gadget_should_discard_mntns_id(mntns_id))
		return 0;

	event = gadget_reserve_buf(&events, sizeof(*event));
	if (!event)
		return 0;

	event->mntns_id = mntns_id;
	event->pid = bpf_get_current_pid_tgid() >> 32;

	bpf_get_current_comm(event->comm, sizeof(event->comm));
	bpf_probe_read_user_str(event->filename, sizeof(event->filename), (const char *)ctx->args[1]);

	//gadget_submit_buf(ctx, &events, event, sizeof(*event));

	return 0;
}

char LICENSE[] SEC("license") = "GPL";
```

```bash 
$ sudo -E ig image build -t badgadget 
```

### Before this PR

Error is printed but program keeps running until Ctrl+C is hit. 

```bash
$ sudo -E ig run badgadget --verify-image=false
INFO[0000] Experimental features enabled
WARN[0000] you set --verify-image=false, image will not be verified
WARN[0000] you set --verify-image=false, image will not be verified
RUNTIME.CONTAINERNAME        MNTNS_ID            PID             COMM            FILENAME
ERRO[0000] starting operator "ebpf": creating eBPF collection: program enter_openat: load program: invalid argument: Unreleased reference id=4 alloc_insn=43 (85 line(s) omitted)


^C$ echo $?
0
```

### After this PR

Error is printed and ig process exits with an error 

```bash 
$ sudo -E ig run badgadget --verify-image=false
INFO[0000] Experimental features enabled
WARN[0000] you set --verify-image=false, image will not be verified
WARN[0000] you set --verify-image=false, image will not be verified
RUNTIME.CONTAINERNAME        MNTNS_ID            PID             COMM            FILENAME
Error: starting operator "oci": starting operator "ebpf": creating eBPF collection: program enter_openat: load program: invalid argument: Unreleased reference id=4 alloc_insn=43 (85 line(s) omitted)

$ echo $?
1
```



