### PR TITLE
pkg/operators/simple: fix onStop() callback being called if only onStart is set

### DIFF
--- a/pkg/operators/simple/simple.go
+++ b/pkg/operators/simple/simple.go
@@ -76,7 +76,7 @@ func (s *simpleOperator) Start(gadgetCtx operators.GadgetContext) error {
 }
 
 func (s *simpleOperator) Stop(gadgetCtx operators.GadgetContext) error {
-	if s.onStart != nil {
+	if s.onStop != nil {
 		return s.onStop(gadgetCtx)
 	}
 	return nil


### PR DESCRIPTION
A wrong check in `Stop()` could lead to a crash if `onStart` had been registered but no `onStop`