### PR TITLE
pkg/operators: Add combiner

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -30,6 +30,7 @@ import (
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
@@ -116,7 +117,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 				}
 				ops = append(ops, op)
 			}
-			ops = append(ops, clioperator.CLIOperator)
+			ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator)
 
 			gadgetCtx := gadgetcontext.New(
 				context.Background(),
@@ -181,7 +182,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			for _, op := range operators.GetDataOperators() {
 				ops = append(ops, op)
 			}
-			ops = append(ops, clioperator.CLIOperator)
+			ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator)
 
 			timeoutDuration := time.Duration(timeoutSeconds) * time.Second
 

--- a/gadgets/snapshot_process/test/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/snapshot_process_test.go
@@ -108,8 +108,7 @@ func TestSnapshotProcess(t *testing.T) {
 				utils.NormalizeInt(&e.Ppid)
 			}
 
-			// TODO: Use match.JSONSingleArrayMode once the combiner operator is implemented
-			match.MatchEntries(t, match.JSONMultiArrayMode, output, normalize, expectedEntry)
+			match.MatchEntries(t, match.JSONSingleArrayMode, output, normalize, expectedEntry)
 		},
 	))
 

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -218,6 +218,8 @@ func NewFromAPI(in *api.DataSource) (DataSource, error) {
 	} else {
 		ds.byteOrder = binary.LittleEndian
 	}
+	ds.tags = in.Tags
+	ds.annotations = in.Annotations
 	// TODO: add more checks / validation
 	return ds, nil
 }

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -176,6 +176,7 @@ func newDataSource(t Type, name string, options ...DataSourceOption) (*dataSourc
 		name:            name,
 		dType:           t,
 		requestedFields: make(map[string]bool),
+		requested:       true,
 		fieldMap:        make(map[string]*field),
 		byteOrder:       binary.NativeEndian,
 		tags:            make([]string, 0),
@@ -714,6 +715,12 @@ func (ds *dataSource) Accessors(rootOnly bool) []FieldAccessor {
 		})
 	}
 	return res
