### PR TITLE
Improve endpoints formatter

### DIFF
--- a/gadgets/snapshot_socket/program.bpf.c
+++ b/gadgets/snapshot_socket/program.bpf.c
@@ -94,16 +94,16 @@ socket_bpf_seq_write(struct seq_file *seq, __u16 family, __u16 proto,
 
 	switch (family) {
 	case AF_INET:
-		entry.src.l3.version = entry.dst.l3.version = 4;
-		entry.src.l3.addr.v4 = src_v4;
-		entry.dst.l3.addr.v4 = dest_v4;
+		entry.src.version = entry.dst.version = 4;
+		entry.src.addr_raw.v4 = src_v4;
+		entry.dst.addr_raw.v4 = dest_v4;
 		break;
 	case AF_INET6:
-		entry.src.l3.version = entry.dst.l3.version = 6;
-		bpf_probe_read_kernel(&entry.dst.l3.addr.v6,
-				      sizeof(entry.dst.l3.addr.v6), dest_v6);
-		bpf_probe_read_kernel(&entry.src.l3.addr.v6,
-				      sizeof(entry.src.l3.addr.v6), src_v6);
+		entry.src.version = entry.dst.version = 6;
+		bpf_probe_read_kernel(&entry.dst.addr_raw.v6,
+				      sizeof(entry.dst.addr_raw.v6), dest_v6);
+		bpf_probe_read_kernel(&entry.src.addr_raw.v6,
+				      sizeof(entry.src.addr_raw.v6), src_v6);
 		break;
 	default:
 		return;

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -282,16 +282,16 @@ static __always_inline int output_dns_event(struct __sk_buff *skb,
 		goto out;
 	event->id = bpf_ntohs(event->id);
 
-	event->src.l3.version = event->dst.l3.version = 4;
+	event->src.version = event->dst.version = 4;
 	err = bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct iphdr, daddr),
-				 &event->dst.l3.addr.v4,
-				 sizeof(event->dst.l3.addr.v4));
+				 &event->dst.addr_raw.v4,
+				 sizeof(event->dst.addr_raw.v4));
 	if (err < 0)
 		goto out;
 
 	err = bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct iphdr, saddr),
