### PR TITLE
ci: Use eastus2 for AKS

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1601,7 +1601,7 @@ jobs:
         # GitHub Action.
         az extension add --name aks-preview
 
-        az aks create -l westeurope -g ${AZURE_AKS_RESOURCE_GROUP} -n ${{ env.CLUSTER_NAME }} -s $node_size --os-sku ${{ matrix.os-sku }} --no-ssh-key
+        az aks create -l eastus2 -g ${AZURE_AKS_RESOURCE_GROUP} -n ${{ env.CLUSTER_NAME }} -s $node_size --os-sku ${{ matrix.os-sku }} --no-ssh-key
     - uses: azure/aks-set-context@v4
       name: Set AKS cluster ${{ env.CLUSTER_NAME }} context
       with:


### PR DESCRIPTION
We seem to have capacity issues with the VMs we request in `westeurope`: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/9693321973/job/26752261184#step:9:30