+}
+
+func (ds *dataSource) SetRequested(v bool) {
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	ds.requested = v
 }
 
 func (ds *dataSource) IsRequested() bool {

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -166,6 +166,7 @@ type DataSource interface {
 
 	Accessors(rootOnly bool) []FieldAccessor
 
+	SetRequested(bool)
 	IsRequested() bool
 
 	// ByteOrder returns a binary accessor using the byte order of the creator of the DataSource

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -177,6 +177,8 @@ type DataSource interface {
 
 	Annotations() map[string]string
 	Tags() []string
+
+	CopyFieldsTo(DataSource) error
 }
 
 type DataSourceOption func(*dataSource)

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -317,7 +317,18 @@ func (c *GadgetContext) LoadGadgetInfo(info *api.GadgetInfo, paramValues api.Par
 	}
 
 	if run {
-		go c.run(localOperators)
+		if err := c.start(localOperators); err != nil {
+			return fmt.Errorf("starting local operators: %w", err)
+		}
+
+		c.Logger().Debugf("running...")
+
+		go func() {
+			// TODO: Client shouldn't need to wait for the timeout. It should be
+			// managed only on the server side.
+			WaitForTimeoutOrDone(c)
+			c.stop(localOperators)
+		}()
 	}
 
 	return nil

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -212,10 +212,26 @@ func (c *GadgetContext) RegisterDataSource(t datasource.Type, name string) (data
 	return ds, nil
 }
 
-func (c *GadgetContext) GetDataSources() map[string]datasource.DataSource {
+func (c *GadgetContext) getDataSources(all bool) map[string]datasource.DataSource {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	return maps.Clone(c.dataSources)
+
+	ret := maps.Clone(c.dataSources)
+	for name, ds := range ret {
+		// Don't forward unrequested data sources if all is false
+		if !all && !ds.IsRequested() {
+			delete(ret, name)
+		}
+	}
+	return ret
+}
+
+func (c *GadgetContext) GetDataSources() map[string]datasource.DataSource {
+	return c.getDataSources(false)
+}
+
+func (c *GadgetContext) GetAllDataSources() map[string]datasource.DataSource {
+	return c.getDataSources(true)
 }
 
 func (c *GadgetContext) SetVar(varName string, value any) {

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -34,6 +34,10 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		return ops[i].Priority() < ops[j].Priority()
 	})
 
+	for _, op := range ops {
+		log.Debugf("operator %q has priority %d", op.Name(), op.Priority())
+	}
+
 	params := make([]*api.Param, 0)
 
 	dataOperatorInstances := make([]operators.DataOperatorInstance, 0, len(ops))

--- a/pkg/gadget-service/api/consts.go
+++ b/pkg/gadget-service/api/consts.go
@@ -68,3 +68,8 @@ const (
 	// TagSrcEbpf defines that a field was extracted from eBPF
 	TagSrcEbpf = "src:ebpf"
 )
+
+const (
+	FetchCountAnnotation    = "fetch-count"
+	FetchIntervalAnnotation = "fetch-interval"
+)

--- a/pkg/operators/combiner/combiner.go
+++ b/pkg/operators/combiner/combiner.go
@@ -1,0 +1,316 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package combiner is a data operator that combines data from a same data
+// source coming from different targets into a single data source. This is
+// useful when we run the same gadget in a distributed environment like
+// Kubernetes and we want to combine the data from all the nodes on the client
+// side so that we can perform further operations on the combined data, e.g.
+// sorting. Notice that this operator is useful only when we have data sources
+// of type array.
+package combiner
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
+)
+
+const (
+	// We need it to be the first operator to run in client side. Only operators
+	// registering data sources should run before the combiner operator.
+	Priority         = -500
+	DataSourcePrefix = "combined"
+	OperatorName     = "Combiner"
+)
+
+type combinerOperator struct{}
+
+func (o *combinerOperator) Name() string {
+	return OperatorName
+}
+
+func (o *combinerOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (o *combinerOperator) GlobalParams() api.Params {
+	return nil
+}
+
+func (o *combinerOperator) InstanceParams() api.Params {
+	return nil
+}
+
+func getFetchAnnotation(ds datasource.DataSource) (time.Duration, error) {
+	intervalAnn, ok := ds.Annotations()[api.FetchIntervalAnnotation]
+	if !ok {
+		return 0, errors.New("missing fetch interval annotation")
+	}
+	fetchInterval, err := time.ParseDuration(intervalAnn)
+	if err != nil {
+		return 0, fmt.Errorf("parsing fetch interval annotation to duration: %w", err)
+	}
+	return fetchInterval, nil
+}
+
+func (o *combinerOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, paramValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	targetsVar, ok := gadgetCtx.GetVar(runtime.NumRunTargets)
+	if !ok {
+		gadgetCtx.Logger().Debugf("combiner: No targets found. Skipping combiner operator")
+		return nil, nil
+	}
+
+	targets, ok := targetsVar.(int)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for number of targets: %T, expected \"int\"", targetsVar)
+	}
+
+	if targets == 0 {
+		return nil, nil
+	}
+
+	configs := make(map[datasource.DataSource]*combinerConfig)
+	for _, ds := range gadgetCtx.GetDataSources() {
+		if ds.Type() == datasource.TypeArray {
+			interval, err := getFetchAnnotation(ds)
+			if err != nil {
+				return nil, fmt.Errorf("getting fetch annotation for ds %s: %w", ds.Name(), err)
+			}
+
+			configs[ds] = &combinerConfig{
+				// TODO: What happen if we receive more than one packet for the same
+				// target? We should probably have a way to handle this case.
+				packetBuf: make(chan datasource.PacketArray, targets),
+				interval:  interval,
+			}
+		}
+	}
+
+	if len(configs) != 0 {
+		gadgetCtx.Logger().Debugf("combiner: array data sources found (%d). Activating combiner operator", len(configs))
+		return &combinerOperatorInstance{
+			targets: targets,
+			configs: configs,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (o *combinerOperator) Priority() int {
+	return Priority
+}
+
+type combinerConfig struct {
+	// Interval to wait for data before emitting the combined data
+	interval time.Duration
+
+	// Buffer to send data to the combiner data source
+	packetBuf chan datasource.PacketArray
+}
+
+type combinerOperatorInstance struct {
+	// Number of targets to (ideally) wait for before emitting the combined data
+	targets int
+
+	configs map[datasource.DataSource]*combinerConfig
+
+	done chan struct{}
+}
+
+func (o *combinerOperatorInstance) Name() string {
+	return OperatorName
+}
+
+func (o *combinerOperatorInstance) InstanceParams() params.ParamDescs {
+	return nil
+}
+
+func (o *combinerOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params {
+	return nil
+}
+
+func (o *combinerOperatorInstance) forwardData(
+	gadgetCtx operators.GadgetContext,
+	config *combinerConfig,
+	combinedDs datasource.DataSource,
+) {
+	combinedPacket, err := combinedDs.NewPacketArray()
+	if err != nil {
+		gadgetCtx.Logger().Debugf("combiner: failed to create new packet array: %s", err)
+		return
+	}
+	defer func() {
+		if combinedPacket != nil {
+			combinedDs.Release(combinedPacket)
+		}
+	}()
+
+	targetCount := 0
+
+	var c <-chan time.Time
+
+	if config.interval == 0 {
+		// Define a maximum waiting time for data from all targets
+		// TODO: Make it configurable?
+		timeout := time.NewTimer(5 * time.Second)
+		defer timeout.Stop()
+		c = timeout.C
+	} else {
+		// Even if we receive data from all targets, we emit the combined data
+		// only after the requested interval
+		ticker := time.NewTicker(config.interval)
+		defer ticker.Stop()
+		c = ticker.C
+	}
+
+	emitAndAllocate := func() error {
+		if err := combinedDs.EmitAndRelease(combinedPacket); err != nil {
+			gadgetCtx.Logger().Errorf("Failed emitting data array for ds combiner %q: %s",
+				combinedDs.Name(), err)
+		}
+
+		// Allocate a new packet array for next iteration
+		combinedPacket, err = combinedDs.NewPacketArray()
+		if err != nil {
+			// We can't continue without a new packet array
+			return fmt.Errorf("creating new packet array: %w", err)
+		}
+
+		targetCount = 0
+		return nil
+	}
+
+	for {
+		select {
+		case <-o.done:
+			gadgetCtx.Logger().Debugf("combiner: done with %q", combinedDs.Name())
+			return
+		case inPacket := <-config.packetBuf:
+			targetCount++
+
+			// TODO: Support Append multiple packets at once?
+			for i := 0; i < inPacket.Len(); i++ {
+				combinedPacket.Append(inPacket.Get(i))
+			}
+
+			// For data sources that don't have an interval, we wait for data
+			// from all targets before emitting the combined data.
+			if config.interval == 0 && targetCount == o.targets {
+				if err := emitAndAllocate(); err != nil {
+					gadgetCtx.Logger().Errorf("Failed emitting and allocating combined data: %s", err)
+				}
+				return
+			}
+		case <-c:
+			if config.interval == 0 {
+				gadgetCtx.Logger().Warnf("Data is incomplete: timeout waiting for data from all targets (%d/%d)",
+					targetCount, o.targets)
+
+				if err := emitAndAllocate(); err != nil {
+					gadgetCtx.Logger().Errorf("Failed emitting and allocating combined data: %s", err)
+					return
+				}
+
+				return
+			}
+
+			if err := emitAndAllocate(); err != nil {
+				gadgetCtx.Logger().Errorf("Failed emitting and allocating combined data: %s", err)
+				return
+			}
+		}
+	}
+}
+
+func (o *combinerOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	o.done = make(chan struct{})
+
+	for ds, config := range o.configs {
+		// Disable original data source to avoid other operators subscribing to it
+		ds.SetRequested(false)
+
+		// Register a new data source that will emit the combined data
+		combinedDs, err := gadgetCtx.RegisterDataSource(
+			datasource.TypeArray,
+			fmt.Sprintf("%s-%s", DataSourcePrefix, ds.Name()),
+		)
+		if err != nil {
+			return fmt.Errorf("registering combiner data source for %s: %w", ds.Name(), err)
+		}
+
+		gadgetCtx.Logger().Debugf("combiner: registered ds %q", combinedDs.Name())
+
+		// Use the same fields and annotations as the original data source
+		ds.CopyFieldsTo(combinedDs)
+		for k, v := range ds.Annotations() {
+			combinedDs.AddAnnotation(k, v)
+		}
+
+		go o.forwardData(gadgetCtx, config, combinedDs)
+
+		gadgetCtx.Logger().Debugf("combiner: subscribing to %q", ds.Name())
+
+		ds.SubscribePacket(func(source datasource.DataSource, packet datasource.Packet) error {
+			// Avoid keeping a reference to the original packet as it will be
+			// released once the callback returns. Use Marshal/Unmarshal to
+			// create a deep copy.
+			b, _ := proto.Marshal(packet.Raw())
+			pArray, err := combinedDs.NewPacketArrayFromRaw(b)
+			if err != nil {
+				return fmt.Errorf("creating packet array from raw: %w", err)
+			}
+
+			// Send the packet to the combiner data source
+			config.packetBuf <- pArray
+
+			return nil
+		}, Priority)
+	}
+
+	return nil
+}
+
+func (o *combinerOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (o *combinerOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	if o.done != nil {
+		close(o.done)
+		o.done = nil
+	}
+	// TODO: Don't close the buffers here. We need to find a way to synchronize
+	// the closing of the buffers with the data source still emitting data.
+	// if o.pktBuffers != nil {
+	//  for _, buf := range o.pktBuffers {
+	//      if buf != nil {
+	//          close(buf)
+	//      }
+	//  }
+	//  o.pktBuffers = nil
+	// }
+	return nil
+}
+
+var CombinerOperator = &combinerOperator{}

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -374,6 +374,11 @@ func (i *ebpfInstance) register(gadgetCtx operators.GadgetContext) error {
 
 		m.accessor = accessor
 		m.ds = ds
+
+		// Configure fetch-count and fetch-interval annotations to make the
+		// combiner operator handle the data correctly
+		// TODO: Make this configurable
+		m.ds.AddAnnotation(api.FetchIntervalAnnotation, "0")
 	}
 	for name, m := range i.mapIters {
 		fields := make([]*Field, 0)

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -136,8 +136,8 @@ func (i *ebpfInstance) evaluateMapParams(paramValues api.ParamValues) error {
 		if iter.count == 0 {
 			iter.count = globalCount
 		}
-		iter.ds.AddAnnotation("fetch-count", fmt.Sprintf("%d", iter.count))
-		iter.ds.AddAnnotation("fetch-interval", iter.interval.String())
+		iter.ds.AddAnnotation(api.FetchCountAnnotation, fmt.Sprintf("%d", iter.count))
+		iter.ds.AddAnnotation(api.FetchIntervalAnnotation, iter.interval.String())
 	}
 	return nil
 }

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -75,6 +75,9 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext, runtimeParams *para
 	if err != nil {
 		return fmt.Errorf("getting target nodes: %w", err)
 	}
+
+	gadgetCtx.SetVar(runtime.NumRunTargets, len(targets))
+
 	_, err = r.runGadgetOnTargets(gadgetCtx, paramValues, targets)
 	return err
 }

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -215,9 +215,13 @@ func (r *Runtime) runGadget(gadgetCtx runtime.GadgetContext, target target, allP
 					continue
 				}
 				gadgetCtx.Logger().Debugf("loaded gadget info")
-				for _, ds := range gadgetCtx.GetDataSources() {
+				for _, ds := range gadgetCtx.GetAllDataSources() {
 					gadgetCtx.Logger().Debugf("registered ds %s", ds.Name())
-					dsMap[dsNameMap[ds.Name()]] = ds
+					if dsId, ok := dsNameMap[ds.Name()]; ok {
+						dsMap[dsId] = ds
+					} else {
+						gadgetCtx.Logger().Debugf("datasource %s not found in gadget info", ds.Name())
+					}
 				}
 				initialized = true
 			default:

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -46,6 +46,7 @@ type GadgetContext interface {
 	ImageName() string
 	RegisterDataSource(datasource.Type, string) (datasource.DataSource, error)
 	GetDataSources() map[string]datasource.DataSource
+	GetAllDataSources() map[string]datasource.DataSource
 	SetVar(string, any)
 	GetVar(string) (any, bool)
 	SerializeGadgetInfo() (*api.GadgetInfo, error)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -29,6 +29,11 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
+const (
+	// NumRunTargets is the number of targets that the gadget will run on
+	NumRunTargets = "n-run-targets"
+)
+
 type GadgetContext interface {
 	ID() string
 	Parser() parser.Parser


### PR DESCRIPTION
# Adding combiner operator

This PR introduces a new operator named "combiner". Only for `TypeArray` datasources, this operator will be in charge of merging outcomes from all targets into a single array on the client side.

## Implementation details

- The combiner operator will activate itself only if:
  - Gadget is run against more than one single target. For instance, it'll never get activated for `ig` used as standalone (without `gadgetctl`).
  - There is at least one `TypeArray` datasources. **NOTE**: From now on, this documentation will assume that the datasources are `TypeArray`.
- The combiner operator requires the datasource to be annotated with `FetchIntervalAnnotation`, which is expected to be `time.Duration` type and is used as following:
  - If `FetchIntervalAnnotation` is 0, the combiner operator will emit a packet once it has received packets from all the targets (A maximum waiting time of 5 seconds has be hardcoded (Make it configurable?). 
  - Instead, if `FetchIntervalAnnotation` is greater than 0, the combiner operator will emit a packet once the timer is triggered, no matter it has received data from all targets or not.
  - The combiner operator is not currently using the `FetchCountAnnotation` and it relies on the server to close the datasource once done (Still to be implemented cc @flyth).
- The combiner operator is configured to have the highest priority on the client side. It is because, during the `PreStart` phase, the combiner operator will modify the datasources to force other operators on client side to subscribe to the datasource created by the combiner operator (From now on, called "combined-datasource") and not to the original ones coming from the server. The idea with this modification is that the combiner operator will subscribe to the original datasources and receive packets from each target separately, while it will emit one single packet on the combined-datasource only once it has received packets from all targets or timeout has been reached (This can be configured using `FetchIntervalAnnotation` as described above). Doing so, the rest of operators running on the server side will receive a packet where data from all nodes has already been combined, so they can sort, print and do any operation on the aggregated data arrays.