-				 &event->src.l3.addr.v4,
-				 sizeof(event->src.l3.addr.v4));
+				 &event->src.addr_raw.v4,
+				 sizeof(event->src.addr_raw.v4));
 	if (err < 0)
 		goto out;
 

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -205,11 +205,11 @@ static __always_inline void trace_v4(struct pt_regs *ctx, pid_t pid,
 	event->pid = pid;
 	event->uid = (u32)uid_gid;
 	event->gid = (u32)(uid_gid >> 32);
-	event->src.l3.version = event->dst.l3.version = 4;
+	event->src.version = event->dst.version = 4;
 	event->src.proto = event->dst.proto = IPPROTO_TCP;
-	BPF_CORE_READ_INTO(&event->src.l3.addr.v4, sk,
+	BPF_CORE_READ_INTO(&event->src.addr_raw.v4, sk,
 			   __sk_common.skc_rcv_saddr);
-	BPF_CORE_READ_INTO(&event->dst.l3.addr.v4, sk, __sk_common.skc_daddr);
+	BPF_CORE_READ_INTO(&event->dst.addr_raw.v4, sk, __sk_common.skc_daddr);
 	event->dst.port = dport;
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	event->mntns_id = mntns_id;
@@ -236,11 +236,11 @@ static __always_inline void trace_v6(struct pt_regs *ctx, pid_t pid,
 	event->uid = (u32)uid_gid;
 	event->gid = (u32)(uid_gid >> 32);
 	event->mntns_id = mntns_id;
-	event->src.l3.version = event->dst.l3.version = 6;
+	event->src.version = event->dst.version = 6;
 	event->src.proto = event->dst.proto = IPPROTO_TCP;
-	BPF_CORE_READ_INTO(&event->src.l3.addr.v6, sk,
+	BPF_CORE_READ_INTO(&event->src.addr_raw.v6, sk,
 			   __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-	BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
+	BPF_CORE_READ_INTO(&event->dst.addr_raw.v6, sk,
 			   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
 	event->dst.port = dport;
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
@@ -333,17 +333,17 @@ static __always_inline int handle_tcp_rcv_state_process(void *ctx,
 	event->src.proto = event->dst.proto = IPPROTO_TCP;
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	if (family == AF_INET) {
-		event->src.l3.version = event->dst.l3.version = 4;
-		event->src.l3.addr.v4 =
+		event->src.version = event->dst.version = 4;
+		event->src.addr_raw.v4 =
 			BPF_CORE_READ(sk, __sk_common.skc_rcv_saddr);
-		event->dst.l3.addr.v4 =
+		event->dst.addr_raw.v4 =
 			BPF_CORE_READ(sk, __sk_common.skc_daddr);
 	} else {
-		event->src.l3.version = event->dst.l3.version = 6;
+		event->src.version = event->dst.version = 6;
 		BPF_CORE_READ_INTO(
-			&event->src.l3.addr.v6, sk,
+			&event->src.addr_raw.v6, sk,
 			__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-		BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
+		BPF_CORE_READ_INTO(&event->dst.addr_raw.v6, sk,
 				   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
 	}
 	event->timestamp_raw = bpf_ktime_get_boot_ns();

--- a/gadgets/trace_tcpdrop/program.bpf.c
+++ b/gadgets/trace_tcpdrop/program.bpf.c
@@ -137,29 +137,29 @@ static __always_inline int __trace_tcp_drop(void *ctx, struct sock *sk,
 	unsigned int family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	switch (family) {
 	case AF_INET:
-		event->src.l3.version = event->dst.l3.version = 4;
+		event->src.version = event->dst.version = 4;
 
-		BPF_CORE_READ_INTO(&event->dst.l3.addr.v4, sk,
+		BPF_CORE_READ_INTO(&event->dst.addr_raw.v4, sk,
 				   __sk_common.skc_daddr);
-		if (event->dst.l3.addr.v4 == 0)
+		if (event->dst.addr_raw.v4 == 0)
 			goto cleanup;
-		BPF_CORE_READ_INTO(&event->src.l3.addr.v4, sk,
+		BPF_CORE_READ_INTO(&event->src.addr_raw.v4, sk,
 				   __sk_common.skc_rcv_saddr);
-		if (event->src.l3.addr.v4 == 0)
+		if (event->src.addr_raw.v4 == 0)
 			goto cleanup;
 		break;
 
 	case AF_INET6:
-		event->src.l3.version = event->dst.l3.version = 6;
+		event->src.version = event->dst.version = 6;
 
 		BPF_CORE_READ_INTO(
-			&event->src.l3.addr.v6, sk,
+			&event->src.addr_raw.v6, sk,
 			__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-		if (event->src.l3.addr.v6 == 0)
+		if (event->src.addr_raw.v6 == 0)
 			goto cleanup;
-		BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
+		BPF_CORE_READ_INTO(&event->dst.addr_raw.v6, sk,
 				   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
-		if (event->dst.l3.addr.v6 == 0)
+		if (event->dst.addr_raw.v6 == 0)
 			goto cleanup;
 		break;
 

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -98,33 +98,33 @@ static __always_inline int __trace_tcp_retrans(void *ctx, const struct sock *sk,
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	switch (family) {
 	case AF_INET:
-		event->src.l3.version = event->dst.l3.version = 4;
+		event->src.version = event->dst.version = 4;
 
-		BPF_CORE_READ_INTO(&event->src.l3.addr.v4, sk,
+		BPF_CORE_READ_INTO(&event->src.addr_raw.v4, sk,
 				   __sk_common.skc_rcv_saddr);
-		if (event->src.l3.addr.v4 == 0)
+		if (event->src.addr_raw.v4 == 0)
 			goto cleanup;
 
-		BPF_CORE_READ_INTO(&event->dst.l3.addr.v4, sk,
+		BPF_CORE_READ_INTO(&event->dst.addr_raw.v4, sk,
 				   __sk_common.skc_daddr);
-		if (event->dst.l3.addr.v4 == 0)
+		if (event->dst.addr_raw.v4 == 0)
 			goto cleanup;
 		break;
 
 	case AF_INET6:
-		event->src.l3.version = event->dst.l3.version = 6;
+		event->src.version = event->dst.version = 6;
 
 		BPF_CORE_READ_INTO(
-			&event->src.l3.addr.v6, sk,
+			&event->src.addr_raw.v6, sk,
 			__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-		if (((u64 *)event->src.l3.addr.v6)[0] == 0 &&
-		    ((u64 *)event->src.l3.addr.v6)[1] == 0)
+		if (((u64 *)event->src.addr_raw.v6)[0] == 0 &&
+		    ((u64 *)event->src.addr_raw.v6)[1] == 0)
 			goto cleanup;
 
-		BPF_CORE_READ_INTO(&event->dst.l3.addr.v6, sk,
+		BPF_CORE_READ_INTO(&event->dst.addr_raw.v6, sk,
 				   __sk_common.skc_v6_daddr.in6_u.u6_addr32);
-		if (((u64 *)event->dst.l3.addr.v6)[0] == 0 &&
-		    ((u64 *)event->dst.l3.addr.v6)[1] == 0)
+		if (((u64 *)event->dst.addr_raw.v6)[0] == 0 &&
+		    ((u64 *)event->dst.addr_raw.v6)[1] == 0)
 			goto cleanup;
 		break;
 

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -13,16 +13,16 @@ union gadget_ip_addr_t {
 
 // struct defining either an IPv4 or IPv6 L3 endpoint
 struct gadget_l3endpoint_t {
-	union gadget_ip_addr_t addr;
+	union gadget_ip_addr_t addr_raw;
 	__u8 version; // 4 or 6
-	__u8 pad[3]; // manual padding to avoid issues between C and Go
 };
 
 // struct defining an L4 endpoint
 struct gadget_l4endpoint_t {
-	struct gadget_l3endpoint_t l3;
-	__u16 port;
+	union gadget_ip_addr_t addr_raw;
+	__u16 port; // L4 port in host byte order
 	__u16 proto; // IP protocol number
+	__u8 version; // 4 or 6
 };
 
 // Inode id of a mount namespace. It's used to enrich the event in user space

--- a/pkg/datasource/accessors.go
+++ b/pkg/datasource/accessors.go
@@ -84,6 +84,9 @@ type FieldAccessor interface {
 	// Annotations returns stored annotations of the field
 	Annotations() map[string]string
 
+	// AddAnnotation sets a new annotation for the field
+	AddAnnotation(key, value string)
+
 	// RemoveReference removes the reference by name from the hierarchy, effectively freeing the name
 	// tbd: name
 	RemoveReference(recurse bool)
@@ -345,6 +348,13 @@ func (a *fieldAccessor) Annotations() map[string]string {
 	}
 	// return a clone to avoid write access
 	return maps.Clone(a.f.Annotations)
+}
+
+func (a *fieldAccessor) AddAnnotation(key, value string) {
+	if a.f.Annotations == nil {
+		a.f.Annotations = map[string]string{}
+	}
+	a.f.Annotations[key] = value
 }
 
 func (a *fieldAccessor) Uint8(data Data) (uint8, error) {

--- a/pkg/datasource/accessors.go
+++ b/pkg/datasource/accessors.go
@@ -43,6 +43,7 @@ func invalidFieldLengthErr(size, expected int) error {
 // FieldAccessor grants access to the underlying buffer of a field
 type FieldAccessor interface {
 	Name() string
+	FullName() string
 
 	// Size returns the expected size of the underlying field or zero, if the field has a dynamic size
 	Size() uint32
@@ -130,6 +131,10 @@ type fieldAccessor struct {
 
 func (a *fieldAccessor) Name() string {
 	return a.f.Name
+}
+
+func (a *fieldAccessor) FullName() string {
+	return a.f.FullName
 }
 
 func (a *fieldAccessor) Rename(name string) error {

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -27,6 +27,12 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
+const (
+	// ColumnsReplaceAnnotation is used to indicate that this field should be
+	// replaced by the one indicated in the annotation when printing it.
+	ColumnsReplaceAnnotation = "columns.replace"
+)
+
 type DataTuple struct {
 	ds   DataSource
 	data Data
@@ -121,6 +127,14 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				if v == "true" {
 					attributes.FixedWidth = true
 				}
+			}
+		}
+
+		// Use replace field if it's defined
+		if replacementField, ok := f.Annotations[ColumnsReplaceAnnotation]; ok {
+			f, ok = ds.fieldMap[replacementField]
+			if !ok {
+				return nil, fmt.Errorf("replacement field %q not found", replacementField)
 			}
 		}
 

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -377,11 +377,6 @@ func (ds *dataSource) AddStaticFields(size uint32, fields []StaticField) (FieldA
 		newFields = append(newFields, nf)
 	}
 
-	// Unref parent fields
-	for p := range parentFields {
-		FieldFlagUnreferenced.AddTo(&newFields[p].Flags)
-	}
-
 	// Check whether parent id is valid
 	for f := range checkParents {
 		parentID := f.Parent - uint32(parentOffset) // adjust offset again to match offset in newFields for this check

--- a/pkg/datasource/formatters/json/json.go
+++ b/pkg/datasource/formatters/json/json.go
@@ -40,6 +40,12 @@ var (
 	closerArrayPretty = []byte("\n]")
 )
 
+const (
+	// SkipFieldAnnotation is used to indicate that this field should be
+	// skipped.
+	SkipFieldAnnotation = "json.skip"
+)
+
 type Formatter struct {
 	ds                datasource.DataSource
 	fns               []func(e *encodeState, data datasource.Data)
@@ -142,6 +148,10 @@ func (f *Formatter) addSubFields(accessors []datasource.FieldAccessor, prefix st
 
 		// skip unreferenced fields
 		if datasource.FieldFlagUnreferenced.In(accessor.Flags()) {
+			continue
+		}
+
+		if val, ok := acc.Annotations()[SkipFieldAnnotation]; ok && val == "true" {
 			continue
 		}
 


### PR DESCRIPTION
This PR improves the way endpoints are formatted in the columns and json formats:

### Testing 

#### Before 

The columns output printed a lot of fields related to the endpoints:

```bash 
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false
INFO[0000] Experimental features enabled
RUNTIME.CONTAINERNA… SRC… SRC… DST… DS… TASK       PID        UID        GID        MNTNS_… TIMESTAMP              SRC.ADDRE… DST.ADDRE…
netem                341… 6    80   6   wget       137202     0          0          4026534 2024-06-25T15:42:05.24 172.17.0.2 1.1.1.1:80
netem                454… 6    443  6   wget       137202     0          0          4026534 2024-06-25T15:42:05.36 172.17.0.2 1.1.1.1:44
netem                606… 6    443  6   wget       137202     0          0          4026534 2024-06-25T15:42:06.44 172.17.0.2 1.0.0.1:4
```

It wasn't possible to choose an endpoint with `--fields`:

```bash
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false --fields=src,dst
INFO[0000] Experimental features enabled
Error: pre-starting operator "cli": setting fields: column "src" is invalid
```

and the endpoints weren't present on the json output:

```bash
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false -o json | jq
INFO[0000] Experimental features enabled
{
  "gid": 0,
  "k8s": {
    "containerName": "",
    "hostnetwork": false,
    "namespace": "",
    "node": "",
    "podName": ""
  },
  "latency": 0,
  "mntns_id": 4026534293,
  "pid": 137803,
  "runtime": {
    "containerId": "31fc2dd570cef84e2f9131e662833b6318cf5dac4d753c0854767e41419743c1",
    "containerImageDigest": "",
    "containerImageName": "wbitt/network-multitool",
    "containerName": "netem",
    "runtimeName": "docker"
  },
  "task": "wget",
  "timestamp": "2024-06-25T15:56:52.668658281-05:00",
  "timestamp_raw": 1719349012668658200,
  "uid": 0
}
```

#### After 

The columns output shows the "summary" version for dst and src columns by default, all other subfields are hidden:

(It's still to improve the annotations / attributes to avoid trimming these fields)

```bash 
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false
INFO[0000] Experimental features enabled
RUNTIME.CONTAINERNAME   SRC          DST          TASK         PID          UID          GID          MNTNS_ID TIMESTAMP
netem                   172.17.0.2:4 1.1.1.1:80   wget         136059       0            0            40265342 2024-06-25T15:38:18.71826
netem                   172.17.0.2:5 1.1.1.1:443  wget         136059       0            0            40265342 2024-06-25T15:38:19.43726
netem                   172.17.0.2:3 1.1.1.1:443  wget         136059       0            0            40265342 2024-06-25T15:38:20.3098
```

```bash
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false --fields=src,dst
INFO[0000] Experimental features enabled
SRC                                                                  DST
172.17.0.2:35584                                                     1.1.1.1:80
172.17.0.2:48386                                                     1.1.1.1:443
172.17.0.2:36782                                                     1.0.0.1:443
```

The json output now shows the fields in this way: (non endpoints fields were manually removed to reduce noise)

```bash 
$ sudo -E ig run trace_tcpconnect:latest --verify-image=false -o json | jq
INFO[0000] Experimental features enabled
{
  "dst": {
    "addr": "1.1.1.1",
    "port": 80,
    "proto": 6,
    "version": 4
  }, 
  "src": {
    "addr": "172.17.0.2",
    "port": 38566,
    "proto": 6,
    "version": 4
  },
}
```

Fixes #3034 
Fixes #2813
Fixes #2816

### TODO
- [ ] Provided human-friendly format for proto (future PR)