### PR TITLE
Revert "gadgets/trace_dns: add empty wasm module"

### DIFF
--- a/gadgets/trace_dns/build.yaml
+++ b/gadgets/trace_dns/build.yaml
@@ -1,1 +1,0 @@
-wasm: program.go

--- a/gadgets/trace_dns/go.mod
+++ b/gadgets/trace_dns/go.mod
@@ -1,7 +1,0 @@
-module main
-
-go 1.19
-
-require (
-	github.com/wapc/wapc-guest-tinygo v0.3.3
-)

--- a/gadgets/trace_dns/go.sum
+++ b/gadgets/trace_dns/go.sum
@@ -1,2 +1,0 @@
-github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
-github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/gadgets/trace_dns/program.go
+++ b/gadgets/trace_dns/program.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	wapc "github.com/wapc/wapc-guest-tinygo"
-)
-
-func main() {
-	wapc.RegisterFunctions(wapc.Functions{})
-}


### PR DESCRIPTION
This reverts commit 40b707f035d0856acd42d3d0511ad8219b1f5e6d.

e4745197c798 ("trace_dns: convert domain to dot notation (without wasm)") handled the name conversion without wasm. Now we can remove all golang related things from this gadget as they aren't needed.


