### PR TITLE
ci: Remove ARO from release needs.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1967,7 +1967,6 @@ jobs:
       - semgrep
       - test-integration-minikube
       - test-integration-aks
-      - test-integration-aro
       - test-components
       - build-ig-cwe
       - test-ig


### PR DESCRIPTION
At the moment, ARO is broken, so let's remove it to avoid it impeding next release.