### PR TITLE
gadgets: Rework the makefile to add better parallelism.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1350,13 +1350,13 @@ jobs:
           export GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
           export BUILDER_IMAGE=${{ needs.build-helper-images.outputs.ebpf_builder_image }}
 
-          make GADGET_BUILD_PARAMS="--update-metadata" build-gadgets -o install/ig
+          make GADGET_BUILD_PARAMS="--update-metadata" build-gadgets -o install/ig -j$(nproc)
 
           # Check that metadata files are updated
           git diff --exit-code HEAD --
 
           # Avoid building the gadgets again
-          make -C gadgets/ push -o build
+          make -C gadgets/ push -o build -j$(nproc)
       - name: Install Cosign
         if: needs.check-secrets.outputs.cosign == 'true'
         uses: sigstore/cosign-installer@main
@@ -1366,7 +1366,7 @@ jobs:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         run: |
-          GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} make -C gadgets/ sign -o push
+          GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} make -C gadgets/ sign -o push -j$(nproc)
 
   test-gadgets:
     name: Test gadgets

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -42,25 +42,25 @@ $(GADGETS):
 		$$GADGET_BUILD_PARAMS \
 		$@
 
-.PHONY:
-push: build
-	@echo "Pushing all gadgets"
-	for GADGET in $(GADGETS); do \
-		sudo -E IG_EXPERIMENTAL=true $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
-	done
-
-sign: push
-	@echo "Signing all gadgets"
-	for GADGET in $(GADGETS); do \
-		digest=$$(sudo -E IG_EXPERIMENTAL=true $(IG) image list --no-trunc | grep "$$GADGET " | awk '{ print $$3 }') ; \
-		cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$$GADGET@$$digest || exit 1 ; \
-	done
+%-push: %
+	@echo "Pushing $*"
+	@sudo -E IG_EXPERIMENTAL=true $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
-clean:
-	for GADGET in $(GADGETS); do \
-		sudo -E IG_EXPERIMENTAL=true $(IG) image remove $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
-	done
+push: $(addsuffix -push,$(GADGETS))
+
+%-sign: %-push
+	@echo "Signing $*"
+	digest=$$(sudo -E IG_EXPERIMENTAL=true $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+
+sign: $(addsuffix -sign,$(GADGETS))
+
+%-clean:
+	sudo -E IG_EXPERIMENTAL=true $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+
+.PHONY:
+clean: $(addsuffix -clean,$(GADGETS))
 
 .PHONY:
 test: build


### PR DESCRIPTION
Hi.

This PR reworks the gadget Makefile to use parallelism instead of `for`:

```bash
$ make sign -j$(nproc)
...
$ echo $?
0
$ sudo -E ../ig image list | grep sched francis/makefile-gadgets-parallel % u=
INFO[0000] Experimental features enabled                
francisacrregistry.azurecr.io/gadget/ci/sched_cls_drop francis-makefile-gadgets-parallel sha256:881f5946584002991586a65245bd726dcd7ffe55d051fe34a2f8797d998ad47b 2024-06-11T13:40:59+01:00
$ cosign verify --key ../cosign.pub francisacrregistry.azurecr.io/gadget/ci/sched_cls_drop@sha256:881f5946584002991586a65245bd726dcd7ffe55d051fe34a2f8797d998ad47b

Verification for francisacrregistry.azurecr.io/gadget/ci/sched_cls_drop@sha256:881f5946584002991586a65245bd726dcd7ffe55d051fe34a2f8797d998ad47b --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The signatures were verified against the specified public key

[{"critical":{"identity":{"docker-reference":"francisacrregistry.azurecr.io/gadget/ci/sched_cls_drop"},"image":{"docker-manifest-digest":"sha256:881f5946584002991586a65245bd726dcd7ffe55d051fe34a2f8797d998ad47b"},"type":"cosign container image signature"},"optional":{"Bundle":{"SignedEntryTimestamp":"MEQCIAoiihYjJU3l+7ofdXNysKuN9pZbO6+dnAangxvMy4ieAiAflhyUGigzTepUD3isdPOsgHbyHbDBN8sj41+sYObIow==","Payload":{"body":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI1MGQwNzY4MzlkMDA5ODA5MDNkMDg1N2U3ZjJhNzBhMjIyYzIwYTE3ZGViNTJmYzVkYWI5NTA1ODc1ZjU1ZTUyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJSDMveUdycG9vNlJsZE1vcTZvb1RzWlFDem42WTRub0dTR2ZtTlFqbXN0aUFpRUF2NWJZRW5KQjFSSmNRbEpFZkk2U3JqbXNhYzRVLzRreXJ6VHEwZWtBcWdnPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCUVZVSk1TVU1nUzBWWkxTMHRMUzBLVFVacmQwVjNXVWhMYjFwSmVtb3dRMEZSV1VsTGIxcEplbW93UkVGUlkwUlJaMEZGTms0MWVFSlRaR3BITTBnM1EwMU5iVnBFYm1wa1ExTjVZVXRTZFFwaWFraDZVbVF3VG5jMVZsbFJhRVpTU1hoWlNtMDVPV0ZUZGpVMmFqUlJiME5KYlhKQmJtNWtVRmN6ZG1SNFNWSkRhV1JTVUN0TWRXNTNQVDBLTFMwdExTMUZUa1FnVUZWQ1RFbERJRXRGV1MwdExTMHRDZz09In19fX0=","integratedTime":1718109683,"logIndex":101690243,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}}}]
```

Best regards.