### PR TITLE
cmd: Support a Configuration File 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Available Commands:
   advise      Recommend system configurations based on collected information
   audit       Audit a subsystem
   completion  Generate the autocompletion script for the specified shell
+  config      Configuration commands (experimental)
   deploy      Deploy Inspektor Gadget on the cluster
   help        Help about any command
   profile     Profile different subsystems

--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -1,0 +1,85 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+var configPath string
+
+// AddConfigFlag adds the --config flag to the command
+func AddConfigFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "config file to use")
+}
+
+// InitConfig initializes the config by reading the config file
+func InitConfig() error {
+	// set the config file path if it is provided
+	if configPath != "" {
+		config.Config = config.NewWithPath(configPath)
+	}
+
+	// we do not want to fail if the config file is not found unless it is explicitly provided
+	if err := config.Config.ReadInConfig(); configPath != "" && err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	return nil
+}
+
+// SetFlagsForParams sets the flags for the given params based on the config
+func SetFlagsForParams(cmd *cobra.Command, params *params.Params, configPrefix string) error {
+	for k := range params.ParamMap() {
+		f := cmd.Flags().Lookup(k)
+		if f == nil {
+			continue
+		}
+
+		configKey := strings.Join([]string{configPrefix, k}, ".")
+		if err := setFlagsFromConfig(f, configKey); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setFlagsFromConfig sets the flags from the config based on the config key if the flag is not changed
+// The precedence order (coming from viper): flag > env > config > default
+func setFlagsFromConfig(f *pflag.Flag, k string) error {
+	// bind env vars to the flags, if set will override the config file values
+	if err := config.Config.BindEnv(k); err != nil {
+		return fmt.Errorf("binding env var %s: %w", k, err)
+	}
+
+	if !f.Changed && config.Config.IsSet(k) {
+		val := config.Config.GetString(k)
+		if val == f.DefValue {
+			return nil
+		}
+
+		if err := f.Value.Set(val); err != nil {
+			return fmt.Errorf("setting flag %s: %w", f.Name, err)
+		}
+	}
+	return nil
+}

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/frontends/console"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
@@ -74,6 +75,20 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 				return fmt.Errorf("initializing runtime: %w", err)
 			}
 			defer runtime.Close()
+
+			// set global operator flags from the config file
+			for o, p := range opGlobalParams {
+				err = SetFlagsForParams(cmd, p, config.OperatorKey+"."+o)
+				if err != nil {
+					return fmt.Errorf("setting operator %s flags: %w", o, err)
+				}
+			}
+
+			// set oci flags from the config file
+			err = SetFlagsForParams(cmd, ociParams, config.OperatorKey+"."+ocihandler.OciHandler.Name())
+			if err != nil {
+				return fmt.Errorf("setting oci flags: %w", err)
+			}
 
 			// we need to re-enable flag parsing, as utils.ParseEarlyFlags() would
 			// not do anything otherwise

--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -22,6 +22,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
@@ -195,4 +196,10 @@ func ParseEarlyFlags(cmd *cobra.Command, rawArgs []string) error {
 	args = removeHelpArg(args)
 	err := cmd.ParseFlags(args)
 	return err
+}
+
+func CopyFlagSet(fs *pflag.FlagSet) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.AddFlagSet(fs)
+	return flags
 }

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -42,6 +43,7 @@ func main() {
 		Use:   filepath.Base(os.Args[0]),
 		Short: "Collection of gadgets for containers",
 	}
+	common.AddConfigFlag(rootCmd)
 	common.AddVerboseFlag(rootCmd)
 
 	skipInfo := false
@@ -81,6 +83,14 @@ func main() {
 		} else if err := commonutils.CheckServerVersionSkew(info.ServerVersion); err != nil {
 			log.Warnf(err.Error())
 		}
