### PR TITLE
gadgets: Provide human readable version of error codes

### DIFF
--- a/gadgets/trace_bind/gadget.yaml
+++ b/gadgets/trace_bind/gadget.yaml
@@ -40,11 +40,9 @@ datasources:
         annotations:
           description: Group ID
           template: uid
-      ret:
+      error_raw:
         annotations:
-          description: Return value of the bind() syscall
-          columns.width: 5
-          columns.alignment: right
+          columns.hidden: true
       opts_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_bind/program.bpf.c
+++ b/gadgets/trace_bind/program.bpf.c
@@ -44,7 +44,7 @@ struct event {
 	__u32 uid;
 	__u32 gid;
 
-	int ret;
+	gadget_errno error_raw;
 	enum bind_options_set opts_raw;
 	// TODO: How to get the name of the device?
 	__u32 bound_dev_if;
@@ -199,7 +199,7 @@ static int probe_exit(struct pt_regs *ctx, short ver)
 	event->pid = pid;
 	event->tid = tid;
 	event->bound_dev_if = BPF_CORE_READ(sock, __sk_common.skc_bound_dev_if);
-	event->ret = ret;
+	event->error_raw = -ret;
 	event->mntns_id = mntns_id;
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	event->uid = (u32)uid_gid;

--- a/gadgets/trace_bind/test/trace_bind_test.go
+++ b/gadgets/trace_bind/test/trace_bind_test.go
@@ -42,7 +42,7 @@ type traceBindEvent struct {
 	Gid  uint32 `json:"gid"`
 
 	Addr       utils.L4Endpoint `json:"addr"`
-	Ret        int32            `json:"ret"`
+	Error      string           `json:"error"`
 	Opts       string           `json:"opts"`
 	BoundDevIF uint32           `json:"bound_dev_if"`
 }

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -52,7 +52,7 @@ datasources:
         annotations:
           template: uid
           columns.hidden: true
-      retval:
+      error:
         annotations:
           columns.width: 5
           columns.alignment: right

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -38,7 +38,7 @@ struct event {
 	__u32 ppid;
 	__u32 loginuid;
 	__u32 sessionid;
-	int retval;
+	gadget_errno error_raw;
 	int args_count;
 	bool upper_layer;
 	bool pupper_layer;
@@ -214,7 +214,7 @@ int ig_execve_x(struct syscall_trace_exit *ctx)
 		}
 	}
 
