### PR TITLE
Align k8s json and columns name

### DIFF
--- a/cmd/common/utils/parser.go
+++ b/cmd/common/utils/parser.go
@@ -123,8 +123,8 @@ func GetKubernetesColumns() []string {
 	return []string{
 		"k8s.node",
 		"k8s.namespace",
-		"k8s.pod",
-		"k8s.container",
+		"k8s.podName",
+		"k8s.containerName",
 	}
 }
 

--- a/docs/builtin-gadgets/audit/seccomp.md
+++ b/docs/builtin-gadgets/audit/seccomp.md
@@ -62,8 +62,8 @@ spec:
 * Start the audit-seccomp gadget.
 
 ```bash
-$ kubectl gadget audit seccomp -o columns=k8s.namespace,k8s.pod,syscall,code
-K8S.NAMESPACE    K8S.POD          SYSCALL          CODE
+$ kubectl gadget audit seccomp -o columns=k8s.namespace,k8s.podname,syscall,code
+K8S.NAMESPACE    K8S.PODNAME      SYSCALL          CODE
 ```
 
 * In another terminal, execute the aforementioned syscalls in the pod.
@@ -77,7 +77,7 @@ Bad system call (core dumped)
 * Observe the syscalls logged by seccomp in the first terminal.
 
 ```
-K8S.NAMESPACE    K8S.POD          SYSCALL          CODE
+K8S.NAMESPACE    K8S.PODNAME      SYSCALL          CODE
 default          mypod            mkdir            log
 default          mypod            unshare          kill_thread
 ```

--- a/docs/builtin-gadgets/profile/cpu.md
+++ b/docs/builtin-gadgets/profile/cpu.md
@@ -29,8 +29,8 @@ Capturing stack traces... Hit Ctrl-C to end.^C
 After a while press with Ctrl-C to stop trace collection
 
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
-minikube         default          random                         random           340800  cat              1
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME                    K8S.CONTAINERNAME PID     COMM             COUNT
+minikube         default          random                         random            340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
         __x64_sys_read
@@ -60,8 +60,8 @@ Instead of waiting, you can use the `--timeout` argument:
 ```bash
 $ kubectl gadget profile cpu --timeout 5 --podname random -K
 Capturing stack traces...
-K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
-minikube         default          random                         random           340800  cat              1
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME                    K8S.CONTAINERNAME PID     COMM             COUNT
+minikube         default          random                         random            340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
         __x64_sys_read
@@ -86,7 +86,7 @@ minikube         default          random                         random         
 This gadget also supports custom column outputting, for example:
 
 ```bash
-$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.pod
+$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.podname
 Capturing stack traces...
 K8S.NODE         K8S.POD
 minikube         random
@@ -97,10 +97,10 @@ minikube         random
 The following command is the same as default printing:
 
 ```bash
-$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.namespace,k8s.pod,k8s.container,pid,comm,count
+$ kubectl gadget profile cpu --timeout 1 --podname random -o columns=k8s.node,k8s.namespace,k8s.podname,k8s.containername,pid,comm,count
 Capturing stack traces...
-K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             COUNT
-minikube         default          random                         random           340800  cat              1
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME                    K8S.CONTAINERNAME PID     COMM             COUNT
+minikube         default          random                         random            340800  cat              1
         entry_SYSCALL_64_after_hwframe
         do_syscall_64
         __x64_sys_read

--- a/docs/builtin-gadgets/snapshot/process.md
+++ b/docs/builtin-gadgets/snapshot/process.md
@@ -22,7 +22,7 @@ There is not any running process in the `demo` namespace now:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   COMM       PID       UID       GID
 ```
 
 Create a pod on the `demo` namespace using the `nginx` image:
@@ -38,7 +38,7 @@ After the pod is running, we can try to get the list of running processes again:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   COMM       PID       UID       GID
 ubuntu-hirsute      demo                mypod               mypod               nginx      411928    0         0
 ubuntu-hirsute      demo                mypod               mypod               nginx      411964    101       101
 ubuntu-hirsute      demo                mypod               mypod               nginx      411965    101       101
@@ -62,7 +62,7 @@ Now there is an additional `sleep` processes running in `mypod`:
 
 ```bash
 $ kubectl gadget snapshot process -n demo
-K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       COMM       PID       UID       GID
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   COMM       PID       UID       GID
 ubuntu-hirsute      demo                mypod               mypod               nginx      411928    0         0
 ubuntu-hirsute      demo                mypod               mypod               nginx      411964    101       101
 ubuntu-hirsute      demo                mypod               mypod               nginx      411965    101       101

--- a/docs/builtin-gadgets/snapshot/socket.md
+++ b/docs/builtin-gadgets/snapshot/socket.md
@@ -33,7 +33,7 @@ done it also using the podname or labels:
 
 ```bash
 $ kubectl gadget snapshot socket -n test-socketcollector
-K8S.NODE            K8S.NAMESPACE       K8S.POD            PROTOCOL SRC                      DST                      STATUS
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME        PROTOCOL SRC                      DST                      STATUS
 minikube-docker     test-socketcollect… nginx-app          TCP      r/0.0.0.0:80             r/0.0.0.0:0              LISTEN
 ```
 
@@ -52,7 +52,7 @@ $ kubectl exec -n test-socketcollector nginx-app -- /bin/bash -c "sed -i 's/list
 Now, we can check again with the snapshot socket gadget what the active socket is:
 
 ```bash
