### PR TITLE
Implement bitfield to string conversion

### DIFF
--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -37,7 +37,7 @@ structs:
       description: Group id of the event's process
       attributes:
         template: uid
-    - name: tcpflags
+    - name: tcpflags_raw
       description: TCP flags from a TCP header
       attributes:
         width: 16

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -37,7 +37,7 @@ structs:
       description: 'TODO: Fill field description'
       attributes:
         template: uid
-    - name: tcpflags
+    - name: tcpflags_raw
       description: 'TODO: Fill field description'
       attributes:
         width: 16

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -31,13 +31,24 @@ enum type {
 	LOSS,
 };
 
+enum tcp_flags_set : __u8 {
+	FIN = 0x01,
+	SYN = 0x02,
+	RST = 0x04,
+	PSH = 0x08,
+	ACK = 0x10,
+	URG = 0x20,
+	ECE = 0x40,
+	CWR = 0x80,
+};
+
 struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
 	gadget_timestamp timestamp_raw;
 	__u8 state;
-	__u8 tcpflags;
+	enum tcp_flags_set tcpflags_raw;
 	__u32 reason;
 	gadget_netns_id netns;
 	enum type type_raw;
@@ -131,7 +142,8 @@ static __always_inline int __trace_tcp_retrans(void *ctx, const struct sock *sk,
 	// Instead, we have to read the TCP flags from the TCP control buffer.
 	if (skb) {
 		tcb = (struct tcp_skb_cb *)&(skb->cb[0]);
-		bpf_probe_read_kernel(&event->tcpflags, sizeof(event->tcpflags),
+		bpf_probe_read_kernel(&event->tcpflags_raw,
+				      sizeof(event->tcpflags_raw),
 				      &tcb->tcp_flags);
 	}
 


### PR DESCRIPTION
This commit adds support for providing a human readable version of a bitfield.
This is done by using the same logic for enums, in this case, the gadget author has to define an enum with all values of the flags and that its name has the "_set" suffix, with this information the formatter will recognize and format it on the right way. Developers can use the "ebpf.formatter.bitfield.separator" annotation to set the separator to be used when joining the flags, by default "|" is used.

### Previous Idea

Before I was trying to use annotations in the metadata file, but after talking to @flyth I realized it was not the best solution and suggested by @flyth decided to implement it using 

### Testing 

Run the trace_tcp{drop,retrans} gadgets and see how they behave. 

### TODO

- [ ] Use arrays once #3032 is implemented (this PR won't block on that)

Fixes #2482
Related #2996