### PR TITLE
gadgets: Uniform common info they provide

### DIFF
--- a/gadgets/snapshot_process/gadget.yaml
+++ b/gadgets/snapshot_process/gadget.yaml
@@ -8,6 +8,7 @@ datasources:
     fields:
       comm:
         annotations:
+          description: Process name
           template: comm
       pid:
         annotations:

--- a/gadgets/snapshot_process/program.bpf.c
+++ b/gadgets/snapshot_process/program.bpf.c
@@ -21,12 +21,15 @@ GADGET_PARAM(show_threads);
 
 struct process_entry {
 	gadget_mntns_id mntns_id;
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
 	__u32 pid;
 	__u32 tid;
-	__u32 ppid;
 	__u32 uid;
 	__u32 gid;
-	char comm[TASK_COMM_LEN];
+
+	__u32 ppid;
 };
 
 GADGET_SNAPSHOTTER(processes, process_entry, ig_snap_proc);

--- a/gadgets/snapshot_process/test/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/snapshot_process_test.go
@@ -33,12 +33,14 @@ type snapshotProcessEntry struct {
 	eventtypes.CommonData
 
 	MountNsID uint64 `json:"mntns_id"`
-	Pid       uint32 `json:"pid"`
-	Tid       uint32 `json:"tid"`
-	Ppid      uint32 `json:"ppid"`
-	Uid       uint32 `json:"uid"`
-	Gid       uint32 `json:"gid"`
-	Comm      string `json:"comm"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Ppid uint32 `json:"ppid"`
 }
 
 func TestSnapshotProcess(t *testing.T) {

--- a/gadgets/snapshot_socket/gadget.yaml
+++ b/gadgets/snapshot_socket/gadget.yaml
@@ -22,7 +22,7 @@ datasources:
           description: Inode number
           columns.width: 10
           columns.hidden: true
-      netns:
+      netns_id:
         annotations:
           description: Network namespace inode id
           template: ns

--- a/gadgets/snapshot_socket/program.bpf.c
+++ b/gadgets/snapshot_socket/program.bpf.c
@@ -52,7 +52,7 @@ struct socket_entry {
 	struct gadget_l4endpoint_t dst;
 	__u32 state;
 	__u32 ino;
-	gadget_netns_id netns;
+	gadget_netns_id netns_id;
 };
 
 GADGET_SNAPSHOTTER(sockets, socket_entry, ig_snap_tcp, ig_snap_udp);
@@ -114,7 +114,7 @@ socket_bpf_seq_write(struct seq_file *seq, __u16 family, __u16 proto,
 	entry.dst.port = bpf_htons(destp);
 	entry.state = state;
 	entry.ino = ino;
-	entry.netns = netns;
+	entry.netns_id = netns;
 
 	bpf_seq_write(seq, &entry, sizeof(entry));
 }

--- a/gadgets/trace_bind/gadget.yaml
+++ b/gadgets/trace_bind/gadget.yaml
@@ -12,21 +12,33 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      mount_ns_id:
+      mntns_id:
         annotations:
+          description: Mount namespace inode id
           template: ns
       addr:
         annotations:
           description: Address the socket is bound to
           columns.width: 32
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
           template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
       ret:
         annotations:
@@ -40,9 +52,6 @@ datasources:
         annotations:
           description: Socket options
           columns.hidden: true
-      comm:
-        annotations:
-          template: comm
       bound_dev_if:
         annotations:
           description: Index of the network interface the socket is bound to

--- a/gadgets/trace_bind/program.bpf.c
+++ b/gadgets/trace_bind/program.bpf.c
@@ -34,15 +34,18 @@ union bind_options {
 
 struct event {
 	gadget_timestamp timestamp_raw;
-	gadget_mntns_id mount_ns_id;
+	gadget_mntns_id mntns_id;
 	struct gadget_l4endpoint_t addr;
-	// user terminology for pid:
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
 	__u32 pid;
+	__u32 tid;
 	__u32 uid;
 	__u32 gid;
+
 	int ret;
 	enum bind_options_set opts_raw;
-	char comm[TASK_COMM_LEN];
 	// TODO: How to get the name of the device?
 	__u32 bound_dev_if;
 };
@@ -194,9 +197,10 @@ static int probe_exit(struct pt_regs *ctx, short ver)
 
 	event->opts_raw = opts.data;
 	event->pid = pid;
+	event->tid = tid;
 	event->bound_dev_if = BPF_CORE_READ(sock, __sk_common.skc_bound_dev_if);
 	event->ret = ret;
-	event->mount_ns_id = mntns_id;
+	event->mntns_id = mntns_id;
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	event->uid = (u32)uid_gid;
 	event->gid = (u32)(uid_gid >> 32);

--- a/gadgets/trace_bind/test/trace_bind_test.go
+++ b/gadgets/trace_bind/test/trace_bind_test.go
@@ -32,15 +32,18 @@ import (
 type traceBindEvent struct {
 	eventtypes.CommonData
 
+	Timestamp string `json:"timestamp"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
 	Addr       utils.L4Endpoint `json:"addr"`
-	Timestamp  string           `json:"timestamp"`
-	MountNsID  uint64           `json:"mount_ns_id"`
-	Pid        uint32           `json:"pid"`
-	Uid        uint32           `json:"uid"`
-	Gid        uint32           `json:"gid"`
 	Ret        int32            `json:"ret"`
 	Opts       string           `json:"opts"`
-	Comm       string           `json:"comm"`
 	BoundDevIF uint32           `json:"bound_dev_if"`
 }
 
