### PR TITLE
cmd/common/config: Remove line to initialize oci operator.

### DIFF
--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -155,7 +155,10 @@ func NewConfigCmd(runtime runtime.Runtime, rootFlags *pflag.FlagSet) *cobra.Comm
 			opGlobalParams.CopyToMap(operatorConfig[opName], "")
 		}
 
-		operatorConfig[ocihandler.OciHandler.Name()] = make(map[string]string)
+		_, ok := operatorConfig[ocihandler.OciHandler.Name()]
+		if !ok {
+			operatorConfig[ocihandler.OciHandler.Name()] = make(map[string]string)
+		}
 		opInstanceParams := apihelpers.ToParamDescs(ocihandler.OciHandler.InstanceParams()).ToParams()
 		opInstanceParams.CopyToMap(operatorConfig[ocihandler.OciHandler.Name()], "")
 		if len(operatorConfig) > 0 {


### PR DESCRIPTION
This operator has now global parameters, so this line was ignoring them as they would have been set by the loop above.

Before, oci global parameters are ignored:

```bash
$ sudo -E ./ig config default                                                main % u=
INFO[0000] Experimental features enabled                
auto-mount-filesystems: "false"
auto-wsl-workaround: "false"
operator:
    localmanager:
        containerd-namespace: k8s.io
        containerd-socketpath: /run/containerd/containerd.sock
        crio-socketpath: /run/crio/crio.sock
        docker-socketpath: /run/docker.sock
        podman-socketpath: /run/podman/podman.sock
        runtime-protocol: internal
        runtimes: docker,containerd,cri-o,podman
    oci:
        allowed-digests: ""
        allowed-registries: ""
        authfile: /var/lib/ig/config.json
        insecure: "false"
        pull: missing
        pull-secret: ""
        validate-metadata: "true"
verbose: "false"
```

After, oci global parameters are present:

```bash
$ sudo -E ./ig config default                                   francis/oci-param % u=
INFO[0000] Experimental features enabled                
auto-mount-filesystems: "false"
auto-wsl-workaround: "false"
operator:
    localmanager:
        containerd-namespace: k8s.io
        containerd-socketpath: /run/containerd/containerd.sock
        crio-socketpath: /run/crio/crio.sock
        docker-socketpath: /run/docker.sock
        podman-socketpath: /run/podman/podman.sock
        runtime-protocol: internal
        runtimes: docker,containerd,cri-o,podman
    oci:
        allowed-digests: ""
        allowed-registries: ""
        authfile: /var/lib/ig/config.json
        insecure: "false"
        public-key: |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
            Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
            -----END PUBLIC KEY-----
        pull: missing
        pull-secret: ""
        validate-metadata: "true"
        verify-image: "true"
verbose: "false"
```