-K8S.NODE            K8S.NAMESPACE       K8S.POD            PROTOCOL SRC                      DST                      STATUS
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME        PROTOCOL SRC                      DST                      STATUS
 minikube-docker     test-socketcollect… nginx-app          TCP      r/0.0.0.0:8080           r/0.0.0.0:0              LISTEN
 ```
 

--- a/docs/builtin-gadgets/top/block-io.md
+++ b/docs/builtin-gadgets/top/block-io.md
@@ -20,7 +20,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget top block-io
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
 ```
 
 Indeed, it is waiting for I/O to occur.
@@ -33,8 +33,8 @@ $ kubectl exec -ti test-pod -- dd if=/dev/zero of=/tmp/foo count=16384
 On *the first terminal*, you should see:
 
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
-minikube         default          test-pod         test-pod         7767    dd               W   0      0      1564672 3046     4
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             R/W MAJOR  MINOR  BYTES   TIME(µs) IOs
+minikube         default          test-pod         test-pod          7767    dd               W   0      0      1564672 3046     4
 ```
 
 This line correspond to the block device I/O initiated by `dd`.

--- a/docs/builtin-gadgets/top/ebpf.md
+++ b/docs/builtin-gadgets/top/ebpf.md
@@ -29,10 +29,10 @@ Now, in a second terminal, start `top file` on the _gadget_ namespace to get som
 
 ```bash
 $ kubectl gadget top file -n gadget
-K8S.NODE         K8S.NAMESPACE    K8S.POD                        K8S.CONTAINER    PID     COMM             READS  WRITES R_KB    W_KB    T FILE
-minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    1      0      0       0       R cap_last_cap
-minikube         gadget           gadget-k2mvp                   gadget           575955  runc:[2:INIT]    2      0      8       0       R group
-minikube         gadget           gadget-k2mvp                   gadget           575955  gadgettracerman  2      0      8       0       R UTC
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME                    K8S.CONTAINERNAME PID     COMM             READS  WRITES R_KB    W_KB    T FILE
+minikube         gadget           gadget-k2mvp                   gadget            575955  runc:[2:INIT]    1      0      0       0       R cap_last_cap
+minikube         gadget           gadget-k2mvp                   gadget            575955  runc:[2:INIT]    2      0      8       0       R group
+minikube         gadget           gadget-k2mvp                   gadget            575955  gadgettracerman  2      0      8       0       R UTC
 ...
 ```
 

--- a/docs/builtin-gadgets/top/file.md
+++ b/docs/builtin-gadgets/top/file.md
@@ -17,7 +17,7 @@ all the events from the beginning:
 
 ```bash
 $ kubectl gadget top file -p mypod
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
 ...
 ```
 
@@ -37,24 +37,24 @@ written by the pod. For instace, apt-get is reading a lot of files in
 when updating the packages list and installing packages.
 
 ```bash
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          425    0      27022   0       R archive.ubuntu.com_ubuntu_dists_focal-updates_main_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          278    0      17775   0       R archive.ubuntu.com_ubuntu_dists_focal_main_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          244    0      15594   0       R security.ubuntu.com_ubuntu_dists_focal-security_main_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          93     0      5921    0       R archive.ubuntu.com_ubuntu_dists_focal_universe_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          91     0      5797    0       R archive.ubuntu.com_ubuntu_dists_focal-updates_universe_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          82     0      5160    0       R archive.ubuntu.com_ubuntu_dists_focal-updates_restricted_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          73     0      4568    0       R security.ubuntu.com_ubuntu_dists_focal-security_restricted_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          70     0      4435    0       R security.ubuntu.com_ubuntu_dists_focal-security_universe_binary-amd64_Packages.lz4
-ubuntu-hirsute   default          mypod            mypod            642727  apt-get          19     0      1172    0       R archive.ubuntu.com_ubuntu_dists_focal_multiverse_binary-amd64_Packages.lz4
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          425    0      27022   0       R archive.ubuntu.com_ubuntu_dists_focal-updates_main_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          278    0      17775   0       R archive.ubuntu.com_ubuntu_dists_focal_main_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          244    0      15594   0       R security.ubuntu.com_ubuntu_dists_focal-security_main_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          93     0      5921    0       R archive.ubuntu.com_ubuntu_dists_focal_universe_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          91     0      5797    0       R archive.ubuntu.com_ubuntu_dists_focal-updates_universe_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          82     0      5160    0       R archive.ubuntu.com_ubuntu_dists_focal-updates_restricted_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          73     0      4568    0       R security.ubuntu.com_ubuntu_dists_focal-security_restricted_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          70     0      4435    0       R security.ubuntu.com_ubuntu_dists_focal-security_universe_binary-amd64_Packages.lz4
+ubuntu-hirsute   default          mypod            mypod             642727  apt-get          19     0      1172    0       R archive.ubuntu.com_ubuntu_dists_focal_multiverse_binary-amd64_Packages.lz4
 ```
 
 After the initial installation is done, we can see how git uses a
 temporary file to store the repository being cloned.
 
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
-ubuntu-hirsute   default          mypod            mypod            647042  git              0      1070   0       4280    R tmp_pack_2rpZd
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             READS  WRITES R_Kb    W_Kb    T FILE
+ubuntu-hirsute   default          mypod            mypod             647042  git              0      1070   0       4280    R tmp_pack_2rpZd
 ```
 
 Finally, we need to clean up our pod, press Ctrl + C on its terminal and

--- a/docs/builtin-gadgets/top/tcp.md
+++ b/docs/builtin-gadgets/top/tcp.md
@@ -19,7 +19,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget top tcp
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID       COMM      IP SRC                   DST                   SENT     RECV
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID       COMM      IP SRC                   DST                   SENT     RECV
 ```
 
 Indeed, it is waiting for TCP connection to occur.
@@ -32,9 +32,9 @@ $ kubectl exec -ti test-pod -- wget 1.1.1.1
 On *the first terminal*, you should see:
 
 ```