@@ -103,14 +106,16 @@ func TestTraceBind(t *testing.T) {
 				// Check the existence of the following fields
 				Timestamp: utils.NormalizedStr,
 				Pid:       utils.NormalizedInt,
-				MountNsID: utils.NormalizedInt,
+				Tid:       utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 			}
 
 			normalize := func(e *traceBindEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Timestamp)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeInt(&e.Pid)
+				utils.NormalizeInt(&e.Tid)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -12,9 +12,30 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      mntnsid:
+      mntns_id:
         annotations:
+          description: Mount namespace inode id
           template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+      uid:
+        annotations:
+          description: User ID
+          template: uid
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
       current_userns:
         annotations:
           template: ns
@@ -28,24 +49,12 @@ datasources:
         annotations:
           columns.width: 20
           columns.hidden: true
-      pid:
-        annotations:
-          template: pid
       cap_raw:
         annotations:
           columns.hidden: true
       cap:
         annotations:
           columns.hidden: true
-      tgid:
-        annotations:
-          template: pid
-      uid:
-        annotations:
-          template: uid
-      gid:
-        annotations:
-          template: uid
       audit:
         annotations:
           columns.width: 11
@@ -58,9 +67,6 @@ datasources:
       syscall:
         annotations:
           columns.width: 20
-      task:
-        annotations:
-          template: comm
       kstack_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_capabilities/test/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/trace_capabilities_test.go
