### PR TITLE
[2nd attempt] container-collection: add process metadata enricher

### DIFF
--- a/docs/crds/gadgets/ebpftop.md
+++ b/docs/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/crds/gadgets/filetop.md
+++ b/docs/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -56,6 +56,7 @@ func TestFilterByContainerName(t *testing.T) {
 				c.K8s.PodLabels = nil
 				c.K8s.PodUID = ""
 				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				c.Runtime.ContainerImageName = ""
 				c.Runtime.ContainerImageDigest = ""
@@ -123,6 +124,7 @@ func TestWatchContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Container.Runtime.ContainerImageName = ""
 				e.Container.Runtime.ContainerImageDigest = ""

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -53,6 +53,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
 				e.Runtime.ContainerImageDigest = ""

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -133,6 +133,7 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 				}
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
 				e.Runtime.ContainerImageDigest = ""

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -89,6 +89,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Gid = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""
 				e.Runtime.ContainerImageDigest = ""

--- a/integration/k8s/audit_seccomp_test.go
+++ b/integration/k8s/audit_seccomp_test.go
@@ -202,6 +202,7 @@ EOF
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
 					e.Runtime.ContainerImageDigest = ""
+					e.Runtime.ContainerStartedAt = 0
 				}
 
 				match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)

--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -103,6 +103,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 				c.SandboxId = ""
 				c.Runtime.ContainerID = ""
 				c.Runtime.ContainerImageDigest = ""
+				c.Runtime.ContainerStartedAt = 0
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {
@@ -177,6 +178,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
 				e.Container.Runtime.ContainerImageDigest = ""
+				e.Container.Runtime.ContainerStartedAt = 0
 
 				// CRI-O uses a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in

--- a/integration/k8s/integration_test.go
+++ b/integration/k8s/integration_test.go
@@ -61,6 +61,7 @@ func normalizeCommonData(e *eventtypes.CommonData, ns string) {
 
 	e.Runtime.ContainerID = ""
 	e.Runtime.ContainerImageDigest = ""
+	e.Runtime.ContainerStartedAt = 0
 
 	switch DefaultTestComponent {
 	case IgTestComponent:

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -80,6 +80,7 @@ func newListContainerTestStep(
 				c.K8s.PodLabels = addPodLabels(pod)
 				c.Runtime.ContainerID = ""
 				c.Runtime.ContainerImageDigest = ""
+				c.Runtime.ContainerStartedAt = 0
 
 				// Docker can provide different values for ContainerImageName. See `getContainerImageNamefromImage`
 				if isDockerRuntime {
@@ -214,6 +215,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
 				e.Container.Runtime.ContainerImageDigest = ""
+				e.Container.Runtime.ContainerStartedAt = 0
 
 				// Docker and CRI-O use a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in
@@ -309,6 +311,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
 				e.Container.Runtime.ContainerImageDigest = ""
+				e.Container.Runtime.ContainerStartedAt = 0
 
 				// Docker and CRI-O use a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in
@@ -405,6 +408,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 				e.Container.SandboxId = ""
 				e.Container.Runtime.ContainerID = ""
 				e.Container.Runtime.ContainerImageDigest = ""
+				e.Container.Runtime.ContainerStartedAt = 0
 				e.Container.K8s.PodLabels = addPodLabels(po)
 				e.Container.K8s.PodUID = ""
 

--- a/integration/k8s/snapshot_socket_test.go
+++ b/integration/k8s/snapshot_socket_test.go
@@ -94,6 +94,7 @@ func TestSnapshotSocket(t *testing.T) {
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
 					e.Runtime.ContainerImageDigest = ""
+					e.Runtime.ContainerStartedAt = 0
 				}
 
 				match.MatchEntries(t, match.JSONSingleArrayMode, output, normalize, expectedEntry)

--- a/integration/k8s/trace_network_test.go
+++ b/integration/k8s/trace_network_test.go
@@ -152,6 +152,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Gid = 0
 				e.Runtime.ContainerID = ""
 				e.Runtime.ContainerImageDigest = ""
+				e.Runtime.ContainerStartedAt = 0
 
 				switch DefaultTestComponent {
 				case IgTestComponent:

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -270,6 +270,7 @@ func NewServer(conf *Conf) (*GadgetTracerManager, error) {
 		opts = append(opts, containercollection.WithLinuxNamespaceEnrichment())
 		opts = append(opts, containercollection.WithKubernetesEnrichment(g.nodeName, nil))
 		opts = append(opts, containercollection.WithTracerCollection(g.tracerCollection))
+		opts = append(opts, containercollection.WithProcEnrichment())
 	}
 
 	podInformerUsed := false

--- a/pkg/ig-manager/ig-manager.go
+++ b/pkg/ig-manager/ig-manager.go
@@ -100,6 +100,7 @@ func NewManager(runtimes []*containerutilsTypes.RuntimeConfig) (*IGManager, erro
 		containercollection.WithMultipleContainerRuntimesEnrichment(runtimes),
 		containercollection.WithContainerFanotifyEbpf(),
 		containercollection.WithTracerCollection(l.tracerCollection),
+		containercollection.WithProcEnrichment(),
 	}
 
 	if !log.IsLevelEnabled(log.DebugLevel) && isDefaultContainerRuntimeConfig(runtimes) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,7 @@ func init() {
 	columns.MustRegisterTemplate("container", "width:30")
 	columns.MustRegisterTemplate("containerImageName", "width:30")
 	columns.MustRegisterTemplate("containerImageDigest", "width:30")
+	columns.MustRegisterTemplate("containerStartedAt", "width:35,hide")
 	columns.MustRegisterTemplate("comm", "maxWidth:16")
 	columns.MustRegisterTemplate("pid", "minWidth:7")
 	columns.MustRegisterTemplate("uid", "minWidth:8")
@@ -138,6 +139,9 @@ type BasicRuntimeMetadata struct {
 	// containerd: events from both initial and new containers are enriched
 	// crio: events from initial containers are enriched
 	ContainerImageDigest string `json:"containerImageDigest,omitempty" column:"containerImageDigest,hide"`
+
+	// ContainerStartedAt is the unix timestamp at which the container was started at
+	ContainerStartedAt Time `json:"containerStartedAt,omitempty" column:"containerStartedAt,template:timestamp,stringer,hide"`
 }
 
 func (b *BasicRuntimeMetadata) IsEnriched() bool {
@@ -204,6 +208,7 @@ func (c *CommonData) SetContainerMetadata(container Container) {
 	c.Runtime.ContainerID = runtime.ContainerID
 	c.Runtime.ContainerImageName = runtime.ContainerImageName
 	c.Runtime.ContainerImageDigest = runtime.ContainerImageDigest
+	c.Runtime.ContainerStartedAt = runtime.ContainerStartedAt
 }
 
 func (c *CommonData) GetNode() string {


### PR DESCRIPTION
# container-collection: add process metadata enricher

This PR picks up #2966, which was merged and then reverted in #3065.

This includes test fixes from #3066.

## How to use

See #2966

## Testing done

- CI

## TODO

In the next PR:
- [ ] Support for image-based gadgets