### PR TITLE
Improve support for WSL with Docker Desktop and Podman Desktop

### DIFF
--- a/pkg/utils/host/workarounds.go
+++ b/pkg/utils/host/workarounds.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -40,6 +41,10 @@ import (
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
+)
+
+const (
+	wslExePath = "/mnt/c/WINDOWS/system32/wsl.exe"
 )
 
 func hasCapSysAdmin() (bool, error) {
@@ -66,7 +71,7 @@ func suggestSdUnitRestart() error {
 		return err
 	}
 	if !hasCap {
-		return errors.New("need CAP_SYS_ADMIN (did you try --auto-sd-unit-restart?)")
+		return errors.New("need CAP_SYS_ADMIN (please try --auto-sd-unit-restart)")
 	}
 	return nil
 }
@@ -273,49 +278,122 @@ filesystemLoop:
 	return mountsSuggested, nil
 }
 
-func suggestWSLWorkaround() error {
+// isDockerWithWSLIntegration returns true if the process is running in a WSL
+// distribution with docker configured to use the WSL2 integration.
+func isDockerDesktopWSL2() bool {
+	dockerExePath, _ := exec.LookPath("docker")
+	if dockerExePath != "" {
+		dockerLinkPath, _ := os.Readlink(dockerExePath)
+		if strings.HasPrefix(dockerLinkPath, "/mnt/wsl/docker-desktop/cli-tools/") {
+			return true
+		}
+	}
+	return false
+}
+
+func isPodmanDesktopWSL2() bool {
+	podmanExePath, _ := exec.LookPath("podman")
+	if podmanExePath != "" {
+		if _, err := os.Stat("/mnt/wsl/podman-sockets/podman-machine-default/podman-root.sock"); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// isKernelWSL2 returns true if the kernel is WSL2.
+func isKernelWSL2() bool {
 	var utsname unix.Utsname
 	err := unix.Uname(&utsname)
 	if err != nil {
-		return err
+		return false
 	}
 	release := unix.ByteSliceToString(utsname.Release[:])
-	if !strings.HasSuffix(release, "-WSL2") {
-		return nil
-	}
-
-	// If /host/proc is correctly set up, we don't need this workaround
-	target, err := os.Readlink(HostProcFs + "/self")
-	if target != "" && err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("%s/self not found on WSL2 (did you try --auto-wsl-workaround?)", HostProcFs)
+	return strings.HasSuffix(release, "-WSL2")
 }
 
-// autoWSLWorkaround overrides HostRoot and HostProcFs if necessary.
-// Docker Desktop with WSL2 sets up host volumes with weird pidns.
-func autoWSLWorkaround() error {
-	// If we're not in a container, we can't use this workaround
-	if HostRoot == "/" {
+// getPid1Environ returns the environment variables of the init process in the
+// given procfs path.
+func getPid1Environ(procPath string) map[string]string {
+	environBytes, _ := os.ReadFile(filepath.Join(procPath, "1", "environ"))
+	environLines := strings.Split(string(environBytes), "\000")
+	environ := make(map[string]string)
+	for _, line := range environLines {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			environ[parts[0]] = parts[1]
+		}
+	}
+	return environ
+}
+
+// getWSLDistroName returns the WSL distribution name from the environment
+func getWSLDistroName() string {
+	// When running ig in a container started with "-v /:/host --pid=host":
+	// - /proc refers to the docker-desktop pidns because the container
+	//   inherits the pidns from runc.
+	// - /host/proc refers to the WSL distribution where the Docker client was
+	//   executed because the volume host path is translated automatically from
+	//   the docker client context to the docker server context.
+	// Therefore, use "/proc" to know if the docker server us running in a
+	// separate WSL machine.
+	pid1Environ := getPid1Environ("/proc")
+
+	// WSL machine's pid1 uses $WSL2_DISTRO_NAME, but child processes use
+	// $WSL_DISTRO_NAME, including the child pidns where runc is running (the
+	// only one we have access to with --pid=host). Since we don't know at this
+	// point if we're running directly in a WSL machine or in container runtime
+	// pidns, we need to test both variables.
+	wslDistroName := pid1Environ["WSL2_DISTRO_NAME"]
+	if wslDistroName == "" {
+		wslDistroName = pid1Environ["WSL_DISTRO_NAME"]
+	}
+
+	log.Debugf("WSL distribution: %s", wslDistroName)
+	return wslDistroName
+}
+
+func suggestWSLWorkaround() error {
+	if !isKernelWSL2() {
 		return nil
 	}
 
-	// If /host/proc is correctly set up, we don't need this workaround
+	wslDistroName := getWSLDistroName()
+
 	target, err := os.Readlink(HostProcFs + "/self")
-	if target != "" && err == nil {
-		return nil
+	hostProcFsAvailable := target != "" && err == nil
+
+	log.Debugf("$HOST_ROOT: %s", HostRoot)
+	log.Debugf("Host procfs available: %v", hostProcFsAvailable)
+
+	// pid 1 (/init) should have $WSL2_DISTRO_NAME defined. If it's not defined,
+	// we're likely running in a container with its own pid namespace.
+	// If the host proc fs is available, this is probably Docker installed on
+	// the WSL distribution (not Docker Desktop with WSL integration).
+	if wslDistroName == "" && !hostProcFsAvailable {
+		return fmt.Errorf("detecting WSL distribution name: empty name (please try to run docker with --pid=host)")
 	}
 
-	log.Warnf("%s's pidns is neither the current pidns or a parent of the current pidns. Remounting.", HostProcFs)
-	err = unix.Mount("/proc", HostProcFs, "", unix.MS_BIND, "")
-	if err != nil {
-		return fmt.Errorf("remounting %s: %w", HostProcFs, err)
+	if !hostProcFsAvailable {
+		return fmt.Errorf("host procfs not available (please try to run ig with --auto-wsl-workaround)")
 	}
-	// Find lifecycle-server process and set HOST_PID to its root
-	processes, err := os.ReadDir(HostProcFs)
+
+	if isDockerDesktopWSL2() || isPodmanDesktopWSL2() {
+		if _, err := os.Stat(filepath.Join(HostRoot, wslExePath)); err != nil {
+			log.Warnf("Docker or Podman uses WSL integration but cannot use wsl.exe workaround")
+			return nil
+		}
+
+		// We can use the workaround based on wsl.exe
+		return fmt.Errorf("docker or podman with WSL integration detected  (please try to run ig with --auto-wsl-workaround)")
+	}
+	return nil
+}
+
+func findProcessInProcfs(procPath string, cmd string) (int, error) {
+	processes, err := os.ReadDir(procPath)
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", HostProcFs, err)
+		return 0, fmt.Errorf("reading %s: %w", procPath, err)
 	}
 	for _, p := range processes {
 		if !p.IsDir() {
@@ -327,27 +405,135 @@ func autoWSLWorkaround() error {
 			continue
 		}
 
-		cmdLine := GetProcCmdline(pid)
-		if cmdLine[0] != "/usr/bin/lifecycle-server" {
+		cmdlineBytes, _ := os.ReadFile(filepath.Join(procPath, p.Name(), "cmdline"))
+		currentCmdLine := strings.Split(string(cmdlineBytes), "\x00")
+		if currentCmdLine[0] != cmd {
 			continue
 		}
-		log.Debugf("Found lifecycle-server process %s", p.Name())
 
-		buf, err := os.ReadFile(fmt.Sprintf("/proc/%s/cgroup", p.Name()))
-		if err != nil {
-			continue
-		}
-		if !strings.Contains(string(buf), "/podruntime/docker") {
-			continue
-		}
-		log.Debugf("Found lifecycle-server process %s in cgroup /podruntime/docker", p.Name())
+		log.Debugf("Found process %q: pid %s", cmd, p.Name())
+		return pid, nil
+	}
+	return 0, fmt.Errorf("process not found: %q", cmd)
+}
 
-		HostRoot = fmt.Sprintf("/proc/%s/root/", p.Name())
-		HostProcFs = filepath.Join(HostRoot, "/proc")
-		log.Warnf("Overriding HostRoot=%s HostProcFs=%s (lifecycle-server)", HostRoot, HostProcFs)
-
+// autoWSLWorkaround overrides HostRoot and HostProcFs if necessary.
+// There are different scenarios to support:
+//
+//  1. ig running in a WSL distribution (not in a container)
+//     - Docker running natively in the WSL distribution
+//     => nothing to do, it's like on native Linux machines
+//     - Docker running with the WSL2 integration
+//     => use wsl.exe to find the container runtime procfs
+//
+//  2. ig running in a native container (not in a container running in WSL)
+//     => nothing to do, it's like on native Linux machines
+//
+//  3. ig running in a container from Docker Desktop with WSL2 integration
+//     => requires --pid=host and procfs substituting because -v /:/host does
+//     not give access to the container runtime filesystem.
+//
+// Same scenarios with Podman.
+func autoWSLWorkaround() error {
+	if !isKernelWSL2() {
 		return nil
 	}
 
-	return errors.New("lifecycle-server process not found")
+	wslDistroName := getWSLDistroName()
+
+	inContainerDistro := wslDistroName == "docker-desktop" || wslDistroName == "podman-machine-default"
+	target, err := os.Readlink(HostProcFs + "/self")
+	hostProcFsAvailable := target != "" && err == nil
+
+	log.Debugf("$HOST_ROOT: %s", HostRoot)
+	log.Debugf("Host procfs available: %v", hostProcFsAvailable)
+
+	if inContainerDistro && !hostProcFsAvailable {
+		log.Debugf("Using WSL workaround for running in %q", wslDistroName)
+
+		// Use /proc and not /host/proc to select the pidns of the container runtime
+		procfsFromDockerDesktop := "/proc"
+
+		// Find lifecycle-server process and set HOST_PID to its root
+		pid, err := findProcessInProcfs(procfsFromDockerDesktop, "/usr/bin/lifecycle-server")
+		if err != nil {
+			return err
+		}
+
+		HostRoot = fmt.Sprintf("/proc/%d/root/", pid)
+		HostProcFs = filepath.Join(HostRoot, "/proc")
+		log.Debugf("Overriding HostRoot=%s HostProcFs=%s (lifecycle-server)", HostRoot, HostProcFs)
+		return nil
+	}
+
+	if isDockerDesktopWSL2() {
+		log.Debugf("Using WSL workaround for using Docker Desktop with WSL integration")
+
+		procfsFromDockerDesktop := filepath.Join(HostRoot, "/mnt/wsl/docker-desktop-procfs")
+		procfsInDockerDesktop := "/mnt/host/wsl/docker-desktop-procfs"
+		// Bind mount procfs from the docker-desktop machine if not already done
+		_, err := os.Stat(filepath.Join(procfsFromDockerDesktop, "1"))
+		if err != nil {
+			log.Debugf("Mounting procfs from docker-desktop machine to %s", procfsFromDockerDesktop)
+
+			os.MkdirAll(procfsFromDockerDesktop, 0o500)
+			cmd := exec.Command(filepath.Join(HostRoot, wslExePath),
+				"-d", "docker-desktop",
+				"--cd", "/",
+				"-u", "root",
+				"mount", "--bind", "/proc", procfsInDockerDesktop)
+			stdoutStderr, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("running wsl.exe: %w\n%s", err, stdoutStderr)
+			}
+		} else {
+			log.Debugf("procfs from docker-desktop machine already available at %s", procfsFromDockerDesktop)
+		}
+		targetProcess := "/usr/bin/lifecycle-server"
+		pid, err := findProcessInProcfs(procfsFromDockerDesktop, targetProcess)
+		if err != nil {
+			return err
+		}
+		HostRoot = filepath.Join(procfsFromDockerDesktop, fmt.Sprint(pid), "root")
+		HostProcFs = filepath.Join(HostRoot, "/proc")
+		log.Debugf("Overriding HostRoot=%s HostProcFs=%s (%s)", HostRoot, HostProcFs, targetProcess)
+		return nil
+	}
+
+	if isPodmanDesktopWSL2() {
+		log.Debugf("Using WSL workaround for using Podman Desktop with WSL integration")
+
+		procfsFromPodmanDesktop := filepath.Join(HostRoot, "/mnt/wsl/podman-desktop-procfs")
+		procfsInPodmanDesktop := "/mnt/wsl/podman-desktop-procfs"
+		// Bind mount procfs from the podman-desktop machine if not already done
+		_, err := os.Stat(filepath.Join(procfsFromPodmanDesktop, "1"))
+		if err != nil {
+			log.Debugf("Mounting procfs from podman-desktop machine to %s", procfsFromPodmanDesktop)
+
+			os.MkdirAll(procfsFromPodmanDesktop, 0o500)
+			cmd := exec.Command(filepath.Join(HostRoot, wslExePath),
+				"-d", "podman-machine-default",
+				"--cd", "/",
+				"-u", "root",
+				"mount", "--bind", "/proc", procfsInPodmanDesktop)
+			stdoutStderr, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("running wsl.exe: %w\n%s", err, stdoutStderr)
+			}
+		} else {
+			log.Debugf("procfs from podman-desktop machine already available at %s", procfsFromPodmanDesktop)
+		}
+		targetProcess := "/lib/systemd/systemd"
+		pid, err := findProcessInProcfs(procfsFromPodmanDesktop, targetProcess)
+		if err != nil {
+			return err
+		}
+		HostRoot = filepath.Join(procfsFromPodmanDesktop, fmt.Sprint(pid), "root")
+		HostProcFs = filepath.Join(HostRoot, "/proc")
+		log.Debugf("Overriding HostRoot=%s HostProcFs=%s (%s)", HostRoot, HostProcFs, targetProcess)
+		return nil
+	}
+
+	log.Debugf("No WSL workaround used")
+	return nil
 }


### PR DESCRIPTION
The existing --auto-wsl-workaround allowed to run ig in a docker container running in the docker-desktop WSL distribution.

This patch adds support for running ig in any WSL distribution and interact with Docker Desktop with the WSL integration.

Additionally, the same is done for Podman Desktop.

Summary of supported WSL configurations:

| ig running on                                 | container runtime                                 | Support |
|-----------------------------------------------|---------------------------------------------------|---------|
| WSL distribution (without container)          | docker installed natively in the WSL distribution | ✅      |
| WSL distribution (without container)          | podman installed natively in the WSL distribution | ✅      |
| WSL distribution (without container)          | Docker Desktop with WSL integration               | ✅      |
| WSL distribution (without container)          | Podman Desktop (podman-machine-default)           | ✅      |
| Docker Desktop container with WSL integration | Docker Desktop with WSL integration               | ✅      |
| Podman Desktop container                      | Podman Desktop (podman-machine-default)           | ✅      |
| -                                             | Docker Desktop with Hyper-V backend               | ❌      |

---

The different Linux distributions run in different pidns and mntns under the same Linux kernel. They share a bind mount, typically in `/mnt/wsl`. And `wsl.exe` can be used in a WSL distribution to execute a command in another WSL distribution.

![image](https://github.com/inspektor-gadget/inspektor-gadget/assets/27575/ca788065-a612-401f-9792-a929178b77ae)
