### PR TITLE
tests: Disable TestTraceNetwork on cri-o

### DIFF
--- a/integration/k8s/trace_network_test.go
+++ b/integration/k8s/trace_network_test.go
@@ -26,6 +26,10 @@ import (
 )
 
 func TestTraceNetwork(t *testing.T) {
+	if containerRuntime == ContainerRuntimeCRIO {
+		t.Skipf("Skip running trace network test for %q runtime. See issue #2358", containerRuntime)
+	}
+
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-network")
 


### PR DESCRIPTION
This test is failing a lot (see issue #2358), creating a lot of noise and forcing us to rerun the CI multiple times.

It's not ideal to disable a failing test, but it's better than wasting a lot of time rerunning the CI. We'll keep the issue for fixing it once we have time.

https://inspektor-gadget.github.io/ig-test-reports/ shows how many times this test is failing, look for test-integration-k8s-ig_cri-o and then for TestTraceNetwork.