### PR TITLE
pkg/oci: Add new options to restrain execution by digest.

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -41,6 +41,7 @@ const (
 	pullSecret            = "pull-secret"
 	verifyImage           = "verify-image"
 	publicKey             = "public-key"
+	allowedDigests        = "allowed-digests"
 )
 
 type ociHandler struct{}
@@ -112,6 +113,12 @@ func (o *ociHandler) InstanceParams() api.Params {
 			Description:  "Public key used to verify the image based gadget",
 			DefaultValue: resources.InspektorGadgetPublicKey,
 			TypeHint:     api.TypeString,
+		},
+		{
+			Key:         allowedDigests,
+			Title:       "Allowed Digests",
+			Description: "List of allowed digests, if image digest is not part of it, execution will be denied. By default, all digests are allowed",
+			TypeHint:    api.TypeString,
 		},
 	}
 }
@@ -185,6 +192,9 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		VerifyOptions: oci.VerifyOptions{
 			VerifyPublicKey: o.ociParams.Get(verifyImage).AsBool(),
 			PublicKey:       o.ociParams.Get(publicKey).AsString(),
+		},
+		AllowedDigestsOptions: oci.AllowedDigestsOptions{
+			AllowedDigests: o.ociParams.Get(allowedDigests).AsStringSlice(),
 		},
 	}
 


### PR DESCRIPTION
Hi!

In this PR, I added the option to restrict execution by digest:

```bash
$ sudo -E ./ig image list --no-trunc                              francis/run-sha % u=
INFO[0000] Experimental features enabled                
REPOSITORY TAG DIGEST CREATED
trace_dns latest sha256:20269b27e10e98d0b63df6596fc242ce58306ca63a048123c8d94fef32a7f391 2024-06-11T13:52:07Z
trace_exec latest sha256:5e2283312cd565b136c8bba4edef065eecfac5d1e39d85c93f5aac18b6c57261 2024-06-11T13:52:08Z
trace_open latest sha256:db968c6a950e8770a1fb623d7fafec90f58777cc7305f14f7b1db6d1b2ea40e4 2024-06-11T13:52:12Z
$ sudo -E ./ig run --authorized-digests=sha256:5e2283312cd565b136c8bba4edef065eecfac5d1e39d85c93f5aac18b6c57261,sha256:db968c6a950e8770a1fb623d7fafec90f58777cc7305f14f7b1db6d1b2ea40e4 trace_exec
[sudo] Mot de passe de francis : 
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
RUNTIME.CONTAINE… MNTNS_… PID       PPID      UID       GID       LOGINUID  SESSIONID R… ARGS_COU… U… ARGS_SI… COMM     ARGS     TIMESTA…
foo               4026534 11821     11801     0         0         42949672… 42949672… 0  1         f… 14       bash     /usr/bi… 2024-06-
foo               4026534 11851     11821     0         0         42949672… 42949672… 0  1         f… 12       ls       /usr/bi… 2024-06-
^C%                                                                                                                                      
$ sudo -E ./ig run --authorized-digests=sha256:5e2283312cd565b136c8bba4edef065eecfac5d1e39d85c93f5aac18b6c57261,sha256:db968c6a950e8770a1fb623d7fafec90f58777cc7305f14f7b1db6d1b2ea40e4 trace_dns                              
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: image digest does not correspond to an authorized digest: "sha256:20269b27e10e98d0b63df6596fc242ce58306ca63a048123c8d94fef32a7f391" not in "sha256:5e2283312cd565b136c8bba4edef065eecfac5d1e39d85c93f5aac18b6c57261, sha256:db968c6a950e8770a1fb623d7fafec90f58777cc7305f14f7b1db6d1b2ea40e4"
```

The verification is, for now, only done at runtime, but we can change this later.

Best regards.