### PR TITLE
fields: Mark fields hidden based on attributes

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -351,6 +351,9 @@ func (ds *dataSource) AddStaticFields(size uint32, fields []StaticField) (FieldA
 				checkParents[nf] = struct{}{}
 			}
 		}
+		if s, ok := f.(HiddenField); ok && s.FieldHidden() {
+			FieldFlagHidden.AddTo(&nf.Flags)
+		}
 		newFields = append(newFields, nf)
 	}
 

--- a/pkg/datasource/field.go
+++ b/pkg/datasource/field.go
@@ -87,6 +87,10 @@ type FlaggedField interface {
 	FieldFlags() FieldFlag
 }
 
+type HiddenField interface {
+	FieldHidden() bool
+}
+
 type ParentedField interface {
 	// FieldParent should return an index to the parent of the field, -1 for no parent
 	FieldParent() int

--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -63,6 +63,10 @@ func (f *Field) FieldType() api.Kind {
 	return f.kind
 }
 
+func (f *Field) FieldHidden() bool {
+	return f.Attributes.Hidden
+}
+
 func (f *Field) FieldAnnotations() map[string]string {
 	out := make(map[string]string)
 


### PR DESCRIPTION
Fixes: #2736 

### Testing Done

#### with change

```
→ go run -exec "sudo -E" ./cmd/ig run trace_open -r docker --verify-image=false
...
RUNTIME.CONTAINERNAME                   PID                   UID                   GID                   MNTNS_ID          ERR FD                   COMM             FNAME                                     TIMESTAMP  
```

#### w/o change

```
→ sudo -E ig run trace_open -r docker --verify-image=false
...
RUNTIME.CONTAINERNAME              PID                 UID                 GID                MNTNS_ID      ERR FD                 FLAGS MODE               COMM             FNAME                                TIMESTAMP 
```

Hidden attribute for fields [`FLAGS`](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/trace_open/gadget.yaml#L37) and [`MODE`](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/trace_open/gadget.yaml#L31) are respected.

#### Showing hidden fields

```
→ go run -exec "sudo -E" ./cmd/ig run trace_open -r docker --verify-image=false --fields runtime.containerName,uid,gid,mode,flags --host
...
RUNTIME.CONTAINERNAME                                                       UID                                      GID                                      MODE                                     FLAGS       
                                                                            129                                      140                                      0                                        524288      
                                                                            129                                      140                                      0                                        524288      
                                                                            129                                      140                                      0                                        524288    
```