### PR TITLE
gadgets: Test endpoints too

### DIFF
--- a/gadgets/trace_sni/test/trace_sni_test.go
+++ b/gadgets/trace_sni/test/trace_sni_test.go
@@ -32,8 +32,6 @@ import (
 type traceSNIEvent struct {
 	eventtypes.CommonData
 
-	// TODO: endpoints, see https://github.com/inspektor-gadget/inspektor-gadget/issues/3034
-
 	Timestamp string `json:"timestamp"`
 	MountNsID uint64 `json:"mntns_id"`
 	NetNs     uint64 `json:"netns"`

--- a/pkg/testing/utils/types.go
+++ b/pkg/testing/utils/types.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+// Define some types that are only used for testing purposes
+
+type L4Endpoint struct {
+	Addr    string `json:"addr"`
+	Version uint8  `json:"version"`
+	Port    uint16 `json:"port"`
+	Proto   uint16 `json:"proto"`
+}
+
+type L3Endpoint struct {
+	Addr    string `json:"addr"`
+	Version uint8  `json:"version"`
+}


### PR DESCRIPTION
The trace_sni gadget doesn't provide any information about endpoints, so the previous TODO was wrong.

