### PR TITLE
trace_dns: fix padding

### DIFF
--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -125,7 +125,7 @@ struct dnshdr {
 
 // DNS resource record
 // https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.3
-#pragma pack(2)
+#pragma pack(push, 2)
 struct dnsrr {
 	__u16 name; // Two octets when using message compression, see https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.4
 	__u16 type;
@@ -134,6 +134,7 @@ struct dnsrr {
 	__u16 rdlength;
 	// Followed by rdata
 };
+#pragma pack(pop)
 
 // Map of DNS query to timestamp so we can calculate latency from query sent to answer received.
 struct query_key_t {


### PR DESCRIPTION
The dns gadget uses '#pragma pack(2)' to define some structs. Using pragma push/pod is preferred to limit the scope of the alignment setting to the struct definition that needs it.

There is no concrete issue at the moment, so there is no need to backport this patch. I was experimenting with some changes in the dns gadget, and the struct alignment was not as I expected.

This patch should make the code more robust for future changes.

Fixes: 4f7150e96093 ("Add NumAnswers and Addresses to DNS trace events")

