### PR TITLE
Specify public key at deploy time for `kubectl-gadget`

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -47,7 +47,7 @@ runs:
           # Inspektor-Gadget container image is loaded into the cluster using "minikube image load" instead of pushing the container image to a registry.
           EXTRA_FLAGS='--image-pull-policy=Never'
         fi
-        ./kubectl-gadget deploy $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
+        ./kubectl-gadget deploy --gadgets-verify-image=${{ inputs.gadget_verify_image }} $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
     - name: Integration tests
       id: integration-tests
       shell: bash
@@ -87,7 +87,6 @@ runs:
           DNSTESTER_IMAGE=${{ inputs.dnstester_image }} \
           GADGET_REPOSITORY=${{ inputs.gadget_repository }} \
           GADGET_TAG=${{ inputs.gadget_tag }} \
-          GADGET_VERIFY_IMAGE=${{ inputs.gadget_verify_image }} \
           -o kubectl-gadget integration-tests |& tee integration.log & wait $!
         echo "IntegrationTestsJob: Done"
     - name: Undeploy Inspektor Gadget

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1484,12 +1484,11 @@ jobs:
     - name: Gadgets tests
       run: |
         tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-        ./kubectl-gadget deploy --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        ./kubectl-gadget deploy --gadgets-verify-image=${{ needs.check-secrets.outputs.cosign }} --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         make \
         GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
         GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
         KUBECTL_GADGET=/home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget \
