### PR TITLE
Finish porting trace dns to image-based gadget

### DIFF
--- a/gadgets/trace_dns/build.yaml
+++ b/gadgets/trace_dns/build.yaml
@@ -1,0 +1,1 @@
+wasm: go/program.go

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -54,17 +54,27 @@ datasources:
       name:
         annotations:
           columns.width: 30
+      qr_raw:
+        annotations:
+          columns.hidden: true
       qr:
         annotations:
+          columns.minwidth: 2
           columns.width: 2
       pkt_type:
         annotations:
           columns.width: 8
+          columns.hidden: true
+      rcode_raw:
+        annotations:
+          columns.hidden: true
       rcode:
         annotations:
+          columns.minwidth: 8
           columns.width: 8
       latency_ns:
         annotations:
+          description: DNS request latency
           columns.width: 8
           columns.hidden: true
       anaddr:
@@ -73,12 +83,25 @@ datasources:
       id:
         annotations:
           columns.hidden: true
+      qtype_raw:
+        annotations:
+          columns.hidden: true
       qtype:
         annotations:
           description: Query type
-      ancount:
+      num_answers:
+        annotations:
+          description: Number of answers
+          columns.hidden: true
+      dns_off:
         annotations:
           columns.hidden: true
-      anaddrcount:
+          json.skip: true
+      data:
         annotations:
           columns.hidden: true
+          json.skip: true
+      data_len:
+        annotations:
+          columns.hidden: true
+          json.skip: true

--- a/gadgets/trace_dns/go/go.mod
+++ b/gadgets/trace_dns/go/go.mod
@@ -1,0 +1,12 @@
+module trace_dns
+
+go 1.22.2
+
+require (
+	// Version doesn't matter because of the replace directive below.
+	github.com/inspektor-gadget/inspektor-gadget v0.0.0
+	golang.org/x/net v0.26.0
+)
+
+// Only needed by in-tree gadgets
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/trace_dns/go/go.sum
+++ b/gadgets/trace_dns/go/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
+golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=

