### PR TITLE
config: Add support for ig-k8s

### DIFF
--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- if not .Values.skipLabels }}
+  labels:
+    {{- include "gadget.labels" . | nindent 4 }}
+  {{- end }}
+  name: {{ include "gadget.fullname" . }}
+  namespace: {{ include "gadget.namespace" . }}
+data:
+    config.yaml: |-
+      hook-mode: {{ .Values.config.hookMode }}
+      fallback-pod-informer: {{ .Values.config.fallbackPodInformer }}
+      events-buffer-length: {{ .Values.config.eventsBufferLength }}
+      containerd-socketpath: {{ .Values.config.containerdSocketPath }}
+      crio-socketpath: {{ .Values.config.crioSocketPath }}
+      docker-socketpath: {{ .Values.config.dockerSocketPath }}
+      podman-socketpath: {{ .Values.config.podmanSocketPath }}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -211,6 +211,9 @@ spec:
               name: pull-secret
               readOnly: true
             {{- end }}
+            - mountPath: /etc/ig
+              name: config
+              readOnly: true
       nodeSelector:
         {{- .Values.nodeSelector | toYaml | nindent 8 }}
       affinity:
@@ -270,9 +273,16 @@ spec:
         {{- if .Values.config.mountPullSecret }}
         - name: pull-secret
           secret:
-            defaultMode: 420
+            defaultMode: 400
             items:
               - key: .dockerconfigjson
                 path: config.json
             secretName: gadget-pull-secret
         {{- end }}
+        - configMap:
+            name: {{ include "gadget.fullname" . }}
+          defaultMode: 400
+          items:
+            - key: config.yaml
+              path: config.yaml
+          name: config

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -37,6 +37,9 @@
         "dockerSocketPath": {
           "type": "string"
         },
+        "podmanSocketPath": {
+          "type": "string"
+        },
         "experimental": {
           "type": "boolean"
         },

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -15,6 +15,8 @@ config:
   crioSocketPath: "/run/crio/crio.sock"
   # -- Docker Engine API Unix socket path
   dockerSocketPath: "/run/docker.sock"
+  # -- Podman API Unix socket path
+  podmanSocketPath: "/run/podman/podman.sock"
 
   # -- Enable experimental features
   experimental: false

--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
@@ -94,6 +95,10 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 
 		log.Infof("starting Inspektor Gadget daemon at %q", socket)
 		service.SetEventBufferLength(eventBufferLength)
+
+		if err = config.Config.ReadInConfig(); err != nil {
+			log.Warnf("reading config: %v", err)
+		}
 
 		return service.Run(gadgetservice.RunConfig{
 			SocketType: socketType,

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -1,0 +1,27 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgettracermanagerconfig
+
+const ConfigPath = "/etc/ig/config.yaml"
+
+const (
+	HookModeKey            = "hook-mode"
+	FallbackPodInformerKey = "fallback-pod-informer"
+	EventsBufferLengthKey  = "events-buffer-length"
+	ContainerdSocketPath   = "containerd-socketpath"
+	CrioSocketPath         = "crio-socketpath"
+	DockerSocketPath       = "docker-socketpath"
+	PodmanSocketPath       = "podman-socketpath"
+)

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -12,6 +12,22 @@ metadata:
   name: gadget
   namespace: gadget
 ---
+# Source: gadget/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gadget
+  namespace: gadget
+data:
+    config.yaml: |-
+      hook-mode: auto
+      fallback-pod-informer: true
+      events-buffer-length: 16384
+      containerd-socketpath: /run/containerd/containerd.sock
+      crio-socketpath: /run/crio/crio.sock
+      docker-socketpath: /run/docker.sock
+      podman-socketpath: /run/podman/podman.sock
+---
 # Source: gadget/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -286,6 +302,9 @@ spec:
             # For this, we use an emptyDir without size limit.
             - mountPath: /var/lib/ig
               name: oci
+            - mountPath: /etc/ig
+              name: config
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       affinity:
@@ -339,3 +358,10 @@ spec:
             path: /sys/kernel/debug
         - name: oci
           emptyDir:
+        - configMap:
+            name: gadget
+          defaultMode: 400
+          items:
+            - key: config.yaml
+              path: config.yaml
+          name: config


### PR DESCRIPTION
This PR allows specifying configuration related to ig-k8s using a configmap. It is mainly split into handling couple of different type of config:

1. config related to gadgettracermanager e.g (`hookMode`, `fallbackPodInformer`, etc) 
2. global params related to operators (currently we don't have any but will allow specify oci params: https://github.com/inspektor-gadget/inspektor-gadget/pull/2902)

Fixes: #2493 

## Testing Done

Since I haven't removed the environment variable, we need to delete the env from the deployment and validate if config is working fine:

```
$ kubectl set env daemonsets -n gadget gadget INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER-
# edit (kubectl edit) the config to disable the pod-informer
$ kubectl get -n gadget cm gadget  -o yaml
apiVersion: v1
data:
  config.yaml: |-
    hook-mode: auto
    fallback-pod-informer: false
    events-buffer-length: 16384
$ kubectl rollout restart -n gadget daemonset
$ ps aux | grep gadgettracermanager
root     1394179  1.6  0.2 5574072 146304 ?      Ssl  18:34   0:00 gadgettracermanager -serve -hook-mode=auto -controller -fallback-podinformer=false
```

Edit: Config file was more priority! 

