### PR TITLE
pkg/container-hook: add new test

### DIFF
--- a/pkg/container-hook/tracer_test.go
+++ b/pkg/container-hook/tracer_test.go
@@ -1,0 +1,123 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package containerhook_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	containerhook "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+)
+
+func TestContainerHook(t *testing.T) {
+	utilstest.RequireRoot(t)
+
+	type testDefinition struct {
+		generateEvent func(t *testing.T) string
+		validateEvent func(t *testing.T, info *utilstest.RunnerInfo, containerID string, events []containerhook.ContainerEvent)
+	}
+
+	for name, test := range map[string]testDefinition{
+		"one_container": {
+			generateEvent: generateEvent(0),
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
+				return &containerhook.ContainerEvent{
+					Type:        containerhook.EventTypeAddContainer,
+					ContainerID: containerID,
+				}
+			}),
+		},
+		"one_container_after_some_failed_containers": {
+			generateEvent: generateEvent(2),
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
+				return &containerhook.ContainerEvent{
+					Type:        containerhook.EventTypeAddContainer,
+					ContainerID: containerID,
+				}
+			}),
+		},
+		"one_container_after_many_failed_containers": {
+			// Test with a number bigger than FANOTIFY_DEFAULT_MAX_GROUPS
+			// https://github.com/torvalds/linux/blob/v6.9/fs/notify/fanotify/fanotify_user.c#L32
+			// #define FANOTIFY_DEFAULT_MAX_GROUPS	128
+			generateEvent: generateEvent(3), // TODO: change this number to 130
+			validateEvent: utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, containerID string) *containerhook.ContainerEvent {
+				return &containerhook.ContainerEvent{
+					Type:        containerhook.EventTypeAddContainer,
+					ContainerID: containerID,
+				}
+			}),
+		},
+	} {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			events := []containerhook.ContainerEvent{}
+			eventCallback := func(event containerhook.ContainerEvent) {
+				// normalize
+				event.ContainerName = ""
+				event.ContainerPID = 0
+				event.ContainerConfig = nil
+				event.Bundle = ""
+
+				events = append(events, event)
+			}
+
+			notifier, err := containerhook.NewContainerNotifier(eventCallback)
+			require.NoError(t, err)
+			require.NotNil(t, notifier, "Returned notifier was nil")
+
+			containerID := test.generateEvent(t)
+
+			// Give some time for the tracer to capture the events
+			time.Sleep(100 * time.Millisecond)
+
+			test.validateEvent(t, nil, containerID, events)
+		})
+	}
+}
+
+func generateEvent(nfailure int) func(t *testing.T) string {
+	return func(t *testing.T) string {
+		// Failed container with bad configuration
+		for i := 0; i < nfailure; i++ {
+			fmt.Printf("running %d\n", i)
+			name := fmt.Sprintf("ig-test-%d-%d", i, rand.Uint32())
+			// /dev/null/invalid is not a valid path, hence it fails during 'runc create'
+			mounts := []string{"/dev/null:/dev/null/invalid"}
+			container := testutils.NewDockerContainer(name, "id",
+				testutils.WithoutLogs(),
+				testutils.WithBindMounts(mounts),
+				testutils.WithExpectStartError())
+			container.Run(t)
+		}
+
+		// Good container with valid configuration
+		name := fmt.Sprintf("ig-test-%d", rand.Uint32())
+		container := testutils.NewDockerContainer(name, "id", testutils.WithoutLogs())
+		container.Run(t)
+		return container.ID()
+	}
+}

--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -110,6 +110,12 @@ func (c *ContainerdContainer) Run(t *testing.T) {
 	if c.options.portBindings != nil {
 		t.Fatalf("testutils/containerd: Port bindings are not supported yet")
 	}
+	if len(c.options.mounts) > 0 {
+		t.Fatalf("testutils/containerd: Mounts are not supported yet")
+	}
+	if c.options.expectStartError {
+		t.Fatalf("testutils/containerd: ExpectStartError is not supported yet")
+	}
 
 	var spec specs.Spec
 	container, err := c.client.NewContainer(c.nsCtx, c.name,

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -28,15 +28,17 @@ const (
 type Option func(*containerOptions)
 
 type containerOptions struct {
-	ctx            context.Context
-	image          string
-	imageTag       string
-	seccompProfile string
-	namespace      string
-	wait           bool
-	logs           bool
-	removal        bool
-	portBindings   nat.PortMap
+	ctx              context.Context
+	expectStartError bool
+	image            string
+	imageTag         string
+	mounts           []string
+	seccompProfile   string
+	namespace        string
+	wait             bool
+	logs             bool
+	removal          bool
+	portBindings     nat.PortMap
 
 	// forceDelete is mostly used for debugging purposes, when a container
 	// fails to be deleted and we want to force it.
@@ -60,9 +62,21 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
+func WithExpectStartError() Option {
+	return func(opts *containerOptions) {
+		opts.expectStartError = true
+	}
+}
+
 func WithImage(image string) Option {
 	return func(opts *containerOptions) {
 		opts.image = image
+	}
+}
+
+func WithBindMounts(mounts []string) Option {
+	return func(opts *containerOptions) {
+		opts.mounts = mounts
 	}
 }
 


### PR DESCRIPTION
This test runs a Docker container and checks it is correctly detected by the container-hook pkg.

This also runs Docker containers with invalid configuration to check if it makes IG misbehave.

There is a TODO in one test: it can only be removed after #2967 is fixed.

## How to use

No changes.

## Testing done

```
go test -exec 'sudo -E' ./pkg/container-hook/...
```
