### PR TITLE
Support for running image-based gadgets test in k8s

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1404,7 +1404,68 @@ jobs:
           make \
           GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
           GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
-          -C gadgets/ test -o build
+          -C gadgets/ test-ig-local -o build
+
+  test-gadgets-k8s:
+    name: Test gadgets K8s
+    #level 3
+    needs:
+      - build-ig
+      - build-gadget-container-images
+      - build-helper-images
+      - build-and-push-gadgets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [docker, containerd, cri-o]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set container repository and determine image tag
+      id: set-repo-determine-image-tag
+      uses: ./.github/actions/set-container-repo-and-determine-image-tag
+      with:
+        registry: ${{ env.REGISTRY }}
+        container-image: ${{ env.CONTAINER_REPO }}
+    - name: Setup go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+      id: go
+    - name: Setup minikube
+      uses: ./.github/actions/setup-minikube
+      with:
+        runtime: ${{ matrix.runtime }}
+    - name: Get gadget-container-image-linux-amd64.tar from artifact.
+      uses: actions/download-artifact@v3
+      with:
+        name: gadget-container-image-linux-amd64.tar
+        path: /home/runner/work/inspektor-gadget/
+    - name: Prepare minikube by loading gadget-container-image-linux-amd64.tar
+      run: |
+        # 'docker load' ensures the image is named correctly e.g podman has issues loading untagged images from archive
+        docker load -i /home/runner/work/inspektor-gadget/gadget-container-image-linux-amd64.tar
+        minikube image load ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+    - name: Get kubectl-gadget-linux-amd64.tar.gz from artifact.
+      uses: actions/download-artifact@v3
+      with:
+        name: kubectl-gadget-linux-amd64-tar-gz
+        path: /home/runner/work/inspektor-gadget/inspektor-gadget/
+    - name: Gadgets tests
+      run: |
+        tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
+        ./kubectl-gadget deploy --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        make \
+        GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
+        GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
+        KUBECTL_GADGET=/home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget \
+        -C gadgets/ test-k8s -o build
+    - name: Undeploy Inspektor Gadget
+      id: undeploy-ig
+      if: always()
+      shell: bash
+      run: ./kubectl-gadget undeploy
 
   test-integration-non-k8s-ig:
     name: Test ig w/o k8s

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -4,6 +4,7 @@ GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
 IG ?= ig
+KUBECTL_GADGET ?= kubectl-gadget
 COSIGN ?= cosign
 GADGETS = \
 	trace_dns \
@@ -63,10 +64,21 @@ clean:
 	done
 
 .PHONY:
-test: build
+test-ig-local: build
+	IG_PATH=$(IG) \
+	IG_RUNTIME=docker \
 	CGO_ENABLED=0 \
 	IG_EXPERIMENTAL=true \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
-	IG=$(IG) \
+	go test -exec 'sudo -E' -v ./...
+
+.PHONY:
+test-k8s: build
+	IG_PATH=$(KUBECTL_GADGET) \
+	IG_RUNTIME=kubernetes \
+	CGO_ENABLED=0 \
+	IG_EXPERIMENTAL=true \
+	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
+	GADGET_TAG=$(GADGET_TAG) \
 	go test -exec 'sudo -E' -v ./...

