### PR TITLE
version: Fix server version for ig-k8s

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -473,6 +473,8 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}
+        build-args: |
+          VERSION=${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
     - name: Publish gadget ${{ matrix.os }} ${{ matrix.platform }} container image as artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -504,6 +506,8 @@ jobs:
         outputs: type=registry,name=${{ steps.set-repo-determine-image-tag.outputs.container-repo }},push=true,push-by-digest=true
         cache-from: type=local,src=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}
+        build-args: |
+          VERSION=${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
     - name: Setup oras
       if: github.event_name != 'pull_request'
       uses: oras-project/setup-oras@v1


### PR DESCRIPTION
It seems after https://github.com/inspektor-gadget/inspektor-gadget/pull/2718 we expected version to be defined via build-args but we missed passing them in the CI steps so ig-k8s image is build without a version. If you install latest version (`v0.28.0`) from the krew the server version is always `v0.0.0`:

```
$ kubectl krew upgrade gadget
$ kubectl gadget version
Client version: v0.28.0
Server version: v0.0.0
```

```
$  kubectl gadget trace open
INFO[0000] Experimental features enabled                
WARN[0000] version skew detected: client (v0.28.0) vs server (v0.0.0) 
K8S.NODE                              K8S.NAMESPACE                         K8S.POD                               K8S.CONTAINER                         PID        COMM             FD   ERR PATH  
```

It is annoying to have the warning `WARN[0000] version skew detected: client (v0.28.0) vs server (v0.0.0)` at each run. 

## Testing Done

### fork (with fix)
```
# pushed a release v0.15.0 in a fork
$ gh run download -n gadget-container-image-linux-amd64.tar -R mqasimsarfraz/inspektor-gadget 9100326573
$ minikube image load gadget-container-image-linux-amd64.tar
$ kubectl gadget deploy --image ghcr.io/mqasimsarfraz/inspektor-gadget:v0.15.0 --image-pull-policy Never
$ kubectl gadget version
Client version: v0.28.0
Server version: v0.15.0
```