### PR TITLE
gadgets: Forward config to datasources

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1378,7 +1378,7 @@ jobs:
           export GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
           export BUILDER_IMAGE=${{ needs.build-helper-images.outputs.ebpf_builder_image }}
 
-          make GADGET_BUILD_PARAMS="--update-metadata" build-gadgets -o install/ig
+          make build-gadgets -o install/ig
 
           # Check that metadata files are updated
           git diff --exit-code HEAD --

--- a/gadgets/snapshot_process/gadget.yaml
+++ b/gadgets/snapshot_process/gadget.yaml
@@ -3,40 +3,42 @@ description: Show running processes
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  processes:
+    fields:
+      comm:
+        annotations:
+          template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+      ppid:
+        annotations:
+          description: Parent process ID
+          template: pid
+      uid:
+        annotations:
+          description: User ID
+          template: uid
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
 snapshotters:
   processes:
     structName: process_entry
 structs:
   process_entry:
     fields:
-    - name: comm
-      description: Process name
-      attributes:
-        template: comm
-    - name: pid
-      description: Process ID
-      attributes:
-        template: pid
-    - name: tid
-      description: Thread ID
-      attributes:
-        template: pid
-    - name: ppid
-      description: Parent process ID
-      attributes:
-        template: pid
-    - name: uid
-      description: User ID
-      attributes:
-        template: uid
-    - name: gid
-      description: Group ID
-      attributes:
-        template: uid
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
 ebpfParams:
   show_threads:
     key: threads

--- a/gadgets/snapshot_socket/gadget.yaml
+++ b/gadgets/snapshot_socket/gadget.yaml
@@ -3,36 +3,32 @@ description: Show TCP and UDP sockets
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  sockets:
+    fields:
+      src:
+        annotations:
+          description: Source address
+          template: l4endpoint
+      dst:
+        annotations:
+          description: Destination address
+          template: l4endpoint
+      state:
+        annotations:
+          columns.width: 10
+      ino:
+        annotations:
+          description: Inode number
+          columns.width: 10
+          columns.hidden: true
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
 snapshotters:
   sockets:
     structName: socket_entry
 structs:
   socket_entry:
     fields:
-    - name: src
-      description: Source address
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      description: Destination address
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: state
-      attributes:
-        width: 10
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: ino
-      description: Inode number
-      attributes:
-        width: 10
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns

--- a/gadgets/trace_bind/gadget.yaml
+++ b/gadgets/trace_bind/gadget.yaml
@@ -3,6 +3,50 @@ description: Trace socket bindings
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  bind:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      mount_ns_id:
+        annotations:
+          template: ns
+      addr:
+        annotations:
+          description: Address the socket is bound to
+          columns.width: 32
+      pid:
+        annotations:
+          template: pid
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      ret:
+        annotations:
+          description: Return value of the bind() syscall
+          columns.width: 5
+          columns.alignment: right
+      opts_raw:
+        annotations:
+          columns.hidden: true
+      opts:
+        annotations:
+          description: Socket options
+          columns.hidden: true
+      comm:
+        annotations:
+          template: comm
+      bound_dev_if:
+        annotations:
+          description: Index of the network interface the socket is bound to
+          columns.width: 10
 tracers:
   bind:
     mapName: events
@@ -10,46 +54,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: mount_ns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: addr
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: pid
-      attributes:
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: ret
-      description: Return value of the bind() syscall
-      attributes:
-        width: 3
-        alignment: left
-    - name: opts_raw
-      description: Socket options
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: comm
-      attributes:
-        template: comm
-    - name: bound_dev_if
-      description: Index of the network interface the socket is bound to
-      attributes:
-        width: 10
-        alignment: left
-        ellipsis: end
 ebpfParams:
   ignore_errors:
     key: ignore_errors

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -3,6 +3,77 @@ description: trace security capabilitiy checks
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  capabilities:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      mntnsid:
+        annotations:
+          template: ns
+      current_userns:
+        annotations:
+          template: ns
+      target_userns:
+        annotations:
+          template: ns
+      cap_effective_raw:
+        annotations:
+          columns.hidden: true
+      cap_effective:
+        annotations:
+          columns.width: 20
+          columns.hidden: true
+      pid:
+        annotations:
+          template: pid
+      cap_raw:
+        annotations:
+          columns.hidden: true
+      cap:
+        annotations:
+          columns.hidden: true
+      tgid:
+        annotations:
+          template: pid
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      audit:
+        annotations:
+          columns.width: 11
+      insetid:
+        annotations:
+          columns.width: 11
+      syscall_raw:
+        annotations:
+          columns.hidden: true
+      syscall:
+        annotations:
+          columns.width: 20
+      task:
+        annotations:
+          template: comm
+      kstack_raw:
+        annotations:
+          columns.hidden: true
+      kstack:
+        annotations:
+          description: kernel stack
+          columns.width: 10
+          columns.hidden: true
+      capable:
+        annotations:
+          description: if the process has the requested capability
+          columns.width: 10
+          columns.hidden: true
 tracers:
   capabilities:
     mapName: events
