### PR TITLE
Dockerfiles: Use JSON for linter ENTRYPOINT.

### DIFF
--- a/Dockerfiles/linter.Dockerfile
+++ b/Dockerfiles/linter.Dockerfile
@@ -3,4 +3,4 @@ FROM golangci/golangci-lint:${VERSION}
 
 # The timeout specified below is used by 'make lint'. Please keep in sync with
 # the timeout specified in .golangci.yml used by the CI.
-ENTRYPOINT golangci-lint run --fix --timeout=10m0s
+ENTRYPOINT ["golangci-lint", "run", "--fix", "--timeout=10m0s"]


### PR DESCRIPTION
This will avoid having a warning printed when we use the linter.