### PR TITLE
add otel-metrics operator for image-based gadgets

### DIFF
--- a/examples/gadgets/operators/otel_metrics/.gitignore
+++ b/examples/gadgets/operators/otel_metrics/.gitignore
@@ -1,0 +1,1 @@
+otel_metrics

--- a/examples/gadgets/operators/otel_metrics/README.md
+++ b/examples/gadgets/operators/otel_metrics/README.md
@@ -1,0 +1,19 @@
+# Open Telemetry Metrics Exporter Operator
+
+This example shows how to export metrics using OpenTelemetry / Prometheus.
+
+### How to run
+
+```bash
+$ go run -exec sudo .
+```
+
+### What it does
+
+<!-- markdown-link-check-disable-next-line -->
+By default, the operator exposes the metrics at http://IP-ADDRESS:2224/metrics (change IP-ADDRESS to your actual IP
+address). This demo  uses a counter, gauge and a histogram that emits new values every second. With the provided
+annotations, the operator will set those fields up properly and export them.
+
+Note that in this demo no actual gadget is run (thus the image parameter is unused) - instead,
+we use a simple operator to emit the metrics.

--- a/examples/gadgets/operators/otel_metrics/main.go
+++ b/examples/gadgets/operators/otel_metrics/main.go
@@ -1,0 +1,180 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	otelmetrics "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
+)
+
+func do() error {
+	var producer func()
+
+	// We will simulate generating metrics for three nodes; these strings will serve as the only key for the metrics
+	nodes := []string{"node1", "node2", "node3"}
+
+	metricsGenerator := simple.New("myHandler",
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			ds, err := gadgetCtx.RegisterDataSource(datasource.TypeSingle, "metrics")
+			if err != nil {
+				return err
+			}
+			ds.AddAnnotation(otelmetrics.AnnotationMetricsExport, "true")
+
+			// The node name will be used as key
+			node, err := ds.AddField(
+				"node",
+				api.Kind_String,
+				datasource.WithAnnotations(map[string]string{
+					otelmetrics.AnnotationMetricsType:        otelmetrics.MetricTypeKey,
+					otelmetrics.AnnotationMetricsDescription: "Node name",
+				}),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Latency will be recorded as histogram
+			latency, err := ds.AddField(
+				"latency",
+				api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					otelmetrics.AnnotationMetricsType:        otelmetrics.MetricTypeHistogram,
+					otelmetrics.AnnotationMetricsDescription: "Latency",
+				}),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Memory will be recorded as gauge
+			mem, err := ds.AddField(
+				"memory",
+				api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					otelmetrics.AnnotationMetricsType:        otelmetrics.MetricTypeGauge,
+					otelmetrics.AnnotationMetricsDescription: "Memory usage",
+				}),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Every second the counter gets increased by 1
+			ctr, err := ds.AddField(
+				"ctr",
+				api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					otelmetrics.AnnotationMetricsType:        otelmetrics.MetricTypeCounter,
+					otelmetrics.AnnotationMetricsDescription: "Number of metric events",
+				}),
+			)
+			if err != nil {
+				return err
+			}
+
+			producer = func() {
+				ticker := time.NewTicker(time.Second)
+				for {
+					select {
+					case <-ticker.C:
+						for _, n := range nodes {
+							// emit new metrics
+							metrics, err := ds.NewPacketSingle()
+							if err != nil {
+								gadgetCtx.Logger().Warnf("failed to create packet: %v", err)
+								continue
+							}
+
+							node.PutString(metrics, n)
+
+							latency.PutUint64(metrics, uint64(rand.Intn(2000)))
+
+							var m runtime.MemStats
+							runtime.ReadMemStats(&m)
+							mem.PutUint64(metrics, m.TotalAlloc)
+
+							ctr.PutUint64(metrics, 1)
+
+							ds.EmitAndRelease(metrics)
+						}
+					case <-gadgetCtx.Context().Done():
+						return
+					}
+				}
+			}
+
+			return nil
+		}),
+		simple.OnStart(func(gadgetCtx operators.GadgetContext) error {
+			go producer()
+			return nil
+		}),
+	)
+
+	// Initialize operator with default settings
+	globalParams := apihelpers.ToParamDescs(otelmetrics.Operator.GlobalParams()).ToParams()
+	globalParams.Set(otelmetrics.ParamOtelMetricsEnabled, "true")
+	otelmetrics.Operator.Init(globalParams)
+
+	l := logger.DefaultLogger()
+	l.SetLevel(logger.DebugLevel)
+
+	gadgetCtx := gadgetcontext.New(
+		context.Background(),
+		"none",
+		gadgetcontext.WithDataOperators(metricsGenerator, otelmetrics.Operator),
+		gadgetcontext.WithLogger(l),
+	)
+
+	// Create the runtime
+	runtime := local.New()
+	if err := runtime.Init(nil); err != nil {
+		return fmt.Errorf("runtime init: %w", err)
+	}
+	defer runtime.Close()
+
+	params := map[string]string{
+		"operator.otel-metrics.otel-metrics-name": "metrics",
+	}
+
+	// Run the gadget
+	if err := runtime.RunGadget(gadgetCtx, nil, params); err != nil {
+		return fmt.Errorf("running gadget: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := do(); err != nil {
+		fmt.Printf("Error running application: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -130,7 +130,10 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0 // indirect
+	go.opentelemetry.io/otel/exporters/prometheus v0.50.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.starlark.net v0.0.0-20230814145427-12f4cb8177e4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -398,10 +398,14 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 h1:R9DE4kQ4k+YtfLI2ULw
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0/go.mod h1:OQFyQVrDlbe+R7xrEyDr/2Wr67Ol0hRUgsfA+V5A95s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0 h1:QY7/0NeRPKlzusf40ZE4t1VlMKbqSNT7cJRYzWuja0s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0/go.mod h1:HVkSiDhTM9BoUJU8qE6j2eSWLLXvi1USXjyd2BXT8PY=
+go.opentelemetry.io/otel/exporters/prometheus v0.50.0 h1:2Ewsda6hejmbhGFyUvWZjUThC98Cf8Zy6g0zkIimOng=
+go.opentelemetry.io/otel/exporters/prometheus v0.50.0/go.mod h1:pMm5PkUo5YwbLiuEf7t2xg4wbP0/eSJrMxIMxKosynY=
 go.opentelemetry.io/otel/metric v1.28.0 h1:f0HGvSl1KRAU1DLgLGFjrwVyismPlnuU6JD6bOeuA5Q=
 go.opentelemetry.io/otel/metric v1.28.0/go.mod h1:Fb1eVBFZmLVTMb6PPohq3TO9IIhUisDsbJoL/+uQW4s=
 go.opentelemetry.io/otel/sdk v1.28.0 h1:b9d7hIry8yZsgtbmM0DKyPWMMUMlK9NEKuIG4aBqWyE=
 go.opentelemetry.io/otel/sdk v1.28.0/go.mod h1:oYj7ClPUA7Iw3m+r7GeEjz0qckQRJK2B8zjcZEfu7Pg=
+go.opentelemetry.io/otel/sdk/metric v1.28.0 h1:OkuaKgKrgAbYrrY0t92c+cC+2F6hsFNnCQArXCKlg08=
+go.opentelemetry.io/otel/sdk/metric v1.28.0/go.mod h1:cWPjykihLAPvXKi4iZc1dpER3Jdq2Z0YLse3moQUCpg=
 go.opentelemetry.io/otel/trace v1.28.0 h1:GhQ9cUuQGmNDd5BTCP2dAvv75RdMxEfTmYejp+lkx9g=
 go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -1,0 +1,507 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelmetrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"golang.org/x/exp/constraints"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const (
+	name = "otel-metrics"
+
+	Priority                      = 50000
+	ParamOtelMetricsEnabled       = "otel-metrics-enabled"
+	ParamOtelMetricsListenAddress = "otel-metrics-listen-address"
+	ParamOtelMetricsName          = "otel-metrics-name"
+
+	MetricTypeKey       = "key"
+	MetricTypeCounter   = "counter"
+	MetricTypeGauge     = "gauge"
+	MetricTypeHistogram = "histogram"
+
+	AnnotationMetricsExport      = "metrics.export"
+	AnnotationMetricsType        = "metrics.type"
+	AnnotationMetricsDescription = "metrics.description"
+	AnnotationMetricsUnit        = "metrics.unit"
+	AnnotationMetricsBoundaries  = "metrics.boundaries"
+)
+
+type otelMetricsOperator struct {
+	exporter      *prometheus.Exporter
+	meterProvider metric.MeterProvider
+	initialized   bool
+
+	// if skipListen is set to true, it will not expose the metrics using http
+	// this is used mainly for unit tests (you can still use the meterProvider & exporter)
+	skipListen bool
+}
+
+func (m *otelMetricsOperator) Name() string {
+	return name
+}
+
+func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
+	if m.initialized {
+		return nil
+	}
+
+	if !globalParams.Get(ParamOtelMetricsEnabled).AsBool() {
+		return nil
+	}
+
+	exporter, err := prometheus.New()
+	if err != nil {
+		return fmt.Errorf("initializing otel metrics exporter: %w", err)
+	}
+	m.exporter = exporter
+	m.meterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+
+	if !m.skipListen {
+		go func() {
+			mux := http.NewServeMux()
+			mux.Handle("/metrics", promhttp.Handler())
+			err := http.ListenAndServe(globalParams.Get(ParamOtelMetricsListenAddress).AsString(), mux)
+			if err != nil {
+				log.Errorf("serving otel metrics on: %s", err)
+				return
+			}
+		}()
+	}
+
+	m.initialized = true
+	return nil
+}
+
+func (m *otelMetricsOperator) GlobalParams() api.Params {
+	return api.Params{
+		{
+			Key:          ParamOtelMetricsEnabled,
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
+		},
+		{
+			Key:          ParamOtelMetricsListenAddress,
+			DefaultValue: "0.0.0.0:2224",
+			TypeHint:     api.TypeString,
+		},
+	}
+}
+
+func (m *otelMetricsOperator) InstanceParams() api.Params {
+	return api.Params{
+		{
+			Key:         ParamOtelMetricsName,
+			TypeHint:    api.TypeString,
+			Description: "override name of the exported datasource; use a comma-separated list with datasource:newname to specify more than one name",
+		},
+	}
+}
+
+func (m *otelMetricsOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	if !m.initialized {
+		return nil, nil
+	}
+
+	// extract name mappings; key will be old name (or empty), value the new name
+	mappings := make(map[string]string)
+	for _, m := range strings.Split(instanceParamValues[ParamOtelMetricsName], ",") {
+		names := strings.SplitN(m, ":", 2)
+		from := ""
+		to := names[0]
+		if len(names) == 2 {
+			from = to
+			to = names[1]
+		}
+		mappings[from] = to
+	}
+
+	instance := &otelMetricsOperatorInstance{
+		op:           m,
+		collectors:   make(map[datasource.DataSource]*metricsCollector),
+		nameMappings: mappings,
+	}
+
+	err := instance.init(gadgetCtx)
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}
+
+func (m *otelMetricsOperator) Priority() int {
+	return Priority
+}
+
+type otelMetricsOperatorInstance struct {
+	op           *otelMetricsOperator
+	collectors   map[datasource.DataSource]*metricsCollector
+	nameMappings map[string]string
+}
+
+func (m *otelMetricsOperatorInstance) Name() string {
+	return name
+}
+
+type metricsCollector struct {
+	meter  metric.Meter
+	keys   []func(datasource.Data) attribute.KeyValue
+	values []func(context.Context, datasource.Data, attribute.Set)
+}
+
+func asInt64Func[T constraints.Integer](extract func(datasource.Data) (T, error)) func(datasource.Data) int64 {
+	return func(data datasource.Data) int64 {
+		v, _ := extract(data)
+		return int64(v)
+	}
+}
+
+func asInt64(f datasource.FieldAccessor) func(datasource.Data) int64 {
+	switch f.Type() {
+	default:
+		// This should not be called with types other than int
+		panic("unsupported field type for asInt64")
+	case api.Kind_Int8:
+		return asInt64Func(f.Int8)
+	case api.Kind_Int16:
+		return asInt64Func(f.Int16)
+	case api.Kind_Int32:
+		return asInt64Func(f.Int32)
+	case api.Kind_Int64:
+		return asInt64Func(f.Int64)
+	case api.Kind_Uint8:
+		return asInt64Func(f.Uint8)
+	case api.Kind_Uint16:
+		return asInt64Func(f.Uint16)
+	case api.Kind_Uint32:
+		return asInt64Func(f.Uint32)
+	case api.Kind_Uint64:
+		return asInt64Func(f.Uint64)
+	}
+}
+
+func asFloat64Func[T constraints.Float](extract func(datasource.Data) (T, error)) func(datasource.Data) float64 {
+	return func(data datasource.Data) float64 {
+		v, _ := extract(data)
+		return float64(v)
+	}
+}
+
+func asFloat64(f datasource.FieldAccessor) func(datasource.Data) float64 {
+	switch f.Type() {
+	default:
+		// This should not be called with types other than float
+		panic("unsupported field type for asFloat4")
+	case api.Kind_Float32:
+		return asFloat64Func(f.Float32)
+	case api.Kind_Float64:
+		return asFloat64Func(f.Float64)
+	}
+}
+
+func (mc *metricsCollector) addKeyFunc(f datasource.FieldAccessor) error {
+	name := f.Name()
+	switch f.Type() {
+	default:
+		return fmt.Errorf("unsupported field type for metrics collector: %s", f.Type())
+	case api.Kind_String, api.Kind_CString:
+		mc.keys = append(mc.keys, func(data datasource.Data) attribute.KeyValue {
+			val, _ := f.String(data)
+			return attribute.KeyValue{Key: attribute.Key(name), Value: attribute.StringValue(val)}
+		})
+	case api.Kind_Uint8,
+		api.Kind_Uint16,
+		api.Kind_Uint32,
+		api.Kind_Uint64,
+		api.Kind_Int8,
+		api.Kind_Int16,
+		api.Kind_Int32,
+		api.Kind_Int64:
+		asIntFn := asInt64(f)
+		mc.keys = append(mc.keys, func(data datasource.Data) attribute.KeyValue {
+			return attribute.KeyValue{Key: attribute.Key(name), Value: attribute.Int64Value(asIntFn(data))}
+		})
+	case api.Kind_Float32, api.Kind_Float64:
+		asFloatFn := asFloat64(f)
+		mc.keys = append(mc.keys, func(data datasource.Data) attribute.KeyValue {
+			return attribute.KeyValue{Key: attribute.Key(name), Value: attribute.Float64Value(asFloatFn(data))}
+		})
+	}
+	return nil
+}
+
+func (mc *metricsCollector) addValFunc(f datasource.FieldAccessor, metricType string) error {
+	var options []metric.InstrumentOption
+	if description := f.Annotations()[AnnotationMetricsDescription]; description != "" {
+		options = append(options, metric.WithDescription(description))
+	}
+	if unit := f.Annotations()[AnnotationMetricsUnit]; unit != "" {
+		options = append(options, metric.WithUnit(unit))
+	}
+
+	switch f.Type() {
+	default:
+		return fmt.Errorf("unsupported field type for metrics value %q: %s", f.Name(), f.Type())
+	case api.Kind_Uint8,
+		api.Kind_Uint16,
+		api.Kind_Uint32,
+		api.Kind_Uint64,
+		api.Kind_Int8,
+		api.Kind_Int16,
+		api.Kind_Int32,
+		api.Kind_Int64:
+		asIntFn := asInt64(f)
+		switch metricType {
+		case MetricTypeCounter:
+			tOptions := make([]metric.Int64CounterOption, len(options))
+			for i, option := range options {
+				tOptions[i] = option
+			}
+			ctr, err := mc.meter.Int64Counter(f.Name(), tOptions...)
+			if err != nil {
+				return fmt.Errorf("adding metric %s for %q: %w", metricType, f.Name(), err)
+			}
+			mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+				ctr.Add(ctx, asIntFn(data), metric.WithAttributeSet(set))
+			})
+		case MetricTypeGauge:
+			tOptions := make([]metric.Int64GaugeOption, len(options))
+			for i, option := range options {
+				tOptions[i] = option
+			}
+			ctr, err := mc.meter.Int64Gauge(f.Name(), tOptions...)
+			if err != nil {
+				return fmt.Errorf("adding metric %s for %q: %w", metricType, f.Name(), err)
+			}
+			mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+				ctr.Record(ctx, asIntFn(data), metric.WithAttributeSet(set))
+			})
+		}
+		return nil
+	case api.Kind_Float32, api.Kind_Float64:
+		asFloatFn := asFloat64(f)
+		switch metricType {
+		case MetricTypeCounter:
+			tOptions := make([]metric.Float64CounterOption, len(options))
+			for i, option := range options {
+				tOptions[i] = option
+			}
+			ctr, err := mc.meter.Float64Counter(f.Name(), tOptions...)
+			if err != nil {
+				return fmt.Errorf("adding metric %s for %q: %w", metricType, f.Name(), err)
+			}
+			mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+				ctr.Add(ctx, asFloatFn(data), metric.WithAttributeSet(set))
+			})
+		case MetricTypeGauge:
+			tOptions := make([]metric.Float64GaugeOption, len(options))
+			for i, option := range options {
+				tOptions[i] = option
+			}
+			ctr, err := mc.meter.Float64Gauge(f.Name(), tOptions...)
+			if err != nil {
+				return fmt.Errorf("adding metric %s for %q: %w", metricType, f.Name(), err)
+			}
+			mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+				ctr.Record(ctx, asFloatFn(data), metric.WithAttributeSet(set))
+			})
+		}
+		return nil
+	}
+}
+
+func toFloat64(s string) (float64, error) {
+	return strconv.ParseFloat(s, 64)
+}
+
+func listToVals[T int64 | float64](list string, conv func(string) (T, error)) ([]T, error) {
+	elements := strings.Split(list, ",")
+	res := make([]T, 0, len(elements))
+	for _, element := range elements {
+		v, err := conv(element)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value: %q: %w", element, err)
+		}
+		res = append(res, v)
+	}
+	return res, nil
+}
+
+func (mc *metricsCollector) addValHistFunc(f datasource.FieldAccessor) error {
+	options := make([]metric.HistogramOption, 0)
+	if buckets := f.Annotations()[AnnotationMetricsBoundaries]; buckets != "" {
+		boundaries, err := listToVals[float64](buckets, toFloat64)
+		if err != nil {
+			return fmt.Errorf("adding metric histogram for %q: %w", f.Name(), err)
+		}
+		options = append(options, metric.WithExplicitBucketBoundaries(boundaries...))
+	}
+	if description := f.Annotations()[AnnotationMetricsDescription]; description != "" {
+		options = append(options, metric.WithDescription(description))
+	}
+	if unit := f.Annotations()[AnnotationMetricsUnit]; unit != "" {
+		options = append(options, metric.WithUnit(unit))
+	}
+
+	switch f.Type() {
+	default:
+		return fmt.Errorf("unsupported field type for metrics value %q: %s", f.Name(), f.Type())
+	case api.Kind_Uint8,
+		api.Kind_Uint16,
+		api.Kind_Uint32,
+		api.Kind_Uint64,
+		api.Kind_Int8,
+		api.Kind_Int16,
+		api.Kind_Int32,
+		api.Kind_Int64:
+		hOptions := make([]metric.Int64HistogramOption, len(options))
+		for i, option := range options {
+			hOptions[i] = option
+		}
+		hist, err := mc.meter.Int64Histogram(f.Name(), hOptions...)
+		if err != nil {
+			return fmt.Errorf("adding metric histogram for %q: %w", f.Name(), err)
+		}
+		asIntFn := asInt64(f)
+		mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+			hist.Record(ctx, asIntFn(data), metric.WithAttributeSet(set))
+		})
+		return nil
+	case api.Kind_Float32, api.Kind_Float64:
+		hOptions := make([]metric.Float64HistogramOption, len(options))
+		for i, option := range options {
+			hOptions[i] = option
+		}
+		hist, err := mc.meter.Float64Histogram(f.Name(), hOptions...)
+		if err != nil {
+			return fmt.Errorf("adding metric histogram for %q: %w", f.Name(), err)
+		}
+		asFloatFn := asFloat64(f)
+		mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+			hist.Record(ctx, asFloatFn(data), metric.WithAttributeSet(set))
+		})
+		return nil
+	}
+}
+
+func (mc *metricsCollector) Collect(ctx context.Context, data datasource.Data) {
+	kvs := make([]attribute.KeyValue, 0, len(mc.keys))
+	for _, kf := range mc.keys {
+		kvs = append(kvs, kf(data))
+	}
+	kset := attribute.NewSet(kvs...)
+	for _, vf := range mc.values {
+		vf(ctx, data, kset)
+	}
+}
+
+func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
+	for _, ds := range gadgetCtx.GetDataSources() {
+		annotations := ds.Annotations()
+		if annotations[AnnotationMetricsExport] != "true" {
+			continue
+		}
+
+		metricsName := ds.Name()
+		mappedName, ok := m.nameMappings[metricsName]
+		if !ok {
+			// try empty (unspecified)
+			mappedName = m.nameMappings[""]
+		}
+
+		if mappedName == "" {
+			gadgetCtx.Logger().Warnf("no name found for metric %q, skipping export", metricsName)
+			continue
+		}
+
+		meter := m.op.meterProvider.Meter(mappedName)
+
+		collector := &metricsCollector{meter: meter}
+
+		hasValueFields := false
+
+		fields := ds.Accessors(false)
+		for _, f := range fields {
+			fieldName := f.Name()
+			metricsType := f.Annotations()[AnnotationMetricsType]
+			switch metricsType {
+			default:
+				continue
+			case MetricTypeKey:
+				err := collector.addKeyFunc(f)
+				if err != nil {
+					return fmt.Errorf("adding key for %q: %w", fieldName, err)
+				}
+			case MetricTypeCounter, MetricTypeGauge:
+				err := collector.addValFunc(f, metricsType)
+				if err != nil {
+					return fmt.Errorf("adding %s for %q: %w", metricsType, fieldName, err)
+				}
+				hasValueFields = true
+			case MetricTypeHistogram:
+				err := collector.addValHistFunc(f)
+				if err != nil {
+					return fmt.Errorf("adding histogram for %q: %w", fieldName, err)
+				}
+				hasValueFields = true
+			}
+			gadgetCtx.Logger().Debugf("registered field %q as type %q", fieldName, metricsType)
+		}
+		if !hasValueFields {
+			continue
+		}
+		m.collectors[ds] = collector
+	}
+	return nil
+}
+
+func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, collector := range m.collectors {
+		err := ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+			collector.Collect(gadgetCtx.Context(), data)
+			return nil
+		}, Priority)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *otelMetricsOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (m *otelMetricsOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+var Operator = &otelMetricsOperator{}

--- a/pkg/operators/otel-metrics/otel-metrics_test.go
+++ b/pkg/operators/otel-metrics/otel-metrics_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelmetrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+)
+
+func TestMetricsCounterAndGauge(t *testing.T) {
+	o := &otelMetricsOperator{skipListen: true}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	globalParams.Set(ParamOtelMetricsEnabled, "true")
+	err := o.Init(globalParams)
+	require.NoError(t, err)
+
+	require.True(t, o.initialized)
+
+	var ds datasource.DataSource
+	var ctr datasource.FieldAccessor
+	var gauge datasource.FieldAccessor
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "metrics")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationMetricsExport, "true")
+
+		ctr, err = ds.AddField("ctr", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeCounter,
+		}))
+		require.NoError(t, err)
+
+		gauge, err = ds.AddField("gauge", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeGauge,
+		}))
+		require.NoError(t, err)
+		return nil
+	}
+	produce := func(operators.GadgetContext) error {
+		for i := range 10 {
+			data, err := ds.NewPacketSingle()
+			require.NoError(t, err)
+			err = ctr.PutUint32(data, uint32(1))
+			assert.NoError(t, err)
+			err = gauge.PutUint32(data, uint32(i))
+			assert.NoError(t, err)
+			err = ds.EmitAndRelease(data)
+			assert.NoError(t, err)
+		}
+		cancel()
+		return nil
+	}
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+	err = gadgetCtx.Run(api.ParamValues{
+		"operator.otel-metrics.otel-metrics-name": "metrics:metrics",
+	})
+
+	require.NoError(t, err)
+
+	md := &metricdata.ResourceMetrics{}
+
+	err = o.exporter.Collect(context.Background(), md)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, md.ScopeMetrics)
+	for _, sm := range md.ScopeMetrics {
+		assert.NotEmpty(t, sm)
+		foundCtr := false
+		foundGauge := false
+		for _, m := range sm.Metrics {
+			if m.Name == "ctr" {
+				foundCtr = true
+				data, ok := (m.Data).(metricdata.Sum[int64])
+				assert.True(t, ok)
+				assert.Equal(t, int64(10), data.DataPoints[0].Value)
+			}
+			if m.Name == "gauge" {
+				foundGauge = true
+				data, ok := (m.Data).(metricdata.Gauge[int64])
+				assert.True(t, ok)
+				assert.Equal(t, int64(9), data.DataPoints[0].Value)
+			}
+		}
+		assert.True(t, foundCtr)
+		assert.True(t, foundGauge)
+	}
+}
+
+func TestMetricsHistogram(t *testing.T) {
+	o := &otelMetricsOperator{skipListen: true}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	globalParams.Set(ParamOtelMetricsEnabled, "true")
+	err := o.Init(globalParams)
+	require.NoError(t, err)
+
+	require.True(t, o.initialized)
+
+	var ds datasource.DataSource
+	var value datasource.FieldAccessor
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	expectedBuckets := []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 3, 2, 3, 0}
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "metrics")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationMetricsExport, "true")
+		value, err = ds.AddField("duration", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeHistogram,
+		}))
+		require.NoError(t, err)
+		return nil
+	}
+	produce := func(operators.GadgetContext) error {
+		for i := range 10 {
+			data, err := ds.NewPacketSingle()
+			require.NoError(t, err)
+			err = value.PutUint32(data, uint32((i+1)*1000))
+			assert.NoError(t, err)
+			err = ds.EmitAndRelease(data)
+			assert.NoError(t, err)
+		}
+		cancel()
+		return nil
+	}
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+	err = gadgetCtx.Run(api.ParamValues{
+		"operator.otel-metrics.otel-metrics-name": "metrics:metrics",
+	})
+	require.NoError(t, err)
+
+	md := &metricdata.ResourceMetrics{}
+
+	err = o.exporter.Collect(context.Background(), md)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, md.ScopeMetrics)
+	for _, sm := range md.ScopeMetrics {
+		assert.NotEmpty(t, sm)
+		found := false
+		for _, m := range sm.Metrics {
+			if m.Name == "duration" {
+				found = true
+				data, ok := (m.Data).(metricdata.Histogram[int64])
+				assert.True(t, ok)
+				assert.Equal(t, 1, len(data.DataPoints))
+				assert.Equal(t, len(expectedBuckets), len(data.DataPoints[0].BucketCounts))
+				assert.Equal(t, expectedBuckets, data.DataPoints[0].BucketCounts)
+			}
+		}
+		assert.True(t, found)
+	}
+}


