### PR TITLE
uprobetracer: use secureopen to avoid TOCTOU issues

### DIFF
--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -42,12 +42,12 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	securejoin "github.com/cyphar/filepath-securejoin"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/kfilefields"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/secureopen"
 )
 
 type ProgType uint32
@@ -167,32 +167,20 @@ func (t *Tracer[Event]) AttachProg(progName string, progType ProgType, attachTo 
 }
 
 func (t *Tracer[Event]) searchForLibrary(containerPid uint32) ([]string, error) {
-	var targetPaths []string
-	var securedTargetPaths []string
+	var unsecurerTargetPaths []string
 
 	filePath := t.attachFilePath
 	if !filepath.IsAbs(filePath) {
-		containerLdCachePath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), "etc/ld.so.cache")
-		if err != nil {
-			return nil, fmt.Errorf("path %q: %w", filePath, err)
-		}
-		ldCachePaths, err := parseLdCache(containerLdCachePath, filePath)
+		ldCachePath := "/etc/ld.so.cache"
+		ldCachePaths, err := parseLdCache(containerPid, ldCachePath, filePath)
 		if err != nil {
 			return nil, fmt.Errorf("parsing ld cache: %w", err)
 		}
-		targetPaths = ldCachePaths
+		unsecurerTargetPaths = ldCachePaths
 	} else {
-		targetPaths = append(targetPaths, filePath)
+		unsecurerTargetPaths = append(unsecurerTargetPaths, filePath)
 	}
-	for _, targetPath := range targetPaths {
-		securedTargetPath, err := securejoin.SecureJoin(filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root"), targetPath)
-		if err != nil {
-			t.logger.Debugf("path %q in ld cache is not available: %s", filePath, err.Error())
-			continue
-		}
-		securedTargetPaths = append(securedTargetPaths, securedTargetPath)
-	}
-	return securedTargetPaths, nil
+	return unsecurerTargetPaths, nil
 }
 
 // attach uprobe program to the inode of the file passed in parameter
@@ -225,20 +213,20 @@ func (t *Tracer[Event]) attachUprobe(file *os.File) (link.Link, error) {
 // try attaching to a container, will update `containerPid2Inodes`
 func (t *Tracer[Event]) attach(containerPid uint32) {
 	var attachedRealInodes []uint64
-	attachFilePaths, err := t.searchForLibrary(containerPid)
+	unsecuredAttachFilePaths, err := t.searchForLibrary(containerPid)
 	if err != nil {
 		t.logger.Debugf("attaching to container %d: %s", containerPid, err.Error())
 	}
 
-	if len(attachFilePaths) == 0 {
+	if len(unsecuredAttachFilePaths) == 0 {
 		t.logger.Debugf("cannot find file to attach in container %d for symbol %q", containerPid, t.attachSymbol)
 	}
 
-	for _, filePath := range attachFilePaths {
+	for _, filePath := range unsecuredAttachFilePaths {
 		// Do not use `O_PATH` flag here, because `ReadRealInodeFromFd` needs the `private_data` field
 		// in kernel "struct file", to access the underlying inode through overlayFS.
 		// Using `O_PATH` flag will cause the `private_data` field to be zero.
-		file, err := os.Open(filePath)
+		file, err := secureopen.OpenInContainer(containerPid, filePath)
 		if err != nil {
 			t.logger.Debugf("opening file '%q' for uprobe: %s", filePath, err.Error())
 			continue

--- a/pkg/utils/secureopen/secureopen.go
+++ b/pkg/utils/secureopen/secureopen.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secureopen provides a way to securely open a file in a container and
+// checking that the path didn't move outside of the container rootfs.
+package secureopen
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+)
+
+// OpenInContainer opens the given path in the given container in read-only
+// mode.
+//
+// The resulting open file is guaranteed to be:
+// - inside the provided container
+// - a regular file
+// - without following magic links from procfs
+//
+// Requires Linux 5.6 for openat2:
+// https://github.com/torvalds/linux/commit/fddb5d430ad9fa91b49b1d34d0202ffe2fa0e179
+func OpenInContainer(containerPid uint32, unsafePath string) (*os.File, error) {
+	root := filepath.Join(host.HostProcFs, fmt.Sprint(containerPid), "root")
+	rootDir, err := os.OpenFile(root, unix.O_PATH, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open o_path %s: %w", root, err)
+	}
+	defer rootDir.Close()
+
+	// Open with O_PATH first
+	howOPath := unix.OpenHow{
+		Flags:   unix.O_PATH,
+		Mode:    0,
+		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+	}
+	fd, err := unix.Openat2(int(rootDir.Fd()), unsafePath, &howOPath)
+	if err != nil {
+		return nil, fmt.Errorf("openat2 %s in %s: %w", unsafePath, root, err)
+	}
+	defer unix.Close(fd)
+
+	// Check if the path is a regular file
+	var stat unix.Stat_t
+	err = unix.Fstat(fd, &stat)
+	if err != nil {
+		return nil, fmt.Errorf("fstat %s in %s: %w", unsafePath, root, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return nil, fmt.Errorf("procfd stat: not a regular file")
+	}
+
+	// Re-open in read-only mode (without O_PATH)
+	procfd := filepath.Join("/proc/self/fd", strconv.Itoa(int(fd)))
+	return os.Open(procfd)
+}
+
+// ReadFileInContainer reads the named file and returns the contents.
+//
+// This is similar to os.ReadFile() except the file is opened with
+// OpenInContainer().
+func ReadFileInContainer(containerPid uint32, unsafePath string) ([]byte, error) {
+	fh, err := OpenInContainer(containerPid, unsafePath)
+	if err != nil {
+		return nil, fmt.Errorf("secureopen: %w", err)
+	}
+	defer fh.Close()
+	return io.ReadAll(fh)
+}


### PR DESCRIPTION
uprobetracer needs to open files in the container rootfs. The file paths in the container could change, so special care should be taken to avoid symlink escapes.

Requires Linux 5.6 for openat2 (https://github.com/torvalds/linux/commit/fddb5d430ad9fa91b49b1d34d0202ffe2fa0e179).

cc @rata @i-Pear 

## How to use

No changes

## Testing done

- [x] Test if the trace_ssl gadget still works.
