### PR TITLE
oci-handler: handle parameters globally

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -336,7 +336,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Parsing EVENTS_BUFFER_LENGTH %q: %v", stringBufferLength, err)
 		}
-		service := gadgetservice.NewService(log.StandardLogger(), bufferLength)
+		service := gadgetservice.NewService(log.StandardLogger())
+		service.SetEventBufferLength(bufferLength)
 
 		socketType, socketPath, err := api.ParseSocketAddress(gadgetServiceHost)
 		if err != nil {

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -41,20 +41,11 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		log.Debugf("initializing data op %q", op.Name())
 		opParamPrefix := fmt.Sprintf("operator.%s", op.Name())
 
-		// Lazily initialize operator
-		// TODO: global params should be filled out from a config file or such; maybe it's a better idea not to
-		// lazily initialize operators at all, but just hand over the config. The "lazy" stuff could then be done
-		// if the operator is instantiated and needs to do work
-		err := op.Init(apihelpers.ToParamDescs(op.GlobalParams()).ToParams())
-		if err != nil {
-			return nil, fmt.Errorf("initializing operator %q: %w", op.Name(), err)
-		}
-
 		// Get and fill params
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
-		err = apihelpers.Validate(instanceParams, opParamValues)
+		err := apihelpers.Validate(instanceParams, opParamValues)
 		if err != nil {
 			return nil, fmt.Errorf("validating params for operator %q: %w", op.Name(), err)
 		}

--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -28,7 +28,22 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
+
+func (s *Service) initOperators() error {
+	for op, globalParams := range s.operators {
+		err := op.Init(globalParams)
+		if err != nil {
+			return fmt.Errorf("initializing operator %s: %w", op.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) GetOperatorMap() map[operators.DataOperator]*params.Params {
+	return s.operators
+}
 
 func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoRequest) (*api.GetGadgetInfoResponse, error) {
 	if req.Version != api.VersionGadgetInfo {
@@ -37,7 +52,7 @@ func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoReque
 
 	// Get all available operators
 	ops := make([]operators.DataOperator, 0)
-	for _, op := range operators.GetDataOperators() {
+	for op := range s.operators {
 		ops = append(ops, op)
 	}
 
@@ -183,7 +198,7 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 	)
 
 	ops := make([]operators.DataOperator, 0)
-	for _, op := range operators.GetDataOperators() {
+	for op := range s.operators {
 		ops = append(ops, op)
 	}
 	ops = append(ops, svc)

--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -33,9 +33,11 @@ import (
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	gadgetregistry "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-registry"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/experimental"
@@ -62,14 +64,25 @@ type Service struct {
 	logger            logger.Logger
 	servers           map[*grpc.Server]struct{}
 	eventBufferLength uint64
+
+	// operatorGlobalParams stores all global parameters for DataOperators (non-legacy)
+	operators map[operators.DataOperator]*params.Params
 }
 
-func NewService(defaultLogger logger.Logger, length uint64) *Service {
-	return &Service{
-		servers:           map[*grpc.Server]struct{}{},
-		logger:            defaultLogger,
-		eventBufferLength: length,
+func NewService(defaultLogger logger.Logger) *Service {
+	ops := make(map[operators.DataOperator]*params.Params)
+	for _, op := range operators.GetDataOperators() {
+		ops[op] = apihelpers.ToParamDescs(op.GlobalParams()).ToParams()
 	}
+	return &Service{
+		servers:   map[*grpc.Server]struct{}{},
+		logger:    defaultLogger,
+		operators: ops,
+	}
+}
+
+func (s *Service) SetEventBufferLength(val uint64) {
+	s.eventBufferLength = val
 }
 
 func (s *Service) GetInfo(ctx context.Context, request *api.InfoRequest) (*api.InfoResponse, error) {
@@ -327,6 +340,11 @@ func (s *Service) Run(runConfig RunConfig, serverOptions ...grpc.ServerOption) e
 	api.RegisterGadgetManagerServer(server, s)
 
 	s.servers[server] = struct{}{}
+
+	err = s.initOperators()
+	if err != nil {
+		return fmt.Errorf("initializing operators: %w", err)
+	}
 
 	return server.Serve(s.listener)
 }


### PR DESCRIPTION
This moves the parameters of the oci-handler from the instances to the global part. The reason is that most of the parameters are security sensitive and thereby should be set on a server level and not be modified by the client (when in a client/server environment like ig as daemon or `ig-k8s`).

We might need to think about additional setting that partially allow overriding these settings from the client, but the default configuration should prevent such behavior.

Also, some parameters will probably have to be added to the deployment on `ig-k8s` and set from the `gadgettracermgr`.

This requires #2901 