### PR TITLE
dependabot: Disable updating indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
       timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
-    allow:
-      - dependency-type: all
     groups:
       golang-x:
         patterns:
@@ -43,8 +41,6 @@ updates:
       timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
-    allow:
-      - dependency-type: all
     groups:
       golang-x:
         patterns:
@@ -67,8 +63,6 @@ updates:
       timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
-    allow:
-      - dependency-type: all
   - package-ecosystem: "gomod"
     directory: "/tools/testjson2md/"
     schedule:
@@ -77,8 +71,6 @@ updates:
       timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
-    allow:
-      - dependency-type: all
   - package-ecosystem: "gomod"
     directory: "/tools/dnstester/"
     schedule:
@@ -87,8 +79,6 @@ updates:
       timezone: "Europe/Paris"
     commit-message:
       prefix: "go:"
-    allow:
-      - dependency-type: all
   - package-ecosystem: "docker"
     directory: "/Dockerfiles"
     schedule:


### PR DESCRIPTION
Avoid dependabot updating indirect dependencies too as it creates too much noise.

#2915 updated the config to use `dependency-type: all` hoping it'll be able to fix the multi modules issues we're having (a dependency update on main go module requires running `go mod tidy` on examples/).  Unfortunately it doesn't totally fix the issue and instead is creating us a lot of noise as the bot is updating a lot of indirect dependencies.

Disable this, perhaps we can reenable it for some modules again once we understand how to fix the multi node issue.