### PR TITLE
container-hook: use a single fanotify to watch pid files

### DIFF
--- a/pkg/container-hook/tracer_test.go
+++ b/pkg/container-hook/tracer_test.go
@@ -15,7 +15,7 @@
 //go:build linux
 // +build linux
 
-package containerhook_test
+package containerhook
 
 import (
 	"fmt"
@@ -26,33 +26,32 @@ import (
 	"github.com/stretchr/testify/require"
 
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
-	containerhook "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 )
 
-func TestContainerHook(t *testing.T) {
+func TestContainerHookEvent(t *testing.T) {
 	utilstest.RequireRoot(t)
 
 	type testDefinition struct {
 		generateEvent func(t *testing.T) string
-		validateEvent func(t *testing.T, info *utilstest.RunnerInfo, containerID string, events []containerhook.ContainerEvent)
+		validateEvent func(t *testing.T, info *utilstest.RunnerInfo, containerID string, events []ContainerEvent)
 	}
 
 	for name, test := range map[string]testDefinition{
 		"one_container": {
 			generateEvent: generateEvent(0),
-			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
-				return &containerhook.ContainerEvent{
-					Type:        containerhook.EventTypeAddContainer,
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *ContainerEvent {
+				return &ContainerEvent{
+					Type:        EventTypeAddContainer,
 					ContainerID: containerID,
 				}
 			}),
 		},
 		"one_container_after_some_failed_containers": {
 			generateEvent: generateEvent(2),
-			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
-				return &containerhook.ContainerEvent{
-					Type:        containerhook.EventTypeAddContainer,
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *ContainerEvent {
+				return &ContainerEvent{
+					Type:        EventTypeAddContainer,
 					ContainerID: containerID,
 				}
 			}),
@@ -61,10 +60,10 @@ func TestContainerHook(t *testing.T) {
 			// Test with a number bigger than FANOTIFY_DEFAULT_MAX_GROUPS
 			// https://github.com/torvalds/linux/blob/v6.9/fs/notify/fanotify/fanotify_user.c#L32
 			// #define FANOTIFY_DEFAULT_MAX_GROUPS	128
-			generateEvent: generateEvent(3), // TODO: change this number to 130
-			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
-				return &containerhook.ContainerEvent{
-					Type:        containerhook.EventTypeAddContainer,
+			generateEvent: generateEvent(130),
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *ContainerEvent {
+				return &ContainerEvent{
+					Type:        EventTypeAddContainer,
 					ContainerID: containerID,
 				}
 			}),
@@ -74,8 +73,8 @@ func TestContainerHook(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			events := []containerhook.ContainerEvent{}
-			eventCallback := func(event containerhook.ContainerEvent) {
+			events := []ContainerEvent{}
+			eventCallback := func(event ContainerEvent) {
 				// normalize
 				event.ContainerName = ""
 				event.ContainerPID = 0
@@ -85,7 +84,7 @@ func TestContainerHook(t *testing.T) {
 				events = append(events, event)
 			}
 
-			notifier, err := containerhook.NewContainerNotifier(eventCallback)
+			notifier, err := NewContainerNotifier(eventCallback)
 			require.NoError(t, err)
 			require.NotNil(t, notifier, "Returned notifier was nil")
 


### PR DESCRIPTION
Before this patch, IG had one fanotify fd for monitoring executions of container runtimes (e.g. `/usr/bin/runc`) and one fanotify fd instantiated for each container between the `runc create` and the `runc start` to watch the creation of the pid file. When `runc create` fails, the pid file is never created and `runc start` is never executed; this leads to IG accumulating fanotify fds.

Fanotify fds are a scarce global resource on Linux:
[FANOTIFY_DEFAULT_MAX_GROUPS=128](https://github.com/torvalds/linux/blob/v6.6/fs/notify/fanotify/fanotify_user.c#L32)

This patch changes the logic to use one permanent fanotify fd to watch the creation of the pid files. The number of fanotify fds used by IG is now always 2 and it is not fluctuating anymore.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/2967


## How to use

No changes.

## Testing done

- [x] Test from #2998 with nfailure=130
