### PR TITLE
pkg/operators/ebpf: Allow passing field configuration as annotations

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -390,9 +390,6 @@ func (ds *dataSource) AddStaticFields(size uint32, fields []StaticField) (FieldA
 				checkParents[nf] = struct{}{}
 			}
 		}
-		if s, ok := f.(HiddenField); ok && s.FieldHidden() {
-			FieldFlagHidden.AddTo(&nf.Flags)
-		}
 		newFields = append(newFields, nf)
 	}
 

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -379,7 +379,9 @@ func (ds *dataSource) AddStaticFields(size uint32, fields []StaticField) (FieldA
 			nf.Flags |= uint32(s.FieldFlags())
 		}
 		if s, ok := f.(AnnotatedField); ok {
-			nf.Annotations = s.FieldAnnotations()
+			for k, v := range s.FieldAnnotations() {
+				nf.Annotations[k] = v
+			}
 		}
 		if s, ok := f.(ParentedField); ok {
 			parent := s.FieldParent()

--- a/pkg/datasource/field.go
+++ b/pkg/datasource/field.go
@@ -87,10 +87,6 @@ type FlaggedField interface {
 	FieldFlags() FieldFlag
 }
 
-type HiddenField interface {
-	FieldHidden() bool
-}
-
 type ParentedField interface {
 	// FieldParent should return an index to the parent of the field, -1 for no parent
 	FieldParent() int

--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -15,6 +15,7 @@
 package ebpfoperator
 
 import (
+	"maps"
 	"reflect"
 	"slices"
 
@@ -25,12 +26,13 @@ import (
 )
 
 type Field struct {
-	Tags   []string
-	Offset uint32
-	Size   uint32
-	parent int
-	name   string
-	kind   api.Kind
+	Tags        []string
+	Annotations map[string]string
+	Offset      uint32
+	Size        uint32
+	parent      int
+	name        string
+	kind        api.Kind
 }
 
 type Struct struct {
@@ -60,6 +62,10 @@ func (f *Field) FieldType() api.Kind {
 
 func (f *Field) FieldParent() int {
 	return f.parent
+}
+
+func (f *Field) FieldAnnotations() map[string]string {
+	return maps.Clone(f.Annotations)
 }
 
 func (i *ebpfInstance) populateStructDirect(btfStruct *btf.Struct) error {


### PR DESCRIPTION
# Allow passing field configuration as annotations from ebpf operator

After https://github.com/inspektor-gadget/inspektor-gadget/commit/a81f33a, `ebpfoperator.Field` neither has the `Attributes` field nor implements `FieldAnnotations()` anymore. So, the ebpf operator is not anymore able to add field configuration when adding fields with `AddStaticFields()`. It prevents the ebpf operator from setting templates or even simply passing generic annotations.

Additionally, this PR cleans up the management of the hidden configuration.

## How to use

Image-based gadgets must work as before.

**NOTE**: The ebpf operator will use field annotations for topper and profilers cc @flyth 

## Testing done

I tested it by applying the hidden annotation from ebpf operator and verifying that none of the fields added by the epbf operator were displayed. This test should validate both commits:

```
diff --git a/pkg/operators/ebpf/ebpf.go b/pkg/operators/ebpf/ebpf.go
index d56197e6d304..0219d7ea19db 100644
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -335,6 +335,10 @@ func (i *ebpfInstance) addDataSource(
        staticFields := make([]datasource.StaticField, 0, len(fields))
        for _, field := range fields {
                staticFields = append(staticFields, field)
+               if field.Annotations == nil {
+                       field.Annotations = make(map[string]string)
+               }
+               field.Annotations[datasource.ColumnsHiddenAnnotation] = "true"
        }
        accessor, err := ds.AddStaticFields(size, staticFields)
        if err != nil {
```