### PR TITLE
cmd/image/export: Allow generating deterministic tarballs

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -227,7 +228,16 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 		MetadataPath:     conf.Metadata,
 		UpdateMetadata:   opts.updateMetadata,
 		ValidateMetadata: opts.validateMetadata,
-		CreatedDate:      time.Now().Format(time.RFC3339),
+	}
+
+	if sourceDateEpoch, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok {
+		sde, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid SOURCE_DATE_EPOCH: %w", err)
+		}
+		buildOpts.CreatedDate = time.Unix(sde, 0).UTC().Format(time.RFC3339)
+	} else {
+		buildOpts.CreatedDate = time.Now().Format(time.RFC3339)
 	}
 
 	desc, err := oci.BuildGadgetImage(context.TODO(), buildOpts, opts.image)

--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -192,6 +192,27 @@ Supported files:
 - `*.wasm`: prebuilt wasm module
 - `*.go`: automatically built with tinygo
 
+#### Reproducible builds
+
+The `build` command supports the
+[`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/)
+env variable:
+
+```bash
+# Set SOURCE_DATE_EPOCH to the last modification of the ebpf program source code.
+# It can be set to any epoch you want.
+$ export SOURCE_DATE_EPOCH="$(date -r program.bpf.c +%s)"
+
+$ sudo -E ig image build -t foo:latest .
+INFO[0000] Experimental features enabled
+Successfully built ghcr.io/inspektor-gadget/gadget/foo:latest@sha256:373f077d366ef2703535e8e862b60f8a35cc1a9312e9e203534b8fce554f8749
+
+# Building again produces the exact same digest
+$ sudo -E ig image build -t foo:latest .
+INFO[0000] Experimental features enabled
+Successfully built ghcr.io/inspektor-gadget/gadget/foo:latest@sha256:373f077d366ef2703535e8e862b60f8a35cc1a9312e9e203534b8fce554f8749
+```
+
 #### `list`
 
 List gadget images on the host.

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 
 	"github.com/distribution/reference"
 	"github.com/opencontainers/image-spec/specs-go"
@@ -291,7 +292,16 @@ func createImageIndex(ctx context.Context, target oras.Target, o *BuildGadgetIma
 	// Read the eBPF program files and push them to the memory store
 	layers := []ocispec.Descriptor{}
 
-	for arch, paths := range o.ObjectPaths {
+	archs := make([]string, 0, len(o.ObjectPaths))
+	for k := range o.ObjectPaths {
+		archs = append(archs, k)
+	}
+
+	// Sort the keys to ensure the order of the layers is deterministic
+	slices.Sort(archs)
+
+	for _, arch := range archs {
+		paths := o.ObjectPaths[arch]
 		manifestDesc, err := createManifestForTarget(ctx, target, o.MetadataPath, arch, paths, o.CreatedDate)
 		if err != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", arch, err)


### PR DESCRIPTION
The build command now supports the SOURCE_DATE_EPOCH env variable[0] to allow reproducible builds. Also, the export command is changed to always sort the index to guarentee the exported tarball is deterministic.

### Testing

#### Before 

```bash 
# IG_SOURCE_PATH is needed to build in-tree gadgets that contain a wasm module
$ export IG_SOURCE_PATH=<absolute path to IG source location>

$ cd gadgets/trace_open # any other gadget works as well

# multiple invocations of build produce an image with a different digest each time
$ sudo -E ig image build . -t trace_open:last
INFO[0000] Experimental features enabled
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:last@sha256:a00e322b2ad607cfb7051dbe241f976b96a189fe7618fc5f4a48e65ffa2fa518

$ sudo -E ig image build . -t trace_open:last
INFO[0000] Experimental features enabled
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:last@sha256:6c530558cb88a5bf3e6be89866477e819111d5af2e077d192c86e42fe05f7946

# exporting those images will for sure produce a tar file with changing digest a well.
```

#### After 

```bash
# IG_SOURCE_PATH is needed to build in-tree gadgets that contain a wasm module
$ export IG_SOURCE_PATH=<absolute path to IG source location>

# the digest is constant when setting SOURCE_DATE_EPOCH

$ SOURCE_DATE_EPOCH=0 sudo -E ig image build . -t trace_open:latest
INFO[0000] Experimental features enabled
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:aa544c4316d583ad7ac4a500b97b67cfbb22e7f3125f8a9a002a4eaedf7f45ef
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:faec585ef38bf306497bb3989753fe9657c05a0fc14d0fabd590ef5ec4aab0b3

$ SOURCE_DATE_EPOCH=0 sudo -E ig image build . -t trace_open:latest
INFO[0000] Experimental features enabled
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:aa544c4316d583ad7ac4a500b97b67cfbb22e7f3125f8a9a002a4eaedf7f45ef
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:faec585ef38bf306497bb3989753fe9657c05a0fc14d0fabd590ef5ec4aab0b3

# the exported images are constant as well
$ SOURCE_DATE_EPOCH=0 sudo -E ig image build . -t trace_open:latest
INFO[0000] Experimental features enabled
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:aa544c4316d583ad7ac4a500b97b67cfbb22e7f3125f8a9a002a4eaedf7f45ef
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:faec585ef38bf306497bb3989753fe9657c05a0fc14d0fabd590ef5ec4aab0b3
$ sudo -E ig image export trace_open:latest /tmp/image1.tar
INFO[0000] Experimental features enabled
Successfully exported images to /tmp/image1.tar

$ SOURCE_DATE_EPOCH=0 sudo -E ig image build . -t trace_open:latest
INFO[0000] Experimental features enabled
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:aa544c4316d583ad7ac4a500b97b67cfbb22e7f3125f8a9a002a4eaedf7f45ef
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:faec585ef38bf306497bb3989753fe9657c05a0fc14d0fabd590ef5ec4aab0b3
$ sudo -E ig image export trace_open:latest /tmp/image2.tar
INFO[0000] Experimental features enabled
Successfully exported images to /tmp/image2.tar

$ sha256sum /tmp/image1.tar /tmp/image2.tar
c3d83221dbda9770558a82cd85c6d1e93891c9dc0e111f5fdd9cd1926459bc54  /tmp/image1.tar
c3d83221dbda9770558a82cd85c6d1e93891c9dc0e111f5fdd9cd1926459bc54  /tmp/image2.tar
mauriciov@mvb-desktop:~/.../trace_open$
```

This will be useful for #2853 and for tests artifacts generated in #2818

