### PR TITLE
Revert "updating field names: pod and container"

### DIFF
--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -151,7 +151,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		return nil, err
 	}
 	ev.podnameAccessor, err = k8s.AddSubField(
-		"podName",
+		"pod",
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
@@ -163,7 +163,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		return nil, err
 	}
 	ev.containernameAccessorK8s, err = k8s.AddSubField(
-		"containerName",
+		"container",
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{


### PR DESCRIPTION
Hi.

This commit breaks our CI because we now have two different fields for the same information: `container` and `containerName`:

```
...
{"gid":101,"k8s":{"containerName":"test-pod","hostnetwork":false,"namespace":"test-run-trace-tcp-835476566685864176","node":"aks-nodepool1-36911517-vmss000002","podName":"test-pod"},"mntns_id":4026532444,"netns":4026532373,"pid":6454,"runtime":{"containerId":"9e14f4193f315cd03557132cfc8560b417e8cb092eadf89cbe6dfe6227b99c9b","containerImageDigest":"","containerImageName":"docker.io/library/nginx:latest","containerName":"","runtimeName":"containerd"},"task":"nginx","timestamp":"2024-06-11T18:49:27.545312552Z","type":2,"type_str":"close","uid":101}

run_helpers.go:158: output doesn't contain the expected entry: {"dst":"","gid":0,"k8s":{"container":"test-pod","hostnetwork":false,"namespace":"test-run-trace-tcp-835476566685864176","node":"","pod":"test-pod"},"mntns_id":0,"netns":0,"pid":0,"runtime":{"containerId":"","containerImageDigest":"","containerImageName":"docker.io/library/nginx:latest","containerName":"","runtimeName":""},"src":"","task":"curl","timestamp":0,"type":0,"type_str":"connect","uid":0}
command.go:254: Inspektor Gadget pod logs:
```

Taken from:
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/9470950431

Let's see if reverting this commit is OK for the CI.

Best regards.
