### PR TITLE
Fix codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,7 +80,7 @@
 /pkg/standardgadgets/ @mauriciovasquezbernal
 /pkg/tracer-collection/ @alban
 /pkg/types/ @blanquicet
-/pkg/uprobetracer/ @alban @i-Pear
+/pkg/uprobetracer/ @alban
 /pkg/utils/bpf-iter-ns/ @alban
 /pkg/utils/host/ @alban
 /tools/ @mqasimsarfraz


### PR DESCRIPTION
Only users with write access to the repository can be codeowners [0].

Fixes: a551d7a7e1ec ("pkg: introduce new package uprobetracer for auto attach/detach")

[0]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

--- 

Detected it because github was printing a warning when looking at https://github.com/inspektor-gadget/inspektor-gadget/blob/main/CODEOWNERS
