### PR TITLE
ig/build: Always pull builder-image if latest tag is used

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -277,15 +277,18 @@ func ensureBuilderImage(ctx context.Context, cli *client.Client, builderImage st
 	f := filters.NewArgs()
 	f.Add("reference", builderImage)
 
-	images, err := cli.ImageList(ctx, image.ListOptions{Filters: f})
-	if err != nil {
-		return fmt.Errorf("listing images: %w", err)
-	}
+	// For :latest we always want to have the newest image that is available upstream
+	if !strings.HasSuffix(builderImage, ":latest") {
+		images, err := cli.ImageList(ctx, image.ListOptions{Filters: f})
+		if err != nil {
+			return fmt.Errorf("listing images: %w", err)
+		}
 
-	for _, img := range images {
-		for _, tag := range img.RepoTags {
-			if tag == builderImage {
-				return nil
+		for _, img := range images {
+			for _, tag := range img.RepoTags {
+				if tag == builderImage {
+					return nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# ig/build: Always pull builder-image if latest tag is used

I had an older builder image on my system and then tried to compile new gadgets. It failed to compile since the builder image was too old.

I think when specifying `:latest` as a tag we should always check upstream to get the newest version.
WDYT?