### PR TITLE
Makefile: Fix how ig-debug version is set.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ig: ig-$(GOHOSTOS)-$(GOHOSTARCH)
 # See: https://pkg.go.dev/cmd/compile
 debug-ig:
 	CGO_ENABLED=0 go build \
-		-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/cmd/common.version=${VERSION} \
+		-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/internal/version.version=${VERSION} \
 		-X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${EBPF_BUILDER} \
 		-extldflags '-static'" \
 		-gcflags='all=-N -l' \


### PR DESCRIPTION
Hi!

We forgot to update this line when we changed how the version is computed.

Best regards.