-K8S.NODE           K8S.NAMESPACE K8S.POD    CONTAINER   PID         COMM       IP SRC                        DST                  SENT       RECV      
-minikube-docker    default       test-pod   test-pod    289548      wget       4  p/default/test-pod:47228   r/1.1.1.1:443        296B       15.49KiB  
-minikube-docker    default       test-pod   test-pod    289540      wget       4  p/default/test-pod:42604   r/1.1.1.1:80         70B        381B      
+K8S.NODE           K8S.NAMESPACE K8S.PODNAMECONTAINER   PID         COMM       IP SRC                        DST                  SENT       RECV
+minikube-docker    default       test-pod   test-pod    289548      wget       4  p/default/test-pod:47228   r/1.1.1.1:443        296B       15.49KiB
+minikube-docker    default       test-pod   test-pod    289540      wget       4  p/default/test-pod:42604   r/1.1.1.1:80         70B        381B
 ```
 
 This line corresponds to the TCP connection initiated by `wget`.

--- a/docs/builtin-gadgets/trace/bind.md
+++ b/docs/builtin-gadgets/trace/bind.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace bind
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             PROTO  ADDR             PORT   OPTS   IF
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID    COMM             PROTO  ADDR             PORT   OPTS   IF
 ```
 
 Indeed, it is waiting for socket binding to occur.
@@ -36,8 +36,8 @@ command terminated with exit code 1
 Go back to *the first terminal* and see:
 
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             PROTO  ADDR             PORT   OPTS   IF
-minikube         default          test-pod         test-pod         58208  nc               IP     ::               4242   .R...  0
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID    COMM             PROTO  ADDR             PORT   OPTS   IF
+minikube         default          test-pod         test-pod          58208  nc               IP     ::               4242   .R...  0
 ```
 
 This line corresponds to the socket binding operation initiated by `nc`.
@@ -58,7 +58,7 @@ Start the gadget first
 
 ```bash
 $ sudo ig trace bind -c test-trace-bind
-K8S.CONTAINER    PID     COMM             PROTO  ADDR             PORT    OPTS    IF
+K8S.CONTAINERNAME PID     COMM             PROTO  ADDR             PORT    OPTS    IF
 ```
 
 In another terminal, run a container that performs a bind operation
@@ -71,8 +71,8 @@ The gadget will print the event on the first terminal:
 
 ```bash
 $ sudo ig trace bind -c test-trace-bind
-K8S.CONTAINER    PID     COMM             PROTO  ADDR             PORT    OPTS    IF
-test-trace-bind  380299  nc               TCP    ::               4242    .R...   0
+K8S.CONTAINERNAME PID     COMM             PROTO  ADDR             PORT    OPTS    IF
+test-trace-bind   380299  nc               TCP    ::               4242    .R...   0
 ```
 
 ### Restricting output to certain PID, ports or succeeded and failed port bindings

--- a/docs/builtin-gadgets/trace/capabilities.md
+++ b/docs/builtin-gadgets/trace/capabilities.md
@@ -60,7 +60,7 @@ Let's use Inspektor Gadget to watch the capability checks:
 
 ```bash
 $ kubectl gadget trace capabilities --selector name=set-priority
-K8S.NODE         K8S.NAMESPACE  K8S.POD                 K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
+K8S.NODE         K8S.NAMESPACE  K8S.PODNAME             K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
 minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711127  nice  setpriority  0    23  SYS_NICE  1      Deny
 minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711260  nice  setpriority  0    23  SYS_NICE  1      Deny
 minikube-docker  default        set-priorit…495c8-t88x8 set-priority  2711457  nice  setpriority  0    23  SYS_NICE  1      Deny
@@ -129,7 +129,7 @@ We can see the same checks but this time with the `Allow` verdict:
 
 ```bash
 $ kubectl gadget trace capabilities --selector name=set-priority
-K8S.NODE         K8S.NAMESPACE  K8S.POD                 K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
+K8S.NODE         K8S.NAMESPACE  K8S.PODNAME             K8S.CONTAINER PID      COMM  SYSCALL      UID  CAP CAPNAME   AUDIT  VERDICT
 minikube-docker  default        set-priorit…66dff-nm5pt set-priority  2718069  nice  setpriority  0    23  SYS_NICE  1      Allow
 minikube-docker  default        set-priorit…66dff-nm5pt set-priority  2718291  nice  setpriority  0    23  SYS_NICE  1      Allow
 ^C

--- a/docs/builtin-gadgets/trace/dns.md
+++ b/docs/builtin-gadgets/trace/dns.md
@@ -23,7 +23,7 @@ Start the dns gadget:
 
 ```bash
 $ kubectl gadget trace dns -n demo
-K8S.NODE                      K8S.NAMESPACE                 K8S.POD                       QR NAMESERVER      TYPE      QTYPE      NAME
+K8S.NODE                      K8S.NAMESPACE                 K8S.PODNAME                   QR NAMESERVER      TYPE      QTYPE      NAME
 ```
 
 Run a pod on a different terminal and perform some DNS requests:
@@ -38,7 +38,7 @@ $ kubectl -n demo run mypod -it --image=wbitt/network-multitool -- /bin/sh
 The requests will be logged by the DNS gadget:
 
 ```bash
-K8S.NODE             K8S.NAMESPACE        K8S.POD              PID         TID         COMM        QR NAMESERVER      TYPE      QTYPE      NAME                RCODE
+K8S.NODE             K8S.NAMESPACE        K8S.PODNAME          PID         TID         COMM        QR NAMESERVER      TYPE      QTYPE      NAME                RCODE
 minikube             demo                 mypod                1285309     1285310     isc-net-00… Q  8.8.4.4         OUTGOING  A          inspektor-gadget.i…
 minikube             demo                 mypod                1285309     1285310     isc-net-00… R  8.8.4.4         HOST      A          inspektor-gadget.i… No Error
 minikube             demo                 mypod                1285594     1285595     isc-net-00… Q  8.8.4.4         OUTGOING  AAAA       inspektor-gadget.i…

