### PR TITLE
GetCgroupID: read cgroup paths under host cgroup namespace

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,7 +65,6 @@
 /pkg/ig-manager/ @blanquicet
 /pkg/kallsyms/ @alban
 /pkg/kfilefields/ @alban @mqasimsarfraz
-/pkg/netnsenter/ @alban
 /pkg/networktracer/ @alban @blanquicet
 /pkg/operators/ @flyth
 /pkg/operators/kubeipresolver/ @burak-ok
@@ -84,5 +83,6 @@
 /pkg/uprobetracer/ @alban
 /pkg/utils/bpf-iter-ns/ @alban
 /pkg/utils/host/ @alban
+/pkg/utils/nsenter/ @alban
 /tools/ @mqasimsarfraz
 /tools/demos/ @alban

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -292,6 +292,11 @@ func main() {
 			log.Fatalf("Detecting net namespace: %v", err)
 		}
 		log.Infof("HostNetwork=%t", hostNetNs)
+		hostCgroupNs, err := host.IsHostCgroupNs()
+		if err != nil {
+			log.Fatalf("Detecting cgroup namespace: %v", err)
+		}
+		log.Infof("HostCgroup=%t", hostCgroupNs)
 
 		node := os.Getenv("NODE_NAME")
 		if node == "" {

--- a/pkg/container-utils/containerutils.go
+++ b/pkg/container-utils/containerutils.go
@@ -34,9 +34,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/podman"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/netnsenter"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+	nsenter "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/nsenter"
 )
 
 var AvailableRuntimes = []string{
@@ -131,7 +131,7 @@ func ParseOCIState(stateBuf []byte) (id string, pid int, err error) {
 func GetIfacePeers(pid int) ([]*net.Interface, error) {
 	var ifaceLinks []int
 
-	err := netnsenter.NetnsEnter(pid, func() error {
+	err := nsenter.NetnsEnter(pid, func() error {
 		links, err := netlink.LinkList()
 		if err != nil {
 			return fmt.Errorf("getting links: %w", err)
@@ -167,7 +167,7 @@ func GetIfacePeers(pid int) ([]*net.Interface, error) {
 
 	ifacesHost := make([]*net.Interface, 0, len(ifaceLinks))
 
-	err = netnsenter.NetnsEnter(1, func() error {
+	err = nsenter.NetnsEnter(1, func() error {
 		for _, ifaceLink := range ifaceLinks {
 			ifaceHost, err := net.InterfaceByIndex(ifaceLink)
 			if err != nil {

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -39,6 +39,7 @@ const (
 func TestRuntimeClientInterface(t *testing.T) {
 	t.Parallel()
 	utilstest.RequireRoot(t)
+	utilstest.HostInit(t)
 
 	for _, runtime := range testutils.SupportedContainerRuntimes {
 		t.Run(runtime.String(), func(t *testing.T) {

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -28,8 +28,8 @@ import (
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	socketcollectortypes "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/snapshot/socket/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/netnsenter"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/nsenter"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang -cflags ${CFLAGS} -type entry  socket ./bpf/socket.bpf.c -- -Werror -O2 -g -c -x c
@@ -77,7 +77,7 @@ func parseStatus(proto string, statusUint uint8) (string, error) {
 
 func (t *Tracer) runCollector(pid uint32, netns uint64) ([]*socketcollectortypes.Event, error) {
 	sockets := []*socketcollectortypes.Event{}
-	err := netnsenter.NetnsEnter(int(pid), func() error {
+	err := nsenter.NetnsEnter(int(pid), func() error {
 		for _, it := range t.iters {
 			reader, err := it.Open()
 			if err != nil {

--- a/pkg/operators/ebpf/snapshotter.go
+++ b/pkg/operators/ebpf/snapshotter.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/netnsenter"
 	bpfiterns "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/bpf-iter-ns"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/nsenter"
 )
 
 type linkSnapshotter struct {
@@ -179,7 +179,7 @@ func (i *ebpfInstance) runSnapshotters() error {
 					}
 					visitedNetNs[container.Netns] = struct{}{}
 
-					err := netnsenter.NetnsEnter(int(container.Pid), func() error {
+					err := nsenter.NetnsEnter(int(container.Pid), func() error {
 						reader, err := l.link.Open()
 						if err != nil {
 							return err

--- a/pkg/tchandler/tracer.go
+++ b/pkg/tchandler/tracer.go
@@ -31,7 +31,7 @@ import (
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/netnsenter"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/nsenter"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang -cflags ${CFLAGS} dispatcher ./bpf/dispatcher.bpf.c -- -I./bpf/
@@ -91,7 +91,7 @@ func NewHandler(direction AttachmentDirection) (*Handler, error) {
 
 	// We need to create the client on the host network namespace, otherwise it's not able to
 	// create the qdisc and filters.
-	err = netnsenter.NetnsEnter(1, func() error {
+	err = nsenter.NetnsEnter(1, func() error {
 		// Setup tc socket for communication with the kernel
 		tcnl, err = tc.Open(&tc.Config{})
 		if err != nil {
@@ -217,7 +217,7 @@ func (t *Handler) AttachContainer(container *containercollection.Container) erro
 
 	// We need to perform these operations from the host network namespace, otherwise we won't
 	// be able to add the filter to the network interface.
-	err = netnsenter.NetnsEnter(1, func() error {
+	err = nsenter.NetnsEnter(1, func() error {
 		for _, iface := range ifaces {
 			if a, ok := t.attachments[iface.Name]; ok {
 				a.users[pid] = struct{}{}

--- a/pkg/utils/host/namespaces.go
+++ b/pkg/utils/host/namespaces.go
@@ -29,30 +29,25 @@ import (
 	"syscall"
 )
 
-var (
-	onceHostPidNs sync.Once
-	isHostPidNs   bool
-	errHostPidNs  error
-
-	onceHostNetNs sync.Once
-	isHostNetNs   bool
-	errHostNetNs  error
-)
-
 // IsHostPidNs returns true if the current process is running in the host PID namespace
 func IsHostPidNs() (bool, error) {
-	onceHostPidNs.Do(func() {
-		isHostPidNs, errHostPidNs = isHostNamespace("pid")
-	})
-	return isHostPidNs, errHostPidNs
+	return sync.OnceValues[bool, error](func() (bool, error) {
+		return isHostNamespace("pid")
+	})()
 }
 
 // IsHostNetNs returns true if the current process is running in the host network namespace
 func IsHostNetNs() (bool, error) {
-	onceHostNetNs.Do(func() {
-		isHostNetNs, errHostNetNs = isHostNamespace("net")
-	})
-	return isHostNetNs, errHostNetNs
+	return sync.OnceValues[bool, error](func() (bool, error) {
+		return isHostNamespace("net")
+	})()
+}
+
+// IsHostCgroupNs returns true if the current process is running in the host cgroup namespace
+func IsHostCgroupNs() (bool, error) {
+	return sync.OnceValues[bool, error](func() (bool, error) {
+		return isHostNamespace("cgroup")
+	})()
 }
 
 // isHostNamespace checks if the current process is running in the specified host namespace

--- a/pkg/utils/nsenter/nsenter.go
+++ b/pkg/utils/nsenter/nsenter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package netnsenter
+package nsenter
 
 import (
 	"runtime"

--- a/pkg/utils/nsenter/nsenter.go
+++ b/pkg/utils/nsenter/nsenter.go
@@ -15,14 +15,19 @@
 package nsenter
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 	netnsig "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/netns"
 )
 
+// NetnsEnter enters the network namespace of a process and executes the provided function
 func NetnsEnter(pid int, f func() error) error {
 	if pid == 0 {
 		return f()
@@ -48,6 +53,41 @@ func NetnsEnter(pid int, f func() error) error {
 
 	// Switch back to the original namespace
 	defer netns.Set(origns)
+
+	return f()
+}
+
+// CgroupnsEnter enters the cgroup namespace of a process and executes the provided function
+func CgroupnsEnter(pid int, f func() error) error {
+	if pid == 0 {
+		return f()
+	}
+
+	// Lock the OS Thread so we don't accidentally switch namespaces
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Save the current cgroup namespace
+	origCgroupPath := filepath.Join("/proc", fmt.Sprint(os.Getpid()), "task", fmt.Sprint(unix.Gettid()), "ns", "cgroup")
+	origns, err := unix.Open(origCgroupPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(origns)
+
+	newCgroupPath := filepath.Join(host.HostProcFs, fmt.Sprint(pid), "ns", "cgroup")
+	cgroupnsHandle, err := unix.Open(newCgroupPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(cgroupnsHandle)
+	err = unix.Setns(cgroupnsHandle, unix.CLONE_NEWCGROUP)
+	if err != nil {
+		return err
+	}
+
+	// Switch back to the original namespace
+	defer unix.Setns(origns, unix.CLONE_NEWCGROUP)
 
 	return f()
 }


### PR DESCRIPTION
# GetCgroupID: read cgroup paths under host cgroup namespace

Before this PR, deploying Inspektor Gadget on Kubernetes often gave one error like this:

```
$ kubectl logs -n gadget gadget-m7bdw
(...)
(...) level=error msg="cgroup enricher: failed to get cgroup paths on container 58ad8(...): cgroup path not found in /proc/PID/cgroup"
```

This is because the container runtime often deploys the IG pod in a new cgroup namespace.

As opposed to the network namespace or the pid namespace, the cgroup namespace cannot be configured in the pod spec. The container runtime typically use `HostCgroup=false` for pods with `privileged=false` (such as IG) and `HostCgroup=true` for pods with `privileged=true` (such as IG v0.3.0 from 2021 before commit ed1c54db3e06679777bd67a6eeecf89d69ff0b47). This depends on the container runtime: docker and containerd behave differently.

When a container is using a new cgroup namespace, cgroup paths in /proc/PID/cgroup are relative to the cgroup namespace root of the caller:
https://docs.kernel.org/admin-guide/cgroup-v2.html (search for `0::/..`)

When IG iterates over the local containers, it reads `/host/proc/PID/cgroup` for each container. For sibling containers, it will look like this:

```
# cat /host/proc/9683/cgroup
0::/../../../kubepods-burstable.slice/kubepods-burstable-podece3579b_3053_4b3e_8f74_467645558f0d.slice/cri-containerd-90893b3b06f1c716965a85a58464302e608ef6a5eb9fea6badc657c740935093.scope
```
Notice the `/../../../`. This prefix is removed when reading the file from the host cgroup namespace:
```
# nsenter --cgroup=/host/proc/1/ns/cgroup cat /host/proc/9683/cgroup
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podece3579b_3053_4b3e_8f74_467645558f0d.slice/cri-containerd-90893b3b06f1c716965a85a58464302e608ef6a5eb9fea6badc657c740935093.scope
```

This is mostly harmless because IG does not make much use of this path, except for reading the pod uid and container id, and that uid+id are unchanged.

However, when IG iterates over its own container, this is different:
```
# cat /host/proc/22740/cgroup
0::/
```
The path is just `/` because relatively to the cgroup namespace root, the current process is at the root of the cgroup tree, hence the error in the log. When reading the file from the host cgroup namespace, the path is correct:
```
# nsenter --cgroup=/host/proc/1/ns/cgroup cat /host/proc/22740/cgroup
0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podaf580c94_e4c0_48f4_9e2b_c84147fb33b8.slice/cri-containerd-a54408d5bf63f53ce67b8a8d6ec00aa51114b73b8df71ff21ec906a01b7006bb.scope
```

This patch switches the current IG thread to the host cgroup namespace before reading the file. Switching the cgroup namespace is allowed thanks to CAP_SYS_ADMIN. This is the same as we do for network namespace.

## How to use

No changes.

## Testing done

After deploying:
```
$ kubectl logs -n gadget  gadget-rt5fn
...
time="..." level=info msg="HostPID=false"
time="..." level=info msg="HostNetwork=false"
time="..." level=info msg="HostCgroup=false"
...
$ kubectl logs -n gadget  gadget-rt5fn|grep error|wc -l
0
$
```