@@ -10,72 +81,6 @@ tracers:
 structs:
   cap_event:
     fields:
-    - name: mntnsid
-      description: mount namespace inode id
-      attributes:
-        template: ns
-    - name: current_userns
-      attributes:
-        template: ns
-    - name: target_userns
-      attributes:
-        template: ns
-    - name: cap_effective_raw
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end
-    - name: timestamp_raw
-      attributes:
-        template: timestamp
-    - name: pid
-      attributes:
-        template: pid
-    - name: cap_raw
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: tgid
-      attributes:
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: audit
-      attributes:
-        width: 11
-        alignment: left
-        ellipsis: end
-    - name: insetid
-      attributes:
-        width: 11
-        alignment: left
-        ellipsis: end
-    - name: syscall_raw
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end
-    - name: task
-      description: command
-      attributes:
-        template: comm
-    - name: kstack_raw
-      description: kernel stack
-      attributes:
-        width: 10
-        alignment: left
-        ellipsis: end
-    - name: capable
-      description: if the process has the requested capability
-      attributes:
-        width: 10
-        alignment: left
-        ellipsis: end
 ebpfParams:
   audit_only:
     key: audit_only

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -3,6 +3,80 @@ description: trace dns requests and responses
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs/latest/
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget
+datasources:
+  dns:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      src:
+        annotations:
+          description: Source endpoint
+          template: l4endpoint
+      dst:
+        annotations:
+          description: Destination endpoint
+          template: l4endpoint
+      pid:
+        annotations:
+          description: PID of the process that sent the request
+          template: pid
+      task:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      name:
+        annotations:
+          columns.width: 30
+      qr:
+        annotations:
+          columns.width: 2
+      pkt_type:
+        annotations:
+          columns.width: 8
+      rcode:
+        annotations:
+          columns.width: 8
+      latency_ns:
+        annotations:
+          columns.width: 8
+          columns.hidden: true
+      anaddr:
+        annotations:
+          columns.width: 16
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      tid:
+        annotations:
+          columns.hidden: true
+      id:
+        annotations:
+          columns.hidden: true
+      qtype:
+        annotations:
+          description: Query type
+      ancount:
+        annotations:
+          columns.hidden: true
+      anaddrcount:
+        annotations:
+          columns.hidden: true
 tracers:
   dns:
     mapName: events
@@ -10,90 +84,3 @@ tracers:
 structs:
   event_t:
     fields:
-    - name: timestamp_raw
-    - name: src
-      description: Source endpoint
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      description: Destination endpoint
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: pid
-      description: PID of the process that sent the request
-      attributes:
-        template: pid
-    - name: task
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        hidden: true
-        template: uid
-    - name: gid
-      attributes:
-        hidden: true
-        template: uid
-    - name: name
-      attributes:
-        width: 30
-    - name: qr
-      attributes:
-        width: 2
-    - name: pkt_type
-      attributes:
-        width: 8
-    - name: rcode
-      attributes:
-        width: 8
-    - name: latency_ns
-      attributes:
-        width: 8
-        hidden: true
-    - name: anaddr
-      attributes:
-        width: 16
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: tid
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: id
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: qtype
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: ancount
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: anaddrcount
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -3,6 +3,70 @@ description: trace process executions
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  exec:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      ppid:
+        annotations:
+          template: pid
+      comm:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      loginuid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      sessionid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      retval:
+        annotations:
+          columns.width: 5
+          columns.alignment: right
+      args_count:
+        annotations:
+          columns.hidden: true
+          json.skip: true
+      args_size:
+        annotations:
+          columns.hidden: true
+          json.skip: true
+      args:
+        annotations:
+          columns.width: 16
+      mntns_id:
+        annotations:
+          template: ns
+      upper_layer:
+        annotations:
+          description: Whether the executable is in the upper layer of the overlay filesystem
+          columns.width: 5
+          columns.hidden: true
+      pupper_layer:
+        annotations:
+          description: Whether the executable's parent in the process hierarchy
+            is in the upper layer of the overlay filesystem. Only initialized when
+            the execution succeeded.
+          columns.width: 5
+          columns.hidden: true
 tracers:
   exec:
     mapName: events
