### PR TITLE
cmd/kubectl-gadget: Set k8s flags for runtime after parsing

### DIFF
--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -82,22 +82,23 @@ func main() {
 	runtimeGlobalParams = grpcRuntime.GlobalParamDescs().ToParams()
 	common.AddFlags(rootCmd, runtimeGlobalParams, nil, grpcRuntime)
 	grpcRuntime.Init(runtimeGlobalParams)
-	config, err := utils.KubernetesConfigFlags.ToRESTConfig()
-	if err != nil {
-		log.Fatalf("Creating RESTConfig: %s", err)
-	}
-	grpcRuntime.SetRestConfig(config)
 
 	// evaluate flags early for runtimeGlobalParams; this will make
 	// sure that all flags relevant for the grpc connection are ready
 	// to be used
 
-	err = commonutils.ParseEarlyFlags(rootCmd, os.Args[1:])
+	err := commonutils.ParseEarlyFlags(rootCmd, os.Args[1:])
 	if err != nil {
 		// Analogous to cobra error message
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	config, err := utils.KubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		log.Fatalf("Creating RESTConfig: %s", err)
+	}
+	grpcRuntime.SetRestConfig(config)
 
 	namespace, _ := utils.GetNamespace()
 	grpcRuntime.SetDefaultValue(gadgets.K8SNamespace, namespace)


### PR DESCRIPTION
Currently we are passing down `KubernetesConfigFlags` to runtime before parsing flags which means all of them will be ignored when talking to Kubernetes. This PR fixes it by setting them for runtime after parsing initial flags

## Testing done

### Before the change

```bash
# kubeconfig flag getting ignored
→ go run ./cmd/kubectl-gadget/ run trace_open --kubeconfig foo.bar
...
RUNTIME.CONTAINERNAME              PID                 UID                 GID                MNTNS_ID      ERR FD                 FLAG… MODE_RAW           COMM             FNAME                                TIMESTAMP_RAW   
```


### After the change

```bash
# kubeconfig flag being respected
→ go run ./cmd/kubectl-gadget/ run trace_open --kubeconfig foo.bar
...
FATA[0000] Creating RESTConfig: stat foo.bar: no such file or directory 
exit status 1
```

Found it when testing: https://github.com/inspektor-gadget/inspektor-gadget/pull/2831