### PR TITLE
pkg/oci: Add option to only run image-based gadgets from specific registries

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -42,6 +42,7 @@ const (
 	verifyImage           = "verify-image"
 	publicKey             = "public-key"
 	allowedDigests        = "allowed-digests"
+	allowedRegistries     = "allowed-registries"
 )
 
 type ociHandler struct{}
@@ -120,6 +121,12 @@ func (o *ociHandler) InstanceParams() api.Params {
 			Description: "List of allowed digests, if image digest is not part of it, execution will be denied. By default, all digests are allowed",
 			TypeHint:    api.TypeString,
 		},
+		{
+			Key:         allowedRegistries,
+			Title:       "Allowed registries",
+			Description: "Only run image-based gadgets from these registries",
+			TypeHint:    api.TypeString,
+		},
 	}
 }
 
@@ -195,6 +202,9 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		},
 		AllowedDigestsOptions: oci.AllowedDigestsOptions{
 			AllowedDigests: o.ociParams.Get(allowedDigests).AsStringSlice(),
+		},
+		AllowedRegistriesOptions: oci.AllowedRegistriesOptions{
+			AllowedRegistries: o.ociParams.Get(allowedRegistries).AsStringSlice(),
 		},
 	}
 


### PR DESCRIPTION
Hi!

This PR implements restriction on the registry to run image-based gadgets:

```bash
$ sudo -E ./ig run --registry ghcr.io/eiffel-fl/gadget trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/inspektor-gadget/gadget/trace_exec:latest was not pulled from ghcr.io/eiffel-fl/gadget
$ sudo -E ./ig run --registry ghcr.io/inspektor-gadget/gadget trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAINERNAME MNTNS_ID  PID         PPID        UID         GID         RE… UP… PU… COMM       ARGS       TIMESTAMP              
^C%
```

The whole tweaking for `kubectl-gadget` will be done later once #3143 is merged.

Best regards.