@@ -10,80 +74,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      attributes:
-        template: pid
-    - name: ppid
-      attributes:
-        template: pid
-    - name: comm
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: loginuid
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: sessionid
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: retval
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 3
-        alignment: left
-        ellipsis: end
-    - name: args_count
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: args_size
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: args
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: upper_layer
-      description: Whether the executable is in the upper layer of the overlay filesystem
-      attributes:
-        width: 5
-        alignment: left
-        ellipsis: end
-    - name: pupper_layer
-      description: Whether the executable's parent in the process hierarchy is in
-        the upper layer of the overlay filesystem. Only initialized when the execution
-        succeeded.
-      attributes:
-        width: 5
-        alignment: left
-        ellipsis: end
 ebpfParams:
   ignore_failed:
     key: ignore-failed

--- a/gadgets/trace_lsm/gadget.yaml
+++ b/gadgets/trace_lsm/gadget.yaml
@@ -3,6 +3,39 @@ description: a strace for LSM tracepoints
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  lsm:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      mntns_id:
+        annotations:
+          template: ns
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          template: pid
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      tracepoint_raw:
+        annotations:
+          columns.hidden: true
+      tracepoint:
+        annotations:
+          description: lsm tracepoint name
+      comm:
+        attributes:
+          template: comm
 tracers:
   lsm:
     mapName: events
@@ -10,33 +43,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      attributes:
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: tracepoint_raw
-      description: lsm tracepoint enum
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: comm
-      description: command
-      attributes:
-        template: comm
-    - name: timestamp_raw
 ebpfParams:
   trace_all:
     key: trace-all

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -3,6 +3,41 @@ description: use uprobe to trace malloc and free in libc.so
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  malloc:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          template: pid
+      comm:
+        annotations:
+          template: comm
+      operation_raw:
+        annotations:
+          columns.hidden: true
+      operation:
+        annotations:
+          description: memory operation type
+      addr:
+        annotations:
+          description: address of malloc/free operations
+          columns.width: 20
+      mntns_id:
+        annotations:
+          template: ns
+      size:
+        annotations:
+          description: size of malloc operations
+          columns.width: 20
 tracers:
   malloc:
     mapName: events
@@ -10,36 +45,3 @@ tracers:
 structs:
   event:
     fields:
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      attributes:
-        template: pid
-    - name: comm
-      description: command
-      attributes:
-        template: comm
-    - name: operation_raw
-      description: memory operation type
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: addr
-      description: address of malloc/free operations
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: size
-      description: size of malloc operations
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end
-    - name: timestamp_raw

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -3,6 +3,73 @@ description: trace mount syscalls
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  mount:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          template: pid
+      comm:
+        annotations:
+          template: comm
+      delta:
+        annotations:
+          columns.width: 8
+          columns.alignment: right
+      mount_ns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      ret:
+        annotations:
+          description: 'TODO: Fill field description'
+          columns.width: 3
+          columns.hidden: true
+      fs:
+        annotations:
+          columns.width: 8
+          columns.hidden: true
+      src:
+        annotations:
+          columns.width: 32
+          columns.minwidth: 24
+          columns.hidden: true
+      dest:
+        annotations:
+          columns.width: 32
+          columns.minwidth: 24
+          columns.hidden: true
+      data:
+        annotations:
+          columns.width: 32
+          columns.minwidth: 24
+          columns.hidden: true
+      op_raw:
+        annotations:
+          columns.hidden: true
+      op:
+        annotations:
+          columns.width: 6
+          columns.minwidth: 6
+          columns.hidden: true
+      flags_raw:
+        annotations:
+          columns.hidden: true
+      flags:
+        annotations:
+          description: mount flags
+      call:
+        annotations:
+          columns.width: 32
 tracers:
   mount:
     mapName: events
@@ -10,58 +77,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: delta
-      attributes:
-        template: timestamp
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      attributes:
-        template: pid
-    - name: mount_ns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: ret
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 3
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: comm
-      attributes:
-        template: comm
-    - name: fs
-      attributes:
-        width: 8
-        hidden: true
-    - name: src
-      attributes:
-        width: 32
-        minWidth: 24
-        hidden: true
-    - name: dest
-      attributes:
-        width: 32
-        minWidth: 24
-        hidden: true
-    - name: data
-      attributes:
-        width: 32
-        minWidth: 24
-        hidden: true
-    - name: op_raw
-      attributes:
-        width: 6
-        minWidth: 6
-        hidden: true
-    - name: flags_raw
-      description: raw flags value
-      attributes:
-        hidden: true
-    - name: timestamp_raw
 ebpfParams:
   target_pid:
     key: pid