--- a/docs/builtin-gadgets/trace/exec.md
+++ b/docs/builtin-gadgets/trace/exec.md
@@ -29,7 +29,7 @@ minikube-docker where myapp1-pod-sbtvw and myapp2-pod-5pg4w are running:
 
 ```bash
 $ kubectl gadget trace exec --selector role=demo --node minikube-docker
-K8S.NODE        K8S.NAMESPACE K8S.POD          K8S.CONTAINER PID     PPID    COMM  PCOMM RET ARGS
+K8S.NODE        K8S.NAMESPACE K8S.PODNAME      K8S.CONTAINER PID     PPID    COMM  PCOMM RET ARGS
 minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226276 2221571 true  sh    0   /bin/true
 minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226277 2221571 date  sh    0   /bin/date
 minikube-docker default       myapp1-pod-sbtvw myapp1-pod    2226278 2221571 cat   sh    0   /bin/cat /proc/version

--- a/docs/builtin-gadgets/trace/fsslower.md
+++ b/docs/builtin-gadgets/trace/fsslower.md
@@ -20,7 +20,7 @@ Let's start the gadget before running our workload:
 
 ```bash
 $ kubectl gadget trace fsslower -f ext4 -m 1 -p mypod
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             T BYTES  OFFSET  LAT      FILE
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             T BYTES  OFFSET  LAT      FILE
 ```
 
 With `-f` we're indicating the type of filesystem we want to trace,
@@ -43,7 +43,7 @@ We can see how fsslower shows the operations that are taking longer than 1ms:
 
 ```bash
 $ kubectl gadget trace fsslower -f ext4 -m 1 -p mypod
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             T BYTES  OFFSET  LAT      FILE
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             T BYTES  OFFSET  LAT      FILE
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       2.66     perl-modules-5.30.list-new
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       1.49     libperl5.30:amd64.list-new
 ubuntu-hirsute   default          mypod            mypod            579778  dpkg             F 0      0       1.45     control

--- a/docs/builtin-gadgets/trace/mount.md
+++ b/docs/builtin-gadgets/trace/mount.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace mount
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    COMM             PID     TID     MNTNS      CALL
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME COMM             PID     TID     MNTNS      CALL
 ```
 
 Indeed, it is waiting for `mount` and `umount` to be called.
@@ -40,15 +40,15 @@ command terminated with exit code 255
 Go back to *the first terminal* and see:
 
 ```bash
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    COMM             PID     TID     MNTNS      CALL
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext3", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext2", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext4", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "vfat", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "msdos", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "iso9660", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "fuseblk", MS_SILENT, "") = -2
-minikube         default          busybox-0        busybox-0        mount            12841   12841   4026532682  mount("/mnt", "/mnt", "xfs", MS_SILENT, "") = -2
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME COMM             PID     TID     MNTNS      CALL
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext3", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext2", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "ext4", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "vfat", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "msdos", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "iso9660", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "fuseblk", MS_SILENT, "") = -2
+minikube         default          busybox-0        busybox-0         mount            12841   12841   4026532682  mount("/mnt", "/mnt", "xfs", MS_SILENT, "") = -2
 ```
 
 All these lines correspond to the error we get from `mount` inside the pod.

--- a/docs/builtin-gadgets/trace/network.md
+++ b/docs/builtin-gadgets/trace/network.md
@@ -20,7 +20,7 @@ $ kubectl run -ti -n demo --image=busybox --restart=Never shell -- wget 1.1.1.1.
 
 * Observe the results:
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD                        TYPE      PROTO  PORT    REMOTE
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME                    TYPE      PROTO  PORT    REMOTE
 minikube         demo             shell                          OUTGOING  UDP    53      svc kube-system/kube-dns
 minikube         demo             shell                          OUTGOING  TCP    80      endpoint 1.1.1.1
 ```

--- a/docs/builtin-gadgets/trace/oomkill.md
+++ b/docs/builtin-gadgets/trace/oomkill.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace oomkill -n oomkill-demo
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    KPID   KCOMM            PAGES  TPID             TCOMM
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME KPID   KCOMM            PAGES  TPID             TCOMM
 ```
 
 The gadget is waiting for the OOM killer to get triggered and kill a process in `oomkill-demo` namespace (alternatively, we could use `-A` and get out-of-memory killer events in all namespaces).
@@ -39,8 +39,8 @@ command terminated with exit code 137
 Go back to *the first terminal* and see:
 
 ```bash
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    KPID   KCOMM            PAGES  TPID             TCOMM
-minikube         oomkill-demo     test-pod         test-container   11507  tail             32768  11507            tail
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME KPID   KCOMM            PAGES  TPID             TCOMM
+minikube         oomkill-demo     test-pod         test-container    11507  tail             32768  11507            tail
 ```
 
 The printed lined corresponds to the killing of the `tail` process by the OOM killer.

--- a/docs/builtin-gadgets/trace/open.md
+++ b/docs/builtin-gadgets/trace/open.md
@@ -21,7 +21,7 @@ thus tracing on all nodes for a pod called "mypod":
 
 ```bash
 $ kubectl gadget trace open --podname mypod
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER   PID    COMM               FD ERR PATH
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINER   PID    COMM               FD ERR PATH
 ip-10-0-30-247   default          mypod            mypod           18455  whoami              3   0 /etc/passwd
 ip-10-0-30-247   default          mypod            mypod           18521  whoami              3   0 /etc/passwd
 ip-10-0-30-247   default          mypod            mypod           18525  whoami              3   0 /etc/passwd

