### PR TITLE
ebpf-builder.Dockerfile: Use uppercase keyword

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -6,7 +6,7 @@ ARG TINYGO_VERSION=0.31.2
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG BPFTOOL_VERSION
 ARG LIBBPF_VERSION
 

--- a/Dockerfiles/gadget.Dockerfile
+++ b/Dockerfiles/gadget.Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDER_IMAGE=golang:1.22-bullseye
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
 # Prepare and build gadget artifacts in a container
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 ARG TARGETARCH
 ARG BUILDARCH

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDER_IMAGE=golang:1.22-bullseye
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11
 
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 ARG TARGETARCH
 ARG BUILDARCH

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDER_IMAGE=golang:1.22
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11
 
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -9,7 +9,7 @@
 ARG BUILDER_IMAGE=golang:1.22-bullseye
 ARG BASE_IMAGE=alpine:3.18
 
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docs/ig.md
+++ b/docs/ig.md
@@ -329,7 +329,7 @@ In order to add `ig` in your own container image, you can take example on the fo
 # In production, you should use a specific version of ig instead of latest:
 # --build-arg BASE_IMAGE=ghcr.io/inspektor-gadget/ig:v0.18.1
 ARG BASE_IMAGE=ghcr.io/inspektor-gadget/ig:latest
-FROM ${BASE_IMAGE} as ig
+FROM ${BASE_IMAGE} AS ig
 
 # Your own image
 FROM alpine:3.17

--- a/examples/builtin-gadgets/withfilter/trace/network/Dockerfile
+++ b/examples/builtin-gadgets/withfilter/trace/network/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-bullseye AS builder
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 WORKDIR /src

--- a/examples/kube-container-collection/Dockerfile
+++ b/examples/kube-container-collection/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/

--- a/examples/runc-hook/Dockerfile
+++ b/examples/runc-hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/


### PR DESCRIPTION
There was a single `as` keyword that was lowercase. While building the image we get a warning:
```
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
```