--- a/gadgets/trace_oomkill/gadget.yaml
+++ b/gadgets/trace_oomkill/gadget.yaml
@@ -3,6 +3,41 @@ description: trace OOM killer
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  events:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      fpid:
+        annotations:
+          template: pid
+      fuid:
+        annotations:
+          template: uid
+      fgid:
+        annotations:
+          template: uid
+      tpid:
+        annotations:
+          template: pid
+      pages:
+        annotations:
+          columns.width: 8
+          columns.alignment: right
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      fcomm:
+        annotations:
+          template: comm
+      tcomm:
+        annotations:
+          template: comm
 tracers:
   oomkill:
     mapName: events
@@ -10,27 +45,3 @@ tracers:
 structs:
   event:
     fields:
-    - name: fpid
-      attributes:
-        template: pid
-    - name: fuid
-      attributes:
-        template: uid
-    - name: fgid
-      attributes:
-        template: uid
-    - name: tpid
-      attributes:
-        template: pid
-    - name: pages
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: timestamp_raw
-    - name: fcomm
-      attributes:
-        template: comm
-    - name: tcomm
-      attributes:
-        template: comm

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -3,6 +3,58 @@ description: trace open files
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  open:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      comm:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      flags_raw:
+        annotations:
+          columns.hidden: true
+      flags:
+        annotations:
+          columns.hidden: true
+          columns.width: 10
+      mode_raw:
+        annotations:
+          columns.hidden: true
+      mode:
+        annotations:
+          description: File access mode
+      err:
+        annotations:
+          description: Error code
+          columns.width: 5
+          columns.alignment: right
+      fd:
+        annotations:
+          description: File descriptor. 0 in case of error
+          columns.minwidth: 2
+          columns.maxwidth: 3
+          columns.alignment: right
+      fname:
+        annotations:
+          columns.width: 32
+          columns.minwidth: 24
+      mntns_id:
+        annotations:
+          template: ns
 tracers:
   open:
     mapName: events
@@ -10,48 +62,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      attributes:
-        template: pid
-    - name: comm
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: flags_raw
-      attributes:
-        width: 5
-        hidden: true
-    - name: mode_raw
-      description: File access mode
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-        ellipsis: end
-    - name: err
-      description: Error code
-      attributes:
-        width: 3
-        alignment: right
-    - name: fd
-      description: File descriptor. 0 in case of error
-      attributes:
-        minWidth: 2
-        maxWidth: 3
-    - name: fname
-      attributes:
-        width: 32
-        minWidth: 24
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
 ebpfParams:
   targ_failed:
     key: failed

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -3,6 +3,45 @@ description: trace signal
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  signal:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      tpid:
+        annotations:
+          template: pid
+      comm:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      ret:
+        annotations:
+          columns.width: 5
+          columns.alignment: right
+      sig_raw:
+        annotations:
+          columns.hidden: true
+      sig:
+        annotations:
+          description: Signal number
+          columns.width: 10
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
 tracers:
   signal:
     mapName: events
@@ -10,32 +49,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      attributes:
-        template: pid
-    - name: tpid
-      attributes:
-        template: pid
-    - name: comm
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: ret
-      attributes:
-        width: 5
-    - name: sig_raw
-      attributes:
-        width: 5
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
 ebpfParams:
   failed_only:
     key: failed

--- a/gadgets/trace_sni/gadget.yaml
+++ b/gadgets/trace_sni/gadget.yaml
@@ -3,6 +3,46 @@ description: trace sni
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  sni:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          description: PID of the process that sent the request
+          template: pid
+      tid:
+        annotations:
+          description: TID of the thread sending the request
+          columns.hidden: true
+          template: pid
+      task:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          hidden: true
+          template: uid
+      gid:
+        annotations:
+          hidden: true
+          template: uid
+      name:
+        annotations:
+          columns.width: 30
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
 tracers:
   sni:
     mapName: events
@@ -10,35 +50,3 @@ tracers:
 structs:
   event_t:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      description: PID of the process that sent the request
