### PR TITLE
ci/linter: bump golangci-lint version to handle Go 1.22 features

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -103,7 +103,7 @@ jobs:
       uses: golangci/golangci-lint-action@v6.0.1
       with:
         # This version number must be kept in sync with Makefile lint one.
-        version: v1.54.2
+        version: v1.59.0
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ output:
   sort-results: true
 
 run:
+  go: "1.22"
   timeout: 10m
   build-tags:
   - docs
@@ -30,13 +31,9 @@ linters:
   - goimports
 
 linters-settings:
-  gofumpt:
-    lang-version: "1.22"
   staticcheck:
-    go: "1.22"
     checks: ["all"]
   stylecheck:
-    go: "1.22"
     checks: ["all"]
   errorlint:
     # https://github.com/polyfloyd/go-errorlint

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BPFTOOL ?= bpftool
 ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
 
 # This version number must be kept in sync with CI workflow lint one.
-LINTER_VERSION ?= v1.54.2
+LINTER_VERSION ?= v1.59.0
 
 EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
 

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -781,7 +781,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			return false, nil
 		}
 	})
-
 	if err != nil {
 		if utilwait.Interrupted(err) && debug {
 			fmt.Println("DUMP PODS:")

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -310,7 +310,6 @@ func main() {
 			HookMode:            hookMode,
 			FallbackPodInformer: fallbackPodInformer,
 		})
-
 		if err != nil {
 			log.Fatalf("failed to create Gadget Tracer Manager server: %v", err)
 		}

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -231,7 +231,6 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 	viper := viper.New()
 	viper.SetConfigType("yaml")
 	err = viper.ReadConfig(bytes.NewReader(metadata))
-
 	if err != nil {
 		return fmt.Errorf("unmarshalling metadata: %w", err)
 	}


### PR DESCRIPTION
e.g. ranging over ints