--- a/gadgets/trace_dns/go/program.go
+++ b/gadgets/trace_dns/go/program.go
@@ -1,0 +1,273 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"golang.org/x/net/dns/dnsmessage"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+// Taken from
+// https://cs.opensource.google/go/x/net/+/refs/tags/v0.27.0:dns/dnsmessage/message.go
+// to trim Type and Rcode prefixes.
+// More information about the DNS message format can be found in
+// https://datatracker.ietf.org/doc/html/rfc1035 and
+// https://datatracker.ietf.org/doc/html/rfc3596.
+
+// A Type is a type of DNS request and response.
+type Type uint16
+
+const (
+	// ResourceHeader.Type and Question.Type
+	TypeA     Type = 1
+	TypeNS    Type = 2
+	TypeCNAME Type = 5
+	TypeSOA   Type = 6
+	TypePTR   Type = 12
+	TypeMX    Type = 15
+	TypeTXT   Type = 16
+	TypeAAAA  Type = 28
+	TypeSRV   Type = 33
+	TypeOPT   Type = 41
+
+	// Question.Type
+	TypeWKS   Type = 11
+	TypeHINFO Type = 13
+	TypeMINFO Type = 14
+	TypeAXFR  Type = 252
+	TypeALL   Type = 255
+)
+
+var typeNames = map[Type]string{
+	TypeA:     "A",
+	TypeNS:    "NS",
+	TypeCNAME: "CNAME",
+	TypeSOA:   "SOA",
+	TypePTR:   "PTR",
+	TypeMX:    "MX",
+	TypeTXT:   "TXT",
+	TypeAAAA:  "AAAA",
+	TypeSRV:   "SRV",
+	TypeOPT:   "OPT",
+	TypeWKS:   "WKS",
+	TypeHINFO: "HINFO",
+	TypeMINFO: "MINFO",
+	TypeAXFR:  "AXFR",
+	TypeALL:   "ALL",
+}
+
+// String implements fmt.Stringer.String.
+func (t Type) String() string {
+	if n, ok := typeNames[t]; ok {
+		return n
+	}
+	return fmt.Sprintf("%d", t)
+}
+
+// An RCode is a DNS response status code.
+type RCode uint16
+
+// Header.RCode values.
+const (
+	RCodeSuccess        RCode = 0 // NoError
+	RCodeFormatError    RCode = 1 // FormErr
+	RCodeServerFailure  RCode = 2 // ServFail
+	RCodeNameError      RCode = 3 // NXDomain
+	RCodeNotImplemented RCode = 4 // NotImp
+	RCodeRefused        RCode = 5 // Refused
+)
+
+var rCodeNames = map[RCode]string{
+	RCodeSuccess:        "Success",
+	RCodeFormatError:    "FormatError",
+	RCodeServerFailure:  "ServerFailure",
+	RCodeNameError:      "NameError",
+	RCodeNotImplemented: "NotImplemented",
+	RCodeRefused:        "Refused",
+}
+
+// String implements fmt.Stringer.String.
+func (r RCode) String() string {
+	if n, ok := rCodeNames[r]; ok {
+		return n
+	}
+	return fmt.Sprintf("%d", r)
+}
+
+//export gadgetInit
+func gadgetInit() int {
+	ds, err := api.GetDataSource("dns")
+	if err != nil {
+		api.Warnf("failed to get datasource: %s", err)
+		return 1
+	}
+
+	dataF, err := ds.GetField("data")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+
+	lenF, err := ds.GetField("data_len")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+
+	dnsOffF, err := ds.GetField("dns_off")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+
+	idF, err := ds.AddField("id", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	qrRawF, err := ds.AddField("qr_raw", api.Kind_Bool)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	qrF, err := ds.AddField("qr", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	qtypeRawF, err := ds.AddField("qtype_raw", api.Kind_Uint16)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	qtypeF, err := ds.AddField("qtype", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	nameF, err := ds.AddField("name", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	rcodeRawF, err := ds.AddField("rcode_raw", api.Kind_Uint16)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	rcodeF, err := ds.AddField("rcode", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	numAnswersF, err := ds.AddField("num_answers", api.Kind_Int32)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	addressesF, err := ds.AddField("addresses", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+
+	ds.Subscribe(func(source api.DataSource, data api.Data) {
+		// Get all fields sent by ebpf
+		payloadLen, err := lenF.Uint32(data)
+		if err != nil {
+			api.Warnf("failed to get data_len: %s", err)
+			return
+		}
+		dnsOff, err := dnsOffF.Uint16(data)
+		if err != nil {
+			api.Warnf("failed to get dns_off: %s", err)
+			return
+		}
+
+		if payloadLen < uint32(dnsOff) {
+			api.Warnf("packet too short: dataLen: %d < dnsOff: %d", payloadLen, dnsOff)
+			return
+		}
+
+		payload, err := dataF.Bytes(data)
+		if err != nil {
+			api.Warnf("failed to get data: %s", err)
+			return
+		}
+
+		msg := dnsmessage.Message{}
+		if err := msg.Unpack(payload[dnsOff:]); err != nil {
+			api.Warnf("failed to unpack dns message: %s", err)
+			return
+		}
+
+		idF.SetString(data, fmt.Sprintf("%.4x", msg.ID))
+
+		qrRawF.SetBool(data, msg.Header.Response)
+		if msg.Header.Response {
+			rcodeRawF.SetUint16(data, uint16(msg.Header.RCode))
+			rcodeF.SetString(data, RCode(msg.Header.RCode).String())
+			qrF.SetString(data, "R")
+		} else {
+			qrF.SetString(data, "Q")
+		}
+
+		if len(msg.Questions) > 0 {
+			question := msg.Questions[0]
+			qtypeRawF.SetUint16(data, uint16(question.Type))
+			qtypeF.SetString(data, Type(question.Type).String())
+			nameF.SetString(data, question.Name.String())
+		}
+
+		numAnswersF.SetInt32(data, int32(len(msg.Answers)))
+
+		var addresses []string
+
+		for _, answer := range msg.Answers {
+			var str string
+			switch answer.Header.Type {
+			case dnsmessage.TypeA:
+				ipv4 := answer.Body.(*dnsmessage.AResource)
+				str = net.IP(ipv4.A[:]).String()
+			case dnsmessage.TypeAAAA:
+				ipv6 := answer.Body.(*dnsmessage.AAAAResource)
+				str = net.IP(ipv6.AAAA[:]).String()
+			}
+
+			addresses = append(addresses, str)
+		}
+
+		addressesF.SetString(data, strings.Join(addresses, ","))
+
+	}, 0)
+
+	return 0
+}
+
+func main() {}

--- a/gadgets/trace_dns/test/trace_dns_test.go
+++ b/gadgets/trace_dns/test/trace_dns_test.go
@@ -1,0 +1,304 @@
+// Copyright 2019-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type traceDNSEvent struct {
+	eventtypes.CommonData
+
+	Timestamp string `json:"timestamp"`
+	MntNsID   uint64 `json:"mntns_id"`
+	NetNsID   uint64 `json:"netns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Src utils.L4Endpoint `json:"src"`
+	Dst utils.L4Endpoint `json:"dst"`
+
+	// Raw fields are comming from wasm, test them too
+	ID        string `json:"id"`
+	Qtype     string `json:"qtype"`
+	QtypeRaw  uint16 `json:"qtype_raw"`
+	PktType   string `json:"pkt_type"`
+	RcodeRaw  uint16 `json:"rcode_raw"`
+	Rcode     string `json:"rcode"`
+	Latency   uint64 `json:"latency_ns"`
+	QrRaw     bool   `json:"qr_raw"`
+	Qr        string `json:"qr"`
+	Name      string `json:"name"`
+	Addresses string `json:"addresses"`
+}
+
+func TestTraceDNS(t *testing.T) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	if utils.CurrentTestComponent == utils.IgLocalTestComponent && utils.Runtime == "containerd" {
+		t.Skip("Skipping test as containerd test utils can't use the network")
+	}
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+	serverContainerName := "test-trace-dns-server"
+	clientContainerName := "test-trace-dns-client"
+	// TODO: this should be configurable
+	serverImage := "ghcr.io/inspektor-gadget/dnstester:latest"
+	clientImage := "docker.io/library/busybox:latest"
+
+	// TODO: The current logic creates the namespace when running the pod, hence
+	// we need a namespace for each pod
+	var nsClient string
+	serverContainerOpts := []containers.ContainerOption{containers.WithContainerImage(serverImage)}
+	clientContainerOpts := []containers.ContainerOption{containers.WithContainerImage(clientImage)}
+
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		nsClient = utils.GenerateTestNamespaceName(t, "test-trace-dns-client")
+		clientContainerOpts = append(clientContainerOpts, containers.WithContainerNamespace(nsClient))
+
+		nsServer := utils.GenerateTestNamespaceName(t, "test-trace-dns-server")
+		serverContainerOpts = append(serverContainerOpts, containers.WithContainerNamespace(nsServer))
+	}
+
+	serverContainer := containerFactory.NewContainer(serverContainerName, "/dnstester", serverContainerOpts...)
+	serverContainer.Start(t)
+	t.Cleanup(func() {
+		serverContainer.Stop(t)
+	})
+
+	serverIP := serverContainer.IP()
+	nslookupCmds := []string{
+		fmt.Sprintf("setuidgid 1000:1111 nslookup -type=a fake.test.com. %s", serverIP),
+		fmt.Sprintf("setuidgid 1000:1111 nslookup -type=aaaa fake.test.com. %s", serverIP),
+	}
+
+	clientContainer := containerFactory.NewContainer(
+		clientContainerName,
+		fmt.Sprintf("while true; do %s; sleep 1; done", strings.Join(nslookupCmds, " ; ")),
+		clientContainerOpts...,
+	)
+	clientContainer.Start(t)
+	t.Cleanup(func() {
+		clientContainer.Stop(t)
+	})
+
+	clientIP := clientContainer.IP()
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+	commonDataOpts := []utils.CommonDataOption{utils.WithContainerImageName(clientImage), utils.WithContainerID(clientContainer.ID())}
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), "--timeout=5"))
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", nsClient), "--timeout=5"))
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(nsClient)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(nsClient))
+	}
+
+	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
+		func(t *testing.T, output string) {
+			expectedEntries := []*traceDNSEvent{
+				// A query from client
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+					Src: utils.L4Endpoint{
+						Addr:    clientIP,
+						Version: 4,
+						Port:    utils.NormalizedInt,
+						Proto:   17,
+					},
+					Dst: utils.L4Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+						Port:    53,
+						Proto:   17,
+					},
+					Comm:     "nslookup",
+					QrRaw:    false,
+					Qr:       "Q",
+					Uid:      1000,
+					Gid:      1111,
+					Name:     "fake.test.com.",
+					Qtype:    "A",
+					QtypeRaw: 1,
+					Rcode:    "",
+					PktType:  "OUTGOING",
+
+					// Check the existence of the following fields
+					MntNsID:   utils.NormalizedInt,
+					NetNsID:   utils.NormalizedInt,
+					Timestamp: utils.NormalizedStr,
+					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
+					ID:        utils.NormalizedStr,
+					Latency:   0,
+				},
+				// A response from server
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+					Src: utils.L4Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+						Port:    53,
+						Proto:   17,
+					},
+					Dst: utils.L4Endpoint{
+						Addr:    clientIP,
+						Version: 4,
+						Port:    utils.NormalizedInt,
+						Proto:   17,
+					},
+					Comm:      "nslookup",
+					QrRaw:     true,
+					Qr:        "R",
+					Uid:       1000,
+					Gid:       1111,
+					Name:      "fake.test.com.",
+					QtypeRaw:  1,
+					Qtype:     "A",
+					Rcode:     "Success",
+					PktType:   "HOST",
+					Addresses: "127.0.0.1",
+
+					// Check the existence of the following fields
+					MntNsID:   utils.NormalizedInt,
+					NetNsID:   utils.NormalizedInt,
+					Timestamp: utils.NormalizedStr,
+					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
+					ID:        utils.NormalizedStr,
+					Latency:   utils.NormalizedInt,
+				},
+				// AAAA query from client
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+					Src: utils.L4Endpoint{
+						Addr:    clientIP,
+						Version: 4,
+						Port:    utils.NormalizedInt,
+						Proto:   17,
+					},
+					Dst: utils.L4Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+						Port:    53,
+						Proto:   17,
+					},
+					Comm:     "nslookup",
+					QrRaw:    false,
+					Qr:       "Q",
+					Uid:      1000,
+					Gid:      1111,
+					Name:     "fake.test.com.",
+					QtypeRaw: 28,
+					Qtype:    "AAAA",
+					Rcode:    "",
+					PktType:  "OUTGOING",
+
+					// Check the existence of the following fields
+					MntNsID:   utils.NormalizedInt,
+					NetNsID:   utils.NormalizedInt,
+					Timestamp: utils.NormalizedStr,
+					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
+					ID:        utils.NormalizedStr,
+					Latency:   0,
+				},
+				// AAAA response from server
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+					Src: utils.L4Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+						Port:    53,
+						Proto:   17,
+					},
+					Dst: utils.L4Endpoint{
+						Addr:    clientIP,
+						Version: 4,
+						Port:    utils.NormalizedInt,
+						Proto:   17,
+					},
+					Comm:      "nslookup",
+					QrRaw:     true,
+					Qr:        "R",
+					Uid:       1000,
+					Gid:       1111,
+					Name:      "fake.test.com.",
+					QtypeRaw:  28,
+					Qtype:     "AAAA",
+					Rcode:     "Success",
+					PktType:   "HOST",
+					Addresses: "::1",
+
+					// Check the existence of the following fields
+					MntNsID:   utils.NormalizedInt,
+					NetNsID:   utils.NormalizedInt,
+					Timestamp: utils.NormalizedStr,
+					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
+					ID:        utils.NormalizedStr,
+					Latency:   utils.NormalizedInt,
+				},
+			}
+
+			normalize := func(e *traceDNSEvent) {
+				utils.NormalizeCommonData(&e.CommonData)
+				utils.NormalizeString(&e.Timestamp)
+				utils.NormalizeInt(&e.Pid)
+				utils.NormalizeInt(&e.Tid)
+				utils.NormalizeInt(&e.MntNsID)
+				utils.NormalizeInt(&e.NetNsID)
+				utils.NormalizeString(&e.ID)
+				utils.NormalizeInt(&e.Latency)
+
+				// Normalize the client port as we don't know it
+				if e.Src.Addr == clientIP {
+					utils.NormalizeInt(&e.Src.Port)
+				}
+
+				if e.Src.Addr == serverIP {
+					utils.NormalizeInt(&e.Dst.Port)
+				}
+			}
+
+			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntries...)
+		},
+	))
+
+	traceDNSCmd := igrunner.New("trace_dns", runnerOpts...)
+
+	igtesting.RunTestSteps([]igtesting.TestStep{traceDNSCmd}, t, testingOpts...)
+}

--- a/gadgets/trace_exec/go/go.mod
+++ b/gadgets/trace_exec/go/go.mod
@@ -2,7 +2,8 @@ module main
 
 go 1.22.0
 
-require github.com/inspektor-gadget/inspektor-gadget v0.27.0
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
 
 // Only needed by in-tree gadgets
 replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/trace_mount/go/go.mod
+++ b/gadgets/trace_mount/go/go.mod
@@ -2,7 +2,8 @@ module main
 
 go 1.22.0
 
-require github.com/inspektor-gadget/inspektor-gadget v0.29.0
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
 
 // Only needed by in-tree gadgets
 replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/trace_open/go/go.mod
+++ b/gadgets/trace_open/go/go.mod
@@ -2,7 +2,8 @@ module main
 
 go 1.22.0
 
-require github.com/inspektor-gadget/inspektor-gadget v0.27.0
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
 
 // Only needed by in-tree gadgets
 replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/pkg/container-utils/testutils/container_interface.go
+++ b/pkg/container-utils/testutils/container_interface.go
@@ -30,6 +30,7 @@ type containerSpec struct {
 
 	// Internal state
 	id           string
+	ip           string
 	pid          int
 	started      bool
 	portBindings nat.PortMap
@@ -41,6 +42,7 @@ type Container interface {
 	Start(t *testing.T)
 	Stop(t *testing.T)
 	ID() string
+	IP() string
 	Pid() int
 	Running() bool
 	PortBindings() nat.PortMap
@@ -48,6 +50,10 @@ type Container interface {
 
 func (c *containerSpec) ID() string {
 	return c.id
+}
+
+func (c *containerSpec) IP() string {
+	return c.ip
 }
 
 func (c *containerSpec) Pid() int {

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -140,6 +140,15 @@ func (d *DockerContainer) Run(t *testing.T) {
 		t.Fatalf("Failed to inspect container: %s", err)
 	}
 	d.pid = containerJSON.State.Pid
+
+	if len(containerJSON.NetworkSettings.Networks) > 1 {
+		t.Fatal("Multiple networks are not supported")
+	}
+
+	if len(containerJSON.NetworkSettings.Networks) == 1 {
+		d.ip = containerJSON.NetworkSettings.IPAddress
+	}
+
 	d.portBindings = containerJSON.NetworkSettings.Ports
 
 	if d.options.logs {

--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -82,6 +82,7 @@ func (c *K8sContainer) Start(t *testing.T) {
 	}, t)
 
 	c.id = getContainerID(t, c.name, c.options.namespace)
+	c.ip = getPodIP(t, c.name, c.options.namespace)
 	c.started = true
 }
 
@@ -236,4 +237,13 @@ func getContainerID(t *testing.T, podName, namespace string) string {
 	parts := strings.Split(ret, "/")
 	require.GreaterOrEqual(t, len(parts), 1, "unexpected container id")
 	return parts[len(parts)-1]
+}
+
+func getPodIP(t *testing.T, podName, namespace string) string {
+	cmd := exec.Command("kubectl", "-n", namespace, "get", "pod", podName, "-o", "jsonpath={.status.podIP}")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	r, err := cmd.Output()
+	require.NoError(t, err, "getting pod ip: %s", stderr.String())
+	return string(r)
 }

--- a/pkg/operators/wasm/fields.go
+++ b/pkg/operators/wasm/fields.go
@@ -157,7 +157,7 @@ func (i *wasmOperatorInstance) fieldGet(ctx context.Context, m wapi.Module, stac
 	}
 
 	if err != nil {
-		i.logger.Warnf("fieldGet failed: %v", err)
+		i.logger.Warnf("fieldGet for field %q failed: %v", field.Name(), err)
 		stack[0] = 0
 		return
 	}
@@ -241,7 +241,7 @@ func (i *wasmOperatorInstance) fieldSet(ctx context.Context, m wapi.Module, stac
 	}
 
 	if err != nil {
-		i.logger.Warnf("fieldSet failed: %v", err)
+		i.logger.Warnf("fieldSet for field %q failed: %v", field.Name(), err)
 		stack[0] = 1
 		return
 	}

--- a/wasmapi/go/fields.go
+++ b/wasmapi/go/fields.go
@@ -189,3 +189,20 @@ func (f Field) SetBytes(data Data, buf []byte) error {
 	}
 	return nil
 }
+
+func (f Field) Bool(data Data) (bool, error) {
+	val := fieldGet(uint32(f), uint32(data), uint32(Kind_Bool))
+	return val == 1, nil
+}
+
+func (f Field) SetBool(data Data, b bool) error {
+	var value uint64
+	if b {
+		value = 1
+	}
+	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Bool), value)
+	if ret != 0 {
+		return errSetField
+	}
+	return nil
+}


### PR DESCRIPTION
    This commit is very similar to d772f2ef04c7 ("dns: Parse DNS packet in user space"),
    but in this case the parsing is done in wasm because it's an image-based
    gadget.

    Unfortunately it seems that using gopacket with tinygo isn't possible,
    so I decided to use golang.org/x/net/dns/dnsmessage that provides
    the functionality we need.

--- 

Opening as draft until #3076 is merged. Feedback is already welcome. 

 Fixes #2999

### TODO 

- [x] Provide raw values for qtype and rcode
