### PR TITLE
ci: Remove documentation-checks from release needs.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1961,7 +1961,6 @@ jobs:
     name: Release
     # level: 5
     needs:
-      - documentation-checks
       - ebpf-objects-checks
       - lint
       - semgrep


### PR DESCRIPTION
This job fails by reporting a link is broken while it can perfectly be accessed [1, 2].
Let's remove it from release needs as it is flaky.

[1]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/9711450008/job/26804916562#step:6:320
[2]: https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster#get-a-red-hat-pull-secret-optional