### PR TITLE
tree-wide: Freeze perf event array map

### DIFF
--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -87,6 +87,10 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("getting a perf reader: %w", err)
 	}
 
+	if err := gadgets.FreezeMaps(t.objs.Events); err != nil {
+		return err
+	}
+
 	t.progLink, err = link.Kprobe("audit_seccomp", t.objs.IgAuditSecc, nil)
 	if err != nil {
 		return fmt.Errorf("attaching kprobe: %w", err)

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -244,3 +244,16 @@ func LoadeBPFSpec(
 
 	return nil
 }
+
+func FreezeMaps(maps ...*ebpf.Map) error {
+	for _, m := range maps {
+		if err := m.Freeze(); err != nil {
+			if info, _ := m.Info(); info != nil {
+				return fmt.Errorf("freezing map %s: %w", info.Name, err)
+			}
+			return fmt.Errorf("freezing map: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -144,6 +144,10 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("creating perf ring buffer: %w", err)
 	}
 
+	if err := gadgets.FreezeMaps(t.objs.bindsnoopMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -187,6 +187,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.capabilitiesMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -167,6 +167,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.execsnoopMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -239,6 +239,11 @@ func (t *Tracer) install() error {
 	if err != nil {
 		return fmt.Errorf("creating perf ring buffer: %w", err)
 	}
+
+	if err := gadgets.FreezeMaps(t.objs.fsslowerMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -125,6 +125,10 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("creating perf ring buffer: %w", err)
 	}
 
+	if err := gadgets.FreezeMaps(t.objs.mountsnoopMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -102,6 +102,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.oomkillMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -190,6 +190,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.opensnoopMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -175,6 +175,10 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("creating perf ring buffer: %w", err)
 	}
 
+	if err := gadgets.FreezeMaps(t.objs.sigsnoopMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -149,6 +149,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.tcptracerMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -146,6 +146,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.tcpconnectMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
@@ -148,6 +148,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.tcpdropMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
@@ -127,6 +127,10 @@ func (t *Tracer) install() error {
 	}
 	t.reader = reader
 
+	if err := gadgets.FreezeMaps(t.objs.tcpretransMaps.Events); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gadgets/traceloop/tracer/tracer.go
+++ b/pkg/gadgets/traceloop/tracer/tracer.go
@@ -707,7 +707,7 @@ func (t *Tracer) AttachContainer(container *containercollection.Container) error
 		<-t.ctx.Done()
 		evs, err := t.Read(container.Runtime.ContainerID)
 		if err != nil {
-			t.gadgetCtx.Logger().Debugf("error reading from container %s: %v", container.Runtime.ContainerID, err)
+			t.gadgetCtx.Logger().Warnf("error reading from container %s: %v", container.Runtime.ContainerID, err)
 			return
 		}
 		for _, ev := range evs {

--- a/pkg/networktracer/tracer.go
+++ b/pkg/networktracer/tracer.go
@@ -232,6 +232,10 @@ func (t *Tracer[Event]) Run(
 		return fmt.Errorf("getting a perf reader: %w", err)
 	}
 
+	if err := gadgets.FreezeMaps(t.collection.Maps[bpfPerfMapName]); err != nil {
+		return err
+	}
+
 	var ok bool
 	t.prog, ok = t.collection.Programs[bpfProgName]
 	if !ok {

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -240,6 +240,13 @@ func (i *ebpfInstance) runTracer(gadgetCtx operators.GadgetContext, tracer *Trac
 		return fmt.Errorf("creating BPF map reader: %w", err)
 	}
 
+	// TODO: freezing ringbuf doesn't work: "device or resource busy"
+	if m.Type() == ebpf.PerfEventArray {
+		if err := gadgets.FreezeMaps(m); err != nil {
+			return err
+		}
+	}
+
 	go tracer.receiveEvents(gadgetCtx)
 
 	<-gadgetCtx.Context().Done()


### PR DESCRIPTION
Applications running in the same host with CAP_SYSADMIN are able to modify the ebpf maps created by other applications, this could cause Inspektor Gadget to stop receiving events if an application does it. 

In order to avoid that possibility, this PR freezes the perf ring buffers used by Inspektor Gadget, so they can't be changes from any other application. 

TODO after merging:
- [ ] How to freeze ring buffers?
- [ ] How to freeze maps from the program definition? (https://cilium.slack.com/archives/C4XCTGYEM/p1720196112426099) 
- [ ] Check if flags like `BPF_F_WRONLY_PROG` and `BPF_F_RDONLY_PROG` are useful for other maps
