### PR TITLE
ci: Use westeurope for AKS.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1602,10 +1602,7 @@ jobs:
         # GitHub Action.
         az extension add --name aks-preview
 
-        # Let's keep thing in the US to avoid data crossing the Atlantic as
-        # GitHub data centers are in the US:
-        # https://github.blog/2017-10-12-evolution-of-our-data-centers/
-        az aks create -l eastus -g ${AZURE_AKS_RESOURCE_GROUP} -n ${{ env.CLUSTER_NAME }} -s $node_size --os-sku ${{ matrix.os-sku }} --no-ssh-key
+        az aks create -l westeurope -g ${AZURE_AKS_RESOURCE_GROUP} -n ${{ env.CLUSTER_NAME }} -s $node_size --os-sku ${{ matrix.os-sku }} --no-ssh-key
     - uses: azure/aks-set-context@v4
       name: Set AKS cluster ${{ env.CLUSTER_NAME }} context
       with:


### PR DESCRIPTION
The VM are not avalaible in eastus:

Let's use westeurope for the moment.