### PR TITLE
pkg/operators/ebpf: make enum handling deterministic

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -115,7 +115,7 @@ func (o *ebpfOperator) InstantiateImageOperator(
 
 		containers: make(map[string]*containercollection.Container),
 
-		enums:      make(map[string]*btf.Enum),
+		enums:      make([]*enum, 0),
 		formatters: make(map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error),
 
 		vars: make(map[string]*ebpfVar),
@@ -172,7 +172,7 @@ type ebpfInstance struct {
 
 	containers map[string]*containercollection.Container
 
-	enums      map[string]*btf.Enum
+	enums      []*enum
 	formatters map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error
 
 	stackIdMap *ebpf.Map

--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -75,7 +75,9 @@ func (i *ebpfInstance) initEnumFormatter(gadgetCtx operators.GadgetContext) erro
 	for _, ds := range gadgetCtx.GetDataSources() {
 		var formatters []func(ds datasource.DataSource, data datasource.Data) error
 
-		for name, enum := range i.enums {
+		for _, en := range i.enums {
+			enum := en.Enum
+			name := en.memberName
 			in := ds.GetField(name)
 			if in == nil {
 				continue

--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -40,6 +40,11 @@ type Struct struct {
 	Size   uint32
 }
 
+type enum struct {
+	*btf.Enum
+	memberName string
+}
+
 func (f *Field) FieldName() string {
 	return f.name
 }
@@ -185,8 +190,8 @@ func (i *ebpfInstance) getFieldsFromMember(member btf.Member, fields *[]*Field, 
 	}
 
 	// Keep enums to convert them to strings
-	if enum, ok := member.Type.(*btf.Enum); ok {
-		i.enums[member.Name] = enum
+	if en, ok := member.Type.(*btf.Enum); ok {
+		i.enums = append(i.enums, &enum{Enum: en, memberName: member.Name})
 	}
 
 	kind := getFieldKind(refType, tags)


### PR DESCRIPTION
This moves the logic from using a map to using an array to fix desync issues when using several nodes.

We still need to address a couple more cases where things like this can happen to make sure the gadgetInfo will always be deterministic.

Fixes #3185