### PR TITLE
metadata: Fix leftovers after review

### DIFF
--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -309,13 +309,13 @@ datasources:
     fields:
       comm:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
       filename:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
       pid:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
 ```
 
 Let's edit the file to customize the output. We define some templates for well-known fields like
@@ -527,17 +527,17 @@ file:
 ```yaml
       gid:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
       mntns_id:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
       pid:
         annotations:
           description: PID of the process opening a file
           template: pid
       uid:
         annotations:
-          'description:': 'TODO: Fill field description'
+          description: 'TODO: Fill field description'
 ```
 
 Edit them, build and run the gadget again:
@@ -549,8 +549,8 @@ Edit them, build and run the gadget again:
           template: comm
       filename:
         annotations:
-          columns.width: "64"
           description: Path of the file being opened
+          columns.width: 64
       gid:
         annotations:
           description: Group ID opening the file

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -179,9 +179,9 @@ func populateTracers(m *metadatav1.GadgetMetadata, spec *ebpf.CollectionSpec) er
 	return nil
 }
 
-// validateTracerMap only checks if the map type. It does not check the map
-// value name and type because such a information is not available in the map
-// definition for perf event arrays and ring buffers.
+// validateTracerMap only checks the map type. It does not check the map name
+// and type because that information is not available in the map definition for
+// perf event arrays and ring buffers.
 func validateTracerMap(tracerMap *ebpf.MapSpec) error {
 	if tracerMap.Type != ebpf.RingBuf && tracerMap.Type != ebpf.PerfEventArray {
 		return fmt.Errorf("map %q has a wrong type, expected: ringbuf or perf event array, got: %s",
@@ -270,7 +270,7 @@ func populateDatasourceFields(ds *metadatav1.DataSource, btfStruct *btf.Struct) 
 		log.Debugf("Adding field %q", member.Name)
 		field := metadatav1.Field{
 			Annotations: map[string]string{
-				"description:": "TODO: Fill field description",
+				"description": "TODO: Fill field description",
 			},
 		}
 
@@ -326,7 +326,6 @@ type tracerInfo struct {
 }
 
 // getTracerInfo returns the tracer info generated with GADGET_TRACER().
-// If there are multiple annotations only the first one is returned.
 func getTracerInfo(spec *ebpf.CollectionSpec) ([]tracerInfo, error) {
 	tracersInfo, err := GetGadgetIdentByPrefix(spec, tracerInfoPrefix)
 	if err != nil {


### PR DESCRIPTION
- Remove extra ':' on description field
- Fix outdated comment on getTracerInfo()
- Improve comment on validateTracerMap()

Fixes: f7c317e0cfeb ("gadgets/run: Update logic to generate and validate metadata")

Ref #3164 