--- a/docs/builtin-gadgets/trace/signal.md
+++ b/docs/builtin-gadgets/trace/signal.md
@@ -20,7 +20,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace signal
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             SIGNAL    TPID   RET
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID    COMM             SIGNAL    TPID   RET
 ```
 
 Indeed, it is waiting for signals to be sent.
@@ -33,10 +33,10 @@ $ kubectl exec -ti debian -- sh -c 'sleep 3 & kill -kill $!'
 Go back to *the first terminal* and see:
 
 ```
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID    COMM             SIGNAL    TPID   RET
-minikube         default          debian           debian           129484 sh               SIGKILL   129491 0
-minikube         default          debian           debian           129484 sh               SIGHUP    129491 0
-minikube         default          debian           debian           129484 sh               SIGHUP    129484 0
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID    COMM             SIGNAL    TPID   RET
+minikube         default          debian           debian            129484 sh               SIGKILL   129491 0
+minikube         default          debian           debian            129484 sh               SIGHUP    129491 0
+minikube         default          debian           debian            129484 sh               SIGHUP    129484 0
 ```
 
 The first line corresponds to `kill` sending signal `SIGKILL` to `sleep`.

--- a/docs/builtin-gadgets/trace/sni.md
+++ b/docs/builtin-gadgets/trace/sni.md
@@ -14,7 +14,7 @@ we can run:
 
 ```bash
 $ kubectl gadget trace sni
-K8S.NODE           K8S.NAMESPACE      K8S.POD            PID        TID       COMM      NAME
+K8S.NODE           K8S.NAMESPACE      K8S.PODNAME        PID        TID       COMM      NAME
 ```
 
 To generate some output for this example, let's create a demo pod in *another terminal*:
@@ -36,7 +36,7 @@ Location: https://github.com/ [following]
 Go back to *the first terminal* and see:
 
 ```
-K8S.NODE           K8S.NAMESPACE      K8S.POD            PID        TID       COMM      NAME
+K8S.NODE           K8S.NAMESPACE      K8S.PODNAME        PID        TID       COMM      NAME
 minikube           default            ubuntu             3917791    3917791   wget      www.github.com
 minikube           default            ubuntu             3917791    3917791   wget      github.com
 minikube           default            ubuntu             3917812    3917812   wget      wikimedia.org

--- a/docs/builtin-gadgets/trace/tcp.md
+++ b/docs/builtin-gadgets/trace/tcp.md
@@ -21,7 +21,7 @@ You can now use the gadget, but output will be empty:
 
 ```bash
 $ kubectl gadget trace tcp
-K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       T PID        COMM       IP SRC                DST               
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   T PID        COMM       IP SRC                DST
 ```
 
 Indeed, it is waiting for TCP connection to be established in the `default` namespace (you can use `-A` to monitor all namespaces and then be sure to not miss any event).
@@ -40,7 +40,7 @@ index.html           100% |*****************************************************
 Go back to *the first terminal* and see:
 
 ```bash
-K8S.NODE            K8S.NAMESPACE       K8S.POD             K8S.CONTAINER       T PID        COMM       IP SRC                DST               
+K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   T PID        COMM       IP SRC                DST
 minikube-docker     default             bb                  bb                  C 253124     wget       4  p/default/bb:50192 o/188.114.96.3:443
 ```
 
@@ -98,6 +98,6 @@ The gadget will print that connection on the first terminal
 
 ```bash
 $ sudo ig trace tcp -c test-trace-tcp
-RUNTIME.CONTAINERNAME     T PID        COMM          IP SRC                      DST                     
-test-trace-tcp            C 269349     wget          4  172.17.0.2:46502         93.184.216.34:443 
+RUNTIME.CONTAINERNAME     T PID        COMM          IP SRC                      DST
+test-trace-tcp            C 269349     wget          4  172.17.0.2:46502         93.184.216.34:443
 ```

--- a/docs/builtin-gadgets/trace/tcpconnect.md
+++ b/docs/builtin-gadgets/trace/tcpconnect.md
@@ -29,7 +29,7 @@ In our trace tcpconnect gadget terminal we can now see the logged connection:
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod
-K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443
 ```
@@ -92,7 +92,7 @@ Switching to the gadget trace tcpconnnect terminal, we see the same connections 
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod  # (still running in old terminal)
-K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80   # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443  # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:40676   r/1.1.1.1:80
@@ -115,7 +115,7 @@ there is no redirect visible to port 443:
 
 ```bash
 $ kubectl gadget trace tcpconnect --podname mypod  # (still running in old terminal)
-K8S.NODE                 K8S.NAMESPACE            K8S.POD                  K8S.CONTAINER            PID        COMM          IP SRC                     DST
+K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        PID        COMM          IP SRC                     DST
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:46779   r/1.1.1.1:80   # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:21731   r/1.1.1.1:443  # (previous output)
 minikube-docker          default                  mypod                    mypod                    2011630    wget          4  p/default/mypod:40676   r/1.1.1.1:80   # (previous output)
@@ -204,7 +204,7 @@ The first terminal show all those connections and their latency. In my case both
 the same node, so it's very low:
 
 ```bash
-K8S.NODE              K8S.NAMESPACE  K8S.POD            K8S.CONTAINER      PID        COMM            IP SRC                         DST                               LATENCY
+K8S.NODE              K8S.NAMESPACE  K8S.PODNAME        K8S.CONTAINERNAME  PID        COMM            IP SRC                         DST                               LATENCY
 minikube-docker       default        myclientpod        myclientpod        2054329    curl            4  p/default/myclientpod:50306 s/default/nginx:80               47.069µs
 minikube-docker       default        myclientpod        myclientpod        2054338    curl            4  p/default/myclientpod:53378 s/default/nginx:80              120.017µs
 ```
