### PR TITLE
UidGidResolver: Make it usable in image based gadgets

### DIFF
--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -36,11 +36,13 @@ datasources:
           description: User ID
           template: uid
           columns.hidden: true
+          uidgidresolver.target: user
       gid:
         annotations:
           description: Group ID
           template: uid
           columns.hidden: true
+          uidgidresolver.target: group
       ppid:
         annotations:
           template: pid
@@ -48,6 +50,7 @@ datasources:
         annotations:
           template: uid
           columns.hidden: true
+          uidgidresolver.target: loginuser
       sessionid:
         annotations:
           template: uid

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -30,12 +30,12 @@ struct event {
 	// user-space terminology for pid and tid
 	__u32 pid;
 	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	char pcomm[TASK_COMM_LEN];
 	__u32 ppid;
-	__u32 loginuid;
+	gadget_uid loginuid;
 	__u32 sessionid;
 	gadget_errno error_raw;
 	int args_count;

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -45,6 +45,14 @@ typedef __u32 gadget_signal;
 // as string.
 typedef __u32 gadget_errno;
 
+// gadget_uid is used to represent a uid. A field is automatically added that contains the corresponding user
+// name on the host system
+typedef __u32 gadget_uid;
+
+// gadget_gid is used to represent a uid. A field is automatically added that contains the corresponding group
+// name on the host system
+typedef __u32 gadget_gid;
+
 // gadget_syscall is used to represent a unix syscall. A field is automatically added that contains the name
 // as string.
 typedef __u64 gadget_syscall;


### PR DESCRIPTION
## UidGidResolver: Make it usable in image based gadgets

This PR introduces the UidGidResolver to the image based gadgets world. The second commit then showcases how it can be used in `trace_exec`