+	}
+
+	// ensure that the runtime flags are set from the config file
+	if err := common.InitConfig(rootCmd); err != nil {
+		log.Fatalf("initializing config: %v", err)
+	}
+	if err = common.SetFlagsForParams(rootCmd, runtimeGlobalParams, config.RuntimeKey); err != nil {
+		log.Fatalf("setting runtime flags from config: %v", err)
 	}
 
 	hiddenColumnTags := []string{"kubernetes"}

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -59,6 +59,9 @@ func main() {
 
 	runtime := grpcruntime.New()
 
+	// save the root flags for later use before we modify them (e.g. add runtime flags)
+	rootFlags := commonutils.CopyFlagSet(rootCmd.PersistentFlags())
+
 	runtimeGlobalParams := runtime.GlobalParamDescs().ToParams()
 	common.AddFlags(rootCmd, runtimeGlobalParams, nil, runtime)
 	err := runtime.Init(runtimeGlobalParams)
@@ -86,7 +89,7 @@ func main() {
 	}
 
 	// ensure that the runtime flags are set from the config file
-	if err := common.InitConfig(rootCmd); err != nil {
+	if err := common.InitConfig(rootFlags); err != nil {
 		log.Fatalf("initializing config: %v", err)
 	}
 	if err = common.SetFlagsForParams(rootCmd, runtimeGlobalParams, config.RuntimeKey); err != nil {

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -101,6 +101,7 @@ func main() {
 
 	rootCmd.AddCommand(common.NewSyncCommand(runtime))
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags))
+	rootCmd.AddCommand(common.NewConfigCmd(runtime, rootFlags))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -81,10 +81,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// save the root flags for later use before we modify them (e.g. add runtime flags)
+	rootFlags := commonutils.CopyFlagSet(rootCmd.PersistentFlags())
+
 	runtime := local.New()
 
 	// ensure that the runtime flags are set from the config file
-	if err = common.InitConfig(); err != nil {
+	if err = common.InitConfig(rootFlags); err != nil {
 		log.Fatalf("initializing config: %v", err)
 	}
 	if err = common.SetFlagsForParams(rootCmd, runtime.GlobalParamDescs().ToParams(), config.RuntimeKey); err != nil {

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -104,6 +104,7 @@ func main() {
 	rootCmd.AddCommand(common.NewLoginCmd())
 	rootCmd.AddCommand(common.NewLogoutCmd())
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags))
+	rootCmd.AddCommand(common.NewConfigCmd(runtime, rootFlags))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -80,6 +80,9 @@ func main() {
 		}
 	}
 
+	// save the root flags for later use before we modify them (e.g. add runtime flags)
+	rootFlags := commonutils.CopyFlagSet(rootCmd.PersistentFlags())
+
 	grpcRuntime = grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
 	runtimeGlobalParams = grpcRuntime.GlobalParamDescs().ToParams()
 	common.AddFlags(rootCmd, runtimeGlobalParams, nil, grpcRuntime)
@@ -97,7 +100,7 @@ func main() {
 	}
 
 	// ensure that the runtime flags are set from the config file
-	if err = common.InitConfig(); err != nil {
+	if err = common.InitConfig(rootFlags); err != nil {
 		log.Fatalf("initializing config: %v", err)
 	}
 	if err = common.SetFlagsForParams(rootCmd, runtimeGlobalParams, igconfig.RuntimeKey); err != nil {

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -29,6 +29,7 @@ import (
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
+	igconfig "github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -57,6 +58,7 @@ func main() {
 		log.Info("Experimental features enabled")
 	}
 
+	common.AddConfigFlag(rootCmd)
 	common.AddVerboseFlag(rootCmd)
 
 	// Some commands don't need the gadget namespace. Run then before to avoid
@@ -92,6 +94,14 @@ func main() {
 		// Analogous to cobra error message
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// ensure that the runtime flags are set from the config file
+	if err = common.InitConfig(); err != nil {
+		log.Fatalf("initializing config: %v", err)
+	}
+	if err = common.SetFlagsForParams(rootCmd, runtimeGlobalParams, igconfig.RuntimeKey); err != nil {
+		log.Fatalf("setting runtime flags from config: %v", err)
 	}
 
 	config, err := utils.KubernetesConfigFlags.ToRESTConfig()

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -163,6 +163,7 @@ func main() {
 	rootCmd.AddCommand(NewTraceloopCmd(gadgetNamespace))
 	rootCmd.AddCommand(common.NewSyncCommand(grpcRuntime))
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, grpcRuntime, hiddenColumnTags))
+	rootCmd.AddCommand(common.NewConfigCmd(grpcRuntime, rootFlags))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/guides/run.md
+++ b/docs/guides/run.md
@@ -122,6 +122,19 @@ Then, it can be used each time a gadget is run:
 $ kubectl gadget run myprivateregistry.io/trace_tcpconnect:latest --pull-secret my-pull-secret
 ```
 
+You can specify the pull secret as part of configuration file to avoid specifying it each time you run a gadget:
+
+```yaml
+# ~/.ig/config.yaml
+...
+operator:
+  oci:
+    pull-secret: "my-pull-secret"
+...
+```
+
+For more information about the configuration file, check the [configuration guide](#configuration-file).
+
 ## With `ig`
 
 ``` bash
@@ -165,3 +178,100 @@ mycontainer3                                        122110  cat              0  
 mycontainer3                                        122110  cat              0        0        3         /lib/libc.so.6
 mycontainer3                                        122110  cat              0        0        3         /dev/null
 ```
+
+## Environment Variables
+
+You can use environment variables to configure the behavior of the `run` command. The environment variables use fully qualified names (as in the [configuration file]())
+with the prefix `INSPEKTOR_GADGET_`.
+
+```bash
+# Enable verbose output
+$ export INSPEKTOR_GADGET_VERBOSE=true
+$ kubectl gadget run trace_open
+INFO[0000] Experimental features enabled                
+DEBU[0000] using target "gadget-b7jrc" ("minikube-docker")
+...
+# Disable image verification (not recommended)
+$ export INSPEKTOR_GADGET_OPERATOR_OCI_VERIFY_IMAGE=false
+$ sudo ig run trace_open
+INFO[0000] Experimental features enabled
+WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
+WARN[0000] you set --verify-image=false, image will not be verified
+WARN[0000] you set --verify-image=false, image will not be verified
+...
+```
+
+## Configuration File
+
+You can use a configuration file to set specific settings that persist across multiple executions. The default location for the configuration file is `~/.ig/config.yaml`.
+You can change the location of the configuration file specifying the `--config` flag.
+
+The default configuration file can be generated using the following command:
+
+```bash
+# Default configuration file for kubectl gadget
+$ kubectl gadget config default
+as: ""
+as-group: []
+as-uid: ""
+cache-dir: /home/qasim/.kube/cache
+...
+
+# Default configuration file for ig
+$ ig config default
+INFO[0000] Experimental features enabled
+auto-mount-filesystems: "false"
+auto-wsl-workaround: "false"
+operator:
+    localmanager:
+        containerd-namespace: k8s.io
+...
+# Default configuration file for gadgetctl
+$ gadgetctl config default
+operator:
+    oci:
+        allowed-digests: ""
+        authfile: /var/lib/ig/config.json
+        insecure: "false"
+...
+```
+
+You can use the default configuration as a starting point (e.g. `ig config default > ~/.ig/config.yaml`) and modify it to suit your needs.
+
+The current configuration can be printed using the following command:
+
+```bash
+# Print the current configuration for kubectl gadget
+$ kubectl gadget config view
+INFO[0000] Experimental features enabled
+as: ""
+as-group: []
+as-uid: ""
+cache-dir: /home/qasim/.kube/cache
+...
+
+# Print the current configuration for ig
+$ ig config view
+INFO[0000] Experimental features enabled
+operator:
+    localmanager:
+        containerd-namespace: k8s.io
+        runtimes: docker,containerd,cri-o,podman
+...
+# Print the current configuration for gadgetctl
+$ gadgetctl config view
+INFO[0000] Experimental features enabled
+operator:
+    oci:
+        authfile: /var/lib/ig/config.json
+        insecure: "false"
+...
+```
+
+## Precedence
+
+The precedence ([coming from viper](https://github.com/spf13/viper?tab=readme-ov-file#why-viper)) of the configuration settings is as follows:
+- Flags passed to the command
+- Environment variables
+- Configuration file
+- Default values

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	OperatorKey = "operator"
+	RuntimeKey  = "runtime"
+)
+
+const (
+	configName      = "config"
+	configType      = "yaml"
+	configEnvPrefix = "INSPEKTOR_GADGET"
+)
+
+var Config *viper.Viper
+
+func init() {
+	h, _ := os.UserHomeDir()
+	Config = NewWithPath(filepath.Join(h, ".ig", configName+"."+configType))
+}
+
+func NewWithPath(path string) *viper.Viper {
+	conf := viper.New()
+
+	conf.SetConfigName(configName)
+	conf.SetConfigType(configType)
+	conf.SetConfigFile(path)
+
+	conf.SetEnvPrefix(configEnvPrefix)
+	conf.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+
+	return conf
+}


### PR DESCRIPTION
Support a Configuration File for `kubectl-gadget`, `gadgetctl` and `ig`. 

1. Flags
2. Environment Variables (`INSPEKTOR_GADGET_`)
3. Config file `[/etc/ig/config.yaml, $HOME/.ig/config.yaml, ./config.yaml]`
4. Defaults



Related: #2493 

### Testing Done

```bash
# generate the default config for ig `(for kubeclt-gadget and gadgetctl it generates different config)`
$ go run -exec "sudo -E" ./cmd/ig config default  > ~/.ig/config.yaml
# view the current config
→ go run -exec "sudo -E" ./cmd/ig config view
...
INFO[0000] Experimental features enabled                
runtime: {}
operator:
    filter: {}
    formatters: {}
    localmanager:
        containerd-namespace: k8s.io
...

# replace config values e.g `verify-image: false` or `verbose: true`:
$ go run -exec "sudo -E" ./cmd/ig run trace_open
...
INFO[0000] Experimental features enabled                
DEBU[0000] bpf already mounted                          
DEBU[0000] debugfs already mounted                      
DEBU[0000] tracefs already mounted 
...
```

### 

- Handle config for ig-k8s, I want to keep the scope of current PR to CLIs only. 