### PR TITLE
localmanager: Avoid crashing if container collection isn't available

### DIFF
--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -527,12 +527,14 @@ func (l *localManagerTraceWrapper) PreStart(gadgetCtx operators.GadgetContext) e
 		return fmt.Errorf("getting ebpfInstance")
 	}
 
-	compat.Subscribe(
-		l.eventWrappers,
-		l.manager.igManager.ContainerCollection.EnrichEventByMntNs,
-		l.manager.igManager.ContainerCollection.EnrichEventByNetNs,
-		0,
-	)
+	if l.manager.igManager != nil {
+		compat.Subscribe(
+			l.eventWrappers,
+			l.manager.igManager.ContainerCollection.EnrichEventByMntNs,
+			l.manager.igManager.ContainerCollection.EnrichEventByNetNs,
+			0,
+		)
+	}
 
 	id := uuid.New()
 	host := l.params.Get(Host).AsBool()


### PR DESCRIPTION
Fixes: b2895ee8c0cd ("pkg/operators/localmanager: add compatibility for DataSources")

### Testing 

Get a system without runc 

```bash 
$ runc
Command 'runc' not found, but can be installed with:
apt install runc
Please ask your administrator.
```
#### Before 

Running a gadget with and without --host produces a crash

```bash 
$ sudo -E ./ig run trace_exec:latest
INFO[0000] Experimental features enabled
WARN[0002] Failed to create container-collection
WARN[0003] Failed to create container-collection
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3632c1d]

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManagerTraceWrapper).PreStart(0xc004407d00, {0x4528868, 0xc002d8af00})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/localmanager/localmanager.go:532 +0xbd
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).run(0xc002d8af00, {0xc002d91590, 0x4, 0x17?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:103 +0x197
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).Run(0xc002d8af00, 0xc0000b5480?)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:167 +0x9e
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget(0x395c6a0?, {0x4550740?, 0xc002d8af00?}, 0xd?, 0xc002979b80?)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/runtime/local/oci.go:35 +0x27
github.com/inspektor-gadget/inspektor-gadget/cmd/common.NewRunCommand.func2(0xc000613808, {0xc000490b90?, 0x1?, 0x1?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/common/oci.go:180 +0x6d7
github.com/spf13/cobra.(*Command).execute(0xc000613808, {0xc000490b90, 0x1, 0x1})
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc00029f208)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/ig/main.go:91 +0x374

$ sudo -E ./ig run trace_exec:latest --host
INFO[0000] Experimental features enabled
WARN[0002] Failed to create container-collection
WARN[0002] Failed to create container-collection
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3632c1d]

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManagerTraceWrapper).PreStart(0xc0039c7780, {0x4528868, 0xc003f60000})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/localmanager/localmanager.go:532 +0xbd
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).run(0xc003f60000, {0xc003f5e0f0, 0x4, 0x17?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:103 +0x197
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).Run(0xc003f60000, 0xc0003f9640?)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:167 +0x9e
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget(0x395c6a0?, {0x4550740?, 0xc003f60000?}, 0xd?, 0xc003f19b80?)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/runtime/local/oci.go:35 +0x27
github.com/inspektor-gadget/inspektor-gadget/cmd/common.NewRunCommand.func2(0xc0003b8908, {0xc0003a4ee0?, 0x2?, 0x2?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/common/oci.go:180 +0x6d7
github.com/spf13/cobra.(*Command).execute(0xc0003b8908, {0xc0003a4ee0, 0x2, 0x2})
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc00057c308)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/ig/main.go:91 +0x374
```

#### After 

There are not crashes. If --host the gadget is able to run.

```bash 
$ sudo -E ./ig run trace_exec:latest
INFO[0000] Experimental features enabled
WARN[0003] Failed to create container-collection
WARN[0004] Failed to create container-collection
Error: pre-starting operator "LocalManager": container-collection isn't available

$ sudo -E ./ig run trace_exec:latest --host
INFO[0000] Experimental features enabled
WARN[0001] Failed to create container-collection
WARN[0002] Failed to create container-collection
WARN[0002] container-collection isn't available: container enrichment and filtering won't work
WARN[0002] container-collection isn't available: no containers will be traced
RUNTIME.CONTAINE… MNTNS_… PID       PPID      UID       GID       LOGINUID  SESSIONID R… ARGS_CO… U… ARGS_SI… COMM     ARGS     TIMESTA
```

Fixes #2873



