### PR TITLE
ci: Shifting deploy and undeploy logic for IG to actions

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -35,12 +35,20 @@ runs:
       with:
         name: kubectl-gadget-linux-amd64-tar-gz
         path: /home/runner/work/inspektor-gadget/inspektor-gadget/
+    - name: Deploy Inspektor Gadget
+      id: deploy-ig
+      shell: bash
+      run: |
+        tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
+        if [[ ${{ inputs.kubernetes_distribution }} == "minikube-github" ]]; then
+          # Inspektor-Gadget container image is loaded into the cluster using "minikube image load" instead of pushing the container image to a registry.
+          EXTRA_FLAGS='--image-pull-policy=Never'
+        fi
+        ./kubectl-gadget deploy $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
     - name: Integration tests
       id: integration-tests
       shell: bash
       run: |
-        tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-
         cleanup() {
             echo "IntegrationTestsJob: Workflow run is being cancelled: $1 was received"
             trap - $1
@@ -73,13 +81,16 @@ runs:
         make \
           KUBERNETES_DISTRIBUTION=${{ inputs.kubernetes_distribution }} \
           KUBERNETES_ARCHITECTURE=${{ inputs.kubernetes_architecture }} \
-          CONTAINER_REPO=${{ inputs.container_repo }} \
-          IMAGE_TAG=${{ inputs.image_tag }} \
           DNSTESTER_IMAGE=${{ inputs.dnstester_image }} \
           GADGET_REPOSITORY=${{ inputs.gadget_repository }} \
           GADGET_TAG=${{ inputs.gadget_tag }} \
           -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
+    - name: Undeploy Inspektor Gadget
+      id: undeploy-ig
+      if: always()
+      shell: bash
+      run: ./kubectl-gadget undeploy
     - name: Prepare and publish test reports
       if: always()
       continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ ig-tests:
 	rm -f ./ig-manager.test
 
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
-# INTEGRATION_TESTS_PARAMS="-run TestTraceExec -no-deploy-ig -no-deploy-spo" make integration-tests
+# INTEGRATION_TESTS_PARAMS="-run TestTraceExec -no-deploy-spo" make integration-tests
 .PHONY: integration-tests
 integration-tests: kubectl-gadget
 	KUBECTL_GADGET="$(shell pwd)/kubectl-gadget" \
@@ -282,7 +282,6 @@ integration-tests: kubectl-gadget
 			-timeout 30m \
 			-k8s-distro $(KUBERNETES_DISTRIBUTION) \
 			-k8s-arch $(KUBERNETES_ARCHITECTURE) \
-			-image $(CONTAINER_REPO):$(IMAGE_TAG) \
 			-dnstester-image $(DNSTESTER_IMAGE) \
 			-gadget-repository $(GADGET_REPOSITORY) \
 			-gadget-tag $(GADGET_TAG) \
@@ -416,7 +415,7 @@ help:
 	@echo  '  controller-tests		- Run controllers unit tests'
 	@echo  '  ig-tests			- Run ig manager unit tests'
 	@echo  '  gadgets-unit-tests		- Run gadget unit tests'
-	@echo  '  integration-tests		- Run integration tests'
+	@echo  '  integration-tests		- Run integration tests (deploy IG before running the tests)'
 	@echo  '  test-gadgets			- Run gadgets test'
 	@echo  ''
 	@echo  'Installing targets:'

--- a/docs/devel/CONTRIBUTING.md
+++ b/docs/devel/CONTRIBUTING.md
@@ -118,6 +118,7 @@ $ make testdata
 ### Integration tests
 
 The integration tests use a Kubernetes cluster to deploy and test Inspektor Gadget.
+Note that, Inspektor Gadget must be deployed on the Kubernetes cluster before running the tests.
 Be sure that you have a valid kubeconfig and run:
 
 ```bash

--- a/integration/command.go
+++ b/integration/command.go
@@ -111,22 +111,6 @@ func (c *Command) Running() bool {
 	return c.started
 }
 
-// DeployInspektorGadget deploys inspector gadget in Kubernetes
-func DeployInspektorGadget(image, imagePullPolicy string) *Command {
-	cmd := fmt.Sprintf("$KUBECTL_GADGET deploy --image-pull-policy=%s --debug --experimental",
-		imagePullPolicy)
-
-	if image != "" {
-		cmd = cmd + " --image=" + image
-	}
-
-	return &Command{
-		Name:           "DeployInspektorGadget",
-		Cmd:            cmd,
-		ExpectedRegexp: "Inspektor Gadget successfully deployed",
-	}
-}
-
 func DeploySPO(limitReplicas, patchWebhookConfig, bestEffortResourceMgmt bool) *Command {
 	cmdStr := fmt.Sprintf(`
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.yaml
@@ -197,13 +181,6 @@ kubectl rollout status -n security-profiles-operator ds spod --timeout=180s || \
 		Cmd:            cmdStr,
 		ExpectedRegexp: `daemon set "spod" successfully rolled out`,
 	}
-}
-
-// CleanupInspektorGadget cleans up inspector gadget in Kubernetes
-var CleanupInspektorGadget = &Command{
-	Name:    "CleanupInspektorGadget",
-	Cmd:     "$KUBECTL_GADGET undeploy",
-	Cleanup: true,
 }
 
 // CleanupSPO cleans up security profile operator in Kubernetes

--- a/integration/k8s/integration_test_kubectl_gadget.go
+++ b/integration/k8s/integration_test_kubectl_gadget.go
@@ -40,9 +40,6 @@ const (
 var cleaningUp = uint32(0)
 
 var (
-	image = flag.String("image", "", "gadget container image")
-
-	doNotDeployIG  = flag.Bool("no-deploy-ig", false, "don't deploy Inspektor Gadget")
 	doNotDeploySPO = flag.Bool("no-deploy-spo", true, "don't deploy the Security Profiles Operator (SPO)")
 
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
@@ -89,17 +86,6 @@ func testMainInspektorGadget(m *testing.M) int {
 
 	initCommands := []*integration.Command{}
 	cleanupCommands := []*integration.Command{integration.DeleteRemainingNamespacesCommand()}
-
-	if !*doNotDeployIG {
-		imagePullPolicy := "Always"
-		if *k8sDistro == K8sDistroMinikubeGH {
-			imagePullPolicy = "Never"
-		}
-		deployCmd := integration.DeployInspektorGadget(*image, imagePullPolicy)
-		initCommands = append(initCommands, deployCmd)
-
-		cleanupCommands = append(cleanupCommands, integration.CleanupInspektorGadget)
-	}
 
 	deploySPO := !integration.CheckNamespace(securityProfileOperatorNamespace) && !*doNotDeploySPO
 	if deploySPO {


### PR DESCRIPTION

Shifting deploy and undeploy logic from `integration_test_kubectl_gadget.go` to `.github/actions/run-integration-tests/action.yml`.

This change is required since tests for image-based gadgets don't have a TestMain file.

## Testing done
Passing of Integration Tests in the CI.