@@ -222,7 +222,7 @@ the server again:
 Now the latency is a lot higher and has some variance because of the emulation configuration:
 
 ```bash
-K8S.NODE              K8S.NAMESPACE  K8S.POD            K8S.CONTAINER      PID        COMM            IP SRC                         DST                               LATENCY
+K8S.NODE              K8S.NAMESPACE  K8S.PODNAME        K8S.CONTAINERNAME  PID        COMM            IP SRC                         DST                               LATENCY
 ...
 minikube-docker       default        myclientpod        myclientpod        2056697    curl            4  p/default/myclientpod:32415 s/default/nginx:80             7.820966ms
 minikube-docker       default        myclientpod        myclientpod        2056832    curl            4  p/default/myclientpod:32927 s/default/nginx:80            64.388825ms

--- a/docs/builtin-gadgets/trace/tcpdrop.md
+++ b/docs/builtin-gadgets/trace/tcpdrop.md
@@ -47,7 +47,7 @@ It is possible to see more detailed information by reading specific columns or u
 
 ```
 $ kubectl gadget trace tcpdrop \
-    -o columns=k8s.node,k8s.namespace,k8s.pod,k8s.container,pid,comm,ip,src.addr,src.port,src.kind,src.ns,src.name,dst.addr,dst.port,dst.kind,dst.ns,dst.name,state,tcpflags,reason
+    -o columns=k8s.node,k8s.namespace,k8s.podname,k8s.containername,pid,comm,ip,src.addr,src.port,src.kind,src.ns,src.name,dst.addr,dst.port,dst.kind,dst.ns,dst.name,state,tcpflags,reason
 ```
 
 ```

--- a/docs/builtin-gadgets/trace/tcpretrans.md
+++ b/docs/builtin-gadgets/trace/tcpretrans.md
@@ -13,7 +13,7 @@ In terminal 1, start the trace tcpretrans gadget:
 
 ```bash
 $ kubectl gadget trace tcpretrans
-K8S.NODE     K8S.NAMESP… K8S.POD     K8S.CONTAI… PID     COMM  IP SRC                    DST                    STATE     TCPFLA… TYPE
+K8S.NODE     K8S.NAMESP… K8S.PODNAME K8S.CONTAI… PID     COMM  IP SRC                    DST                    STATE     TCPFLA… TYPE
 ```
 
 In terminal 2, start a pod and configure the network emulator to drop 25% of the packets. This will cause TCP retransmissions:
@@ -31,7 +31,7 @@ root@shell:/# curl nginx
 The results in terminal 1 will show that some TCP transmissions cause by the dropped packets:
 
 ```
-K8S.NODE     K8S.NAMESP… K8S.POD     K8S.CONTAI… PID     COMM  IP SRC                    DST                    STATE     TCPFLA… TYPE
+K8S.NODE     K8S.NAMESP… K8S.PODNAME K8S.CONTAI… PID     COMM  IP SRC                    DST                    STATE     TCPFLA… TYPE
 miniku…ocker default     shell       shell       60274   curl  4  p/default/shell:46022  s/default/nginx:80     ESTABLIS…         LOSS
 miniku…ocker default     shell       shell       60274   curl  4  p/default/shell:46022  s/default/nginx:80     ESTABLIS… PSH|ACK RETRANS
 ```

--- a/docs/builtin-gadgets/traceloop.md
+++ b/docs/builtin-gadgets/traceloop.md
@@ -35,7 +35,7 @@ result lost forever? Let's check with the traceloop gadget:
 
 ```bash
 $ kubectl gadget traceloop list
-K8S.NODE                                K8S.NAMESPACE                          K8S.POD                                K8S.CONTAINER                          CONTAINERID
+K8S.NODE                                K8S.NAMESPACE                          K8S.PODNAME                            K8S.CONTAINERNAME                      CONTAINERID
 minikube                                kube-system                            kube-scheduler-minikube                kube-scheduler                         2b63eb745ce2cf
 ...
 minikube                                test                                   mypod                                  mypod                                  ef6f2d3f44b555

--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.labels,k8s.container,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.pod,k8s.labels,k8s.container,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/docs/design/001-prometheus.md
+++ b/docs/design/001-prometheus.md
@@ -127,8 +127,8 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
 ```
 
 The category and gadget fields define which gadget to use. The labels indicate how metrics are
@@ -159,8 +159,8 @@ will only consider events in the default namespace.
   category: trace
   gadget: exec
   labels:
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
   selector:
     - "k8s.namespace:default"
 ```
@@ -175,8 +175,8 @@ Or only count events for a given command:
   gadget: exec
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
   selector:
     - "comm:cat"
 ```
@@ -191,8 +191,8 @@ And finally, we can provide counters for failed operations:
   gadget: exec
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
   selector:
     - "retval:!0"
 ```
@@ -225,8 +225,8 @@ Another example is:
   gadget: seccomp
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
     - syscall
   selector:
     - "syscall:bpf"
@@ -243,8 +243,8 @@ increase a counter using a field on the event:
   gadget: fsslower
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
   field: bytes
   selector:
     - "filesystem:ext4"
@@ -268,8 +268,8 @@ snapshotters.
   gadget: process
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
 
 # Number of sockets in CLOSE_WAIT state
 - name: number_of_sockets_close_wait
@@ -278,8 +278,8 @@ snapshotters.
   gadget: socket
   labels:
     - k8s.namespace
-    - k8s.pod
-    - k8s.container
+    - k8s.podName
+    - k8s.containerName
   selector:
     - "status:CLOSE_WAIT"
 ```
