### PR TITLE
pkg/oci: Remove undeeded authOpts for getSigningInformation().

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -638,7 +638,7 @@ func getImageDigest(ctx context.Context, store *oci.Store, imageRef string) (str
 	return desc.Digest.String(), nil
 }
 
-func getSigningInformation(ctx context.Context, repo *remote.Repository, imageDigest string, authOpts *AuthOptions) ([]byte, []byte, error) {
+func getSigningInformation(ctx context.Context, repo *remote.Repository, imageDigest string) ([]byte, []byte, error) {
 	signatureTag, err := craftSignatureTag(imageDigest)
 	if err != nil {
 		return nil, nil, fmt.Errorf("crafting signature tag: %w", err)
@@ -716,7 +716,7 @@ func verifyImage(ctx context.Context, image string, imgOpts *ImageOptions) error
 		return fmt.Errorf("creating repository: %w", err)
 	}
 
-	signatureBytes, payloadBytes, err := getSigningInformation(ctx, repo, imageDigest, &imgOpts.AuthOptions)
+	signatureBytes, payloadBytes, err := getSigningInformation(ctx, repo, imageDigest)
 	if err != nil {
 		return fmt.Errorf("getting signing information: %w", err)
 	}


### PR DESCRIPTION
This parameter was never used.

Fixes: 9f17b006486e ("pkg/oci: Add new options to check image was signed with given public key.")