-      attributes:
-        template: pid
-    - name: task
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        hidden: true
-        template: uid
-    - name: gid
-      attributes:
-        hidden: true
-        template: uid
-    - name: name
-      attributes:
-        width: 30
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: tid
-      description: TID of the thread sending the request
-      attributes:
-        hidden: true
-        template: pid

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -4,6 +4,54 @@ description: Captures data on read/recv or write/send functions of OpenSSL, GnuT
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  ssl:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      latency_ns:
+        annotations:
+          columns.width: 10
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          template: pid
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      comm:
+        annotations:
+          template: comm
+      len:
+        annotations:
+          columns.hidden: true
+      buf:
+        annotations:
+          description: unencrypted buffer
+          columns.width: 32
+      retval:
+        annotations:
+          description: return value
+          columns.width: 20
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      operation_raw:
+        annotations:
+          columns.hidden: true
+      operation:
+        annotations:
+          description: type of SSL operations
 tracers:
   ssl:
     mapName: events
@@ -11,54 +59,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: mntns_id
-      description: mount namespace inode id
-      attributes:
-        template: ns
-    - name: operation_raw
-      description: type of SSL operations
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: timestamp_raw
-    - name: latency_ns
-      attributes:
-        template: timestamp
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      attributes:
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: len
-      description: data length
-      attributes:
-        width: 10
-        alignment: left
-        ellipsis: end
-    - name: comm
-      description: command
-      attributes:
-        template: comm
-    - name: buf
-      description: unencrypted buffer
-      attributes:
-        width: 32
-        alignment: left
-        ellipsis: end
-    - name: retval
-      description: return value
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end
 ebpfParams:
   record_data:
     key: record-data

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -3,6 +3,47 @@ description: monitor connect, accept and close events of TCP connections
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  tracetcp:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      task:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      src:
+        annotations:
+          template: l4endpoint
+      dst:
+        annotations:
+          template: l4endpoint
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      type_raw:
+        annotations:
+          columns.hidden: true
+      type:
+        annotations:
+          description: Type of TCP connection event
 tracers:
   tracetcp:
     mapName: events
@@ -10,41 +51,6 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      attributes:
-        template: pid
-    - name: task
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: src
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns
-    - name: type_raw
-      description: Type of TCP connection event
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
 ebpfParams:
   filter_pid:
     key: pid

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -3,6 +3,46 @@ description: trace tcp connections
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  tcpconnect:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      pid:
+        annotations:
+          template: pid
+      task:
+        annotations:
+          template: comm
+      uid:
+        annotations:
+          template: uid
+      gid:
+        annotations:
+          template: uid
+      src:
+        annotations:
+          template: l4endpoint
+      dst:
+        annotations:
+          template: l4endpoint
+      latency:
+        annotations:
+          columns.width: 16
+          columns.alignment: right
+          columns.hidden: true
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      retcode:
+        annotations:
+          columns.width: 7
+          columns.alignment: right
 tracers:
   tcpconnect:
     mapName: events
@@ -10,37 +50,3 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: pid
-      attributes:
-        template: pid
-    - name: task
-      attributes:
-        template: comm
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      attributes:
-        template: uid
-    - name: src
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: latency
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        hidden: true
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: retcode
-      attributes:
-        width: 7

--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -3,6 +3,76 @@ description: trace TCP packets dropped by the kernel
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  tcpdrop:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      src:
+        annotations:
+          template: l4endpoint
+      dst:
+        annotations:
+          template: l4endpoint
+      task:
+        annotations:
+          template: comm
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          description: Thread id that generated event
+          columns.hidden: true
+          template: pid
+      uid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          description: Group id of the event's process
+          template: uid
+          columns.hidden: true
+      tcpflags_raw:
+        annotations:
+          columns.hidden: true
+      tcpflags:
+        annotations:
+          description: TCP flags from a TCP header
+      reason_raw:
+        annotations:
+          columns.hidden: true
+      reason:
+        annotations:
+          description: Reason for dropping a packet
+          columns.ellipsis: start
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      mount_ns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      state_raw:
+        annotations:
+          columns.hidden: true
+      state:
+        annotations:
+          description: State of the TCP connection
+      kernel_stack_raw:
+        annotations:
+          columns.hidden: true
+      kernel_stack:
+        annotations:
+          description: Kernel stack
+          columns.hidden: true
+          columns.width: 20
 tracers:
   tcpdrop:
     mapName: events
