### PR TITLE
pkg/operators/formatters: Add syscall formatter

### DIFF
--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -41,4 +41,8 @@ typedef __u64 gadget_timestamp;
 // as string.
 typedef __u32 gadget_signal;
 
+// gadget_syscall is used to represent a unix syscall. A field is automatically added that contains the name
+// as string.
+typedef __u64 gadget_syscall;
+
 #endif /* __TYPES_H */


### PR DESCRIPTION
# pkg/operators/formatters: Add syscall formatter

Syscalls will be formatted to strings, such as `SYS_OPENAT`.

Solves #2908

## How to use

Use `gadget_syscall` as the type of event field.

## Testing done
