### PR TITLE
cmd/image/build: Add progress bar when pulling builder image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nxadm/tail v1.4.11 // indirect


### PR DESCRIPTION
The builder image is quite big. Add a progress bar to avoid annoying users.

### Testing

Remove the existing builder image

```bash 
$ docker image rm ghcr.io/inspektor-gadget/ebpf-builder
```

Try to build any gadget

```bash 
$ sudo -E ig image build .
INFO[0000] Experimental features enabled
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
c6cf28de8a06: Already exists
891494355808: Downloading [==============>                                    ]  6.881MB/24.05MB
6582c62583ef: Downloading [==============>                                    ]  18.38MB/64.14MB
6d74711819e4: Downloading [>                                                  ]  1.072MB/92.2MB
5ca436926747: Waiting
a583c4d6eaf8: Waiting
4f4fb700ef54: Waiting
335c54f5b534: Waiting
14b1c00c11bb: Waiting
aeb9d738ef34: Waiting
81b9be2a2111: Waiting
ea9ad05084c1: Waiting
af59ca28e4a0: Waiting
de563d0d4ab0: Waiting
69f89a347106: Waiting
```
