### PR TITLE
Update README.md for all image-based gadgets

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -31,6 +31,8 @@ GADGETS = \
 	ci/sched_cls_drop \
 	#
 
+DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
 GADGETS_README = $(addsuffix /README.md, $(GADGETS))
 
 .PHONY: all
@@ -55,7 +57,13 @@ $(GADGETS):
 
 .PHONY: $(GADGETS_README)
 $(GADGETS_README):
-	gomplate -d gadget=$(@:README.md=gadget.yaml) -d artifacthubpkg=$(@:README.md=artifacthub-pkg.yml) < README.template > $@
+	gomplate -d gadget=$(@:README.md=gadget.yaml) -d artifacthubpkg=$(@:README.md=artifacthub-pkg.yml) --file README.template --out $@.new
+	if ! cmp $@ $@.new > /dev/null ; then \
+		mv $@.new $@ ; \
+		sed -i 's/^createdAt:.*$$/createdAt: "$(DATE)"/g' $(@:README.md=artifacthub-pkg.yml) ; \
+	else \
+		rm -f $@.new ; \
+	fi
 
 .PHONY:
 push: build

--- a/gadgets/snapshot_process/artifacthub-pkg.yml
+++ b/gadgets/snapshot_process/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "snapshot process"
 category: monitoring-logging
 displayName: "snapshot process"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "Show running processes"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/snapshot_socket/artifacthub-pkg.yml
+++ b/gadgets/snapshot_socket/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "snapshot socket"
 category: monitoring-logging
 displayName: "snapshot socket"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "Show TCP and UDP sockets"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/top_file/artifacthub-pkg.yml
+++ b/gadgets/top_file/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "top file"
 category: monitoring-logging
 displayName: "top file"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "Periodically report read/write activity by file"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_capabilities/README.md
+++ b/gadgets/trace_capabilities/README.md
@@ -1,0 +1,31 @@
+# trace capabilities
+
+trace security capabilitiy checks
+
+## Getting started
+Pulling the gadget:
+```
+sudo IG_EXPERIMENTAL=true ig image pull ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest
+```
+Running the gadget:
+```
+sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest [flags]
+kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest [flags]
+```
+
+## Flags
+
+### `--audit_only`
+Only show audit checks
+
+Default value: "false"
+
+### `--print-stack`
+controls whether the gadget will send kernel stack to userspace
+
+Default value: "true"
+
+### `--unique`
+Only show a capability once on the same container
+
+Default value: "false"

--- a/gadgets/trace_capabilities/artifacthub-pkg.yml
+++ b/gadgets/trace_capabilities/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace capabilities"
 category: monitoring-logging
 displayName: "trace capabilities"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:03Z"
 description: "trace security capabilitiy checks"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_dns/artifacthub-pkg.yml
+++ b/gadgets/trace_dns/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace dns"
 category: monitoring-logging
 displayName: "trace dns"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:03Z"
 description: "trace dns requests and responses"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_exec/artifacthub-pkg.yml
+++ b/gadgets/trace_exec/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace exec"
 category: monitoring-logging
 displayName: "trace exec"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:03Z"
 description: "trace process executions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_lsm/artifacthub-pkg.yml
+++ b/gadgets/trace_lsm/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace lsm"
 category: monitoring-logging
 displayName: "trace lsm"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:03Z"
 description: "a strace for LSM tracepoints"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_malloc/artifacthub-pkg.yml
+++ b/gadgets/trace_malloc/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace malloc"
 category: monitoring-logging
 displayName: "trace malloc"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "use uprobe to trace malloc and free in libc.so"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_mount/artifacthub-pkg.yml
+++ b/gadgets/trace_mount/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace mount"
 category: monitoring-logging
 displayName: "trace mount"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace mount syscalls"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_oomkill/artifacthub-pkg.yml
+++ b/gadgets/trace_oomkill/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace oomkill"
 category: monitoring-logging
 displayName: "trace oomkill"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace OOM killer"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_open/artifacthub-pkg.yml
+++ b/gadgets/trace_open/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace open"
 category: monitoring-logging
 displayName: "trace open"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace open files"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_signal/artifacthub-pkg.yml
+++ b/gadgets/trace_signal/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace signal"
 category: monitoring-logging
 displayName: "trace signal"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace signal"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_sni/artifacthub-pkg.yml
+++ b/gadgets/trace_sni/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace sni"
 category: monitoring-logging
 displayName: "trace sni"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace sni"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_ssl/artifacthub-pkg.yml
+++ b/gadgets/trace_ssl/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace ssl"
 category: monitoring-logging
 displayName: "trace ssl"
-createdAt: "2024-04-20T14:09:00+08:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "use uprobe to capture data on read/recv or write/send functions of OpenSSL, GnuTLS, NSS and Libcrypto"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcp/artifacthub-pkg.yml
+++ b/gadgets/trace_tcp/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace tcp"
 category: monitoring-logging
 displayName: "trace tcp"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "monitor connect, accept and close events of TCP connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpconnect/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpconnect/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace tcpconnect"
 category: monitoring-logging
 displayName: "trace tcpconnect"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace tcp connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpdrop/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpdrop/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace tcpdrop"
 category: monitoring-logging
 displayName: "trace tcpdrop"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace TCP packets dropped by the kernel"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpretrans/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpretrans/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 0.29.0
 name: "trace tcpretrans"
 category: monitoring-logging
 displayName: "trace tcpretrans"
-createdAt: "2024-03-25T14:32:05+01:00"
+createdAt: "2024-07-01T09:22:04Z"
 description: "trace TCP retransmissions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""


### PR DESCRIPTION
The date is updated so that artifacthub picks up the changes.

trace_capabilities' README is added.

Fixes: #2671 (Support kernel stack map)
Fixes: #3092 (Add README.md for all image-based gadgets)
