### PR TITLE
dependabot: Group gomod updates by dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,20 @@ updates:
       prefix: "go:"
     allow:
       - dependency-type: all
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      docker:
+        patterns:
+          - "github.com/docker/docker/*"
+          - "github.com/moby/moby/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
   # Update other go depedendencies
   - package-ecosystem: "gomod"
     directory: "/examples/"
@@ -31,6 +45,20 @@ updates:
       prefix: "go:"
     allow:
       - dependency-type: all
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      docker:
+        patterns:
+          - "github.com/docker/docker/*"
+          - "github.com/moby/moby/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
   - package-ecosystem: "gomod"
     directory: "/tools/eks-cleanup/"
     schedule:


### PR DESCRIPTION
There are some dependencies that need to be updated together. Use the grouping feature to update them in the same PR.

Inspired from https://github.com/containerd/containerd/pull/9532.

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Examples of PRs that could have been grouped:
docker/moby:
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2870
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2869
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2865

otel
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2883
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2882
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2881

k8s:
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2854
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2855
- https://github.com/inspektor-gadget/inspektor-gadget/pull/2856

---

Discussion: It's possible to use `*` as pattern to update all dependencies on the same PR, however I think it's too risky. 
