### PR TITLE
ci: improve handling of public-key-check

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -23,6 +23,9 @@ inputs:
   gadget_tag:
     description: 'Tag used for gadgets OCI images'
     required: true
+  gadget_verify_image:
+    description: 'Whether to verify the gadget image.'
+    default: 'true'
   test_summary_suffix:
     description: 'Suffix of the test summary file'
     required: true
@@ -84,6 +87,7 @@ runs:
           DNSTESTER_IMAGE=${{ inputs.dnstester_image }} \
           GADGET_REPOSITORY=${{ inputs.gadget_repository }} \
           GADGET_TAG=${{ inputs.gadget_tag }} \
+          GADGET_VERIFY_IMAGE=${{ inputs.gadget_verify_image }} \
           -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
     - name: Undeploy Inspektor Gadget

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -719,7 +719,6 @@ jobs:
     if: github.event_name != 'pull_request'
     needs:
       - build-gadget-container-images
-      - public-key-check
       - check-secrets
     runs-on: ubuntu-latest
     permissions:
@@ -786,7 +785,6 @@ jobs:
     needs:
       - build-ig-container-images
       - check-secrets
-      - public-key-check
     runs-on: ubuntu-latest
     permissions:
       # allow publishing container image
@@ -847,7 +845,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-secrets
-      - public-key-check
     outputs:
       dnstester_image: ${{ steps.image-tag.outputs.dnstester }}
       ebpf_builder_image: ${{ steps.image-tag.outputs.ebpf-builder }}
@@ -1261,15 +1258,11 @@ jobs:
     # level: 1
     needs: check-secrets
     runs-on: ubuntu-latest
-    # When this job is run by a PR coming from a fork, it will not have access
-    # to secrets.
-    # Also, unless specified in the secrets configuration, dependabot cannot access
-    # to secrets.
-    # So, we skip this job when run by dependabot and from a PR coming from a
-    # fork.
-    # We still need to run this job on push, otherwise it will not be run when
-    # we merge something on main.
-    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') && needs.check-secrets.outputs.cosign == 'true'
+    # The first check means that job will only run if the secrets are present. So it will be skipped
+    # for forks, PRs from forks and dependabot PRs (if no dependabot secret are configured).
+    # The second check ensures if we forgot configuring the secrets in main repo
+    # (inspektor-gadget/inspektor-gadget) so we can catch it early.
+    if: needs.check-secrets.outputs.cosign == 'true' || (github.event_name == 'push' && github.repository == 'inspektor-gadget/inspektor-gadget')
     steps:
       - uses: actions/checkout@v4
       - name: Install Cosign
@@ -1339,7 +1332,6 @@ jobs:
       - build-ig
       - build-helper-images
       - check-secrets
-      - public-key-check
     runs-on: ubuntu-latest
     permissions:
       # allow publishing container image
@@ -1982,6 +1974,7 @@ jobs:
       - check-secrets
       - scan-gadget-container-images
       - publish-gadget-images-manifest
+      - public-key-check
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1433,6 +1433,7 @@ jobs:
       - build-gadget-container-images
       - build-helper-images
       - build-and-push-gadgets
+      - check-secrets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1873,6 +1874,7 @@ jobs:
       - build-gadget-container-images
       - build-helper-images
       - build-and-push-gadgets
+      - check-secrets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1916,6 +1918,7 @@ jobs:
         dnstester_image: ${{ needs.build-helper-images.outputs.dnstester_image }}
         gadget_repository: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
         gadget_tag: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+        gadget_verify_image: ${{ needs.check-secrets.outputs.cosign }}
         test_summary_suffix: ${{ matrix.runtime }}
     - if: ${{ matrix.runtime == 'docker' }}
       name: Check that README is up-to-date

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1392,6 +1392,7 @@ jobs:
       - build-ig
       - build-helper-images
       - build-and-push-gadgets
+      - check-secrets
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -1421,6 +1422,7 @@ jobs:
           make \
           GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
           GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
+          IG_FLAGS="--verify-image=${{ needs.check-secrets.outputs.cosign }}" \
           -C gadgets/ test-ig-local -o build
 
   test-gadgets-k8s:
@@ -1477,6 +1479,7 @@ jobs:
         GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
         GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
         KUBECTL_GADGET=/home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget \
