### PR TITLE
prometheus: Use different name for metrics config

### DIFF
--- a/docs/guides/prometheus.md
+++ b/docs/guides/prometheus.md
@@ -10,8 +10,8 @@ Kubernetes (`ig-k8s`) and in Linux hosts (`ig`).
 
 
 ```bash
-$ kubectl gadget prometheus --config @<path>
-$ ig prometheus --config @<path> --metrics-listen-address $IP:$PORT --metrics-path /metrics
+$ kubectl gadget prometheus --metrics-config @<path>
+$ ig prometheus --metrics-config @<path> --metrics-listen-address $IP:$PORT --metrics-path /metrics
 ```
 
 ## Configuration File
@@ -303,7 +303,7 @@ metrics:
 Start the gadget
 
 ```bash
-$ kubectl gadget prometheus --config @myconfig.yaml
+$ kubectl gadget prometheus --metrics-config @myconfig.yaml
 INFO[0000] Running. Press Ctrl + C to finish
 INFO[0000] minikube             | Publishing metrics...
 ```
@@ -346,7 +346,7 @@ metrics:
 Restart the gadget
 
 ```bash
-$ kubectl gadget prometheus --config @myconfig.yaml
+$ kubectl gadget prometheus --metrics-config @myconfig.yaml
 INFO[0000] Running. Press Ctrl + C to finish
 INFO[0000] minikube             | Publishing metrics...
 ```
@@ -387,7 +387,7 @@ $ prometheus --config.file prometheus.yaml
 Then, start the prometheus gadget with the same configuration as above Kubernetes section:
 
 ```bash
-$ sudo ig prometheus --config @myconfig.yaml
+$ sudo ig prometheus --metrics-config @myconfig.yaml
 INFO[0000] Running. Press Ctrl + C to finish
 INFO[0000] Publishing metrics...
 ```
@@ -424,7 +424,7 @@ At this point, Grafana is available at http://localhost:3000 and Prometheus at h
 with the following configuration:
 
 ```bash
-$ sudo ig prometheus --config @tools/monitoring/config/histogram.yaml
+$ sudo ig prometheus --metrics-config @tools/monitoring/config/histogram.yaml
 INFO[0000] Running. Press Ctrl + C to finish
 ```
 

--- a/integration/k8s/prometheus_test.go
+++ b/integration/k8s/prometheus_test.go
@@ -111,7 +111,7 @@ EOF
 		counterMetricsCommand := []TestStep{
 			&Command{
 				Name:         "RunPrometheusGadget",
-				Cmd:          "$KUBECTL_GADGET prometheus --config @testdata/prometheus/counter.yaml",
+				Cmd:          "$KUBECTL_GADGET prometheus --metrics-config @testdata/prometheus/counter.yaml",
 				StartAndStop: true,
 			},
 			SleepForSecondsCommand(2),

--- a/pkg/gadgets/prometheus/tracer/gadget.go
+++ b/pkg/gadgets/prometheus/tracer/gadget.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ParamConfig = "config"
+	ParamConfig = "metrics-config"
 )
 
 type fakeEvent struct{}

--- a/tools/monitoring/README.md
+++ b/tools/monitoring/README.md
@@ -4,7 +4,7 @@ This directory contains docker compose files for spinning up grafana and prometh
 Prometheus is configured to scrape metrics from the `ig` instance running on the host machine as:
 
 ```bash
-go run -exec sudo ../../cmd/ig/ prometheus --config @config/histogram.yaml
+go run -exec sudo ../../cmd/ig/ prometheus --metrics-config @config/histogram.yaml
 INFO[0000] Running. Press Ctrl + C to finish
 ...
 ```


### PR DESCRIPTION
Use different name for metric flag for prometheus to avoid conflict with: https://github.com/inspektor-gadget/inspektor-gadget/pull/2831

cc: @eiffel-fl 