@@ -10,62 +80,3 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: src
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: task
-      attributes:
-        template: comm
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      description: Thread id that generated event
-      attributes:
-        hidden: true
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      description: Group id of the event's process
-      attributes:
-        template: uid
-    - name: tcpflags_raw
-      description: TCP flags from a TCP header
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: reason_raw
-      description: Reason for dropping a packet
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: start
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns
-    - name: mount_ns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: state_raw
-      description: State of the TCP connection
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: kernel_stack_raw
-      description: Kernel stack
-      attributes:
-        width: 20
-        alignment: left
-        ellipsis: end

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -3,6 +3,71 @@ description: trace TCP retransmissions
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+datasources:
+  tcpretrans:
+    fields:
+      timestamp_raw:
+        annotations:
+          columns.hidden: true
+      timestamp:
+        annotations:
+          template: timestamp
+      src:
+        annotations:
+          template: l4endpoint
+      dst:
+        annotations:
+          template: l4endpoint
+      task:
+        annotations:
+          template: comm
+      pid:
+        annotations:
+          template: pid
+      tid:
+        annotations:
+          description: Thread id that generated event
+          columns.hidden: true
+          template: pid
+      uid:
+        annotations:
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          description: Group id of the event's process
+          template: uid
+          columns.hidden: true
+      tcpflags_raw:
+        annotations:
+          columns.hidden: true
+      tcpflags:
+        annotations:
+          description: TCP flags from a TCP header
+      reason_raw:
+        annotations:
+          columns.hidden: true
+      reason:
+        annotations:
+          description: Reason for retransmission
+      netns:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      type_raw:
+        annotations:
+          columns.hidden: true
+      type:
+        annotations:
+          description: Type of the retransmission, either RETRANS or LOSS
+          columns.width: 10
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      state:
+        annotations:
+          description: Connection state
 tracers:
   tcpretrans:
     mapName: events
@@ -10,62 +75,3 @@ tracers:
 structs:
   event:
     fields:
-    - name: timestamp_raw
-    - name: src
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: dst
-      attributes:
-        minWidth: 24
-        maxWidth: 50
-    - name: task
-      attributes:
-        template: comm
-    - name: pid
-      attributes:
-        template: pid
-    - name: tid
-      description: 'TODO: Fill field description'
-      attributes:
-        hidden: true
-        template: pid
-    - name: uid
-      attributes:
-        template: uid
-    - name: gid
-      description: 'TODO: Fill field description'
-      attributes:
-        template: uid
-    - name: tcpflags_raw
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: reason
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end
-    - name: netns
-      description: Network namespace inode id
-      attributes:
-        template: ns
-    - name: type_raw
-      description: Type of the retransmission, either RETRANS or LOSS
-      attributes:
-        width: 7
-        alignment: left
-        ellipsis: end
-    - name: mntns_id
-      description: Mount namespace inode id
-      attributes:
-        template: ns
-    - name: state
-      description: 'TODO: Fill field description'
-      attributes:
-        width: 16
-        alignment: left
-        ellipsis: end

