### PR TITLE
oci: Return error if op.Prepare() fails

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -264,8 +264,7 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Prepare(o.gadgetCtx)
 		if err != nil {
-			o.gadgetCtx.Logger().Errorf("preparing operator %q: %v", opInst.Name(), err)
-			continue
+			return fmt.Errorf("preparing operator %q: %w", opInst.Name(), err)
 		}
 
 		// Add gadget params prefixed with operators' name


### PR DESCRIPTION
If an operator fails, let's bail out instead of trying to continue. The previous logic was calling Start() on an operator that failed on Prepare(), producing seg faults on the wasm operator. (not merged at the time of writing this commit)

--- 

Found it while running tests for the wasm operator (#2818)

```bash
$ go test -exec 'sudo' .
time="2024-05-30T18:23:45-05:00" level=error msg="preparing operator \"wasm\": initializing wasm: instantiating wasm: import func[env.dataArrayAppend]: signature mismatch: i32i32_v != i32i32_i32"
--- FAIL: TestWasmDataArray (0.25s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x17db720]

goroutine 10 [running]:
testing.tRunner.func1.2({0x296e0a0, 0x401c560})
        /usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x377
panic({0x296e0a0?, 0x401c560?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).callGuestFunction(0xc00227ba48?, {0x2fb1da8, 0xc0005941e0}, {0x2c6d730, 0x5})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/wasm.go:227 +0x40
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).Start(0xc0002f6fc0, {0x2fc4110?, 0xc0005d6180?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/wasm.go:242 +0x45
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler.(*OciHandlerInstance).Start(0xc0005ae200, {0x2c7d8db?, 0x403b6c0?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/oci-handler/oci.go:283 +0xa8
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).run(0xc0005d6180, {0xc000592180, 0x2, 0xc0003b0320?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:110 +0x3a6
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).Run(0xc0005d6180, 0xc000475e98?)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/gadget-context/run.go:158 +0x9e
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget(...)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/runtime/local/oci.go:35
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm_test.TestWasmDataArray(0xc0003dba00)
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/wasm_test.go:294 +0x5ea
testing.tRunner(0xc0003dba00, 0x2d97768)
        /usr/local/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1742 +0x390
FAIL    github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm 0.277s
FAIL
```

The guest was defining a function in a wrong way, hence `Prepare()` was failing, but `Start()` was still being called producing a crash.
