### PR TITLE
local/kube manager operators: Print warning for multiple net/mnt ns fields 

### DIFF
--- a/gadgets/snapshot_socket/program.bpf.c
+++ b/gadgets/snapshot_socket/program.bpf.c
@@ -52,7 +52,7 @@ struct socket_entry {
 	struct gadget_l4endpoint_t dst;
 	__u32 state;
 	__u32 ino;
-	__u32 netns;
+	gadget_netns_id netns;
 };
 
 GADGET_SNAPSHOTTER(sockets, socket_entry, ig_snap_tcp, ig_snap_udp);

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -39,7 +39,7 @@ struct event_t {
 	struct gadget_l4endpoint_t dst;
 
 	gadget_mntns_id mntns_id;
-	__u32 netns;
+	gadget_netns_id netns;
 	__u32 pid;
 	__u32 tid;
 	__u32 uid;

--- a/gadgets/trace_sni/program.bpf.c
+++ b/gadgets/trace_sni/program.bpf.c
@@ -59,7 +59,7 @@ struct event_t {
 	gadget_timestamp timestamp;
 
 	gadget_mntns_id mntns_id;
-	__u32 netns;
+	gadget_netns_id netns;
 
 	__u32 pid;
 	__u32 tid;

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -35,7 +35,7 @@ struct event {
 	__u32 pid;
 	__u32 uid;
 	__u32 gid;
-	__u32 netns;
+	gadget_netns_id netns;
 	enum event_type type;
 };
 

--- a/gadgets/trace_tcpdrop/program.bpf.c
+++ b/gadgets/trace_tcpdrop/program.bpf.c
@@ -50,7 +50,7 @@ struct event {
 	enum tcp_state state;
 	__u8 tcpflags;
 	enum skb_drop_reason reason;
-	__u32 netns;
+	gadget_netns_id netns;
 
 	// The original gadget has instances of these fields for both process context and
 	// socket context. Since sub-structures in the `event` are not yet supported, we only use

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -39,7 +39,7 @@ struct event {
 	__u8 state;
 	__u8 tcpflags;
 	__u32 reason;
-	__u32 netns;
+	gadget_netns_id netns;
 	enum type type;
 
 	gadget_mntns_id mntns_id;

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -28,6 +28,9 @@ struct gadget_l4endpoint_t {
 // Inode id of a mount namespace. It's used to enrich the event in user space
 typedef __u64 gadget_mntns_id;
 
+// Inode id of a network namespace. It's used to enrich the event in user space
+typedef __u32 gadget_netns_id;
+
 // gadget_timestamp is a type that represents the nanoseconds since the system boot. Gadgets can use
 // this type to provide a timestamp. The value contained must be the one returned by
 // bpf_ktime_get_boot_ns() and it's automatically converted by Inspektor Gadget to a human friendly

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -24,10 +24,10 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
+// Keep this aligned with include/gadget/types.h
 const (
-	MntNsIdType     = "type:gadget_mntns_id"
-	NetNsIdType     = "type:gadget_netns_id"
-	NetNsIdFallback = "name:netns"
+	MntNsIdType = "type:gadget_mntns_id"
+	NetNsIdType = "type:gadget_netns_id"
 )
 
 type EventWrapperBase struct {
@@ -56,7 +56,7 @@ func GetEventWrappers(gadgetCtx operators.GadgetContext) (map[datasource.DataSou
 	res := make(map[datasource.DataSource]*EventWrapperBase)
 	for _, ds := range gadgetCtx.GetDataSources() {
 		mntnsFields := ds.GetFieldsWithTag(MntNsIdType)
-		netnsFields := ds.GetFieldsWithTag(NetNsIdType, NetNsIdFallback)
+		netnsFields := ds.GetFieldsWithTag(NetNsIdType)
 		if len(mntnsFields) == 0 && len(netnsFields) == 0 {
 			continue
 		}

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -51,7 +51,7 @@ type (
 	NetNsEnrichFunc func(event operators.ContainerInfoFromNetNSID)
 )
 
-// GetEventWrappers checks for data sources containing refererences to mntns/netns that we could enrich data for
+// GetEventWrappers checks for data sources containing references to mntns/netns that we could enrich data for
 func GetEventWrappers(gadgetCtx operators.GadgetContext) (map[datasource.DataSource]*EventWrapperBase, error) {
 	res := make(map[datasource.DataSource]*EventWrapperBase)
 	for _, ds := range gadgetCtx.GetDataSources() {
@@ -68,17 +68,26 @@ func GetEventWrappers(gadgetCtx operators.GadgetContext) (map[datasource.DataSou
 		var mntnsField datasource.FieldAccessor
 		var netnsField datasource.FieldAccessor
 
-		for _, f := range mntnsFields {
+		if len(mntnsFields) > 0 {
 			gadgetCtx.Logger().Debugf("using mntns enrichment")
-			mntnsField = f
+			mntnsField = mntnsFields[0]
+
 			// We only support one of those per DataSource for now
-			break
+			if len(mntnsFields) > 1 {
+				gadgetCtx.Logger().Warnf("multiple fields of %q found in DataSource %q, only %q will be used",
+					MntNsIdType, ds.Name(), mntnsField.Name())
+			}
 		}
-		for _, f := range netnsFields {
+
+		if len(netnsFields) > 0 {
 			gadgetCtx.Logger().Debugf("using netns enrichment")
-			netnsField = f
+			netnsField = netnsFields[0]
+
 			// We only support one of those per DataSource for now
-			break
+			if len(netnsFields) > 1 {
+				gadgetCtx.Logger().Warnf("multiple fields of %q found in DataSource %q, only %q will be used",
+					NetNsIdType, ds.Name(), netnsField.Name())
+			}
 		}
 
 		accessors, err := WrapAccessors(ds, mntnsField, netnsField)


### PR DESCRIPTION
# Print warning for multiple net/mnt ns fields in local/kube manager operators

Let users know that we are not using all the net/mnt ns fields for enrichment but just one.

## How to use

A gadget defining more than one mntns or netns fileds. For instance:

```c
struct process_entry {
	gadget_mntns_id mntns_id;
	gadget_mntns_id jose;
	__u32 pid;
	__u32 tid;
	__u32 ppid;
	__u32 uid;
	__u32 gid;
	char comm[TASK_COMM_LEN];
};
```

IG will print a warning error like this:

```bash
$ IG_EXPERIMENTAL=true go run --exec "sudo -E" ./cmd/ig/... run $LOCAL_REPO/snapshot_process --insecure --verify-image=false -o jsonpretty -v
...
DEBU[0000] using mntns enrichment
WARN[0000] multiple fields with "type:gadget_mntns_id" found in DataSource "processes", only "mntns_id" will be used
...
```