--- a/pkg/datasource/accessors.go
+++ b/pkg/datasource/accessors.go
@@ -254,11 +254,12 @@ func (a *fieldAccessor) AddSubField(name string, kind api.Kind, opts ...FieldOpt
 	}
 
 	nf := &field{
-		Name:     name,
-		FullName: parentFullName + "." + name,
-		Kind:     kind,
-		Parent:   a.f.Index,
-		Index:    uint32(len(a.ds.fields)),
+		Name:        name,
+		FullName:    parentFullName + "." + name,
+		Kind:        kind,
+		Parent:      a.f.Index,
+		Index:       uint32(len(a.ds.fields)),
+		Annotations: maps.Clone(defaultFieldAnnotations),
 	}
 	for _, opt := range opts {
 		opt(nf)
@@ -274,6 +275,8 @@ func (a *fieldAccessor) AddSubField(name string, kind api.Kind, opts ...FieldOpt
 		nf.PayloadIndex = a.ds.payloadCount
 		a.ds.payloadCount++
 	}
+
+	a.ds.applyFieldConfig(nf)
 
 	a.ds.fields = append(a.ds.fields, nf)
 	a.ds.fieldMap[nf.FullName] = nf

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -31,6 +31,17 @@ const (
 	// ColumnsReplaceAnnotation is used to indicate that this field should be
 	// replaced by the one indicated in the annotation when printing it.
 	ColumnsReplaceAnnotation = "columns.replace"
+
+	ColumnsWidthAnnotation     = "columns.width"
+	ColumnsMaxWidthAnnotation  = "columns.maxwidth"
+	ColumnsMinWidthAnnotation  = "columns.minwidth"
+	ColumnsAlignmentAnnotation = "columns.alignment"
+	ColumnsEllipsisAnnotation  = "columns.ellipsis"
+	ColumnsHiddenAnnotation    = "columns.hidden"
+	ColumnsFixedAnnotation     = "columns.fixed"
+
+	DescriptionAnnotation = "description"
+	TemplateAnnotation    = "template"
 )
 
 type DataTuple struct {
@@ -80,7 +91,7 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 		// extract attributes from annotations
 		for k, v := range f.Annotations {
 			switch k {
-			case "columns.alignment":
+			case ColumnsAlignmentAnnotation:
 				switch metadatav1.Alignment(v) {
 				case metadatav1.AlignmentLeft:
 					attributes.Alignment = columns.AlignLeft
@@ -89,7 +100,7 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				default:
 					return nil, fmt.Errorf("invalid alignment type for column %q: %s", f.Name, v)
 				}
-			case "columns.ellipsis":
+			case ColumnsEllipsisAnnotation:
 				switch metadatav1.EllipsisType(v) {
 				case metadatav1.EllipsisNone:
 					attributes.EllipsisType = ellipsis.None
@@ -102,28 +113,25 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				default:
 					return nil, fmt.Errorf("invalid ellipsis type for column %q: %s", f.Name, v)
 				}
-			case "columns.width":
+			case ColumnsWidthAnnotation:
 				var err error
 				attributes.Width, err = strconv.Atoi(v)
 				if err != nil {
 					return nil, fmt.Errorf("reading width for column %q: %w", f.Name, err)
 				}
-			case "columns.minWidth":
+			case ColumnsMinWidthAnnotation:
 				var err error
 				attributes.MinWidth, err = strconv.Atoi(v)
 				if err != nil {
 					return nil, fmt.Errorf("reading minWidth for column %q: %w", f.Name, err)
 				}
-			case "columns.maxWidth":
+			case ColumnsMaxWidthAnnotation:
 				var err error
 				attributes.MaxWidth, err = strconv.Atoi(v)
 				if err != nil {
 					return nil, fmt.Errorf("reading maxWidth for column %q: %w", f.Name, err)
 				}
-			case "columns.template":
-				attributes.Template = v
-				df.Template = v
-			case "columns.fixed":
+			case ColumnsFixedAnnotation:
 				if v == "true" {
 					attributes.FixedWidth = true
 				}
@@ -196,4 +204,72 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 		}
 	}
 	return cols, nil
+}
+
+var defaultFieldAnnotations = map[string]string{
+	ColumnsWidthAnnotation:     "16",
+	ColumnsEllipsisAnnotation:  string(metadatav1.EllipsisEnd),
+	ColumnsAlignmentAnnotation: string(metadatav1.AlignmentLeft),
+}
+
+var annotationsTemplates = map[string]map[string]string{
+	"timestamp": {
+		ColumnsWidthAnnotation:    "35",
+		ColumnsMaxWidthAnnotation: "35",
+		ColumnsEllipsisAnnotation: "end",
+	},
+	"node": {
+		ColumnsWidthAnnotation:    "30",
+		ColumnsEllipsisAnnotation: string(metadatav1.EllipsisMiddle),
+	},
+	"pod": {
+		ColumnsWidthAnnotation:    "30",
+		ColumnsEllipsisAnnotation: string(metadatav1.EllipsisMiddle),
+	},
+	"container": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"namespace": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerImageName": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerImageDigest": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerStartedAt": {
+		ColumnsHiddenAnnotation: "true",
+		ColumnsWidthAnnotation:  "35",
+	},
+	"comm": {
+		DescriptionAnnotation:     "Process name",
+		ColumnsMaxWidthAnnotation: "16",
+	},
+	"pid": {
+		ColumnsMinWidthAnnotation:  "7",
+		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+	},
+	"uid": {
+		ColumnsMinWidthAnnotation:  "8",
+		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+	},
+	"gid": {
+		ColumnsMinWidthAnnotation:  "8",
+		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+	},
+	"ns": {
+		ColumnsHiddenAnnotation:    "true",
+		ColumnsWidthAnnotation:     "12",
+		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+	},
+	"l4endpoint": {
+		ColumnsMinWidthAnnotation: "22",
+		ColumnsWidthAnnotation:    "40",
+		ColumnsMaxWidthAnnotation: "52",
+	},
+	"syscall": {
+		ColumnsWidthAnnotation:    "18",
+		ColumnsMaxWidthAnnotation: "28",
+	},
 }

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -143,7 +143,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			"columns.template": "namespace",
+			datasource.TemplateAnnotation: "namespace",
 		}),
 		datasource.WithOrder(-30),
 	)
@@ -155,7 +155,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			"columns.template": "pod",
+			datasource.TemplateAnnotation: "pod",
 		}),
 		datasource.WithOrder(-29),
 	)
