### PR TITLE
image-based gadgets: introduce map iterators

### DIFF
--- a/include/gadget/macros.h
+++ b/include/gadget/macros.h
@@ -55,4 +55,10 @@
 	const struct type *unusedevent_##name##___##type __attribute__((unused)); \
     __GADGET_SNAPSHOTTER_IMPL(name, type, __VA_ARGS__)
 
+// GADGET_MAPITER defines maps that IG should periodically fetch into data sources
+// - name is the name of the map iterator
+// - mapname is the name of the hash map used to send events to user space.
+#define GADGET_MAPITER(name, mapname) \
+	const void *gadget_mapiter_##name##___##mapname __attribute__((unused));
+
 #endif /* __MACROS_H */

--- a/pkg/operators/cli/helpers.go
+++ b/pkg/operators/cli/helpers.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clioperator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+func clearScreen() {
+	switch runtime.GOOS {
+	case "linux":
+		fmt.Print("\033[H\033[2J")
+	case "windows":
+		cmd := exec.Command("cmd", "/c", "cls")
+		cmd.Stdout = os.Stdout
+		cmd.Run()
+	default:
+		// It's a best effort approach here as we aren't 100% it'll work
+		// on all cases.
+		fmt.Print("\033[H\033[2J")
+	}
+}

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -15,11 +15,40 @@
 package ebpfoperator
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
+	"strings"
+	"time"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
+	"golang.org/x/sys/unix"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 )
+
+const (
+	ParamMapIterInterval = "map-fetch-interval"
+	ParamMapIterCount    = "map-fetch-count"
+)
+
+type mapIter struct {
+	name          string
+	mapName       string
+	keyStructName string
+	valStructName string
+
+	ds          datasource.DataSource
+	keyAccessor datasource.FieldAccessor
+	valAccessor datasource.FieldAccessor
+
+	interval time.Duration
+	count    int
+}
 
 func (i *ebpfInstance) populateMap(t btf.Type, varName string) error {
 	i.logger.Debugf("populating map %q", varName)
@@ -35,5 +64,220 @@ func (i *ebpfInstance) populateMap(t btf.Type, varName string) error {
 	// Set variable to nil pointer to map, so it's present
 	var nilVal *ebpf.Map
 	i.gadgetCtx.SetVar(varName, nilVal)
+	return nil
+}
+
+func (i *ebpfInstance) mapParams() api.Params {
+	if len(i.mapIters) == 0 {
+		return nil
+	}
+	return api.Params{
+		{
+			Key:          ParamMapIterInterval,
+			Description:  "interval in which to iterate over maps",
+			DefaultValue: "1000ms",
+			TypeHint:     api.TypeString,
+			Title:        "Map fetch interval",
+		},
+		{
+			Key:          ParamMapIterCount,
+			Description:  "number of map fetch cycles - use 0 for unlimited",
+			DefaultValue: "0",
+			TypeHint:     api.TypeInt,
+			Title:        "Map fetch count",
+		},
+	}
+}
+
+func (i *ebpfInstance) evaluateMapParams(paramValues api.ParamValues) error {
+	if len(i.mapIters) == 0 {
+		return nil
+	}
+
+	globalDuration := time.Duration(0)
+	globalCount := 0
+
+	durations, err := apihelpers.GetDurationValuesPerDataSource(paramValues[ParamMapIterInterval])
+	if err != nil {
+		return fmt.Errorf("evaluating map fetch interval: %w", err)
+	}
+	for dsName, duration := range durations {
+		if dsName == "" {
+			globalDuration = duration
+			continue
+		}
+		iter, ok := i.mapIters[dsName]
+		if !ok {
+			return fmt.Errorf("map fetch interval found for non-existing iterator %q", dsName)
+		}
+		iter.interval = duration
+	}
+
+	counts, err := apihelpers.GetIntValuesPerDataSource(paramValues[ParamMapIterCount])
+	if err != nil {
+		return fmt.Errorf("evaluating map fetch interval: %w", err)
+	}
+	for dsName, count := range counts {
+		if dsName == "" {
+			globalCount = count
+			continue
+		}
+		iter, ok := i.mapIters[dsName]
+		if !ok {
+			return fmt.Errorf("map fetch count found for non-existing iterator %q", dsName)
+		}
+		iter.count = count
+	}
+
+	for _, iter := range i.mapIters {
+		if iter.interval == 0 {
+			iter.interval = globalDuration
+		}
+		if iter.count == 0 {
+			iter.count = globalCount
+		}
+		iter.ds.AddAnnotation("fetch-count", fmt.Sprintf("%d", iter.count))
+		iter.ds.AddAnnotation("fetch-interval", iter.interval.String())
+	}
+	return nil
+}
+
+func (i *ebpfInstance) runMapIterators() error {
+	for _, iter := range i.mapIters {
+		iterMap, ok := i.collection.Maps[iter.mapName]
+		if !ok {
+			return fmt.Errorf("map %q not found", iter.mapName)
+		}
+		fetch := func() {
+			p, err := iter.ds.NewPacketArray()
+			if err != nil {
+				i.logger.Errorf("error creating packet for map iterator: %v", err)
+				return
+			}
+
+			var prevKey []byte
+
+			batchSize := 100 // discuss
+
+			keySize := int(iterMap.KeySize())
+			valSize := int(iterMap.ValueSize())
+			for {
+				keys := make([]byte, keySize*batchSize)
+				vals := make([]byte, valSize*batchSize)
+				keysPtr := Pointer{ptr: unsafe.Pointer(&keys[0])}
+				valuesPtr := Pointer{ptr: unsafe.Pointer(&vals[0])}
+
+				// TODO: use cilium lib once raw byte access has been added
+				// TODO: open PR to actually make that happen
+				nk := make([]byte, keySize)
+				attr := MapLookupBatchAttr{
+					MapFd:    uint32(iterMap.FD()),
+					Keys:     keysPtr,
+					Values:   valuesPtr,
+					Count:    uint32(batchSize),
+					OutBatch: Pointer{ptr: unsafe.Pointer(&nk[0])},
+				}
+				if prevKey != nil {
+					attr.InBatch = Pointer{ptr: unsafe.Pointer(&prevKey[0])}
+				}
+
+				_, err := BPF(BPF_MAP_LOOKUP_AND_DELETE_BATCH, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
+				if err != nil && !errors.Is(err, unix.ENOENT) {
+					i.logger.Warnf("error from map iterator: %v", err)
+					break
+				}
+				n := int(attr.Count)
+
+				prevKey = nk
+				for c := range n {
+					d := p.New()
+					iter.keyAccessor.Set(d, keys[keySize*c:keySize*(c+1)])
+					iter.valAccessor.Set(d, vals[valSize*c:valSize*(c+1)])
+					p.Append(d)
+				}
+				if errors.Is(err, unix.ENOENT) { // ebpf.ErrKeyNotExist when doing this with cilium/ebpf later on
+					break
+				}
+			}
+			iter.ds.EmitAndRelease(p)
+		}
+		go func() {
+			if iter.interval == 0 {
+				// Only a single time; is this really useful?
+				fetch()
+				return
+			}
+			ctr := 0
+			ticker := time.NewTicker(iter.interval)
+			for {
+				select {
+				case <-i.gadgetCtx.Context().Done():
+					return
+				case <-ticker.C:
+					fetch()
+					ctr++
+					if iter.count > 0 && ctr >= iter.count {
+						// TODO: close DS
+						return
+					}
+				}
+			}
+		}()
+	}
+	return nil
+}
+
+func (i *ebpfInstance) populateMapIter(t btf.Type, varName string) error {
+	i.logger.Debugf("populating mapiter %q", varName)
+
+	info := strings.Split(varName, typeSplitter)
+	if len(info) != 2 {
+		return fmt.Errorf("invalid name for gadget_mapiter type: %q", varName)
+	}
+
+	name := info[0]
+	mapName := info[1]
+
+	if _, ok := i.mapIters[name]; ok {
+		return fmt.Errorf("duplicate map iterator %q", varName)
+	}
+
+	// Get types
+	iterMap, ok := i.collectionSpec.Maps[mapName]
+	if !ok {
+		return fmt.Errorf("map %q not found in eBPF object", mapName)
+	}
+
+	keyStruct, ok := iterMap.Key.(*btf.Struct)
+	if !ok {
+		return fmt.Errorf("map %q key is not a struct", mapName)
+	}
+
+	valStruct, ok := iterMap.Value.(*btf.Struct)
+	if !ok {
+		return fmt.Errorf("map %q value is not a struct", mapName)
+	}
+
+	if iterMap.KeySize != keyStruct.Size || iterMap.ValueSize != valStruct.Size {
+		return fmt.Errorf("key/value sizes of map %q does not match size of structs", mapName)
+	}
+
+	err := i.populateStructDirect(keyStruct)
+	if err != nil {
+		return fmt.Errorf("populating key struct for map iter %q: %w", varName, err)
+	}
+
+	err = i.populateStructDirect(valStruct)
+	if err != nil {
+		return fmt.Errorf("populating value struct for map iter %q: %w", varName, err)
+	}
+
+	iter := &mapIter{
+		name:          name,
+		mapName:       mapName,
+		keyStructName: keyStruct.Name,
+		valStructName: valStruct.Name,
+	}
+	i.mapIters[name] = iter
 	return nil
 }

--- a/pkg/operators/ebpf/rawbpf.go
+++ b/pkg/operators/ebpf/rawbpf.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpfoperator
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// This is a patched version of their counterparts from cilium/ebpf; the upstream code doesn't allow reading bytes
+// from maps but instead wants to deserialize itself. However, we need to deserialize with our own libraries and
+// thus get the raw data from the map in a performant way.
+
+const (
+	BPF_MAP_LOOKUP_AND_DELETE_BATCH uintptr = 25
+)
+
+type Pointer struct {
+	ptr unsafe.Pointer
+}
+
+type MapLookupBatchAttr struct {
+	InBatch   Pointer
+	OutBatch  Pointer
+	Keys      Pointer
+	Values    Pointer
+	Count     uint32
+	MapFd     uint32
+	ElemFlags uint64
+	Flags     uint64
+}
+
+func BPF(cmd uintptr, attr unsafe.Pointer, size uintptr) (uintptr, error) {
+	r1, _, errNo := unix.Syscall(unix.SYS_BPF, uintptr(cmd), uintptr(attr), size)
+	runtime.KeepAlive(attr)
+
+	var err error
+	if errNo != 0 {
+		err = errNo
+	}
+
+	return r1, err
+}

--- a/pkg/operators/ebpf/types.go
+++ b/pkg/operators/ebpf/types.go
@@ -29,6 +29,8 @@ const (
 	// include/gadget/buffer.h.
 	tracerMapPrefix = "gadget_map_tracer_"
 
+	mapIterPrefix = "gadget_mapiter_"
+
 	// Prefix used to mark variables used by operators
 	varPrefix = "gadget_var_"
 )


### PR DESCRIPTION
Map iterators are the base of (most) toppers and profilers. Gadgets write data into maps that are regularly fetched (and emptied) into data sources.

Follow-up PRs will be
* support for toppers
* support for profilers
* export from those maps directly to otel-metrics

In addition to the map iterators, this PR also adds the features shared by those follow-up PRs:

* perform a clear screen before outputting data from the CLI operator if the `cli.clear-screen-before` annotation is present on the data source
* add a `none` output mode to the CLI operator, that is basically ignoring the data
* helpers to get per-datasource values from params