### PR TITLE
gadgets/ports: Convert to host endianess inside the gadget

### DIFF
--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -131,10 +131,12 @@ static __always_inline bool fill_tuple(struct tuple_key_t *tuple,
 	}
 
 	BPF_CORE_READ_INTO(&tuple->dst.port, sk, __sk_common.skc_dport);
+	tuple->dst.port = bpf_ntohs(tuple->dst.port);
 	if (tuple->dst.port == 0)
 		return false;
 
 	BPF_CORE_READ_INTO(&tuple->src.port, sockp, inet_sport);
+	tuple->src.port = bpf_ntohs(tuple->src.port);
 	if (tuple->src.port == 0)
 		return false;
 
@@ -378,7 +380,6 @@ int BPF_KRETPROBE(ig_tcp_accept, struct sock *sk)
 	sport = BPF_CORE_READ(sk, __sk_common.skc_num);
 
 	fill_tuple(&t, sk, family);
-	t.src.port = bpf_ntohs(sport);
 	/* do not send event if IP address is 0.0.0.0 or port is 0 */
 	if (__builtin_memcmp(t.src.l3.addr.v6, ip_v6_zero,
 			     sizeof(t.src.l3.addr.v6)) == 0 ||

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -209,8 +209,7 @@ static __always_inline void trace_v4(struct pt_regs *ctx, pid_t pid,
 	BPF_CORE_READ_INTO(&event->src.l3.addr.v4, sk,
 			   __sk_common.skc_rcv_saddr);
 	BPF_CORE_READ_INTO(&event->dst.l3.addr.v4, sk, __sk_common.skc_daddr);
-	event->dst.port =
-		bpf_ntohs(dport); // host expects data in host byte order
+	event->dst.port = dport;
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	event->mntns_id = mntns_id;
 	bpf_get_current_comm(event->task, sizeof(event->task));
@@ -241,8 +240,7 @@ static __always_inline void trace_v6(struct pt_regs *ctx, pid_t pid,
 			   __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
 	BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
 			   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
-	event->dst.port =
-		bpf_ntohs(dport); // host expects data in host byte order
+	event->dst.port = dport;
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	bpf_get_current_comm(event->task, sizeof(event->task));
 	event->timestamp = bpf_ktime_get_boot_ns();
@@ -270,7 +268,7 @@ static __always_inline int exit_tcp_connect(struct pt_regs *ctx, int ret,
 
 	sk = *skpp;
 
-	BPF_CORE_READ_INTO(&dport, sk, __sk_common.skc_dport);
+	dport = bpf_ntohs(BPF_CORE_READ(sk, __sk_common.skc_dport));
 	if (filter_port(dport))
 		goto end;
 

--- a/gadgets/trace_tcpdrop/program.bpf.c
+++ b/gadgets/trace_tcpdrop/program.bpf.c
@@ -112,11 +112,11 @@ static __always_inline int __trace_tcp_drop(void *ctx, struct sock *sk,
 	bpf_probe_read_kernel(&event->tcpflags, sizeof(event->tcpflags),
 			      &tcphdr->flags);
 
-	BPF_CORE_READ_INTO(&event->dst.port, sk, __sk_common.skc_dport);
+	event->dst.port = bpf_ntohs(BPF_CORE_READ(sk, __sk_common.skc_dport));
 	if (event->dst.port == 0)
 		goto cleanup;
 
-	BPF_CORE_READ_INTO(&event->src.port, sockp, inet_sport);
+	event->src.port = bpf_ntohs(BPF_CORE_READ(sockp, inet_sport));
 	if (event->src.port == 0)
 		goto cleanup;
 

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -15,7 +15,6 @@
 package formatters
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
@@ -317,7 +316,7 @@ var replacers = []replacer{
 				return nil, fmt.Errorf("adding string field: %w", err)
 			}
 			return func(entry datasource.Data) error {
-				port := binary.BigEndian.Uint16(ports[0].Get(entry))
+				port, _ := ports[0].Uint16(entry)
 				out.Set(entry, []byte(fmt.Sprintf("%s:%d", string(l3strings[0].Get(entry)), port)))
 				return nil
 			}, nil


### PR DESCRIPTION
We need to make sure that the network to host endianess conversion is done only once. Before this PR it was sometimes done inside the eBPF and additionally in userspace -> swapping twice == doing nothing

The variable type inside the event struct is `__u16`, which indicates a "normal" `uint16`. If we want to handle the endianess swap in userspace it would be benefitial to mark it as `__be16` to mark these variables explicitly to be big endian (network endian)

This PR is a quick fix to resolve the bugs. Introduction of `__u16` and its handling in userspace should be done in another PR.

Please check if I found all spots. I went over the gadgets multiple times and checked if the corresponding linux variables are `__u16` or `__be16`. The `trace dns` gadget was not intuitive for me to check so I left it alone

Discussion: https://kubernetes.slack.com/archives/CSYL75LF6/p1716912609099669?thread_ts=1716909341.055269&cid=CSYL75LF6