@@ -33,20 +33,22 @@ import (
 type traceCapabilitiesEvent struct {
 	eventtypes.CommonData
 
-	MountNsID     uint64 `json:"mntnsid"`
-	Timestamp     string `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
 	CurrentUserNs uint64 `json:"current_user_ns"`
 	TargetUserNs  uint64 `json:"target_user_ns"`
 	CapEffective  string `json:"cap_effective"`
-	Pid           uint32 `json:"pid"`
 	Cap           string `json:"cap"`
-	Tgid          uint32 `json:"tgid"`
-	Uid           uint32 `json:"uid"`
-	Gid           uint32 `json:"gid"`
 	Audit         uint32 `json:"audit"`
 	Insetid       uint32 `json:"insetid"`
 	Syscall       string `json:"syscall"`
-	Task          string `json:"task"`
 	Kstack        string `json:"kstack"`
 	Capable       bool   `json:"capable"`
 }
@@ -104,15 +106,15 @@ func TestTraceCapabilities(t *testing.T) {
 					Syscall:    "SYS_SETPRIORITY",
 					Audit:      1,
 					Capable:    false,
-					Task:       "nice",
+					Comm:       "nice",
 
 					// Check the existence of the following fields
-					MountNsID:     utils.NormalizedInt,
+					MntNsID:       utils.NormalizedInt,
 					Timestamp:     utils.NormalizedStr,
 					Pid:           utils.NormalizedInt,
+					Tid:           utils.NormalizedInt,
 					Uid:           0,
 					Gid:           0,
-					Tgid:          0,
 					Kstack:        utils.NormalizedStr,
 					Insetid:       0,
 					CapEffective:  utils.NormalizedStr,
@@ -123,16 +125,16 @@ func TestTraceCapabilities(t *testing.T) {
 
 			normalize := func(e *traceCapabilitiesEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeInt(&e.Pid)
+				utils.NormalizeInt(&e.Tid)
 				utils.NormalizeString(&e.Kstack)
 				utils.NormalizeString(&e.CapEffective)
 
 				// Manually normalize fields that might contain 0
 				e.Uid = 0
 				e.Gid = 0
-				e.Tgid = 0
 				e.CurrentUserNs = 0
 				e.TargetUserNs = 0
 				e.Insetid = 0

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -20,21 +20,37 @@ datasources:
         annotations:
           description: Destination endpoint
           template: l4endpoint
+      netns_id:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
-          description: PID of the process that sent the request
+          description: Process ID
           template: pid
-      task:
+      tid:
         annotations:
-          template: comm
+          description: Thread ID
+          columns.hidden: true
+          template: pid
       uid:
         annotations:
-          template: uid
+          description: User ID
           columns.hidden: true
+          template: uid
       gid:
         annotations:
-          template: uid
+          description: Group ID
           columns.hidden: true
+          template: uid
       name:
         annotations:
           columns.width: 30
@@ -54,17 +70,6 @@ datasources:
       anaddr:
         annotations:
           columns.width: 16
-      netns:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      tid:
-        annotations:
-          columns.hidden: true
       id:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -39,12 +39,14 @@ struct event_t {
 	struct gadget_l4endpoint_t dst;
 
 	gadget_mntns_id mntns_id;
-	gadget_netns_id netns;
+	gadget_netns_id netns_id;
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
 	__u32 pid;
 	__u32 tid;
 	__u32 uid;
 	__u32 gid;
-	char task[TASK_COMM_LEN];
 
 	__u16 id;
 	unsigned short qtype;
@@ -265,7 +267,7 @@ static __always_inline int output_dns_event(struct __sk_buff *skb,
 
 	__builtin_memset(event, 0, sizeof(*event));
 
-	event->netns = skb->cb[0]; // cb[0] initialized by dispatcher.bpf.c
+	event->netns_id = skb->cb[0]; // cb[0] initialized by dispatcher.bpf.c
 
 	// Keep the timestamp in a variable on the stack as a workaround to a
 	// kernel bug causing the following issue with the verifier:
@@ -384,8 +386,8 @@ static __always_inline int output_dns_event(struct __sk_buff *skb,
 		event->mntns_id = skb_val->mntns;
 		event->pid = skb_val->pid_tgid >> 32;
 		event->tid = (__u32)skb_val->pid_tgid;
-		__builtin_memcpy(&event->task, skb_val->task,
-				 sizeof(event->task));
+		__builtin_memcpy(&event->comm, skb_val->task,
+				 sizeof(event->comm));
 		event->uid = (__u32)skb_val->uid_gid;
 		event->gid = (__u32)(skb_val->uid_gid >> 32);
 	}

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -12,26 +12,38 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      pid:
+      mntns_id:
         annotations:
-          template: pid
-      ppid:
-        annotations:
-          template: pid
+          description: Mount namespace inode id
+          template: ns
       comm:
         annotations:
+          description: Process name
           template: comm
       pcomm:
         annotations:
           template: pcomm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
           columns.hidden: true
       gid:
         annotations:
+          description: Group ID
           template: uid
           columns.hidden: true
+      ppid:
+        annotations:
+          template: pid
       loginuid:
         annotations:
           template: uid
@@ -55,9 +67,6 @@ datasources:
       args:
         annotations:
           columns.width: 16
-      mntns_id:
-        annotations:
-          template: ns
       upper_layer:
         annotations:
           description: Whether the executable is in the upper layer of the overlay filesystem

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -24,12 +24,18 @@
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)
 
 struct event {
-	gadget_mntns_id mntns_id;
 	gadget_timestamp timestamp_raw;
+	gadget_mntns_id mntns_id;
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
 	__u32 pid;
-	__u32 ppid;
+	__u32 tid;
 	__u32 uid;
 	__u32 gid;
+
+	char pcomm[TASK_COMM_LEN];
+	__u32 ppid;
 	__u32 loginuid;
 	__u32 sessionid;
 	int retval;
@@ -37,8 +43,6 @@ struct event {
 	bool upper_layer;
 	bool pupper_layer;
 	unsigned int args_size;
-	char comm[TASK_COMM_LEN];
-	char pcomm[TASK_COMM_LEN];
 	char args[FULL_MAX_ARGS_ARR];
 };
 
@@ -106,6 +110,7 @@ int ig_execve_e(struct syscall_trace_enter *ctx)
 
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
 	event->pid = tgid;
+	event->tid = pid;
 	event->uid = uid;
 	event->gid = gid;
 	event->loginuid = BPF_CORE_READ(task, loginuid.val);

--- a/gadgets/trace_exec/test/trace_exec_test.go
+++ b/gadgets/trace_exec/test/trace_exec_test.go
@@ -34,19 +34,22 @@ import (
 type traceExecEvent struct {
 	eventtypes.CommonData
 
-	MountNsID   uint64 `json:"mntns_id"`
-	Timestamp   string `json:"timestamp"`
-	Pid         uint32 `json:"pid"`
+	Timestamp string `json:"timestamp"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Pcomm       string `json:"pcomm"`
 	Ppid        uint32 `json:"ppid"`
-	Uid         uint32 `json:"uid"`
-	Gid         uint32 `json:"gid"`
 	Loginuid    uint32 `json:"loginuid"`
 	Sessionid   uint32 `json:"sessionid"`
 	Retval      int32  `json:"retval"`
 	UpperLayer  bool   `json:"upper_layer"`
 	PupperLayer bool   `json:"pupper_layer"`
-	Comm        string `json:"comm"`
-	Pcomm       string `json:"pcomm"`
 	Args        string `json:"args"`
 }
 
@@ -110,9 +113,10 @@ func TestTraceExec(t *testing.T) {
 					UpperLayer: false,
 
 					// Check the existence of the following fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					Ppid:      utils.NormalizedInt,
 					Loginuid:  utils.NormalizedInt,
 					Sessionid: utils.NormalizedInt,
@@ -128,9 +132,10 @@ func TestTraceExec(t *testing.T) {
 					UpperLayer: true,
 
 					// Check the existence of the following fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					Ppid:      utils.NormalizedInt,
 					Loginuid:  utils.NormalizedInt,
 					Sessionid: utils.NormalizedInt,
@@ -148,9 +153,10 @@ func TestTraceExec(t *testing.T) {
 					PupperLayer: true,
 
 					// Check the existence of the following fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					Ppid:      utils.NormalizedInt,
 					Loginuid:  utils.NormalizedInt,
 					Sessionid: utils.NormalizedInt,
@@ -160,9 +166,10 @@ func TestTraceExec(t *testing.T) {
 			normalize := func(e *traceExecEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Runtime.ContainerID)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeInt(&e.Pid)
+				utils.NormalizeInt(&e.Tid)
 				utils.NormalizeInt(&e.Ppid)
 				utils.NormalizeInt(&e.Loginuid)
 				utils.NormalizeInt(&e.Sessionid)

--- a/gadgets/trace_lsm/gadget.yaml
+++ b/gadgets/trace_lsm/gadget.yaml
@@ -14,18 +14,27 @@ datasources:
           template: timestamp
       mntns_id:
         annotations:
+          description: Mount namespace inode id
           template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
+          description: Thread ID
           template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
       tracepoint_raw:
         annotations:
@@ -33,9 +42,6 @@ datasources:
       tracepoint:
         annotations:
           description: lsm tracepoint name
-      comm:
-        attributes:
-          template: comm
 ebpfParams:
   trace_all:
     key: trace-all

--- a/gadgets/trace_lsm/program.bpf.c
+++ b/gadgets/trace_lsm/program.bpf.c
@@ -167,14 +167,17 @@
 enum lsm_tracepoint { FOR_EACH_LSM_HOOK(ENUM_ITEM) };
 
 struct event {
-	gadget_mntns_id mntns_id;
 	gadget_timestamp timestamp_raw;
-	u32 pid;
-	u32 tid;
-	u32 uid;
-	u32 gid;
-	enum lsm_tracepoint tracepoint_raw;
+	gadget_mntns_id mntns_id;
+
 	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
+	__u32 pid;
+	__u32 tid;
+	__u32 uid;
+	__u32 gid;
+
+	enum lsm_tracepoint tracepoint_raw;
 };
 
 GADGET_TRACER_MAP(events, 1024 * 256);

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -12,15 +12,30 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
+          description: Thread ID
           template: pid
-      comm:
+      uid:
         annotations:
-          template: comm
+          description: User ID
+          template: uid
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
       operation_raw:
         annotations:
           columns.hidden: true
@@ -31,9 +46,6 @@ datasources:
         annotations:
           description: address of malloc/free operations
           columns.width: 20
-      mntns_id:
-        annotations:
-          template: ns
       size:
         annotations:
           description: size of malloc operations

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -12,23 +12,36 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
+          description: Thread ID
           template: pid
-      comm:
+      uid:
         annotations:
-          template: comm
+          description: User ID
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
+          columns.hidden: true
       delta:
         annotations:
           columns.width: 8
           columns.alignment: right
-      mount_ns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       ret:
         annotations:
           description: 'TODO: Fill field description'

--- a/gadgets/trace_mount/test/trace_mount_test.go
+++ b/gadgets/trace_mount/test/trace_mount_test.go
@@ -33,20 +33,24 @@ import (
 type traceMountEvent struct {
 	eventtypes.CommonData
 
-	Delta     uint64 `json:"delta"`
-	Flags     string `json:"flags"`
-	Pid       int    `json:"pid"`
-	Tid       int    `json:"tid"`
-	MountNsID uint64 `json:"mount_ns_id"`
 	Timestamp string `json:"timestamp"`
-	Ret       int    `json:"ret"`
-	Comm      string `json:"comm"`
-	Fs        string `json:"fs"`
-	Src       string `json:"src"`
-	Dest      string `json:"dest"`
-	Data      string `json:"data"`
-	Op        string `json:"op"`
-	Call      string `json:"call"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Delta uint64 `json:"delta"`
+	Flags string `json:"flags"`
+	Ret   int    `json:"ret"`
+	Fs    string `json:"fs"`
+	Src   string `json:"src"`
+	Dest  string `json:"dest"`
+	Data  string `json:"data"`
+	Op    string `json:"op"`
+	Call  string `json:"call"`
 }
 
 func TestTraceMount(t *testing.T) {
@@ -110,7 +114,7 @@ func TestTraceMount(t *testing.T) {
 				Delta:     utils.NormalizedInt,
 				Pid:       utils.NormalizedInt,
 				Tid:       utils.NormalizedInt,
-				MountNsID: utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 				Fs:        utils.NormalizedStr,
 				Call:      utils.NormalizedStr,
 			}
@@ -122,7 +126,7 @@ func TestTraceMount(t *testing.T) {
 				utils.NormalizeString(&e.Flags)
 				utils.NormalizeInt(&e.Pid)
 				utils.NormalizeInt(&e.Tid)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeString(&e.Fs)
 				utils.NormalizeString(&e.Call)
 			}

--- a/gadgets/trace_oomkill/program.bpf.c
+++ b/gadgets/trace_oomkill/program.bpf.c
@@ -14,13 +14,13 @@
 #define TASK_COMM_LEN 16
 
 struct event {
+	gadget_timestamp timestamp_raw;
+	gadget_mntns_id mntns_id;
 	__u32 fpid;
 	__u32 fuid;
 	__u32 fgid;
 	__u32 tpid;
 	__u64 pages;
-	gadget_mntns_id mntns_id;
-	gadget_timestamp timestamp_raw;
 	char fcomm[TASK_COMM_LEN];
 	char tcomm[TASK_COMM_LEN];
 };

--- a/gadgets/trace_oomkill/test/trace_oomkill_test.go
+++ b/gadgets/trace_oomkill/test/trace_oomkill_test.go
@@ -36,7 +36,7 @@ type traceOomKillEvent struct {
 	Fgid      uint32 `json:"fgid"`
 	Tpid      uint32 `json:"tpid"`
 	Pages     uint64 `json:"pages"`
-	MountNsID uint64 `json:"mntns_id"`
+	MntNsID   uint64 `json:"mntns_id"`
 	Timestamp string `json:"timestamp"`
 	Fcomm     string `json:"fcomm"`
 	Tcomm     string `json:"tcomm"`
@@ -92,7 +92,7 @@ func TestTraceOomKill(t *testing.T) {
 
 				// Check the existence of the following fields
 				Timestamp: utils.NormalizedStr,
-				MountNsID: utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 				Fpid:      utils.NormalizedInt,
 				Fuid:      utils.NormalizedInt,
 				Fgid:      utils.NormalizedInt,
@@ -106,7 +106,7 @@ func TestTraceOomKill(t *testing.T) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Runtime.ContainerID)
 				utils.NormalizeString(&e.Timestamp)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeInt(&e.Fpid)
 				utils.NormalizeInt(&e.Tpid)
 				utils.NormalizeInt(&e.Pages)

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -12,17 +12,29 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      pid:
+      mntns_id:
         annotations:
-          template: pid
+          description: Mount namespace inode id
+          template: ns
       comm:
         annotations:
+          description: Process name
           template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
       flags_raw:
         annotations:
@@ -40,6 +52,7 @@ datasources:
       err:
         annotations:
           description: Error code
+          columns.minwidth: 3
           columns.width: 5
           columns.alignment: right
       fd:
@@ -52,9 +65,6 @@ datasources:
         annotations:
           columns.width: 32
           columns.minwidth: 24
-      mntns_id:
-        annotations:
-          template: ns
 ebpfParams:
   targ_failed:
     key: failed

--- a/gadgets/trace_open/test/trace_open_test.go
+++ b/gadgets/trace_open/test/trace_open_test.go
@@ -33,16 +33,19 @@ type traceOpenEvent struct {
 	eventtypes.CommonData
 
 	Timestamp string `json:"timestamp"`
-	Pid       uint32 `json:"pid"`
-	Uid       uint32 `json:"uid"`
-	Gid       uint32 `json:"gid"`
-	MountNsID uint64 `json:"mntns_id"`
-	Fd        uint32 `json:"fd"`
-	Err       int32  `json:"err"`
-	Flags     string `json:"flags"`
-	Mode      string `json:"mode"`
-	Comm      string `json:"comm"`
-	FName     string `json:"fname"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Fd    uint32 `json:"fd"`
+	Err   int32  `json:"err"`
+	Flags string `json:"flags"`
+	Mode  string `json:"mode"`
+	FName string `json:"fname"`
 }
 
 func TestTraceOpen(t *testing.T) {
@@ -102,14 +105,16 @@ func TestTraceOpen(t *testing.T) {
 				// Check the existence of the following fields
 				Timestamp: utils.NormalizedStr,
 				Pid:       utils.NormalizedInt,
-				MountNsID: utils.NormalizedInt,
+				Tid:       utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 			}
 
 			normalize := func(e *traceOpenEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeInt(&e.Pid)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.Tid)
+				utils.NormalizeInt(&e.MntNsID)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -12,21 +12,34 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      pid:
+      mntns_id:
         annotations:
-          template: pid
-      tpid:
-        annotations:
-          template: pid
+          description: Mount namespace inode id
+          template: ns
       comm:
         annotations:
+          description: Process name
           template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
+      tpid:
+        annotations:
+          description: Target process ID
+          template: pid
       ret:
         annotations:
           columns.width: 5
@@ -38,10 +51,6 @@ datasources:
         annotations:
           description: Signal number
           columns.width: 10
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
 ebpfParams:
   failed_only:
     key: failed

--- a/gadgets/trace_signal/program.bpf.c
+++ b/gadgets/trace_signal/program.bpf.c
@@ -15,15 +15,20 @@ struct value {
 };
 
 struct event {
-	__u32 pid;
-	__u32 tpid;
-	gadget_mntns_id mntns_id;
 	gadget_timestamp timestamp_raw;
+	gadget_mntns_id mntns_id;
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
+	__u32 pid;
+	__u32 tid;
 	__u32 uid;
 	__u32 gid;
+
+	__u32 tpid;
+
 	gadget_signal sig_raw;
 	int ret;
-	char comm[TASK_COMM_LEN];
 };
 
 const volatile pid_t filtered_pid = 0;
@@ -193,6 +198,7 @@ int ig_sig_generate(struct trace_event_raw_signal_generate *ctx)
 		return 0;
 
 	event->pid = pid;
+	event->tid = (__u32)pid_tgid;
 	event->tpid = tpid;
 	event->mntns_id = mntns_id;
 	event->sig_raw = sig;

--- a/gadgets/trace_signal/test/trace_signal_test.go
+++ b/gadgets/trace_signal/test/trace_signal_test.go
@@ -32,16 +32,18 @@ import (
 type traceSignalEvent struct {
 	eventtypes.CommonData
 
-	Pid       int    `json:"pid"`
-	Tid       int    `json:"tpid"`
-	MountNsID uint64 `json:"mntns_id"`
 	Timestamp string `json:"timestamp"`
-	Uid       int    `json:"uid"`
-	Gid       int    `json:"gid"`
+	MntNsID   uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
 	Signal    string `json:"sig"`
 	SignalRaw int    `json:"sig_raw"`
 	Ret       int    `json:"ret"`
-	Comm      string `json:"comm"`
 }
 
 func TestTraceSignal(t *testing.T) {
@@ -101,7 +103,7 @@ func TestTraceSignal(t *testing.T) {
 				Pid:       utils.NormalizedInt,
 				Tid:       utils.NormalizedInt,
 				Timestamp: utils.NormalizedStr,
-				MountNsID: utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 			}
 
 			normalize := func(e *traceSignalEvent) {
@@ -109,7 +111,7 @@ func TestTraceSignal(t *testing.T) {
 				utils.NormalizeInt(&e.Pid)
 				utils.NormalizeInt(&e.Tid)
 				utils.NormalizeString(&e.Timestamp)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)

--- a/gadgets/trace_sni/gadget.yaml
+++ b/gadgets/trace_sni/gadget.yaml
@@ -12,30 +12,7 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
-      pid:
-        annotations:
-          description: PID of the process that sent the request
-          template: pid
-      tid:
-        annotations:
-          description: TID of the thread sending the request
-          columns.hidden: true
-          template: pid
-      task:
-        annotations:
-          template: comm
-      uid:
-        annotations:
-          hidden: true
-          template: uid
-      gid:
-        annotations:
-          hidden: true
-          template: uid
-      name:
-        annotations:
-          columns.width: 30
-      netns:
+      netns_id:
         annotations:
           description: Network namespace inode id
           template: ns
@@ -43,3 +20,26 @@ datasources:
         annotations:
           description: Mount namespace inode id
           template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+      uid:
+        annotations:
+          description: User ID
+          template: uid
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
+      name:
+        annotations:
+          columns.width: 30

--- a/gadgets/trace_sni/program.bpf.c
+++ b/gadgets/trace_sni/program.bpf.c
@@ -57,15 +57,16 @@
 
 struct event_t {
 	gadget_timestamp timestamp_raw;
-
 	gadget_mntns_id mntns_id;
-	gadget_netns_id netns;
+	gadget_netns_id netns_id;
 
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
 	__u32 pid;
 	__u32 tid;
 	__u32 uid;
 	__u32 gid;
-	char task[TASK_COMM_LEN];
+
 	char name[TLS_MAX_SERVER_NAME_LEN];
 };
 
@@ -220,7 +221,7 @@ int ig_trace_sni(struct __sk_buff *skb)
 		0,
 	};
 
-	event.netns = skb->cb[0]; // cb[0] initialized by dispatcher.bpf.c
+	event.netns_id = skb->cb[0]; // cb[0] initialized by dispatcher.bpf.c
 	for (int i = 0; i < TLS_MAX_SERVER_NAME_LEN; i++) {
 		if (sni[i] == '\0')
 			break;
@@ -234,8 +235,8 @@ int ig_trace_sni(struct __sk_buff *skb)
 		event.mntns_id = skb_val->mntns;
 		event.pid = skb_val->pid_tgid >> 32;
 		event.tid = (__u32)skb_val->pid_tgid;
-		__builtin_memcpy(&event.task, skb_val->task,
-				 sizeof(event.task));
+		__builtin_memcpy(&event.comm, skb_val->task,
+				 sizeof(event.comm));
 		event.uid = (__u32)skb_val->uid_gid;
 		event.gid = (__u32)(skb_val->uid_gid >> 32);
 	}

--- a/gadgets/trace_sni/test/trace_sni_test.go
+++ b/gadgets/trace_sni/test/trace_sni_test.go
@@ -33,14 +33,16 @@ type traceSNIEvent struct {
 	eventtypes.CommonData
 
 	Timestamp string `json:"timestamp"`
-	MountNsID uint64 `json:"mntns_id"`
-	NetNs     uint64 `json:"netns"`
-	Pid       uint32 `json:"pid"`
-	Tid       uint32 `json:"tid"`
-	Uid       uint32 `json:"uid"`
-	Gid       uint32 `json:"gid"`
-	Task      string `json:"task"`
-	Name      string `json:"name"`
+	MntNsID   uint64 `json:"mntns_id"`
+	NetNs     uint64 `json:"netns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Name string `json:"name"`
 }
 
 func TestTraceSNI(t *testing.T) {
@@ -92,14 +94,14 @@ func TestTraceSNI(t *testing.T) {
 		func(t *testing.T, output string) {
 			expectedEntry := &traceSNIEvent{
 				CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
-				Task:       "wget",
+				Comm:       "wget",
 				Name:       "inspektor-gadget.io",
 				Uid:        1000,
 				Gid:        1111,
 
 				// Check the existence of the following fields
 				Timestamp: utils.NormalizedStr,
-				MountNsID: utils.NormalizedInt,
+				MntNsID:   utils.NormalizedInt,
 				NetNs:     utils.NormalizedInt,
 				Pid:       utils.NormalizedInt,
 				Tid:       utils.NormalizedInt,
@@ -108,7 +110,7 @@ func TestTraceSNI(t *testing.T) {
 			normalize := func(e *traceSNIEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Timestamp)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeInt(&e.NetNs)
 				utils.NormalizeInt(&e.Pid)
 				utils.NormalizeInt(&e.Tid)

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -16,21 +16,30 @@ datasources:
       latency_ns:
         annotations:
           columns.width: 10
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
+          description: Thread ID
           template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
-      comm:
-        annotations:
-          template: comm
       len:
         annotations:
           columns.hidden: true
@@ -42,10 +51,6 @@ datasources:
         annotations:
           description: return value
           columns.width: 20
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       operation_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_ssl/program.bpf.c
+++ b/gadgets/trace_ssl/program.bpf.c
@@ -46,17 +46,20 @@ enum operation {
 };
 
 struct event {
-	gadget_mntns_id mntns_id;
-	enum operation operation_raw;
 	gadget_timestamp timestamp_raw;
+	gadget_mntns_id mntns_id;
+
+	char comm[TASK_COMM_LEN];
+	// user-space terminology for pid and tid
+	__u32 pid;
+	__u32 tid;
+	__u32 uid;
+	__u32 gid;
+
+	enum operation operation_raw;
 	u64 latency_ns;
-	u32 pid;
-	u32 tid;
-	u32 uid;
-	u32 gid;
 	u32 len;
 	u64 retval;
-	char comm[TASK_COMM_LEN];
 	u8 buf[MAX_BUF_SIZE];
 };
 

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -12,17 +12,33 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
+      netns_id:
+        annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
-      task:
+      tid:
         annotations:
-          template: comm
+          description: Thread ID
+          template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
       src:
         annotations:
@@ -30,14 +46,6 @@ datasources:
       dst:
         annotations:
           template: l4endpoint
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      netns:
-        annotations:
-          description: Network namespace inode id
-          template: ns
       type_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_tcp/test/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/trace_tcp_test.go
@@ -32,16 +32,19 @@ import (
 type traceTCPEvent struct {
 	eventtypes.CommonData
 
-	Src       utils.L4Endpoint `json:"src"`
-	Dst       utils.L4Endpoint `json:"dst"`
-	Task      string           `json:"task"`
-	MountNsID uint64           `json:"mntns_id"`
-	Timestamp string           `json:"timestamp"`
-	Pid       uint32           `json:"pid"`
-	Uid       uint32           `json:"uid"`
-	Gid       uint32           `json:"gid"`
-	NetNsID   uint64           `json:"netns"`
-	Type      string           `json:"type"`
+	Timestamp string `json:"timestamp"`
+	MntNsID   uint64 `json:"mntns_id"`
+	NetNsID   uint64 `json:"netns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Src  utils.L4Endpoint `json:"src"`
+	Dst  utils.L4Endpoint `json:"dst"`
+	Type string           `json:"type"`
 }
 
 func TestTraceTCP(t *testing.T) {
@@ -106,15 +109,16 @@ func TestTraceTCP(t *testing.T) {
 						Port:    utils.NormalizedInt,
 						Proto:   6,
 					},
-					Task: "curl",
+					Comm: "curl",
 					Uid:  0,
 					Gid:  0,
 					Type: "connect",
 
 					// Check only the existence of these fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					NetNsID:   utils.NormalizedInt,
 				},
 				{
@@ -131,15 +135,16 @@ func TestTraceTCP(t *testing.T) {
 						Port:    utils.NormalizedInt,
 						Proto:   6,
 					},
-					Task: "nginx",
+					Comm: "nginx",
 					Uid:  101,
 					Gid:  101,
 					Type: "accept",
 
 					// Check only the existence of these fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					NetNsID:   utils.NormalizedInt,
 				},
 				{
@@ -156,24 +161,26 @@ func TestTraceTCP(t *testing.T) {
 						Port:    utils.NormalizedInt,
 						Proto:   6,
 					},
-					Task: "curl",
+					Comm: "curl",
 					Uid:  0,
 					Gid:  0,
 					Type: "close",
 
 					// Check only the existence of these fields
-					MountNsID: utils.NormalizedInt,
+					MntNsID:   utils.NormalizedInt,
 					Timestamp: utils.NormalizedStr,
 					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
 					NetNsID:   utils.NormalizedInt,
 				},
 			}
 
 			normalize := func(e *traceTCPEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeInt(&e.Pid)
+				utils.NormalizeInt(&e.Tid)
 				utils.NormalizeInt(&e.NetNsID)
 				// Checking the ports is a little bit complicated as successive
 				// calls to curl with --local-port fail because of

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -12,17 +12,29 @@ datasources:
       timestamp:
         annotations:
           template: timestamp
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
+          template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
-      task:
+      tid:
         annotations:
-          template: comm
+          description: Thread ID
+          template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
       gid:
         annotations:
+          description: Group ID
           template: uid
       src:
         annotations:
@@ -35,10 +47,6 @@ datasources:
           columns.width: 16
           columns.alignment: right
           columns.hidden: true
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       retcode:
         annotations:
           columns.width: 7

--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -18,26 +18,39 @@ datasources:
       dst:
         annotations:
           template: l4endpoint
-      task:
+      netns_id:
         annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
           template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
-          description: Thread id that generated event
-          columns.hidden: true
+          description: Thread ID
           template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
           columns.hidden: true
       gid:
         annotations:
-          description: Group id of the event's process
+          description: Group ID
           template: uid
           columns.hidden: true
+      task:
+        annotations:
+          template: comm
       tcpflags_raw:
         annotations:
           columns.hidden: true
@@ -51,14 +64,6 @@ datasources:
         annotations:
           description: Reason for dropping a packet
           columns.ellipsis: start
-      netns:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mount_ns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       state_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -18,26 +18,39 @@ datasources:
       dst:
         annotations:
           template: l4endpoint
-      task:
+      netns_id:
         annotations:
+          description: Network namespace inode id
+          template: ns
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Process name
           template: comm
       pid:
         annotations:
+          description: Process ID
           template: pid
       tid:
         annotations:
-          description: Thread id that generated event
-          columns.hidden: true
+          description: Thread ID
           template: pid
       uid:
         annotations:
+          description: User ID
           template: uid
           columns.hidden: true
       gid:
         annotations:
-          description: Group id of the event's process
+          description: Group ID
           template: uid
           columns.hidden: true
+      task:
+        annotations:
+          template: comm
       tcpflags_raw:
         annotations:
           columns.hidden: true
@@ -50,10 +63,6 @@ datasources:
       reason:
         annotations:
           description: Reason for retransmission
-      netns:
-        annotations:
-          description: Network namespace inode id
-          template: ns
       type_raw:
         annotations:
           columns.hidden: true
@@ -61,10 +70,6 @@ datasources:
         annotations:
           description: Type of the retransmission, either RETRANS or LOSS
           columns.width: 10
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       state:
         annotations:
           description: Connection state


### PR DESCRIPTION
This commit updates image-based gadgets to provide the same common information:
- comm: Process Name
- pid: Process ID
- tid: Thread ID
- uid: User ID
- gid: Group ID

This commit specifically:
- Adds the Tid field missing on some gadgets
- Renames task to comm on others
- Reorders the event struct to follow the same pattern on all gadgets
- Adds missing description to metadata files

Ref #1567 

(I'm not marking #1567 as fixed by this PR, as I still want to investigate if we can provide  a structure with this common info and some helpers to fill it).