-	event->retval = ret;
+	event->error_raw = -ret;
 	bpf_get_current_comm(&event->comm, sizeof(event->comm));
 
 	if (parent != NULL) {

--- a/gadgets/trace_exec/test/trace_exec_test.go
+++ b/gadgets/trace_exec/test/trace_exec_test.go
@@ -47,7 +47,7 @@ type traceExecEvent struct {
 	Ppid        uint32 `json:"ppid"`
 	Loginuid    uint32 `json:"loginuid"`
 	Sessionid   uint32 `json:"sessionid"`
-	Retval      int32  `json:"retval"`
+	Error       string `json:"error"`
 	UpperLayer  bool   `json:"upper_layer"`
 	PupperLayer bool   `json:"pupper_layer"`
 	Args        string `json:"args"`

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -42,11 +42,12 @@ datasources:
         annotations:
           columns.width: 8
           columns.alignment: right
-      ret:
+      error_raw:
         annotations:
-          description: 'TODO: Fill field description'
-          columns.width: 3
           columns.hidden: true
+      error:
+        annotations:
+          description: return value
       fs:
         annotations:
           columns.width: 8

--- a/gadgets/trace_mount/go/program.go
+++ b/gadgets/trace_mount/go/program.go
@@ -20,14 +20,14 @@ import (
 	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
 )
 
-func getCallStr(op int32, source string, target string, fs string, flags string, data string, ret int32) string {
+func getCallStr(op int32, source string, target string, fs string, flags string, data string, errorRaw uint32) string {
 	switch op {
 	case 0:
 		format := `mount("%s", "%s", "%s", %s, "%s") = %d`
-		return fmt.Sprintf(format, source, target, fs, flags, data, ret)
+		return fmt.Sprintf(format, source, target, fs, flags, data, errorRaw)
 	case 1:
 		format := `umount("%s", %s) = %d`
-		return fmt.Sprintf(format, target, flags, ret)
+		return fmt.Sprintf(format, target, flags, errorRaw)
 	}
 
 	return ""
@@ -72,7 +72,7 @@ func gadgetInit() int {
 		return 1
 	}
 
-	retField, err := ds.GetField("ret")
+	errorRawField, err := ds.GetField("error_raw")
 	if err != nil {
 		api.Warnf("failed to get field: %s", err)
 		return 1
@@ -99,9 +99,9 @@ func gadgetInit() int {
 		dest, _ := destField.String(data)
 		fs, _ := fsField.String(data)
 		dataStr, _ := dataField.String(data)
-		ret, _ := retField.Int32(data)
+		errorRaw, _ := errorRawField.Uint32(data)
 
-		callField.SetString(data, getCallStr(opRaw, src, dest, fs, flags, dataStr, ret))
+		callField.SetString(data, getCallStr(opRaw, src, dest, fs, flags, dataStr, errorRaw))
 	}, 0)
 
 	return 0

--- a/gadgets/trace_mount/program.bpf.c
+++ b/gadgets/trace_mount/program.bpf.c
@@ -77,7 +77,7 @@ struct event {
 
 	__u64 delta;
 	enum flags_set flags_raw;
-	int ret;
+	gadget_errno error_raw;
 	char fs[FS_NAME_LEN];
 	char src[PATH_MAX];
 	char dest[PATH_MAX];
@@ -159,7 +159,7 @@ static int probe_exit(void *ctx, int ret)
 	eventp->tid = tid;
 	eventp->uid = (u32)uid_gid;
 	eventp->gid = (u32)(uid_gid >> 32);
-	eventp->ret = ret;
+	eventp->error_raw = -ret;
 	eventp->op_raw = argp->op;
 	bpf_get_current_comm(&eventp->comm, sizeof(eventp->comm));
 	if (argp->src)

--- a/gadgets/trace_mount/test/trace_mount_test.go
+++ b/gadgets/trace_mount/test/trace_mount_test.go
@@ -44,7 +44,7 @@ type traceMountEvent struct {
 
 	Delta uint64 `json:"delta"`
 	Flags string `json:"flags"`
-	Ret   int    `json:"ret"`
+	Error string `json:"error"`
 	Fs    string `json:"fs"`
 	Src   string `json:"src"`
 	Dest  string `json:"dest"`
@@ -105,7 +105,7 @@ func TestTraceMount(t *testing.T) {
 				Op:         "MOUNT",
 				Src:        "/mnt",
 				Dest:       "/mnt",
-				Ret:        -int(unix.ENOENT),
+				Error:      unix.ErrnoName(unix.ENOENT),
 				Data:       "",
 
 				// Check only the existence of these fields

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -49,12 +49,9 @@ datasources:
       mode:
         annotations:
           description: File access mode
-      err:
+      error_raw:
         annotations:
-          description: Error code
-          columns.minwidth: 3
-          columns.width: 5
-          columns.alignment: right
+          columns.hidden: true
       fd:
         annotations:
           description: File descriptor. 0 in case of error

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -32,7 +32,7 @@ struct event {
 	__u32 uid;
 	__u32 gid;
 
-	__s32 err;
+	gadget_errno error_raw;
 	__u32 fd;
 	int flags_raw;
 	__u16 mode_raw;
@@ -165,7 +165,7 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
 	event->flags_raw = ap->flags;
 	event->mode_raw = ap->mode;
-	event->err = errval;
+	event->error_raw = errval;
 	event->fd = fd;
 	event->mntns_id = gadget_get_mntns_id();
 	event->timestamp_raw = bpf_ktime_get_boot_ns();

--- a/gadgets/trace_open/test/trace_open_test.go
+++ b/gadgets/trace_open/test/trace_open_test.go
@@ -42,7 +42,7 @@ type traceOpenEvent struct {
 	Gid  uint32 `json:"gid"`
 
 	Fd    uint32 `json:"fd"`
-	Err   int32  `json:"err"`
+	Error string `json:"error"`
 	Flags string `json:"flags"`
 	Mode  string `json:"mode"`
 	FName string `json:"fname"`
@@ -96,7 +96,7 @@ func TestTraceOpen(t *testing.T) {
 				Comm:       "cat",
 				FName:      "/dev/null",
 				Fd:         3,
-				Err:        0,
+				Error:      "",
 				Uid:        1000,
 				Gid:        1111,
 				Flags:      "O_RDONLY",

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -40,10 +40,9 @@ datasources:
         annotations:
           description: Target process ID
           template: pid
-      ret:
+      error_raw:
         annotations:
-          columns.width: 5
-          columns.alignment: right
+          columns.hidden: true
       sig_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_signal/program.bpf.c
+++ b/gadgets/trace_signal/program.bpf.c
@@ -28,7 +28,7 @@ struct event {
 	__u32 tpid;
 
 	gadget_signal sig_raw;
-	int ret;
+	gadget_errno error_raw;
 };
 
 const volatile pid_t filtered_pid = 0;
@@ -104,7 +104,7 @@ static int probe_exit(void *ctx, int ret)
 	if (!eventp)
 		goto cleanup;
 
-	eventp->ret = ret;
+	eventp->error_raw = -ret;
 	eventp->timestamp_raw = bpf_ktime_get_boot_ns();
 	eventp->uid = (u32)uid_gid;
 	eventp->gid = (u32)(uid_gid >> 32);
@@ -202,7 +202,7 @@ int ig_sig_generate(struct trace_event_raw_signal_generate *ctx)
 	event->tpid = tpid;
 	event->mntns_id = mntns_id;
 	event->sig_raw = sig;
-	event->ret = ret;
+	event->error_raw = -ret;
 	event->uid = (u32)uid_gid;
 	event->gid = (u32)(uid_gid >> 32);
 	bpf_get_current_comm(event->comm, sizeof(event->comm));

--- a/gadgets/trace_signal/test/trace_signal_test.go
+++ b/gadgets/trace_signal/test/trace_signal_test.go
@@ -43,7 +43,7 @@ type traceSignalEvent struct {
 
 	Signal    string `json:"sig"`
 	SignalRaw int    `json:"sig_raw"`
-	Ret       int    `json:"ret"`
+	Error     string `json:"error"`
 }
 
 func TestTraceSignal(t *testing.T) {
@@ -96,7 +96,7 @@ func TestTraceSignal(t *testing.T) {
 				Gid:        0,
 				Signal:     "SIGTERM",
 				SignalRaw:  15,
-				Ret:        0,
+				Error:      "",
 				Comm:       "sh",
 
 				// Check only the existence of these fields

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -47,9 +47,9 @@ datasources:
         annotations:
           description: unencrypted buffer
           columns.width: 32
-      retval:
+      error:
         annotations:
-          description: return value
+          description: error value
           columns.width: 20
       operation_raw:
         annotations:

--- a/gadgets/trace_ssl/program.bpf.c
+++ b/gadgets/trace_ssl/program.bpf.c
@@ -59,7 +59,7 @@ struct event {
 	enum operation operation_raw;
 	u64 latency_ns;
 	u32 len;
-	u64 retval;
+	gadget_errno error_raw;
 	u8 buf[MAX_BUF_SIZE];
 };
 
@@ -181,7 +181,7 @@ static __always_inline int probe_ssl_rw_exit(struct pt_regs *ctx,
 	event->uid = uid_gid;
 	event->gid = uid_gid >> 32;
 	event->len = len;
-	event->retval = PT_REGS_RC(ctx);
+	event->error_raw = -PT_REGS_RC(ctx);
 
 	bpf_get_current_comm(&event->comm, sizeof(event->comm));
 
@@ -276,7 +276,7 @@ int trace_uretprobe_libssl_SSL_do_handshake(struct pt_regs *ctx)
 	event->uid = uid_gid;
 	event->gid = uid_gid >> 32;
 	event->len = 0;
-	event->retval = PT_REGS_RC(ctx);
+	event->error_raw = -PT_REGS_RC(ctx);
 	bpf_get_current_comm(&event->comm, sizeof(event->comm));
 
 	gadget_submit_buf(ctx, &events, event, BASE_EVENT_SIZE);
@@ -361,7 +361,7 @@ static __always_inline int probe_crypto_exit(struct pt_regs *ctx,
 	event->uid = uid_gid;
 	event->gid = uid_gid >> 32;
 	event->len = 0;
-	event->retval = PT_REGS_RC(ctx);
+	event->error_raw = -PT_REGS_RC(ctx);
 	bpf_get_current_comm(&event->comm, sizeof(event->comm));
 
 	gadget_submit_buf(ctx, &events, event, BASE_EVENT_SIZE);

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -47,7 +47,6 @@ datasources:
           columns.width: 16
           columns.alignment: right
           columns.hidden: true
-      retcode:
+      error_raw:
         annotations:
-          columns.width: 7
-          columns.alignment: right
+          columns.hidden: true

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -48,7 +48,7 @@ struct event {
 	__u32 gid;
 
 	__u64 latency;
-	int retcode;
+	gadget_errno error_raw;
 };
 
 const volatile int filter_ports[MAX_PORTS];
@@ -220,7 +220,7 @@ static __always_inline void trace_v4(struct pt_regs *ctx, __u64 pid_tgid,
 	event->mntns_id = mntns_id;
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
-	event->retcode = ret;
+	event->error_raw = -ret;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 }
@@ -252,7 +252,7 @@ static __always_inline void trace_v6(struct pt_regs *ctx, __u64 pid_tgid,
 	event->src.port = BPF_CORE_READ(sk, __sk_common.skc_num);
 	bpf_get_current_comm(event->comm, sizeof(event->comm));
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
-	event->retcode = ret;
+	event->error_raw = -ret;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 }

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -41,6 +41,10 @@ typedef __u64 gadget_timestamp;
 // as string.
 typedef __u32 gadget_signal;
 
+// gadget_errno is used to represent a unix errno. A field is automatically added that contains the name
+// as string.
+typedef __u32 gadget_errno;
+
 // gadget_syscall is used to represent a unix syscall. A field is automatically added that contains the name
 // as string.
 typedef __u64 gadget_syscall;

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -276,4 +276,7 @@ var annotationsTemplates = map[string]map[string]string{
 		ColumnsWidthAnnotation:    "18",
 		ColumnsMaxWidthAnnotation: "28",
 	},
+	"errorString": {
+		ColumnsWidthAnnotation: "12",
+	},
 }


### PR DESCRIPTION
# gadgets: Provide human readable version of error codes

```
$ go run --exec "sudo -E" ./cmd/ig/... run t --verify-image=false --fields task,src,dst,retcode
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] you set --verify-image=false, image will not be verified 
WARN[0000] you set --verify-image=false, image will not be verified 
TASK       SRC                      DST                   RETCODE            
wget       172.17.0.2:51382         1.1.1.1:80                               
wget       172.17.0.2:45834         1.1.1.1:443                              
wget       172.17.0.2:45846         1.1.1.1:443                              
wget       0.0.0.0:0                192.168.2.1:0         ECONNREFUSED       
wget       0.0.0.0:0                192.168.1.2:0         EHOSTUNREACH       
wget       172.17.0.2:37268         192.168.2.50:80       unknown error -512
```

1. the first 3 lines are from a succesfull connect.
2. forth line is where my router refused the connection
3. fifth is an address in a subnet which I don't have access to
4. sixth I canceled the wget command with `Ctrl+C`

Problems:
1. [Not problem of this PR] So for some of the error cases we seem to have lost the source ip address. I think it was because of https://github.com/inspektor-gadget/inspektor-gadget/pull/3069
2. So the `unknown error -512` is actually `ERESTARTSYS` https://elixir.bootlin.com/linux/latest/source/include/linux/errno.h#L14 . The comment mentions that it shouldn't be seen by user programs. Also the comment metions that it still can be seen by `ptrace`, which I tested - [yes it is seen and resolved](https://github.com/search?q=repo%3Astrace%2Fstrace%20ERESTARTSYS&type=code). Do we just accept the fact that we show this "to the user"?