### PR TITLE
gadget-context: make sure cancel() is called on gadgetContext

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -89,6 +89,7 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 }
 
 func (c *GadgetContext) run(dataOperatorInstances []operators.DataOperatorInstance) error {
+	defer c.cancel()
 	log := c.Logger()
 
 	for _, opInst := range dataOperatorInstances {


### PR DESCRIPTION
Without calling cancel on the gadgetContext itself, we're leaking memory as many goroutines won't exit. Although we should probably also optimize and use local synchronization in operators (and waiting for cleanup on Stop()), this makes sure that at least when exiting gadgetcontext.run(), everything gets cancelled.