### PR TITLE
tools/ekscleanup: Use go.work.

### DIFF
--- a/go.work
+++ b/go.work
@@ -3,3 +3,4 @@ go 1.22.2
 use .
 
 use ./examples
+use ./tools/eks-cleanup

--- a/go.work.sum
+++ b/go.work.sum
@@ -862,9 +862,8 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=


### PR DESCRIPTION
Hi.

The recent addition of `go.work` broke the CI:
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/9281060516/job/25536388441#step:5:12

Adding this package to `go.work` solves this issue:

```bash
$ go run . -dryrun                          francis/fix-ekscleanup %
error: describing stacks: describing stacks: NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
exit status 1
$ git checkout main                         francis/fix-ekscleanup %
Basculement sur la branche 'main'
Votre branche est à jour avec 'origin/main'.
$ go run .                                                 main % u=
main module (github.com/inspektor-gadget/inspektor-gadget) does not contain package github.com/inspektor-gadget/inspektor-gadget/tools/eks-cleanup
```

Best regards.