### PR TITLE
clean up operator initialization code

### DIFF
--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -86,7 +86,9 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 		}
 
 		log.Infof("starting Inspektor Gadget daemon at %q", socket)
-		service := gadgetservice.NewService(log.StandardLogger(), eventBufferLength)
+		service := gadgetservice.NewService(log.StandardLogger())
+		service.SetEventBufferLength(eventBufferLength)
+
 		return service.Run(gadgetservice.RunConfig{
 			SocketType: socketType,
 			SocketPath: socketPath,

--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
@@ -63,6 +64,12 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 		16384,
 		"The events buffer length. A low value could impact horizontal scaling.")
 
+	service := gadgetservice.NewService(log.StandardLogger())
+
+	for _, params := range service.GetOperatorMap() {
+		common.AddFlags(daemonCmd, params, nil, runtime)
+	}
+
 	daemonCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if os.Geteuid() != 0 {
 			return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
@@ -86,7 +93,6 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 		}
 
 		log.Infof("starting Inspektor Gadget daemon at %q", socket)
-		service := gadgetservice.NewService(log.StandardLogger())
 		service.SetEventBufferLength(eventBufferLength)
 
 		return service.Run(gadgetservice.RunConfig{

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -335,7 +335,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Parsing EVENTS_BUFFER_LENGTH %q: %v", stringBufferLength, err)
 		}
-		service := gadgetservice.NewService(log.StandardLogger(), bufferLength)
+		service := gadgetservice.NewService(log.StandardLogger())
+		service.SetEventBufferLength(bufferLength)
 
 		socketType, socketPath, err := api.ParseSocketAddress(gadgetServiceHost)
 		if err != nil {

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -41,20 +41,11 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		log.Debugf("initializing data op %q", op.Name())
 		opParamPrefix := fmt.Sprintf("operator.%s", op.Name())
 
-		// Lazily initialize operator
-		// TODO: global params should be filled out from a config file or such; maybe it's a better idea not to
-		// lazily initialize operators at all, but just hand over the config. The "lazy" stuff could then be done
-		// if the operator is instantiated and needs to do work
-		err := op.Init(apihelpers.ToParamDescs(op.GlobalParams()).ToParams())
-		if err != nil {
-			return nil, fmt.Errorf("initializing operator %q: %w", op.Name(), err)
-		}
-
 		// Get and fill params
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
-		err = apihelpers.Validate(instanceParams, opParamValues)
+		err := apihelpers.Validate(instanceParams, opParamValues)
 		if err != nil {
 			return nil, fmt.Errorf("validating params for operator %q: %w", op.Name(), err)
 		}

--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -28,7 +28,22 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
+
+func (s *Service) initOperators() error {
+	for op, globalParams := range s.operators {
+		err := op.Init(globalParams)
+		if err != nil {
+			return fmt.Errorf("initializing operator %s: %w", op.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) GetOperatorMap() map[operators.DataOperator]*params.Params {
+	return s.operators
+}
 
 func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoRequest) (*api.GetGadgetInfoResponse, error) {
 	if req.Version != api.VersionGadgetInfo {
@@ -37,7 +52,7 @@ func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoReque
 
 	// Get all available operators
 	ops := make([]operators.DataOperator, 0)
-	for _, op := range operators.GetDataOperators() {
+	for op := range s.operators {
 		ops = append(ops, op)
 	}
 
@@ -183,7 +198,7 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 	)
 
 	ops := make([]operators.DataOperator, 0)
-	for _, op := range operators.GetDataOperators() {
+	for op := range s.operators {
 		ops = append(ops, op)
 	}
 	ops = append(ops, svc)

--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -33,9 +33,11 @@ import (
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -62,12 +64,20 @@ type Service struct {
 	logger            logger.Logger
 	servers           map[*grpc.Server]struct{}
 	eventBufferLength uint64
+
+	// operators stores all global parameters for DataOperators (non-legacy)
+	operators map[operators.DataOperator]*params.Params
 }
 
 func NewService(defaultLogger logger.Logger, length uint64) *Service {
+	ops := make(map[operators.DataOperator]*params.Params)
+	for _, op := range operators.GetDataOperators() {
+		ops[op] = apihelpers.ToParamDescs(op.GlobalParams()).ToParams()
+	}
 	return &Service{
 		servers:           map[*grpc.Server]struct{}{},
 		logger:            defaultLogger,
+		operators:         ops,
 		eventBufferLength: length,
 	}
 }
@@ -327,6 +337,11 @@ func (s *Service) Run(runConfig RunConfig, serverOptions ...grpc.ServerOption) e
 	api.RegisterGadgetManagerServer(server, s)
 
 	s.servers[server] = struct{}{}
+
+	err = s.initOperators()
+	if err != nil {
+		return fmt.Errorf("initializing operators: %w", err)
+	}
 
 	return server.Serve(s.listener)
 }

--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -69,17 +69,20 @@ type Service struct {
 	operators map[operators.DataOperator]*params.Params
 }
 
-func NewService(defaultLogger logger.Logger, length uint64) *Service {
+func NewService(defaultLogger logger.Logger) *Service {
 	ops := make(map[operators.DataOperator]*params.Params)
 	for _, op := range operators.GetDataOperators() {
 		ops[op] = apihelpers.ToParamDescs(op.GlobalParams()).ToParams()
 	}
 	return &Service{
-		servers:           map[*grpc.Server]struct{}{},
-		logger:            defaultLogger,
-		operators:         ops,
-		eventBufferLength: length,
+		servers:   map[*grpc.Server]struct{}{},
+		logger:    defaultLogger,
+		operators: ops,
 	}
+}
+
+func (s *Service) SetEventBufferLength(val uint64) {
+	s.eventBufferLength = val
 }
 
 func (s *Service) GetInfo(ctx context.Context, request *api.InfoRequest) (*api.InfoResponse, error) {


### PR DESCRIPTION
Previously, for image-based gadgets, operators would lazily be initialized by the gadget context. That made it difficult to forward the actual global configuration of operators. Since we didn't really use those in the past, it was not a big issue.

However, now that we're for example using image verification that can be enabled/disabled using parameters, we need to clean this up. Currently, the client decides whether image validation is done by sending the appropriate flag to the server. This is however insecure, as the client shouldn't have authority over that decision. We may later on allow (using another param/setting that can be enabled on the server) clients to override certain behavior, but in general the server should decide about the security features.

This PR moves the initialization to all our entry points for image-based gadgets and exports the parameters to be set there, if applicable.

This means:
* cmd/common/oci.go exposes global operator params to client (or ig used in standalone mode)
* pkg/gadget-service collects and exposes params using a function
* cmd/ig/daemon.go uses the params exposed by the gadget-service
* gadgettracermgr should also expose those params exposed by the gadget-service, this is however currently not handled in this PR (but maybe should also be added; using env variables on deployment maybe?)

Fixes #2891