### PR TITLE
gadgettracermanager: Set environment to Kubernetes

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -37,6 +37,9 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	// Import this early to set the environment variable before any other package is imported
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/k8s"
+
 	// This is a blank include that actually imports all gadgets
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/all-gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"


### PR DESCRIPTION
Fixes: #3014 

## Testing done



### Before this change
```
$ make minikube-deploy
$ ./kubectl-gadget run trace_open:latest -A
INFO[0000] Experimental features enabled
RUNTIME.CONTAINERNAME   PID          UID          GID          MNTNS_ID  ERR FD          COMM        FNAME                   TIMESTAMP
```


### After this change

```
$ make minikube-deploy
$ ./kubectl-gadget run trace_open:latest -A
→ ./kubectl-gadget run trace_open -A
INFO[0000] Experimental features enabled                
K8S.NAMESPACE        K8S.PODNAME          K8S.CONTAINERNAME    PID         UID         GID         MNTNS_ID E… FD          COMM       FNAME                 MODE       FLAGS      K8S.NODE   TIMESTAMP             
gadget               gadget-lsknt         gadget               844834      0           0           40265331  0 66          gadgettrac /sys/kernel/debug/tra ---------- O_RDONLY|O minikube-d 2024-07-05T12:45:15.66
gadget               gadget-lsknt         gadget               844834      0           0           40265331  0 68          gadgettrac /host/proc            ---------- O_RDONLY|O minikube-d 2024-07-05T12:45:16.25
gadget               gadget-lsknt         gadget               845840      0           0           40265331  0 5           runc:[2:IN /sys/kernel/mm/transp ---------- O_RDONLY   minikube-d 2024-07-05T12:45:16.55

```