+        IG_FLAGS="--verify-image=${{ needs.check-secrets.outputs.cosign }}" \
         -C gadgets/ test-k8s -o build
     - name: Undeploy Inspektor Gadget
       id: undeploy-ig

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MINIKUBE ?= minikube
 KUBERNETES_DISTRIBUTION ?= ""
 GADGET_TAG ?= $(shell ./tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
+GADGET_VERIFY_IMAGE ?= true
 TEST_COMPONENT ?= inspektor-gadget
 
 GOHOSTOS ?= $(shell go env GOHOSTOS)
@@ -285,6 +286,7 @@ integration-tests: kubectl-gadget
 			-dnstester-image $(DNSTESTER_IMAGE) \
 			-gadget-repository $(GADGET_REPOSITORY) \
 			-gadget-tag $(GADGET_TAG) \
+			-gadget-verify-image=$(GADGET_VERIFY_IMAGE) \
 			-test-component $(TEST_COMPONENT) \
 			$$INTEGRATION_TESTS_PARAMS
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -5,6 +5,7 @@ GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
 IG ?= ig
 KUBECTL_GADGET ?= kubectl-gadget
+IG_FLAGS ?=
 COSIGN ?= cosign
 GADGETS = \
 	trace_dns \
@@ -71,6 +72,7 @@ test-ig-local: build
 	IG_EXPERIMENTAL=true \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
+	IG_FLAGS=$(IG_FLAGS) \
 	go test -exec 'sudo -E' -v ./...
 
 .PHONY:
@@ -81,4 +83,5 @@ test-k8s: build
 	IG_EXPERIMENTAL=true \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
+	IG_FLAGS=$(IG_FLAGS) \
 	go test -exec 'sudo -E' -v ./...

--- a/integration/k8s/integration_test_kubectl_gadget.go
+++ b/integration/k8s/integration_test_kubectl_gadget.go
@@ -44,8 +44,9 @@ var (
 
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
 
-	gadgetRepository = flag.String("gadget-repository", "ghcr.io/inspektor-gadget/gadget", "repository where gadget images are stored")
-	gadgetTag        = flag.String("gadget-tag", "latest", "tag used for gadgets's OCI images")
+	gadgetRepository  = flag.String("gadget-repository", "ghcr.io/inspektor-gadget/gadget", "repository where gadget images are stored")
+	gadgetTag         = flag.String("gadget-tag", "latest", "tag used for gadgets's OCI images")
+	gadgetVerifyImage = flag.Bool("gadget-verify-image", true, "verify gadget image before running tests")
 )
 
 func cleanupFunc(cleanupCommands []*integration.Command) {

--- a/integration/k8s/run_schedcls_test.go
+++ b/integration/k8s/run_schedcls_test.go
@@ -49,7 +49,7 @@ func TestRunSchedCLS(t *testing.T) {
 	RunTestSteps(commandsPreTest, t)
 	nginxIP := GetTestPodIP(t, ns, "nginx-pod")
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/ci/sched_cls_drop:%s -n %s", *gadgetRepository, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/ci/sched_cls_drop:%s --verify-image=%t -n %s", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
 	runSchedCLSCmd := &Command{
 		Name:         "StartRunSchedCLS",
 		Cmd:          cmd,

--- a/integration/k8s/run_snapshot_process_test.go
+++ b/integration/k8s/run_snapshot_process_test.go
@@ -50,7 +50,7 @@ func TestRunSnapshotProcess(t *testing.T) {
 	commands := []TestStep{
 		&Command{
 			Name:         "StartRunSnapshotProcessGadget",
-			Cmd:          fmt.Sprintf("$KUBECTL_GADGET run %s/snapshot_process:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns),
+			Cmd:          fmt.Sprintf("$KUBECTL_GADGET run %s/snapshot_process:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns),
 			StartAndStop: true,
 			ValidateOutput: func(t *testing.T, output string) {
 				expectedBaseJsonObj := RunEventToObj(t, &types.Event{

--- a/integration/k8s/run_top_file_test.go
+++ b/integration/k8s/run_top_file_test.go
@@ -103,7 +103,7 @@ func TestRunTopFile(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/top_file:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/top_file:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
 
 	runTopFile(t, ns, cmd)
 }

--- a/integration/k8s/run_trace_oomkill_test.go
+++ b/integration/k8s/run_trace_oomkill_test.go
@@ -127,7 +127,7 @@ func TestRunTraceOOMKill(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_oomkill:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_oomkill:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
 
 	runTraceOOMKill(t, ns, cmd)
 }

--- a/integration/k8s/run_trace_sni_test.go
+++ b/integration/k8s/run_trace_sni_test.go
@@ -98,7 +98,7 @@ func TestRunTraceSni(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_sni:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_sni:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
 
 	runTraceSni(t, ns, cmd)
 }

--- a/integration/k8s/run_trace_tcp_test.go
+++ b/integration/k8s/run_trace_tcp_test.go
@@ -102,7 +102,7 @@ func TestRunTraceTcp(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_tcp:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/trace_tcp:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
 
 	runTraceTcp(t, ns, cmd)
 }

--- a/pkg/testing/ig/ig.go
+++ b/pkg/testing/ig/ig.go
@@ -102,6 +102,12 @@ func New(image string, opts ...Option) igtesting.TestStep {
 		opt(factoryRunner)
 	}
 
+	// append IG_FLAGS flags separately to ensure
+	// one from the option aren't overwritten
+	if flags, ok := os.LookupEnv("IG_FLAGS"); ok {
+		factoryRunner.flags = append(factoryRunner.flags, flags)
+	}
+
 	factoryRunner.createCmd()
 
 	return factoryRunner


### PR DESCRIPTION
Currently, in order to publish ig-k8s image / gadget images on a fork users will have to:

- Set secrets for cosign (`COSIGN_PRIVATE_KEY/COSIGN_PASSWORD`)
- Update the public key in source (pkg/resources/inspektor-gadget.pub) 

Otherwise `public-key-check` job [will fail](https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/9061503098/job/24893441499) and ig-k8s image /gadgets images won't be published. The idea of this PR is to improve this workflow by not signing images by default on forks. `public-key-check` is removed from the `needs` of both the image publishing steps, allowing images to be published but not signed on forks. Having said that, `public-key-check` is moved to release to ensure if incorrect keys are configured we won't be able to release. So it isn't a fatal job for CI runs on main but only for releases.

Also tests need to be adapted to allow running without verification on a fork! 

## Testing Done

- A CI run in fork with Actions secrets configured (not Dependabot secrets) checks the public key: https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/9595327823/job/26459837791
- A CI run in fork without Actions secrets configured skips the public key checking: https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/9594669084