-        IG_FLAGS="--verify-image=${{ needs.check-secrets.outputs.cosign }}" \
         -C gadgets/ test-k8s -o build
     - name: Undeploy Inspektor Gadget
       id: undeploy-ig

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ MINIKUBE ?= minikube
 KUBERNETES_DISTRIBUTION ?= ""
 GADGET_TAG ?= $(shell ./tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
-GADGET_VERIFY_IMAGE ?= true
 TEST_COMPONENT ?= inspektor-gadget
 
 GOHOSTOS ?= $(shell go env GOHOSTOS)
@@ -286,7 +285,6 @@ integration-tests: kubectl-gadget
 			-dnstester-image $(DNSTESTER_IMAGE) \
 			-gadget-repository $(GADGET_REPOSITORY) \
 			-gadget-tag $(GADGET_TAG) \
-			-gadget-verify-image=$(GADGET_VERIFY_IMAGE) \
 			-test-component $(TEST_COMPONENT) \
 			$$INTEGRATION_TESTS_PARAMS
 

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -88,6 +88,10 @@ spec:
               value: {{ .Values.config.eventsBufferLength | quote }}
             - name: GADGET_TRACER_MANAGER_LOG_LEVEL
               value: {{ .Values.config.daemonLogLevel | quote }}
+            - name: GADGET_VERIFY_IMAGE
+              value: {{ .Values.config.gadgetVerifyImage | quote }}
+            - name: GADGET_PUBLIC_KEY
+              value: {{ .Values.config.gadgetPublicKey | quote }}
           securityContext:
             readOnlyRootFilesystem: true
             # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -25,6 +25,16 @@ config:
   # -- Daemon Log Level. Valid values are: "trace", "debug", "info", "warning", "error", "fatal", "panic"
   daemonLogLevel: "info"
 
+  # -- Verify image-based gadgets
+  gadgetVerifyImage: true
+
+  # -- Public key used to verify image-based gadgets
+  gadgetPublicKey: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
+    Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
+    -----END PUBLIC KEY-----
+
   # -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from private registry
   mountPullSecret: false
 

--- a/integration/k8s/integration_test_kubectl_gadget.go
+++ b/integration/k8s/integration_test_kubectl_gadget.go
@@ -44,9 +44,8 @@ var (
 
 	k8sDistro = flag.String("k8s-distro", "", "allows to skip tests that are not supported on a given Kubernetes distribution")
 
-	gadgetRepository  = flag.String("gadget-repository", "ghcr.io/inspektor-gadget/gadget", "repository where gadget images are stored")
-	gadgetTag         = flag.String("gadget-tag", "latest", "tag used for gadgets's OCI images")
-	gadgetVerifyImage = flag.Bool("gadget-verify-image", true, "verify gadget image before running tests")
+	gadgetRepository = flag.String("gadget-repository", "ghcr.io/inspektor-gadget/gadget", "repository where gadget images are stored")
+	gadgetTag        = flag.String("gadget-tag", "latest", "tag used for gadgets's OCI images")
 )
 
 func cleanupFunc(cleanupCommands []*integration.Command) {

--- a/integration/k8s/run_insecure_test.go
+++ b/integration/k8s/run_insecure_test.go
@@ -60,9 +60,14 @@ func TestRunInsecure(t *testing.T) {
 	}
 	RunTestSteps(orasCpCmds, t)
 
+	cosignSignCmd := &Command{
+		Name: "SignTestImage",
+		Cmd:  fmt.Sprintf("docker run -e COSIGN_PRIVATE_KEY=env://COSIGN_PRIVATE_KEY --rm gcr.io/projectsigstore/cosign:v1.13.0 sign --key env://COSIGN_PRIVATE_KEY --yes --recursive %s", fmt.Sprintf("%s:5000/trace_open:%s", registryIP, *gadgetTag)),
+	}
+	cosignSignCmd.Run(t)
+
 	// TODO: Ideally it should not depend on a real gadget, but we don't have a "test gadget" available yet.
-	// As the image was not signed, we need to set --verify-image=false.
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run --verify-image=false %s:5000/trace_open:%s -n %s -o json --insecure --timeout 2", registryIP, *gadgetTag, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s:5000/trace_open:%s -n %s -o json --insecure --timeout 2", registryIP, *gadgetTag, ns)
 
 	// run the gadget without verifying its output as we only need to check if it runs
 	traceOpenCmd := &Command{

--- a/integration/k8s/run_schedcls_test.go
+++ b/integration/k8s/run_schedcls_test.go
@@ -49,7 +49,7 @@ func TestRunSchedCLS(t *testing.T) {
 	RunTestSteps(commandsPreTest, t)
 	nginxIP := GetTestPodIP(t, ns, "nginx-pod")
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/ci/sched_cls_drop:%s --verify-image=%t -n %s", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/ci/sched_cls_drop:%s -n %s", *gadgetRepository, *gadgetTag, ns)
 	runSchedCLSCmd := &Command{
 		Name:         "StartRunSchedCLS",
 		Cmd:          cmd,

--- a/integration/k8s/run_top_file_test.go
+++ b/integration/k8s/run_top_file_test.go
@@ -103,7 +103,7 @@ func TestRunTopFile(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/top_file:%s --verify-image=%t -n %s -o json", *gadgetRepository, *gadgetTag, *gadgetVerifyImage, ns)
+	cmd := fmt.Sprintf("$KUBECTL_GADGET run %s/top_file:%s -n %s -o json", *gadgetRepository, *gadgetTag, ns)
 
 	runTopFile(t, ns, cmd)
 }

--- a/pkg/environment/k8s/k8s.go
+++ b/pkg/environment/k8s/k8s.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package k8s sets the environnment to Kubernetes. Imported by kubectl-gadget.
+// Package k8s sets the environment to Kubernetes. Imported by kubectl-gadget.
 package k8s
 
 import "github.com/inspektor-gadget/inspektor-gadget/pkg/environment"

--- a/pkg/environment/local/local.go
+++ b/pkg/environment/local/local.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package local sets the environnment to Local. Imported by ig.
+// Package local sets the environment to Local. Imported by ig.
 package local
 
 import "github.com/inspektor-gadget/inspektor-gadget/pkg/environment"

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -36,8 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
-
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
@@ -51,6 +49,8 @@ import (
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	oras_auth "oras.land/oras-go/v2/registry/remote/auth"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 )
 
 type AuthOptions struct {

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -26,6 +26,7 @@ import (
 
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/local"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -172,6 +172,10 @@ spec:
               value: "16384"
             - name: GADGET_TRACER_MANAGER_LOG_LEVEL
               value: "info"
+            - name: GADGET_VERIFY_IMAGE
+              value: "true"
+            - name: GADGET_PUBLIC_KEY
+              value: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh\nIr4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==\n-----END PUBLIC KEY-----\n"
           securityContext:
             readOnlyRootFilesystem: true
             # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate


### PR DESCRIPTION
Hi!

In this PR, I modified how public key related flags are handled for `kubectl-gadget`:

```bash
$ ./kubectl-gadget deploy --image-pull-policy=Never --gadgets-verify-image=false
...
Inspektor Gadget successfully deployed
$ ./kubectl-gadget run --verify-image=false trace_exec     francis/config-public-key %
INFO[0000] Experimental features enabled                
Error: unknown flag: --verify-image
$ ./kubectl-gadget run trace_exec                          francis/config-public-key %
INFO[0000] Experimental features enabled                
WARN[0000] minikube-docker      | you set --verify-image=false, image will not be verified 
K8S.NAMESPACE  K8S.PODNAME    K8S.CONTAINER… MNTNS… PID      PPID     UID      GID      R… U… P… COMM    ARGS    K8S.NO… TIMESTAMP       
^C%
$ ./kubectl-gadget undeploy                                francis/config-public-key %
...
Inspektor Gadget successfully removed
$ ./kubectl-gadget deploy --image-pull-policy=Never --gadgets-public-key="$(cat eiffel-fl.pub)"
...
Inspektor Gadget successfully deployed
$ ./kubectl-gadget run trace_exec                          francis/config-public-key %
INFO[0000] Experimental features enabled                
Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "trace_exec": verifying signature: invalid signature when validating ASN.1 encoded signature
$ ./kubectl-gadget run ghcr.io/eiffel-fl/gadget/trace_exec francis/config-public-key %
INFO[0000] Experimental features enabled                
K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNA… MNTNS_… TIMESTAMP           PID      PPID     UID      GID      … U… COMM     K8S.NODE
^C%
```

The situation is the same for `ig`:

```bash
$ sudo -E ./ig run trace_exec                              francis/config-public-key %
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
RUNTIME.CONTAINERNAME MNTNS_ID  PID         PPID        UID         GID         RE… UP… PU… COMM       ARGS       TIMESTAMP              
minikube-docker       402653302 228211      117729      0           0           0   fa… fa… bridge     /opt/cni/… 2024-07-09T17:07:46.692
$ sudo -E ./ig run --verify-image=false trace_exec         francis/config-public-key %
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] you set --verify-image=false, image will not be verified 
WARN[0000] you set --verify-image=false, image will not be verified 
RUNTIME.CONTAINERNAME MNTNS_ID  PID         PPID        UID         GID         RE… UP… PU… COMM       ARGS       TIMESTAMP              
minikube-docker       402653302 226213      117729      0           0           0   fa… fa… bridge     /opt/cni/… 2024-07-09T17:05:36.501
$ sudo -E ./ig run --public-key="$(cat eiffel-fl.pub)" trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "trace_exec": verifying signature: invalid signature when validating ASN.1 encoded signature
$ sudo -E ./ig run --public-key="$(cat eiffel-fl.pub)" ghcr.io/eiffel-fl/gadget/trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
RUNTIME.CONTAINERNAME    MNTNS_ID   TIMESTAMP                    PID           PPID         UID          GID          R… UP… COMM        
minikube-docker          4026533029 9933516646550                229109        117501       0            0            0  fa… runc        
minikube-docker          4026533029 9933521555946                229115        117501       0            0            0  fa… docker-init
```

Best regards.

Once merged, TODO:
- [ ] Apply the same for allowed digests.
- [ ] Modify `--public-key` to accept a list.
- [ ] Apply the same for `gadgetctl/ig daemon`.
- [ ] After #3145 is merged, apply the same and expand it to have several registries.