### PR TITLE
pkg/gadgets/capabilities: fix pid and tgid fields

### DIFF
--- a/pkg/gadgets/trace/capabilities/tracer/bpf/capable.bpf.c
+++ b/pkg/gadgets/trace/capabilities/tracer/bpf/capable.bpf.c
@@ -178,8 +178,8 @@ int BPF_KRETPROBE(ig_trace_cap_x)
 	event.current_userns = ap->current_userns;
 	event.target_userns = ap->target_userns;
 	event.cap_effective = ap->cap_effective;
-	event.pid = pid_tgid >> 32;
-	event.tgid = pid_tgid;
+	event.pid = pid_tgid;
+	event.tgid = pid_tgid >> 32;
 	event.cap = ap->cap;
 	event.uid = (u32)uid_gid;
 	event.gid = (u32)(uid_gid >> 32);


### PR DESCRIPTION
# pkg/gadgets/capabilities: fix pid and tgid fields

The `bpf_get_current_pid_tgid` helper returns `tgid << 32 | pid`, so:
```
event.pid = (u32)pid_tgid;
event.tgid = pid_tgid >> 32;
```

git blame: fbc8f659aaf215d5ffb9