### PR TITLE
pkg/gadgets/run/types: Test string equality rather than contain to de…

### DIFF
--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -254,14 +254,17 @@ func validateStructs(m *metadatav1.GadgetMetadata, spec *ebpf.CollectionSpec) er
 		mntnsFields := 0
 		netnsFields := 0
 
+		mntNsIdType := strings.TrimPrefix(compat.MntNsIdType, "type:")
+		netNsIdType := strings.TrimPrefix(compat.NetNsIdType, "type:")
+
 		btfStructFields := make(map[string]btf.Member, len(btfStruct.Members))
 		for _, m := range btfStruct.Members {
 			btfStructFields[m.Name] = m
 
-			if m.Type.TypeName() != "" && strings.Contains(compat.MntNsIdType, m.Type.TypeName()) {
+			if mntNsIdType == m.Type.TypeName() {
 				mntnsFields++
 			}
-			if m.Type.TypeName() != "" && strings.Contains(compat.NetNsIdType, m.Type.TypeName()) {
+			if netNsIdType == m.Type.TypeName() {
 				netnsFields++
 			}
 		}


### PR DESCRIPTION
Hi.

This PR fixes a bad behavior for namespace related types:

```bash
$ make trace_tcpretrans                                             main *% u=
Building trace_tcpretrans
INFO[0000] Experimental features enabled                
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:6a72849ccc5b43377fbfc2feea0a164d84aaa2e53524fbd3f374bf60c6e2cd69
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
WARN[0002] Using multiple fields of "type:gadget_mntns_id" may cause unpredictable behavior during enrichment 
WARN[0002] Using multiple fields of "type:gadget_netns_id" may cause unpredictable behavior during enrichment 
Successfully built ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest@sha256:a350d5096a053151a4364cd7d46fb577f6c5cabd3497425bdcf3b06852645f78
$ make trace_tcpretrans                                 francis/fix-ns-check %
Building trace_tcpretrans
INFO[0000] Experimental features enabled                
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:6a72849ccc5b43377fbfc2feea0a164d84aaa2e53524fbd3f374bf60c6e2cd69
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:francis-fix-ns-check@sha256:14dd8ef82e307682aa13c921650f5b3e31e37f946b3e8be97db4106075a98479
```

We should definitely have `-Werror` set in our CI to catch this kind of mistake.

Best regards.