### PR TITLE
artifacthub: use field 'digest' instead of 'createdAt' for reindexing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,16 @@ jobs:
 
         echo "version=${inspektor_gadget_version}" >> $GITHUB_OUTPUT
 
+        DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
         for PKGFILE in $(find gadgets/ -name artifacthub-pkg.yml) ; do
+            # - The 'createdAt' field identifies the release date. It should not
+            #   be changed in between releases.
+            # - The 'digest' field is modified to request reindexing from
+            #   artifacthub. It is fine to modify it more often.
             sed -i \
                 -e "s/^version:.*$/version: ${inspektor_gadget_version}/" \
+                -e "s/^createdAt:.*$/createdAt: \"${DATE}\"/" \
+                -e "s/^digest:.*$/digest: \"${DATE}\"/" \
                 $PKGFILE
         done
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -58,9 +58,10 @@ $(GADGETS):
 .PHONY: $(GADGETS_README)
 $(GADGETS_README):
 	gomplate -d gadget=$(@:README.md=gadget.yaml) -d artifacthubpkg=$(@:README.md=artifacthub-pkg.yml) --file README.template --out $@.new
+	@# Modify field 'digest' to request reindexing from artifacthub.
 	if ! cmp $@ $@.new > /dev/null ; then \
 		mv $@.new $@ ; \
-		sed -i 's/^createdAt:.*$$/createdAt: "$(DATE)"/g' $(@:README.md=artifacthub-pkg.yml) ; \
+		sed -i 's/^digest:.*$$/digest: "$(DATE)"/g' $(@:README.md=artifacthub-pkg.yml) ; \
 	else \
 		rm -f $@.new ; \
 	fi

--- a/gadgets/snapshot_process/artifacthub-pkg.yml
+++ b/gadgets/snapshot_process/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "snapshot process"
 category: monitoring-logging
 displayName: "snapshot process"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "Show running processes"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/snapshot_socket/artifacthub-pkg.yml
+++ b/gadgets/snapshot_socket/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "snapshot socket"
 category: monitoring-logging
 displayName: "snapshot socket"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "Show TCP and UDP sockets"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/top_file/artifacthub-pkg.yml
+++ b/gadgets/top_file/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "top file"
 category: monitoring-logging
 displayName: "top file"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "Periodically report read/write activity by file"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_capabilities/artifacthub-pkg.yml
+++ b/gadgets/trace_capabilities/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace capabilities"
 category: monitoring-logging
 displayName: "trace capabilities"
 createdAt: "2024-07-01T09:22:03Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace security capabilitiy checks"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_dns/artifacthub-pkg.yml
+++ b/gadgets/trace_dns/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace dns"
 category: monitoring-logging
 displayName: "trace dns"
 createdAt: "2024-07-01T09:22:03Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace dns requests and responses"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_exec/artifacthub-pkg.yml
+++ b/gadgets/trace_exec/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace exec"
 category: monitoring-logging
 displayName: "trace exec"
 createdAt: "2024-07-01T09:22:03Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace process executions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_lsm/artifacthub-pkg.yml
+++ b/gadgets/trace_lsm/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace lsm"
 category: monitoring-logging
 displayName: "trace lsm"
 createdAt: "2024-07-01T09:22:03Z"
+digest: "2024-07-01T13:58:59Z"
 description: "a strace for LSM tracepoints"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_malloc/artifacthub-pkg.yml
+++ b/gadgets/trace_malloc/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace malloc"
 category: monitoring-logging
 displayName: "trace malloc"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "use uprobe to trace malloc and free in libc.so"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_mount/artifacthub-pkg.yml
+++ b/gadgets/trace_mount/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace mount"
 category: monitoring-logging
 displayName: "trace mount"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace mount syscalls"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_oomkill/artifacthub-pkg.yml
+++ b/gadgets/trace_oomkill/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace oomkill"
 category: monitoring-logging
 displayName: "trace oomkill"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace OOM killer"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_open/artifacthub-pkg.yml
+++ b/gadgets/trace_open/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace open"
 category: monitoring-logging
 displayName: "trace open"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace open files"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_signal/artifacthub-pkg.yml
+++ b/gadgets/trace_signal/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace signal"
 category: monitoring-logging
 displayName: "trace signal"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace signal"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_sni/artifacthub-pkg.yml
+++ b/gadgets/trace_sni/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace sni"
 category: monitoring-logging
 displayName: "trace sni"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace sni"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_ssl/artifacthub-pkg.yml
+++ b/gadgets/trace_ssl/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace ssl"
 category: monitoring-logging
 displayName: "trace ssl"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "use uprobe to capture data on read/recv or write/send functions of OpenSSL, GnuTLS, NSS and Libcrypto"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcp/artifacthub-pkg.yml
+++ b/gadgets/trace_tcp/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace tcp"
 category: monitoring-logging
 displayName: "trace tcp"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "monitor connect, accept and close events of TCP connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpconnect/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpconnect/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace tcpconnect"
 category: monitoring-logging
 displayName: "trace tcpconnect"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace tcp connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpdrop/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpdrop/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace tcpdrop"
 category: monitoring-logging
 displayName: "trace tcpdrop"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace TCP packets dropped by the kernel"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpretrans/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpretrans/artifacthub-pkg.yml
@@ -4,6 +4,7 @@ name: "trace tcpretrans"
 category: monitoring-logging
 displayName: "trace tcpretrans"
 createdAt: "2024-07-01T09:22:04Z"
+digest: "2024-07-01T13:58:59Z"
 description: "trace TCP retransmissions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""


### PR DESCRIPTION
artifacthub-pkg.yml has the following fields:
- `createdAt`: date identifying a release. It should not be modified in between releases to avoid confusing users.
- `digest`: string used by artifacthub to request a reindexing

#3102 was wrong to use the `createdAt` for requesting reindexing from artifacthub. It might work on the artifacthub staging area but it does not work with the artifacthub in prod.

Fixes: be7b7dd96fe2 ("Update README.md for all image-based gadgets")
Fixes: 81ce92dd3ca8 ("release: automatically update artifact hub version")

## How to use

Regenerate readmes with:
```bash
make -C gadgets readmes
```

## Testing done

See tests from #3102.

Note: I used the following command to insert the `digest` field.
```
DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
for i in $(find gadgets/ -name artifacthub-pkg.yml) ; do sed -i '/^createdAt:.*$/adigest: "'$DATE'"' $i ; done
```