--- a/gadgets/testing/testing.go
+++ b/gadgets/testing/testing.go
@@ -20,7 +20,11 @@ import (
 )
 
 func RequireEnvironmentVariables(t testing.TB) {
-	if os.Getenv("IG") == "" {
-		t.Skip("environment variable IG undefined")
+	if os.Getenv("IG_PATH") == "" {
+		t.Skip("environment variable IG_PATH undefined")
+	}
+
+	if os.Getenv("IG_RUNTIME") == "" {
+		t.Skip("environment variable IG_RUNTIME undefined")
 	}
 }

--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -1,0 +1,197 @@
+// Copyright 2019-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/command"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+)
+
+func NewK8sContainer(name, cmd string, options ...Option) Container {
+	c := &K8sContainer{
+		containerSpec: containerSpec{
+			name:    name,
+			cmd:     cmd,
+			options: defaultContainerOptions(),
+		},
+	}
+	for _, o := range options {
+		o(c.options)
+	}
+	return c
+}
+
+type K8sContainer struct {
+	containerSpec
+
+	// additional fields would be added when using golang api
+}
+
+// TODO:later on:use the golang api directly
+
+func (c *K8sContainer) Run(t *testing.T) {
+	c.Start(t)
+	c.Stop(t)
+}
+
+func (c *K8sContainer) Start(t *testing.T) {
+	// TODO: handle pid, portBindings.
+
+	igtesting.RunTestSteps([]igtesting.TestStep{
+		createTestNamespaceCommand(c.options.namespace),
+		podCommand(t, c.name, c.options.image, c.options.namespace, `["/bin/sh", "-c"]`, c.cmd),
+		sleepForSecondsCommand(2),
+		waitUntilPodReadyCommand(t, c.options.namespace, c.name),
+	}, t)
+
+	c.id = getContainerID(t, c.name, c.options.namespace)
+	c.started = true
+}
+
+func (c *K8sContainer) Stop(t *testing.T) {
+	igtesting.RunTestSteps([]igtesting.TestStep{
+		deletePodCommand(t, c.name, c.options.namespace),
+		deleteTestNamespaceCommand(t, c.options.namespace),
+	}, t)
+
+	c.started = false
+}
+
+const (
+	namespaceLabelKey   string = "scope"
+	namespaceLabelValue string = "ig-integration-tests"
+)
+
+// podCommand returns a Command that starts a pod with a specified image, command and args
+func podCommand(t *testing.T, podname, image, namespace, cmd, commandArgs string) *command.Command {
+	cmdLine := ""
+	if cmd != "" {
+		cmdLine = fmt.Sprintf("\n    command: %s", cmd)
+	}
+
+	commandArgsLine := ""
+	if commandArgs != "" {
+		commandArgsLine = fmt.Sprintf("\n    args:\n    - %s", commandArgs)
+	}
+
+	cmdStr := fmt.Sprintf(`kubectl apply -f - <<"EOF"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    run: %s
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: %s
+    image: %s%s%s
+EOF
+`, podname, namespace, podname, podname, image, cmdLine, commandArgsLine)
+
+	return &command.Command{
+		Name:           fmt.Sprintf("Run %s", podname),
+		Cmd:            exec.Command("/bin/sh", "-c", cmdStr),
+		StartAndStop:   true,
+		ValidateOutput: match.ExpectStringToMatch(t, fmt.Sprintf("pod/%s created\n", podname)),
+	}
+}
+
+// deletePodCommand returns a Command which deletes a pod whom
+// name is given as parameter.
+func deletePodCommand(t *testing.T, podname, namespace string) *command.Command {
+	return &command.Command{
+		Name:           fmt.Sprintf("Delete %s", podname),
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl delete -n=%s pod %s", namespace, podname)),
+		ValidateOutput: match.ExpectStringToMatch(t, fmt.Sprintf("pod \"%s\" deleted\n", podname)),
+	}
+}
+
+// createTestNamespaceCommand returns a Command which creates a namespace whom
+// name is given as parameter.
+func createTestNamespaceCommand(namespace string) *command.Command {
+	cmd := fmt.Sprintf(`kubectl apply -f - <<"EOF"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels: {"%s": "%s"}
+EOF
+while true; do
+  kubectl -n %s get serviceaccount default
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  sleep 1
+done
+	`, namespace, namespaceLabelKey, namespaceLabelValue, namespace)
+
+	return &command.Command{
+		Name: "Create test namespace",
+		Cmd:  exec.Command("/bin/sh", "-c", cmd),
+	}
+}
+
+// deleteTestNamespaceCommand returns a Command which deletes a namespace whom
+// name is given as parameter.
+func deleteTestNamespaceCommand(t *testing.T, namespace string) *command.Command {
+	return &command.Command{
+		Name:           "DeleteTestNamespace",
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl delete ns %s", namespace)),
+		ValidateOutput: match.ExpectStringToMatch(t, fmt.Sprintf("namespace \"%s\" deleted\n", namespace)),
+	}
+}
+
+// waitUntilPodReadyCommand returns a Command which waits until pod with the specified name in
+// the given as parameter namespace is ready.
+func waitUntilPodReadyCommand(t *testing.T, namespace string, podname string) *command.Command {
+	return &command.Command{
+		Name:           "WaitForTestPod",
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", namespace, podname)),
+		ValidateOutput: match.ExpectStringToMatch(t, fmt.Sprintf("pod/%s condition met\n", podname)),
+	}
+}
+
+// sleepForSecondsCommand returns a Command which sleeps for given seconds
+func sleepForSecondsCommand(seconds int) *command.Command {
+	return &command.Command{
+		Name: "SleepForSeconds",
+		Cmd:  exec.Command("/bin/sh", "-c", fmt.Sprintf("sleep %d", seconds)),
+	}
+}
+
+func getContainerID(t *testing.T, podName, namespace string) string {
+	cmd := exec.Command("kubectl", "get", "pod", podName, "--namespace", namespace, "-o", "jsonpath={.status.containerStatuses[0].containerID}")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	r, err := cmd.Output()
+	require.NoError(t, err, "getting container id: %s", stderr.String())
+
+	ret := string(r)
+	parts := strings.Split(ret, "/")
+	require.GreaterOrEqual(t, len(parts), 1, "unexpected container id")
+	return parts[len(parts)-1]
+}

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -151,7 +151,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		return nil, err
 	}
 	ev.podnameAccessor, err = k8s.AddSubField(
-		"pod",
+		"podName",
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
@@ -163,7 +163,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		return nil, err
 	}
 	ev.containernameAccessorK8s, err = k8s.AddSubField(
-		"container",
+		"containerName",
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{

--- a/pkg/testing/containers/containerd.go
+++ b/pkg/testing/containers/containerd.go
@@ -22,7 +22,7 @@ import (
 
 type ContainerdManager struct{}
 
-func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...containerOption) *TestContainer {
+func (cm *ContainerdManager) NewContainer(name, cmd string, opts ...ContainerOption) *TestContainer {
 	c := &TestContainer{}
 
 	for _, o := range opts {

--- a/pkg/testing/containers/factory.go
+++ b/pkg/testing/containers/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 type ContainerFactory interface {
-	NewContainer(name, cmd string, opts ...containerOption) *TestContainer
+	NewContainer(name, cmd string, opts ...ContainerOption) *TestContainer
 }
 
 // NewContainerFactory returns a new instance of a ContainerFactory based on the
@@ -35,6 +35,10 @@ func NewContainerFactory(containerRuntime string) (ContainerFactory, error) {
 	case types.RuntimeNameContainerd:
 		return &ContainerdManager{}, nil
 	default:
+		if containerRuntime == RuntimeKubernetes {
+			return &K8sManager{}, nil
+		}
+
 		return nil, fmt.Errorf("unknown container runtime %q", containerRuntime)
 	}
 }

--- a/pkg/testing/containers/k8s.go
+++ b/pkg/testing/containers/k8s.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Inspektor Gadget authors
+// Copyright 2019-2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,20 @@
 
 package containers
 
-import (
-	"context"
+import "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
-)
+// RuntimeKubernetes is used to implement container factory interface for running containers in k8s (not an actual runtime)
+const RuntimeKubernetes = "kubernetes"
 
-type DockerManager struct{}
+type K8sManager struct{}
 
-func (dm *DockerManager) NewContainer(name, cmd string, opts ...ContainerOption) *TestContainer {
+func (km *K8sManager) NewContainer(name string, cmd string, opts ...ContainerOption) *TestContainer {
 	c := &TestContainer{}
 
 	for _, o := range opts {
 		o(&c.cOptions)
 	}
-	c.options = append(c.options, testutils.WithContext(context.Background()))
 
-	c.Container = testutils.NewDockerContainer(name, cmd, c.options...)
+	c.Container = testutils.NewK8sContainer(name, cmd, c.options...)
 	return c
 }

--- a/pkg/testing/containers/options.go
+++ b/pkg/testing/containers/options.go
@@ -24,9 +24,9 @@ type cOptions struct {
 	startAndStop bool
 }
 
-// containerOption is a function that modifies a ContainerSpec and exposes only
+// ContainerOption is a function that modifies a ContainerSpec and exposes only
 // few options from testutils.Option to the user.
-type containerOption func(opts *cOptions)
+type ContainerOption func(opts *cOptions)
 
 func (o *cOptions) IsCleanup() bool {
 	return o.cleanup
@@ -36,25 +36,31 @@ func (o *cOptions) IsStartAndStop() bool {
 	return o.startAndStop
 }
 
-func WithContainerImage(image string) containerOption {
+func WithContainerImage(image string) ContainerOption {
 	return func(opts *cOptions) {
 		opts.options = append(opts.options, testutils.WithImage(image))
 	}
 }
 
-func WithContainerSeccompProfile(profile string) containerOption {
+func WithContainerSeccompProfile(profile string) ContainerOption {
 	return func(opts *cOptions) {
 		opts.options = append(opts.options, testutils.WithSeccompProfile(profile))
 	}
 }
 
-func WithCleanup() containerOption {
+func WithContainerNamespace(namespace string) ContainerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithNamespace(namespace))
+	}
+}
+
+func WithCleanup() ContainerOption {
 	return func(opts *cOptions) {
 		opts.cleanup = true
 	}
 }
 
-func WithStartAndStop() containerOption {
+func WithStartAndStop() ContainerOption {
 	return func(opts *cOptions) {
 		opts.startAndStop = true
 	}

--- a/pkg/testing/ig/ig.go
+++ b/pkg/testing/ig/ig.go
@@ -44,38 +44,38 @@ func (ig *runner) createCmd() {
 	ig.Cmd = exec.Command(ig.path, args...)
 }
 
-type option func(*runner)
+type Option func(*runner)
 
 // WithPath used for providing custom path to ig executable.
-func WithPath(path string) option {
+func WithPath(path string) Option {
 	return func(ig *runner) {
 		ig.path = path
 	}
 }
 
 // WithFlags args should be in form: "--flag_name=value" or "-shorthand=value".
-func WithFlags(flags ...string) option {
+func WithFlags(flags ...string) Option {
 	return func(ig *runner) {
 		ig.flags = flags
 	}
 }
 
 // WithStartAndStop used to set StartAndStop value to true.
-func WithStartAndStop() option {
+func WithStartAndStop() Option {
 	return func(ig *runner) {
 		ig.StartAndStop = true
 	}
 }
 
 // WithValidateOutput used to compare the actual output with expected output.
-func WithValidateOutput(validateOutput func(t *testing.T, output string)) option {
+func WithValidateOutput(validateOutput func(t *testing.T, output string)) Option {
 	return func(ig *runner) {
 		ig.ValidateOutput = validateOutput
 	}
 }
 
-// New creates a new IG configured with the options passed as parameters.
-func New(image string, opts ...option) igtesting.TestStep {
+// New creates a new IG configured with the Options passed as parameters.
+func New(image string, opts ...Option) igtesting.TestStep {
 	commandName := fmt.Sprintf("Run_%s", image)
 	repository := os.Getenv("GADGET_REPOSITORY")
 	tag := os.Getenv("GADGET_TAG")
@@ -86,7 +86,7 @@ func New(image string, opts ...option) igtesting.TestStep {
 		image = fmt.Sprintf("%s:%s", image, tag)
 	}
 
-	ig := &runner{
+	factoryRunner := &runner{
 		path:  "ig",
 		image: image,
 		Command: command.Command{
@@ -94,15 +94,15 @@ func New(image string, opts ...option) igtesting.TestStep {
 		},
 	}
 
-	if path, ok := os.LookupEnv("IG"); ok {
-		ig.path = path
+	if path, ok := os.LookupEnv("IG_PATH"); ok {
+		factoryRunner.path = path
 	}
 
 	for _, opt := range opts {
-		opt(ig)
+		opt(factoryRunner)
 	}
 
-	ig.createCmd()
+	factoryRunner.createCmd()
 
-	return ig
+	return factoryRunner
 }

--- a/pkg/testing/utils/component.go
+++ b/pkg/testing/utils/component.go
@@ -1,0 +1,67 @@
+// Copyright 2019-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type TestComponent string
+
+const (
+	// Used to test gadget using ig for container running locally
+	IgLocalTestComponent TestComponent = "ig-local"
+
+	// Used to test gadget using ig for container running in k8s
+	IgK8sTestComponent TestComponent = "ig-k8s"
+
+	// Used to test gadget using kubectl-gadget for container running in k8s
+	KubectlGadgetTestComponent TestComponent = "kubectl-gadget"
+)
+
+var (
+	Runtime              = eventtypes.RuntimeNameDocker.String()
+	ContainerRuntime     = Runtime
+	CurrentTestComponent = IgLocalTestComponent
+)
+
+func InitTest(t *testing.T) {
+	if os.Getenv("IG_RUNTIME") != "" {
+		Runtime = os.Getenv("IG_RUNTIME")
+		ContainerRuntime = Runtime
+
+		if Runtime == containers.RuntimeKubernetes {
+			// Get container runtime used in the cluster
+			ContainerRuntime = GetContainerRuntime(t)
+
+			if CurrentTestComponent == IgLocalTestComponent {
+				CurrentTestComponent = IgK8sTestComponent
+			}
+		}
+	}
+
+	if strings.Contains(os.Getenv("IG_PATH"), string(KubectlGadgetTestComponent)) {
+		CurrentTestComponent = KubectlGadgetTestComponent
+
+		if Runtime != containers.RuntimeKubernetes {
+			t.Fatalf("invalid value of runtime for kubectl-gadget. Valid value is %s", containers.RuntimeKubernetes)
+		}
+	}
+}

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -1,0 +1,178 @@
+// Copyright 2019-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+var (
+	seed int64      = time.Now().UTC().UnixNano()
+	r    *rand.Rand = rand.New(rand.NewSource(seed))
+)
+
+type CommonDataOption func(commonData *eventtypes.CommonData)
+
+// WithContainerImageName sets the ContainerImageName to facilitate the tests
+func WithContainerImageName(imageName string) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		if CurrentTestComponent == IgLocalTestComponent || !IsDockerRuntime() {
+			commonData.Runtime.ContainerImageName = imageName
+		}
+	}
+}
+
+// WithContainerID sets the ContainerID to facilitate the tests
+func WithContainerID(containerID string) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		commonData.Runtime.ContainerID = containerID
+	}
+}
+
+// WithK8sNamespace sets the Namepsace to facilitate the tests
+func WithK8sNamespace(namespace string) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		commonData.K8s.Namespace = namespace
+	}
+}
+
+func BuildCommonData(containerName string, options ...CommonDataOption) eventtypes.CommonData {
+	var e eventtypes.CommonData
+
+	switch CurrentTestComponent {
+	case IgLocalTestComponent:
+		e = eventtypes.CommonData{
+			Runtime: eventtypes.BasicRuntimeMetadata{
+				RuntimeName:   eventtypes.String2RuntimeName(ContainerRuntime),
+				ContainerName: containerName,
+			},
+		}
+	case KubectlGadgetTestComponent:
+		e = eventtypes.CommonData{
+			K8s: eventtypes.K8sMetadata{
+				BasicK8sMetadata: eventtypes.BasicK8sMetadata{
+					// Pod and Container name are defined by BusyboxPodCommand.
+					// Note the Pod is also assigned the containerName
+					PodName:       containerName,
+					ContainerName: containerName,
+				},
+			},
+			// TODO: Include the Node
+		}
+	}
+
+	for _, option := range options {
+		option(&e)
+	}
+	return e
+}
+
+func NormalizeCommonData(e *eventtypes.CommonData) {
+	// The container image digest is not currently enriched for Docker containers:
+	// https://github.com/inspektor-gadget/inspektor-gadget/issues/2365
+	if e.Runtime.RuntimeName == eventtypes.RuntimeNameDocker {
+		e.Runtime.ContainerImageDigest = ""
+	}
+
+	if CurrentTestComponent == KubectlGadgetTestComponent {
+		e.K8s.Node = ""
+		// TODO: Verify container runtime and container name
+		e.Runtime.RuntimeName = ""
+		e.Runtime.ContainerName = ""
+	}
+}
+
+func IsDockerRuntime() bool {
+	return ContainerRuntime == eventtypes.RuntimeNameDocker.String()
+}
+
+// PrintLogsFn returns a function that print logs in case the test fails.
+func PrintLogsFn(namespaces ...string) func(t *testing.T) {
+	return func(t *testing.T) {
+		if !t.Failed() {
+			return
+		}
+
+		if CurrentTestComponent == KubectlGadgetTestComponent {
+			t.Logf("Inspektor Gadget pod logs:")
+			t.Logf(getPodLogs("gadget"))
+		}
+
+		for _, ns := range namespaces {
+			t.Logf("Logs in namespace %s:", ns)
+			t.Logf(getPodLogs(ns))
+		}
+	}
+}
+
+// getPodLogs returns a string with the logs of all pods in namespace ns
+func getPodLogs(ns string) string {
+	if CurrentTestComponent != KubectlGadgetTestComponent {
+		return ""
+	}
+
+	var sb strings.Builder
+	logCommands := []string{
+		fmt.Sprintf("kubectl get pods -n %s -o wide", ns),
+		fmt.Sprintf(`for pod in $(kubectl get pods -n %[1]s -o name); do
+			kubectl logs -n %[1]s $pod --previous;
+			kubectl logs -n %[1]s $pod;
+		done`, ns),
+	}
+
+	for _, c := range logCommands {
+		cmd := exec.Command("/bin/sh", "-xc", c)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			sb.WriteString(fmt.Sprintf("Error: failed to run log command: %s, %s\n", cmd.String(), err))
+			continue
+		}
+		sb.WriteString(string(output))
+	}
+
+	return sb.String()
+}
+
+// GetContainerRuntime returns the container runtime the cluster is using.
+func GetContainerRuntime(t *testing.T) string {
+	cmd := exec.Command("kubectl", "get", "node", "-o", "jsonpath={.items[0].status.nodeInfo.containerRuntimeVersion}")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	r, err := cmd.Output()
+	require.NoError(t, err, "getting container runtime: %s", stderr.String())
+
+	ret := string(r)
+	parts := strings.Split(ret, ":")
+	require.GreaterOrEqual(t, len(parts), 1, "unexpected container runtime version")
+	return parts[0]
+}
+
+// GenerateTestNamespaceName returns a string which can be used as unique
+// namespace.
+// The returned value is: namespace_parameter-random_integer.
+func GenerateTestNamespaceName(t *testing.T, namespace string) string {
+	t.Logf("Seed used: %d", seed)
+	return fmt.Sprintf("%s-%d", namespace, r.Int())
+}


### PR DESCRIPTION
Support for running image-based gadgets test in k8s cluster with kubectl-gadget.

Previously we were running the test with ig alongside local containers, this PR adds support for running these tests with kubectl-gadget in the k8s cluster (minikube).

We try to have a single test, which applies different options for the **factory runner** as well as **expected entry** based on whether it's `ig` or `kubectl-gadget`.

Issue #2046

## How to use

Set `IG_PATH=ig` (for testing with local containers using ig) or `IG_PATH=kubectl-gadget` and `IG_RUNTIME=kubernetes` (for testing with containers running in minikube cluster, need to run `minikube-deploy` before).

Note: You can set this to the actual path of those applications as well, for example, `./ig` or `./kubectl-gadget`, should contain the keyword `kubectl-gadget` for `CurrentTestComponent` to be set as `KubectlGadgetTestComponent`.

Test Command: `make -C ./gadgets test-k8s`