@@ -309,7 +309,7 @@ We'll support the same bucket configuration as described in
     type: exp2
   labels:
     - k8s.namespace
-    - k8s.pod
+    - k8s.podName
   selector:
     - "qr:R"
 ```

--- a/docs/guides/common-features.md
+++ b/docs/guides/common-features.md
@@ -102,7 +102,7 @@ $ kubectl gadget trace open -h
     flags
     fullPath (requires --full-path)
     gid
-    k8s.container
+    k8s.containerName
 ...
 ```
 
@@ -121,7 +121,7 @@ For example, in case we want to add `uid` and `gid` columns to the default colum
 
 ```bash
 $ kubectl gadget trace open -A -o columns=+uid,+gid
-K8S.NODE      K8S.NAMESPACE K8S.POD       K8S.CONTAINER PID     COMM   FD ERR PATH                     UID        GID
+K8S.NODE      K8S.NAMESPACE K8S.PODNAME   K8S.CONTAINER PID     COMM   FD ERR PATH                     UID        GID
 miniku…docker default       test-p…-v6rqg nginx         1149213 docke… 3  0   /etc/ld.so.cache         0          0
 
 ```
@@ -148,14 +148,14 @@ namespace during a window of 5 seconds, like this:
 
 ```bash
 $ kubectl gadget trace open -n gadget --timeout 5
-K8S.NODE         K8S.NAMESPACE    K8S.POD          K8S.CONTAINER    PID     COMM             FD    ERR PATH
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /etc/ld.so.cache
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libpthread.so.0
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libseccomp.so.2
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libc.so.6
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  3     0   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0   /usr/bin/gadgettracermanager
-minikube         gadget           gadget-vhcj7     gadget           1303299 gadgettracerman  6     0   /etc/localtime
+K8S.NODE         K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNAME PID     COMM             FD    ERR PATH
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  3     0   /etc/ld.so.cache
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libpthread.so.0
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libseccomp.so.2
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  3     0   /lib/x86_64-linux-gnu/libc.so.6
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  3     0   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  6     0   /usr/bin/gadgettracermanager
+minikube         gadget           gadget-vhcj7     gadget            1303299 gadgettracerman  6     0   /etc/localtime
 ```
 
 ## Kubernetes CLI Runtime options

--- a/docs/guides/prometheus.md
+++ b/docs/guides/prometheus.md
@@ -94,8 +94,8 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
 ```
 
 By default, a counter is increased by one each time there is an event, however it's possible to
@@ -111,8 +111,8 @@ metrics:
     category: trace
     gadget: exec
     labels:
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
     selector:
       - "k8s.namespace:default"
 ```
@@ -130,8 +130,8 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
     selector:
       - "comm:cat"
 ```
@@ -147,7 +147,7 @@ metrics:
     gadget: dns
     labels:
       - k8s.namespace
-      - k8s.pod
+      - k8s.podName
     selector:
       - "qr:Q" # Only count query events
 ```
@@ -173,8 +173,8 @@ metrics:
     gadget: process
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
 ```
 
 Number of sockets in `CLOSE_WAIT` state
@@ -188,8 +188,8 @@ metrics:
     gadget: socket
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
     selector:
       - "status:CLOSE_WAIT"
 ```
@@ -296,8 +296,8 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
 ```
 
 Start the gadget
@@ -337,8 +337,8 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
     selector:
      - "comm:cat"
 ```