### PR DESCRIPTION
This introduces a new otel-metrics operator for image-based gadgets. This operator can consume and export data from data sources / fields if they're correctly annotated:

* DataSource needs "metrics.export" set to "true" to be considered by the operator
* Fields need "metrics.type" set to either "key", "counter", "gauge" or "histogram"
  * counter/gauge/histogram will export those fields using the specified type
  * "key" can be used optionally (and multiple times) to group metrics by the unique set of keys given
* optionally, "metrics.description" and "metrics.unit" can be used to provide some metadata to the exporter
* fields without a "metrics.type" will be ignored

To actually enable metrics export, the `otel-metrics-name` param __must__ be set to the exported name explicitly. This ensures a stable export name. Open Telemetry suggests:

```
This name uniquely identifies the [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope), such as the [instrumentation library](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-library) (e.g. io.opentelemetry.contrib.mongodb), package, module or class name. If an application or library has built-in OpenTelemetry instrumentation, both [Instrumented library](https://opentelemetry.io/docs/specs/otel/glossary/#instrumented-library) and [Instrumentation library](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-library) can refer to the same library. In that scenario, the name denotes a module name or component name within that library or application.
```

I think its good to leave the decision up to the user, since it's effectively them creating the scope by using a specifically configured gadget.

If enabled, the operator will listen on an HTTP port and provide the prometheus-like interface.

A demo to use it from the Go API has been included.

With the recent update to the otel packages, the workarounds for synchronous gauges could finally be removed and the code further simplified.

Functionality that will automatically annotate/export eBPF maps will follow in a separate PR.

### Todo

* [ ] Proper documentation of annotations
* [ ] add IG internal metrics #2981