### PR TITLE
minikube.mk: switch minikube to use kubernetes v1.30.0

### DIFF
--- a/minikube.mk
+++ b/minikube.mk
@@ -1,5 +1,5 @@
 MINIKUBE_VERSION ?= v1.33.1
-KUBERNETES_VERSION ?= v1.30.1
+KUBERNETES_VERSION ?= v1.30.0
 MINIKUBE_DRIVER ?= docker
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Minikube v1.33.1 supports Kubernetes v1.30.0 but not v1.30.1. Switch to a supported version.

Using an unsupported version causes minikube to fetch a Kubernetes version list from internet, and this often causes the following error in the CI:

> ! Specified Kubernetes version 1.30.1 is newer than the newest supported version: v1.30.0. Use `minikube config defaults kubernetes-version` for details.
> ! Specified Kubernetes version 1.30.1 not found in Kubernetes version list
> * Searching the internet for Kubernetes version...
>
> X Exiting due to K8S_FAIL_CONNECT: error fetching Kubernetes version list from GitHub: GET https://api.github.com/repos/kubernetes/kubernetes/releases/tags/v1.30.1: 403 API rate limit exceeded for 172.183.154.99. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 21m40s]

Fixes: 8f76dacf556d ("minikube: Upgrade to v1.33.1")