--- a/docs/guides/run.md
+++ b/docs/guides/run.md
@@ -21,13 +21,13 @@ Check the different gadgets available in https://github.com/orgs/inspektor-gadge
 ```bash
 $ kubectl gadget run trace_tcpconnect
 INFO[0000] Experimental features enabled
-K8S.NODE               K8S.NAMESPACE         K8S.POD               K8S.CONTAINER         PID     TASK        SRC                      DST
+K8S.NODE               K8S.NAMESPACE         K8S.PODNAME           K8S.CONTAINERNAME     PID     TASK        SRC                      DST
 ubuntu-hirsute         default               mypod2                mypod2                174085  wget        p/default/mypod2:37848   r/1.1.1.1:80
 ubuntu-hirsute         default               mypod2                mypod2                174085  wget        p/default/mypod2:33150   r/1.1.1.1:443
 
 $ kubectl gadget run trace_open
 INFO[0000] Experimental features enabled
-K8S.NODE               K8S.NAMESPACE          K8S.POD                K8S.CONTAINER          PID     COMM        UID      GID      RET FNAME
+K8S.NODE               K8S.NAMESPACE          K8S.PODNAME            K8S.CONTAINERNAME      PID     COMM        UID      GID      RET FNAME
 ubuntu-hirsute         default                mypod2                 mypod2                 225071  sh          0        0        3   /
 ubuntu-hirsute         default                mypod2                 mypod2                 225071  sh          0        0        3   /root/.ash_history
 ubuntu-hirsute         default                mypod2                 mypod2                 242164  cat         0        0        -2  /etc/ld.so.cache

--- a/integration/k8s/prometheus_test.go
+++ b/integration/k8s/prometheus_test.go
@@ -135,13 +135,13 @@ EOF
 
 					expectedEntry := &Result{
 						Metric: map[string]string{
-							"__name__":        "executed_processes_total",
-							"k8s_container":   "test-pod",
-							"job":             "gadget",
-							"k8s_namespace":   ns,
-							"k8s_pod":         "test-pod",
-							"instance":        "",
-							"otel_scope_name": "",
+							"__name__":          "executed_processes_total",
+							"k8s_containerName": "test-pod",
+							"job":               "gadget",
+							"k8s_namespace":     ns,
+							"k8s_podName":       "test-pod",
+							"instance":          "",
+							"otel_scope_name":   "",
 						},
 						Value: []interface{}{nil, "100"},
 					}

--- a/integration/k8s/testdata/prometheus/counter.yaml
+++ b/integration/k8s/testdata/prometheus/counter.yaml
@@ -6,7 +6,7 @@ metrics:
     gadget: exec
     labels:
       - k8s.namespace
-      - k8s.pod
-      - k8s.container
+      - k8s.podName
+      - k8s.containerName
     selector:
       - "comm:cat"

--- a/pkg/gadgets/snapshot/process/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/process/tracer/gadget.go
@@ -92,7 +92,7 @@ func (g *GadgetDesc) OutputFormats() (gadgets.OutputFormats, string) {
 }
 
 func (g *GadgetDesc) SortByDefault() []string {
-	return []string{"k8s.node", "k8s.namespace", "k8s.pod", "k8s.container", "comm", "pid", "tid", "ppid"}
+	return []string{"k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName", "comm", "pid", "tid", "ppid"}
 }
 
 func init() {

--- a/pkg/gadgets/snapshot/socket/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/socket/tracer/gadget.go
@@ -74,7 +74,7 @@ func (g *GadgetDesc) EventPrototype() any {
 
 func (g *GadgetDesc) SortByDefault() []string {
 	return []string{
-		"k8s.node", "k8s.namespace", "k8s.pod", "protocol", "status", "src", "dst", "inode",
+		"k8s.node", "k8s.namespace", "k8s.podName", "protocol", "status", "src", "dst", "inode",
 	}
 }
 

--- a/pkg/gadgets/snapshot/socket/types/socket-collector.go
+++ b/pkg/gadgets/snapshot/socket/types/socket-collector.go
@@ -58,7 +58,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("k8s.container")
+		col, _ := cols.GetColumn("k8s.containerName")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/top/ebpf/types/types.go
+++ b/pkg/gadgets/top/ebpf/types/types.go
@@ -56,9 +56,9 @@ func GetColumns() *columns.Columns[Stats] {
 
 	col, _ := cols.GetColumn("k8s.namespace")
 	col.Visible = false
-	col, _ = cols.GetColumn("k8s.pod")
+	col, _ = cols.GetColumn("k8s.podName")
 	col.Visible = false
-	col, _ = cols.GetColumn("k8s.container")
+	col, _ = cols.GetColumn("k8s.containerName")
 	col.Visible = false
 	col, _ = cols.GetColumn("runtime.containerName")
 	col.Visible = false

--- a/pkg/gadgets/trace/dns/types/dns.go
+++ b/pkg/gadgets/trace/dns/types/dns.go
@@ -65,7 +65,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("k8s.container")
+		col, _ := cols.GetColumn("k8s.containerName")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/trace/network/types/types.go
+++ b/pkg/gadgets/trace/network/types/types.go
@@ -74,7 +74,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("k8s.container")
+		col, _ := cols.GetColumn("k8s.containerName")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/trace/sni/types/snisnoop.go
+++ b/pkg/gadgets/trace/sni/types/snisnoop.go
@@ -40,7 +40,7 @@ func GetColumns() *columns.Columns[Event] {
 
 	// Hide container column for kubernetes environment
 	if environment.Environment == environment.Kubernetes {
-		col, _ := cols.GetColumn("k8s.container")
+		col, _ := cols.GetColumn("k8s.containerName")
 		col.Visible = false
 	}
 

--- a/pkg/gadgets/traceloop/types/types.go
+++ b/pkg/gadgets/traceloop/types/types.go
@@ -75,7 +75,7 @@ func GetColumns() *columns.Columns[Event] {
 	// They can be printed later nonetheless with the following code snippet:
 	// column, _ := columns.GetColumn("pod")
 	// column.Visible = true
-	columns := []string{"k8s.node", "k8s.namespace", "k8s.pod", "k8s.container"}
+	columns := []string{"k8s.node", "k8s.namespace", "k8s.podName", "k8s.containerName"}
 	for _, name := range columns {
 		column, ok := cols.GetColumn(name)
 		if !ok {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -146,9 +146,9 @@ func (b *BasicRuntimeMetadata) IsEnriched() bool {
 
 type BasicK8sMetadata struct {
 	Namespace     string            `json:"namespace,omitempty" column:"namespace,template:namespace"`
-	PodName       string            `json:"podName,omitempty" column:"pod,template:pod"`
+	PodName       string            `json:"podName,omitempty" column:"podName,template:pod"`
 	PodLabels     map[string]string `json:"podLabels,omitempty" column:"labels,hide"`
-	ContainerName string            `json:"containerName,omitempty" column:"container,template:container"`
+	ContainerName string            `json:"containerName,omitempty" column:"containerName,template:container"`
 }
 
 func (b *BasicK8sMetadata) IsEnriched() bool {


### PR DESCRIPTION
Use podName (instead of pod) and containerName (instead of container) for both, json and columns output for the k8s fields.

This commit changes the header printed for the built-in gadgets from

$ ./kubectl-gadget trace exec
INFO[0000] Experimental features enabled
K8S.NODE          K8S.NAMESPACE     K8S.POD           K8S.CONTAINER     PID       PPID      COMM     PCOMM    RET ARGS

to

$ ./kubectl-gadget trace exec
INFO[0000] Experimental features enabled
K8S.NODE          K8S.NAMESPACE     K8S.PODNAME       K8S.CONTAINERNAME PID       PPID      COMM     PCOMM    RET ARGS

It's not a breaking change as users should be parsing the json output instead of the columns output.

