### PR TITLE
formatters: Avoid changing name of the field

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event_t:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: src
       description: Source endpoint
       attributes:

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -33,7 +33,7 @@
 #define MAX_ADDR_ANSWERS 1
 
 struct event_t {
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
@@ -273,7 +273,7 @@ static __always_inline int output_dns_event(struct __sk_buff *skb,
 	//     R3 type=mem expected=fp, pkt, pkt_meta, map_key, map_value
 	// Fixed in Linux 5.17 by:
 	// https://github.com/torvalds/linux/commit/a672b2e36a648afb04ad3bda93b6bda947a479a5
-	timestamp = event->timestamp = bpf_ktime_get_boot_ns();
+	timestamp = event->timestamp_raw = bpf_ktime_get_boot_ns();
 
 	long err = bpf_skb_load_bytes(skb,
 				      DNS_OFF + offsetof(struct dnshdr, id),

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -25,7 +25,7 @@
 
 struct event {
 	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	__u32 pid;
 	__u32 ppid;
 	__u32 uid;
@@ -102,7 +102,7 @@ int ig_execve_e(struct syscall_trace_enter *ctx)
 
 	gadget_enter_exec();
 
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	event->pid = tgid;
 	event->uid = uid;
 	event->gid = gid;

--- a/gadgets/trace_lsm/gadget.yaml
+++ b/gadgets/trace_lsm/gadget.yaml
@@ -26,7 +26,7 @@ structs:
     - name: gid
       attributes:
         template: uid
-    - name: tracepoint
+    - name: tracepoint_raw
       description: lsm tracepoint enum
       attributes:
         width: 16
@@ -36,9 +36,7 @@ structs:
       description: command
       attributes:
         template: comm
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
 ebpfParams:
   trace_all:
     key: trace-all

--- a/gadgets/trace_lsm/program.bpf.c
+++ b/gadgets/trace_lsm/program.bpf.c
@@ -168,12 +168,12 @@ enum lsm_tracepoint { FOR_EACH_LSM_HOOK(ENUM_ITEM) };
 
 struct event {
 	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	u32 pid;
 	u32 tid;
 	u32 uid;
 	u32 gid;
-	enum lsm_tracepoint tracepoint;
+	enum lsm_tracepoint tracepoint_raw;
 	char comm[TASK_COMM_LEN];
 };
 
@@ -210,12 +210,12 @@ FOR_EACH_LSM_HOOK(DECLARE_LSM_PARAMETER)
 		uid_gid = bpf_get_current_uid_gid();                   \
                                                                        \
 		event.mntns_id = mntns_id;                             \
-		event.timestamp = bpf_ktime_get_boot_ns();             \
+		event.timestamp_raw = bpf_ktime_get_boot_ns();         \
 		event.pid = pid_tgid >> 32;                            \
 		event.tid = pid_tgid;                                  \
 		event.uid = uid_gid;                                   \
 		event.gid = uid_gid >> 32;                             \
-		event.tracepoint = name;                               \
+		event.tracepoint_raw = name;                           \
 		bpf_get_current_comm(event.comm, sizeof(event.comm));  \
                                                                        \
 		bpf_ringbuf_output(&events, &event, sizeof(event), 0); \

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -20,7 +20,7 @@ structs:
       description: command
       attributes:
         template: comm
-    - name: operation
+    - name: operation_raw
       description: memory operation type
       attributes:
         width: 16
@@ -42,6 +42,4 @@ structs:
         width: 20
         alignment: left
         ellipsis: end
-    - name: timestamp_ns
-      attributes:
-        template: timestamp
+    - name: timestamp_raw

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -31,10 +31,10 @@ struct event {
 	__u32 pid;
 	__u32 tid;
 	char comm[TASK_COMM_LEN];
-	enum memop operation;
+	enum memop operation_raw;
 	__u64 addr;
 	__u64 size;
-	__u64 timestamp_ns;
+	gadget_timestamp timestamp_raw;
 };
 
 /* used for context between uprobes and uretprobes of allocations */
@@ -112,10 +112,10 @@ static __always_inline int gen_alloc_exit(struct pt_regs *ctx,
 	event->pid = pid_tgid >> 32;
 	event->tid = tid;
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
-	event->operation = operation;
+	event->operation_raw = operation;
 	event->addr = addr;
 	event->size = size;
-	event->timestamp_ns = bpf_ktime_get_ns();
+	event->timestamp_raw = bpf_ktime_get_ns();
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 
@@ -145,10 +145,10 @@ static __always_inline int gen_free_enter(struct pt_regs *ctx,
 	event->pid = pid_tgid >> 32;
 	event->tid = tid;
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
-	event->operation = operation;
+	event->operation_raw = operation;
 	event->addr = addr;
 	event->size = 0;
-	event->timestamp_ns = bpf_ktime_get_ns();
+	event->timestamp_raw = bpf_ktime_get_ns();
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -47,7 +47,7 @@ structs:
       attributes:
         width: 32
         minWidth: 24
-    - name: op
+    - name: op_raw
       attributes:
         width: 6
         minWidth: 6
@@ -57,9 +57,7 @@ structs:
         width: 20
         alignment: left
         ellipsis: end
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
 ebpfParams:
   target_pid:
     key: pid

--- a/gadgets/trace_mount/program.bpf.c
+++ b/gadgets/trace_mount/program.bpf.c
@@ -35,14 +35,14 @@ struct event {
 	__u32 pid;
 	__u32 tid;
 	gadget_mntns_id mount_ns_id;
-	__u64 timestamp;
+	gadget_timestamp timestamp_raw;
 	int ret;
 	char comm[TASK_COMM_LEN];
 	char fs[FS_NAME_LEN];
 	char src[PATH_MAX];
 	char dest[PATH_MAX];
 	char data[DATA_LEN];
-	enum op op;
+	enum op op_raw;
 };
 
 const volatile pid_t target_pid = 0;
@@ -112,13 +112,13 @@ static int probe_exit(void *ctx, int ret)
 		goto cleanup;
 
 	eventp->mount_ns_id = gadget_get_mntns_id();
-	eventp->timestamp = bpf_ktime_get_boot_ns();
+	eventp->timestamp_raw = bpf_ktime_get_boot_ns();
 	eventp->delta = bpf_ktime_get_ns() - argp->ts;
 	eventp->flags = argp->flags;
 	eventp->pid = pid;
 	eventp->tid = tid;
 	eventp->ret = ret;
-	eventp->op = argp->op;
+	eventp->op_raw = argp->op;
 	bpf_get_current_comm(&eventp->comm, sizeof(eventp->comm));
 	if (argp->src)
 		bpf_probe_read_user_str(eventp->src, sizeof(eventp->src),

--- a/gadgets/trace_mount/test/trace_mount_test.go
+++ b/gadgets/trace_mount/test/trace_mount_test.go
@@ -38,14 +38,14 @@ type traceMountEvent struct {
 	Pid       int    `json:"pid"`
 	Tid       int    `json:"tid"`
 	MountNsID uint64 `json:"mount_ns_id"`
-	Timestamp uint64 `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
 	Ret       int    `json:"ret"`
 	Comm      string `json:"comm"`
 	Fs        string `json:"fs"`
 	Src       string `json:"src"`
 	Dest      string `json:"dest"`
 	Data      string `json:"data"`
-	OpStr     string `json:"op_str"`
+	Op        string `json:"op"`
 }
 
 func TestTraceMount(t *testing.T) {
@@ -97,7 +97,7 @@ func TestTraceMount(t *testing.T) {
 			expectedEntry := &traceMountEvent{
 				CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
 				Comm:       "mount",
-				OpStr:      "MOUNT",
+				Op:         "MOUNT",
 				Src:        "/mnt",
 				Dest:       "/mnt",
 				Ret:        -int(unix.ENOENT),
@@ -105,7 +105,7 @@ func TestTraceMount(t *testing.T) {
 
 				// Check only the existence of these fields
 				Flags:     utils.NormalizedInt,
-				Timestamp: utils.NormalizedInt,
+				Timestamp: utils.NormalizedStr,
 				Delta:     utils.NormalizedInt,
 				Pid:       utils.NormalizedInt,
 				Tid:       utils.NormalizedInt,
@@ -115,7 +115,7 @@ func TestTraceMount(t *testing.T) {
 
 			normalize := func(e *traceMountEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
-				utils.NormalizeInt(&e.Timestamp)
+				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeInt(&e.Delta)
 				utils.NormalizeInt(&e.Flags)
 				utils.NormalizeInt(&e.Pid)

--- a/gadgets/trace_oomkill/gadget.yaml
+++ b/gadgets/trace_oomkill/gadget.yaml
@@ -23,14 +23,11 @@ structs:
       attributes:
         template: pid
     - name: pages
-      attributes: {}
     - name: mntns_id
       description: Mount namespace inode id
       attributes:
         template: ns
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: fcomm
       attributes:
         template: comm

--- a/gadgets/trace_oomkill/program.bpf.c
+++ b/gadgets/trace_oomkill/program.bpf.c
@@ -20,7 +20,7 @@ struct event {
 	__u32 tpid;
 	__u64 pages;
 	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	char fcomm[TASK_COMM_LEN];
 	char tcomm[TASK_COMM_LEN];
 };
@@ -54,7 +54,7 @@ int BPF_KPROBE(ig_oom_kill, struct oom_control *oc, const char *message)
 	bpf_probe_read_kernel(&event->tcomm, sizeof(event->tcomm),
 			      BPF_CORE_READ(oc, chosen, comm));
 	event->mntns_id = mntns_id;
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 
 	return 0;

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -22,7 +22,7 @@ struct args_t {
 };
 
 struct event {
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	/* user terminology for pid: */
 	__u32 pid;
 	__u32 uid;
@@ -161,7 +161,7 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 	event->err = errval;
 	event->fd = fd;
 	event->mntns_id = gadget_get_mntns_id();
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 
 	/* emit event */
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       attributes:
         template: pid
@@ -31,7 +29,7 @@ structs:
     - name: ret
       attributes:
         width: 5
-    - name: sig
+    - name: sig_raw
       attributes:
         width: 5
     - name: mntns_id

--- a/gadgets/trace_signal/program.bpf.c
+++ b/gadgets/trace_signal/program.bpf.c
@@ -18,10 +18,10 @@ struct event {
 	__u32 pid;
 	__u32 tpid;
 	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	__u32 uid;
 	__u32 gid;
-	gadget_signal sig;
+	gadget_signal sig_raw;
 	int ret;
 	char comm[TASK_COMM_LEN];
 };
@@ -100,10 +100,10 @@ static int probe_exit(void *ctx, int ret)
 		goto cleanup;
 
 	eventp->ret = ret;
-	eventp->timestamp = bpf_ktime_get_boot_ns();
+	eventp->timestamp_raw = bpf_ktime_get_boot_ns();
 	eventp->uid = (u32)uid_gid;
 	eventp->gid = (u32)(uid_gid >> 32);
-	eventp->sig = vp->sig;
+	eventp->sig_raw = vp->sig;
 	eventp->mntns_id = vp->mntns_id;
 	gadget_submit_buf(ctx, &events, eventp, sizeof(*eventp));
 
@@ -195,12 +195,12 @@ int ig_sig_generate(struct trace_event_raw_signal_generate *ctx)
 	event->pid = pid;
 	event->tpid = tpid;
 	event->mntns_id = mntns_id;
-	event->sig = sig;
+	event->sig_raw = sig;
 	event->ret = ret;
 	event->uid = (u32)uid_gid;
 	event->gid = (u32)(uid_gid >> 32);
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 	return 0;
 }

--- a/gadgets/trace_sni/gadget.yaml
+++ b/gadgets/trace_sni/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event_t:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       description: PID of the process that sent the request
       attributes:

--- a/gadgets/trace_sni/program.bpf.c
+++ b/gadgets/trace_sni/program.bpf.c
@@ -56,7 +56,7 @@
 #define TASK_COMM_LEN 16
 
 struct event_t {
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 
 	gadget_mntns_id mntns_id;
 	gadget_netns_id netns;
@@ -226,7 +226,7 @@ int ig_trace_sni(struct __sk_buff *skb)
 			break;
 		event.name[i] = sni[i];
 	}
-	event.timestamp = bpf_ktime_get_boot_ns();
+	event.timestamp_raw = bpf_ktime_get_boot_ns();
 
 	// Enrich event with process metadata
 	struct sockets_value *skb_val = gadget_socket_lookup(skb);

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -15,15 +15,13 @@ structs:
       description: mount namespace inode id
       attributes:
         template: ns
-    - name: operation
+    - name: operation_raw
       description: type of SSL operations
       attributes:
         width: 16
         alignment: left
         ellipsis: end
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: latency_ns
       attributes:
         template: timestamp

--- a/gadgets/trace_ssl/program.bpf.c
+++ b/gadgets/trace_ssl/program.bpf.c
@@ -47,8 +47,8 @@ enum operation {
 
 struct event {
 	gadget_mntns_id mntns_id;
-	enum operation operation;
-	gadget_timestamp timestamp;
+	enum operation operation_raw;
+	gadget_timestamp timestamp_raw;
 	u64 latency_ns;
 	u32 pid;
 	u32 tid;
@@ -170,8 +170,8 @@ static __always_inline int probe_ssl_rw_exit(struct pt_regs *ctx,
 		goto clean;
 
 	event->mntns_id = ssl_data->mntns_id;
-	event->operation = op;
-	event->timestamp = ts;
+	event->operation_raw = op;
+	event->timestamp_raw = ts;
 	event->latency_ns = ts - ssl_data->start_time;
 	event->pid = pid;
 	event->tid = tid;
@@ -265,8 +265,8 @@ int trace_uretprobe_libssl_SSL_do_handshake(struct pt_regs *ctx)
 		goto clean;
 
 	event->mntns_id = ssl_data->mntns_id;
-	event->operation = libssl_SSL_do_handshake;
-	event->timestamp = ts;
+	event->operation_raw = libssl_SSL_do_handshake;
+	event->timestamp_raw = ts;
 	event->latency_ns = ts - ssl_data->start_time;
 	event->pid = pid_tgid >> 32;
 	event->tid = tid;
@@ -350,8 +350,8 @@ static __always_inline int probe_crypto_exit(struct pt_regs *ctx,
 		goto clean;
 
 	event->mntns_id = crypto_data->mntns_id;
-	event->operation = op;
-	event->timestamp = ts;
+	event->operation_raw = op;
+	event->timestamp_raw = ts;
 	event->latency_ns = ts - crypto_data->start_time;
 	event->pid = pid_tgid >> 32;
 	event->tid = tid;

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       attributes:
         template: pid
@@ -41,7 +39,7 @@ structs:
       description: Network namespace inode id
       attributes:
         template: ns
-    - name: type
+    - name: type_raw
       description: Type of TCP connection event
       attributes:
         width: 16

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -31,12 +31,12 @@ struct event {
 
 	char task[TASK_COMM_LEN];
 	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	__u32 pid;
 	__u32 uid;
 	__u32 gid;
 	gadget_netns_id netns;
-	enum event_type type;
+	enum event_type type_raw;
 };
 
 const volatile uid_t filter_uid = -1;
@@ -146,8 +146,8 @@ static __always_inline void fill_event(struct tuple_key_t *tuple,
 				       __u64 uid_gid, __u16 family, __u8 type,
 				       __u64 mntns_id)
 {
-	event->timestamp = bpf_ktime_get_boot_ns();
-	event->type = type;
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
+	event->type_raw = type;
 	event->pid = pid;
 	event->uid = (__u32)uid_gid;
 	event->gid = (__u32)(uid_gid >> 32);

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: pid
       attributes:
         template: pid

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -38,7 +38,7 @@ struct event {
 	struct gadget_l4endpoint_t dst;
 
 	char task[TASK_COMM_LEN];
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	__u32 pid;
 	__u32 uid;
 	__u32 gid;
@@ -214,7 +214,7 @@ static __always_inline void trace_v4(struct pt_regs *ctx, pid_t pid,
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	event->mntns_id = mntns_id;
 	bpf_get_current_comm(event->task, sizeof(event->task));
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 }
@@ -245,7 +245,7 @@ static __always_inline void trace_v6(struct pt_regs *ctx, pid_t pid,
 		bpf_ntohs(dport); // host expects data in host byte order
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	bpf_get_current_comm(event->task, sizeof(event->task));
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 }
@@ -347,7 +347,7 @@ static __always_inline int handle_tcp_rcv_state_process(void *ctx,
 		BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
 				   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
 	}
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 
 cleanup:

--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: src
       attributes:
         minWidth: 24
@@ -45,7 +43,7 @@ structs:
         width: 16
         alignment: left
         ellipsis: end
-    - name: reason
+    - name: reason_raw
       description: Reason for dropping a packet
       attributes:
         width: 16
@@ -59,7 +57,7 @@ structs:
       description: Mount namespace inode id
       attributes:
         template: ns
-    - name: state
+    - name: state_raw
       description: State of the TCP connection
       attributes:
         width: 16

--- a/gadgets/trace_tcpdrop/program.bpf.c
+++ b/gadgets/trace_tcpdrop/program.bpf.c
@@ -46,10 +46,10 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	gadget_timestamp timestamp;
-	enum tcp_state state;
+	gadget_timestamp timestamp_raw;
+	enum tcp_state state_raw;
 	__u8 tcpflags;
-	enum skb_drop_reason reason;
+	enum skb_drop_reason reason_raw;
 	gadget_netns_id netns;
 
 	// The original gadget has instances of these fields for both process context and
@@ -106,9 +106,9 @@ static __always_inline int __trace_tcp_drop(void *ctx, struct sock *sk,
 	if (!event)
 		return 0;
 
-	event->timestamp = bpf_ktime_get_boot_ns();
-	event->state = BPF_CORE_READ(sk, __sk_common.skc_state);
-	event->reason = reason;
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
+	event->state_raw = BPF_CORE_READ(sk, __sk_common.skc_state);
+	event->reason_raw = reason;
 	bpf_probe_read_kernel(&event->tcpflags, sizeof(event->tcpflags),
 			      &tcphdr->flags);
 

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -10,9 +10,7 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp
-      attributes:
-        template: timestamp
+    - name: timestamp_raw
     - name: src
       attributes:
         minWidth: 24
@@ -55,7 +53,7 @@ structs:
       description: Network namespace inode id
       attributes:
         template: ns
-    - name: type
+    - name: type_raw
       description: Type of the retransmission, either RETRANS or LOSS
       attributes:
         width: 7

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -35,12 +35,12 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	gadget_timestamp timestamp;
+	gadget_timestamp timestamp_raw;
 	__u8 state;
 	__u8 tcpflags;
 	__u32 reason;
 	gadget_netns_id netns;
-	enum type type;
+	enum type type_raw;
 
 	gadget_mntns_id mntns_id;
 	__u32 pid;
@@ -81,8 +81,8 @@ static __always_inline int __trace_tcp_retrans(void *ctx, const struct sock *sk,
 
 	sockp = (struct inet_sock *)sk;
 
-	event->type = type;
-	event->timestamp = bpf_ktime_get_boot_ns();
+	event->type_raw = type;
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
 
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	switch (family) {

--- a/integration/k8s/run_trace_oomkill_test.go
+++ b/integration/k8s/run_trace_oomkill_test.go
@@ -34,15 +34,16 @@ func runTraceOOMKill(t *testing.T, ns string, cmd string) {
 			})
 
 			expectedTraceOOMKillJsonObj := map[string]interface{}{
-				"fpid":      0,
-				"fuid":      0,
-				"fgid":      0,
-				"tpid":      0,
-				"pages":     0,
-				"mntns_id":  0,
-				"timestamp": "",
-				"fcomm":     "",
-				"tcomm":     "tail",
+				"fpid":          0,
+				"fuid":          0,
+				"fgid":          0,
+				"tpid":          0,
+				"pages":         0,
+				"mntns_id":      0,
+				"timestamp":     "",
+				"timestamp_raw": 0,
+				"fcomm":         "",
+				"tcomm":         "tail",
 			}
 
 			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceOOMKillJsonObj)
@@ -63,6 +64,7 @@ func runTraceOOMKill(t *testing.T, ns string, cmd string) {
 				m["pages"] = uint32(0)
 				m["mntns_id"] = 0
 				m["timestamp"] = ""
+				m["timestamp_raw"] = 0
 			}
 
 			ExpectEntriesToMatchObj(t, output, normalize, expectedJsonObj)

--- a/integration/k8s/run_trace_sni_test.go
+++ b/integration/k8s/run_trace_sni_test.go
@@ -34,15 +34,17 @@ func runTraceSni(t *testing.T, ns string, cmd string) {
 			})
 
 			expectedTraceSniJsonObj := map[string]interface{}{
-				"task":      "wget",
-				"name":      "inspektor-gadget.io",
-				"timestamp": "",
-				"pid":       0,
-				"tid":       0,
-				"uid":       1000,
-				"gid":       1111,
-				"mntns_id":  0,
-				"netns":     0,
+				"task":          "wget",
+				"name":          "inspektor-gadget.io",
+				"timestamp":     "",
+				"timestamp_raw": 0,
+
+				"pid":      0,
+				"tid":      0,
+				"uid":      1000,
+				"gid":      1111,
+				"mntns_id": 0,
+				"netns":    0,
 			}
 
 			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceSniJsonObj)
@@ -56,6 +58,7 @@ func runTraceSni(t *testing.T, ns string, cmd string) {
 				SetEventRuntimeContainerName(m, "")
 
 				m["timestamp"] = ""
+				m["timestamp_raw"] = 0
 				m["pid"] = uint32(0)
 				m["tid"] = uint32(0)
 

--- a/integration/k8s/run_trace_tcp_test.go
+++ b/integration/k8s/run_trace_tcp_test.go
@@ -34,18 +34,18 @@ func runTraceTcp(t *testing.T, ns string, cmd string) {
 			})
 
 			expectedTraceTcpJsonObj := map[string]interface{}{
-				"task":      "curl",
-				"timestamp": 0,
-				"src":       "",
-				"dst":       "",
-				"type_str":  "connect",
-				// needed due to type being an enum
-				"type":     0,
-				"pid":      0,
-				"uid":      0,
-				"gid":      0,
-				"mntns_id": 0,
-				"netns":    0,
+				"task":          "curl",
+				"timestamp":     "",
+				"timestamp_raw": 0,
+				"src":           "",
+				"dst":           "",
+				"type":          "connect",
+				"type_raw":      0,
+				"pid":           0,
+				"uid":           0,
+				"gid":           0,
+				"mntns_id":      0,
+				"netns":         0,
 			}
 
 			expectedJsonObj := MergeJsonObjs(t, expectedBaseJsonObj, expectedTraceTcpJsonObj)
@@ -58,7 +58,8 @@ func runTraceTcp(t *testing.T, ns string, cmd string) {
 				SetEventRuntimeContainerID(m, "")
 				SetEventRuntimeContainerName(m, "")
 
-				m["timestamp"] = 0
+				m["timestamp"] = ""
+				m["timestamp_raw"] = 0
 				m["src"] = ""
 				m["dst"] = ""
 				m["pid"] = uint32(0)

--- a/pkg/metadata/v1/metadata.go
+++ b/pkg/metadata/v1/metadata.go
@@ -88,7 +88,7 @@ type Field struct {
 	// Field description
 	Description string `yaml:"description,omitempty"`
 	// Attributes defines how the field should be formatted
-	Attributes FieldAttributes `yaml:"attributes"`
+	Attributes FieldAttributes `yaml:"attributes,omitempty"`
 	// Annotations represents extra information that is not relevant to Inspektor Gadget, but
 	// for other applications, like color font for instance.
 	Annotations map[string]interface{} `yaml:"annotations,omitempty"`

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -111,7 +111,7 @@ func (o *ebpfOperator) InstantiateImageOperator(
 		containers: make(map[string]*containercollection.Container),
 
 		enums:      make(map[string]*btf.Enum),
-		converters: make(map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error),
+		formatters: make(map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error),
 
 		vars: make(map[string]*ebpfVar),
 
@@ -168,7 +168,7 @@ type ebpfInstance struct {
 	containers map[string]*containercollection.Container
 
 	enums      map[string]*btf.Enum
-	converters map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error
+	formatters map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error
 
 	gadgetCtx operators.GadgetContext
 }
@@ -289,7 +289,7 @@ func (i *ebpfInstance) init(gadgetCtx operators.GadgetContext) error {
 		return fmt.Errorf("registering datasources: %w", err)
 	}
 
-	err = i.initConverters(gadgetCtx)
+	err = i.initFormatters(gadgetCtx)
 	if err != nil {
 		return fmt.Errorf("initializing formatters: %w", err)
 	}
@@ -356,11 +356,11 @@ func (i *ebpfInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params
 }
 
 func (i *ebpfInstance) Prepare(gadgetCtx operators.GadgetContext) error {
-	for ds, converters := range i.converters {
-		for _, converter := range converters {
-			converter := converter
+	for ds, formatters := range i.formatters {
+		for _, formatter := range formatters {
+			formatter := formatter
 			ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
-				return converter(ds, data)
+				return formatter(ds, data)
 			}, 0)
 		}
 	}

--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -22,6 +22,11 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
+)
+
+const (
+	enumTargetNameAnnotation = "ebpf.formatter.enum"
 )
 
 func byteSliceAsUint64(in []byte, signed bool, ds datasource.DataSource) uint64 {
@@ -76,7 +81,13 @@ func (i *ebpfInstance) initEnumFormatter(gadgetCtx operators.GadgetContext) erro
 				}
 			}
 
-			out, err := ds.AddField(name+"_str", api.Kind_String)
+			targetName, err := annotations.GetTargetNameFromAnnotation(i.logger, "enum", in, enumTargetNameAnnotation)
+			if err != nil {
+				i.logger.Warnf("Failed to get target name for enum field %q: %v", in.Name(), err)
+				continue
+			}
+
+			out, err := ds.AddField(targetName, api.Kind_String)
 			if err != nil {
 				return err
 			}

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -22,13 +22,16 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/syscalls"
 )
 
@@ -48,6 +51,12 @@ const (
 
 	// Name of the type to store a syscall
 	SyscallTypeName = "gadget_syscall"
+)
+
+const (
+	timestampTargetAnnotation = "formatters.timestamp.target"
+	syscallTargetAnnotation   = "formatters.syscall.target"
+	signalTargetAnnotation    = "formatters.signal.target"
 )
 
 type formattersOperator struct{}
@@ -84,7 +93,7 @@ func (f *formattersOperator) InstantiateDataOperator(gadgetCtx operators.GadgetC
 			}
 			logger.Debugf("> found %d fields for replacer %v", len(fields), r.selectors)
 			for _, field := range fields {
-				replFunc, err := r.replace(ds, field)
+				replFunc, err := r.replace(logger, ds, field)
 				if err != nil {
 					logger.Debugf(">  skipping field %q: %v", field.Name(), err)
 					continue
@@ -126,7 +135,7 @@ type replacer struct {
 	selectors []string
 
 	// replace will be called for incoming data with the source and target fields set
-	replace func(datasource.DataSource, datasource.FieldAccessor) (func(datasource.Data) error, error)
+	replace func(logger.Logger, datasource.DataSource, datasource.FieldAccessor) (func(datasource.Data) error, error)
 
 	// priority to be used when subscribing to the DataSource
 	priority int
@@ -137,18 +146,19 @@ var replacers = []replacer{
 	{
 		name:      "signal",
 		selectors: []string{"type:" + SignalTypeName},
-		replace: func(ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
-			oldName := in.Name()
-
-			if err := in.Rename(oldName + "_raw"); err != nil {
-				return nil, fmt.Errorf("renaming field: %w", err)
-			}
-			in.SetHidden(true, false)
-
-			signalField, err := ds.AddField(oldName, api.Kind_String)
+		replace: func(logger logger.Logger, ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
+			outName, err := annotations.GetTargetNameFromAnnotation(logger, "formatters.signal", in, signalTargetAnnotation)
 			if err != nil {
 				return nil, err
 			}
+
+			signalField, err := ds.AddField(outName, api.Kind_String)
+			if err != nil {
+				return nil, err
+			}
+
+			in.SetHidden(true, false)
+
 			return func(data datasource.Data) error {
 				inBytes := in.Get(data)
 				switch len(inBytes) {
@@ -167,21 +177,23 @@ var replacers = []replacer{
 	{
 		name:      "syscall",
 		selectors: []string{"type:" + SyscallTypeName},
-		replace: func(ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
+		replace: func(logger logger.Logger, ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
 			if in.Type() != api.Kind_Uint64 {
 				return nil, fmt.Errorf("checking field %q: expected uint64", in.Name())
 			}
 
-			oldName := in.Name()
-			if err := in.Rename(oldName + "_raw"); err != nil {
-				return nil, fmt.Errorf("renaming field: %w", err)
-			}
-			in.SetHidden(true, false)
-
-			syscallField, err := ds.AddField(oldName, api.Kind_String)
+			outName, err := annotations.GetTargetNameFromAnnotation(logger, "formatters.syscall", in, syscallTargetAnnotation)
 			if err != nil {
 				return nil, err
 			}
+
+			syscallField, err := ds.AddField(outName, api.Kind_String)
+			if err != nil {
+				return nil, err
+			}
+
+			in.SetHidden(true, false)
+
 			return func(data datasource.Data) error {
 				syscallNumber, err := in.Uint64(data)
 				if err != nil {
@@ -202,27 +214,29 @@ var replacers = []replacer{
 	{
 		name:      "timestamp",
 		selectors: []string{"type:" + TimestampTypeName},
-		replace: func(ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
-			// Read annotations to allow user-defined behavior; this needs to be documented // TODO
-			annotations := in.Annotations()
-
-			// remove reference to old field for backwards compatibility
-			in.RemoveReference(false)
-
+		replace: func(logger logger.Logger, ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
 			timestampFormat := "2006-01-02T15:04:05.000000000Z07:00"
-			if format := annotations["formatters.timestamp.format"]; format != "" {
+			if format := in.Annotations()["formatters.timestamp.format"]; format != "" {
+				logger.Debugf("formatter.timestamp: using custom timestamp format %q for field %q", format, in.Name())
 				timestampFormat = format
 			}
 
-			outName := in.Name()
-			if out := annotations["formatters.timestamp.target"]; out != "" {
-				outName = out
+			outName, err := annotations.GetTargetNameFromAnnotation(logger, "formatters.timestamp", in, timestampTargetAnnotation)
+			if err != nil {
+				return nil, err
 			}
 
-			out, err := ds.AddField(outName, api.Kind_String)
-			if err != nil {
-				return nil, nil
+			opts := []datasource.FieldOption{
+				datasource.WithAnnotations(map[string]string{
+					"columns.template": "timestamp",
+				}),
 			}
+			out, err := ds.AddField(outName, api.Kind_String, opts...)
+			if err != nil {
+				return nil, err
+			}
+
+			in.SetHidden(true, false)
 
 			return func(data datasource.Data) error {
 				inBytes := in.Get(data)
@@ -230,11 +244,20 @@ var replacers = []replacer{
 				default:
 					return nil
 				case 8:
+					var result error
+
 					// TODO: WallTimeFromBootTime() converts too much for this, create a new func that does less
 					correctedTime := gadgets.WallTimeFromBootTime(ds.ByteOrder().Uint64(inBytes))
 					ds.ByteOrder().PutUint64(inBytes, uint64(correctedTime))
 					t := time.Unix(0, int64(correctedTime))
-					return out.Set(data, []byte(t.Format(timestampFormat)))
+					if err := out.Set(data, []byte(t.Format(timestampFormat))); err != nil {
+						multierror.Append(result, err)
+					}
+					if err := in.PutUint64(data, uint64(correctedTime)); err != nil {
+						multierror.Append(result, err)
+					}
+
+					return result
 				}
 			}, nil
 		},
@@ -243,7 +266,7 @@ var replacers = []replacer{
 	{
 		name:      "l3endpoint",
 		selectors: []string{"type:" + L3EndpointTypeName},
-		replace: func(ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
+		replace: func(logger logger.Logger, ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
 			// We do some length checks in here - since we expect the in field to be part of an eBPF struct that
 			// is always sized statically, we can avoid checking the individual entries later on.
 			in.SetHidden(true, false)
@@ -289,7 +312,7 @@ var replacers = []replacer{
 	{
 		name:      "l4endpoint",
 		selectors: []string{"type:" + L4EndpointTypeName},
-		replace: func(ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
+		replace: func(logger logger.Logger, ds datasource.DataSource, in datasource.FieldAccessor) (func(data datasource.Data) error, error) {
 			// We do some length checks in here - since we expect the in field to be part of an eBPF struct that
 			// is always sized statically, we can avoid checking the individual entries later on.
 			in.SetHidden(true, false)

--- a/pkg/utils/annotations/annotations.go
+++ b/pkg/utils/annotations/annotations.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+func GetTargetNameFromAnnotation(
+	logger logger.Logger,
+	logPrefix string,
+	in datasource.FieldAccessor,
+	targetAnnotation string,
+) (string, error) {
+	annotations := in.Annotations()
+
+	if outName, ok := annotations[targetAnnotation]; ok {
+		logger.Debugf("%s: using custom target field %q for field %q", logPrefix, outName, in.Name())
+		return outName, nil
+	}
+
+	if outName, ok := strings.CutSuffix(in.Name(), "_raw"); ok {
+		logger.Debugf("%s: using %q as target field for %q", logPrefix, outName, in.Name())
+		return outName, nil
+	}
+
+	return "", fmt.Errorf("neither %q annotation nor '_raw' suffix found", targetAnnotation)
+}


### PR DESCRIPTION
The current logic of the formatters changes the name of the original field (adding a "_raw" suffix) and creates a new field with the original name.

This behavior is not right as the name and type of the fields depends on the operators being run, hence, it could cause issues when parsing the output of Inspektor Gadget and enabling / disabling the formatters operator.

This commit fixes it by keeping the original name in all the cases. The new name is derived from an annotation on the metadata file.

## Testing 

Columns output prints the pretty version of the fields (sig and timestamp in this example)

```bash 
$ sudo -E ig run trace_signal:latest --verify-image=false
...
RUNTIME.CONTAINERNAME  PID          TPID         MNTNS_ID  UID          GID         RET COMM        SIG         TIMESTAMP
c3                     16770        85763        402653492 0            0           0   sh          SIGTERM     2024-06-17T09:40:55.4905
```

Raw fields are also available in the json output: 

```bash 
$ sudo -E ig run trace_signal:latest --verify-image=false -o json | jq
...
{
  "comm": "sh",
  "gid": 0,
  "k8s": {
    "containerName": "",
    "hostnetwork": false,
    "namespace": "",
    "node": "",
    "podName": ""
  },
  "mntns_id": 4026534922,
  "pid": 16770,
  "ret": 0,
  "runtime": {
    "containerId": "67df57854c8dd52b766560725f3daec0a2bc423f00875f58f1197ca3b34a68f5",
    "containerImageDigest": "",
    "containerImageName": "busybox",
    "containerName": "c3",
    "runtimeName": "docker"
  },
  "sig": "SIGTERM",
  "sig_raw": 15,
  "timestamp": "2024-06-17T09:41:44.057569398-05:00",
  "timestamp_raw": 1718635304057569300,
  "tpid": 85846,
  "uid": 0
}
```

## Discussions

### `_raw` suffix 

@alban suggested to use a `_raw` suffix and automatically trim it from the operators. It's good because avoids having to specify the annotation, but I don't like having this "magic" behavior, so this PR always use the annotation. Should I implement the raw suffic support too?

## TODO

- [ ] Future PR: Carry on annotations, attributes, description to created field

- Ref #3020
- Ref #2816 (Fixes part of it, however {l3,l4}endpoints are still TBD in another PR) 