@@ -167,7 +167,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			"columns.template": "container",
+			datasource.TemplateAnnotation: "container",
 		}),
 		datasource.WithOrder(-28),
 	)
@@ -199,7 +199,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"containerName",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			"columns.template": "container",
+			datasource.TemplateAnnotation: "container",
 		}),
 		datasource.WithOrder(-26),
 	)
@@ -210,8 +210,8 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"runtimeName",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			"columns.width": "19",
-			"columns.fixed": "true",
+			datasource.ColumnsWidthAnnotation: "19",
+			datasource.ColumnsFixedAnnotation: "true",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
 		datasource.WithOrder(-25),
@@ -223,8 +223,8 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"containerId",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			"columns.width":    "13",
-			"columns.maxWidth": "64",
+			datasource.ColumnsWidthAnnotation:    "13",
+			datasource.ColumnsMaxWidthAnnotation: "64",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
 		datasource.WithOrder(-24),

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"io"
 
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
@@ -175,4 +176,12 @@ type DataSource interface {
 
 	Annotations() map[string]string
 	Tags() []string
+}
+
+type DataSourceOption func(*dataSource)
+
+func WithConfig(v *viper.Viper) DataSourceOption {
+	return func(source *dataSource) {
+		source.config = v
+	}
 }

--- a/pkg/datasource/field_test.go
+++ b/pkg/datasource/field_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import (
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+func TestDataSourceFieldConfig(t *testing.T) {
+	type testCase struct {
+		name                string
+		expectedAnnotations map[string]string
+		expectedFlags       FieldFlag
+		config              string
+	}
+
+	testCases := []testCase{
+		{
+			name:   "no-anotations",
+			config: "",
+		},
+		{
+			name: "columns.hidden",
+			expectedAnnotations: map[string]string{
+				"columns.hidden": "true",
+			},
+			expectedFlags: FieldFlagHidden,
+			config: `
+fields:
+  foo:
+    annotations:
+      columns.hidden: true
+`,
+		},
+		{
+			name: "many-annotations",
+			expectedAnnotations: map[string]string{
+				"columns.width":    "40",
+				"columns.maxwidth": "80",
+				"foo-ann":          "yes",
+			},
+			expectedFlags: FieldFlagHidden,
+			config: `
+fields:
+  foo:
+    annotations:
+      columns.width: 40
+      columns.maxwidth: 80
+      foo-ann: yes
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			err := v.ReadConfig(strings.NewReader(tc.config))
+			require.NoError(t, err)
+
+			ds, err := New(TypeArray, "myds", WithConfig(v))
+			require.NoError(t, err)
+
+			fooAcc, err := ds.AddField("foo", api.Kind_String)
+			require.NoError(t, err)
+
+			expectedAnnotations := maps.Clone(defaultFieldAnnotations)
+			maps.Copy(expectedAnnotations, tc.expectedAnnotations)
+
+			assert.Equal(t, fooAcc.Annotations(), expectedAnnotations)
+		})
+	}
+}

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -146,7 +146,7 @@ func (o *cliOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api
 		fmt.Fprintf(&sb, "  %q (data source):\n", ds.Name())
 		for _, f := range availableFields {
 			fmt.Fprintf(&sb, "    %s\n", f.FullName)
-			if desc, ok := f.Annotations["description"]; ok { // TODO: const to API?
+			if desc, ok := f.Annotations[datasource.DescriptionAnnotation]; ok {
 				fmt.Fprintf(&sb, "      %s\n", desc)
 			}
 		}

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -284,7 +284,7 @@ var replacers = []replacer{
 
 			opts := []datasource.FieldOption{
 				datasource.WithAnnotations(map[string]string{
-					"columns.template": "timestamp",
+					datasource.TemplateAnnotation: "timestamp",
 				}),
 			}
 			out, err := ds.AddField(outName, api.Kind_String, opts...)


### PR DESCRIPTION
This PR changes the way how the configuration of the fields is specified in the metadata file. It introduces a new datasources section that allows to (1) set annotations for the data source (will be used later for toppers and other support), (2) specify the 
field configuration. 

Check individual commits for more information. 

### Testing 

Run the gadgets and check that the output makes sense. Also, try changing the annotations in the metadata and check that they have an effect in the way fields are printed.

### Next 
There are some things we could do later on:
- [ ] Automatically apply the annotations based on the field type, for instance gadget_mntns_id gadget_timestamp, etc.
- [ ] Fix the logic that updates the metadata file.

Fixes #3052
