### PR TITLE
docs: point to the installation instructions on the IG website instead of the TOC on the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Install Inspektor Gadget on Kubernetes:
 $ kubectl gadget deploy
 ```
 
-Read the detailed [install instructions](docs/getting-started/_index.md) to find more information.
+Read the detailed [install instructions](https://www.inspektor-gadget.io/docs/latest/getting-started/) to find more information.
 
 ## How to use
 


### PR DESCRIPTION
This is the first link that we provide on the README for a documentation and right now it's just pointing to a TOC that you wouldn't really understand as a non-developer. Pointing it to the rendered version on the official website is much more suited for general audiences.

(Was on a call with @mqasimsarfraz and we discovered this randomly when talking about the docs)