### PR TITLE
Add support for more iterators: task_file, ksym

### DIFF
--- a/docs/reference/program-types.md
+++ b/docs/reference/program-types.md
@@ -29,9 +29,19 @@ Currently we support some iterators and fentry/fexit programs.
 
 #### Iterators
 
-The section name must use `iter/<iter_type>`. `<iter_type>` is one of `task`, `tcp` or `udp`. `tcp`
-and `udp` iterators are invoked in different network namespaces matching the filter configuration
-when running the gadget.
+The section name must use `iter/<iter_type>`. ig supports the following `<iter_type>`:
+- `ksym`
+- `task`
+- `task_file`
+- `tcp`
+- `udp`
+
+`tcp` and `udp` iterators are invoked in different network namespaces matching
+the filter configuration when running the gadget.
+
+You can find the list of iterator types supported by Linux with:
+- `git grep -w ^DEFINE_BPF_ITER_FUNC` in the Linux sources (16 types as of Linux 6.9)
+- `sudo bpftool btf dump id 1 format c |grep 'struct bpf_iter__'` in the current kernel
 
 #### Fentry / Fexit
 

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -74,7 +74,7 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 		case strings.HasPrefix(p.SectionName, iterPrefix):
 			i.logger.Debugf("Attaching iter %q to %q", p.Name, p.AttachTo)
 			switch p.AttachTo {
-			case "task", "tcp", "udp":
+			case "task", "task_file", "tcp", "udp", "ksym":
 				return link.AttachIter(link.IterOptions{
 					Program: prog,
 				})


### PR DESCRIPTION
This patch implements support for bpf iterators of type "task_file" and "ksym".

Note: support for ksym iterators added in Linux 6.0: https://github.com/torvalds/linux/commit/647cafa223490

This is useful for the snapshot-file gadget:
- https://artifacthub.io/packages/inspektor-gadget/snapshot-file/snapshot-file
- https://github.com/alban/snapshot-file
- https://github.com/inspektor-gadget/inspektor-gadget/pull/1725