### PR TITLE
gadgets: Update top_file to use map iterators instead of toppers

### DIFF
--- a/gadgets/snapshot_process/test/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/snapshot_process_test.go
@@ -32,7 +32,7 @@ import (
 type snapshotProcessEntry struct {
 	eventtypes.CommonData
 
-	MountNsID uint64 `json:"mntns_id"`
+	MntNsID uint64 `json:"mntns_id"`
 
 	Comm string `json:"comm"`
 	Pid  uint32 `json:"pid"`
@@ -94,15 +94,15 @@ func TestSnapshotProcess(t *testing.T) {
 				Gid:        1111,
 
 				// Check the existence of the following fields
-				MountNsID: utils.NormalizedInt,
-				Pid:       utils.NormalizedInt,
-				Tid:       utils.NormalizedInt,
-				Ppid:      utils.NormalizedInt,
+				MntNsID: utils.NormalizedInt,
+				Pid:     utils.NormalizedInt,
+				Tid:     utils.NormalizedInt,
+				Ppid:    utils.NormalizedInt,
 			}
 
 			normalize := func(e *snapshotProcessEntry) {
 				utils.NormalizeCommonData(&e.CommonData)
-				utils.NormalizeInt(&e.MountNsID)
+				utils.NormalizeInt(&e.MntNsID)
 				utils.NormalizeInt(&e.Pid)
 				utils.NormalizeInt(&e.Tid)
 				utils.NormalizeInt(&e.Ppid)

--- a/gadgets/top_file/gadget.yaml
+++ b/gadgets/top_file/gadget.yaml
@@ -17,6 +17,16 @@ datasources:
           description: Thread ID
           template: pid
           columns.hidden: true
+      uid:
+        annotations:
+          description: User ID
+          template: uid
+          columns.hidden: true
+      gid:
+        annotations:
+          description: Group ID
+          template: uid
+          columns.hidden: true
       comm:
         annotations:
           description: Command name

--- a/gadgets/top_file/gadget.yaml
+++ b/gadgets/top_file/gadget.yaml
@@ -3,56 +3,76 @@ description: Periodically report read/write activity by file
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://inspektor-gadget.io/docs
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
-toppers:
+datasources:
   file:
-    mapName: stats
-    structName: file_stat
-structs:
-  file_stat:
+    annotations:
+      cli.clear-screen-before: "true"
     fields:
-    - name: pid
-      description: Process ID
-      attributes:
-        template: pid
-    - name: tid
-      description: Thread ID
-      attributes:
-        hidden: true
-        template: pid
-    - name: comm
-      description: Command name
-      attributes:
-        template: comm
-    - name: reads
-      description: Reads by file
-      attributes:
-        width: 8
-    - name: writes
-      description: Writes by file
-      attributes:
-        width: 8
-    - name: rbytes
-      description: Bytes read by file
-      attributes:
-        width: 8
-    - name: wbytes
-      description: Bytes written by file
-      attributes:
-        width: 8
-    - name: t
-      description: Type of file, 'R' for regular files, 'S' for sockets and 'O' for
-        others (including pipes). By default only regular files are shown; use the
-        --all-files option to show all file types.
-      attributes:
-        width: 1
-    - name: file
-      description: File name
-      attributes:
-        width: 30
-    - name: mntns_id
-      description: Mount namespace ID
-      attributes:
-        template: ns
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+          columns.hidden: true
+      comm:
+        annotations:
+          description: Command name
+          template: comm
+      reads:
+        annotations:
+          description: Reads by file
+          columns.width: 8
+          columns.alignment: right
+      writes:
+        annotations:
+          description: Writes by file
+          columns.width: 8
+          columns.alignment: right
+      rbytes:
+        annotations:
+          description: Bytes read by file
+          columns.width: 8
+          columns.alignment: right
+      wbytes:
+        annotations:
+          description: Bytes written by file
+          columns.width: 8
+          columns.alignment: right
+      t:
+        annotations:
+          description: Type of file, 'R' for regular files, 'S' for sockets and 'O'
+            for others (including pipes). By default, only regular files are shown;
+            use the --all-files flag to include all file types.
+          columns.width: 1
+      t_raw:
+        annotations:
+          description: Raw value of file type. '0' for regular files, '1' for sockets
+            and '2' for others.
+          columns.width: 1
+          columns.hidden: true
+      file:
+        annotations:
+          description: File name
+          columns.width: 30
+      dev:
+        annotations:
+          description: The device on which the file resides
+          columns.hidden: true
+          columns.width: 12
+          columns.alignment: right
+      inode:
+        annotations:
+          description: The inode id of the file
+          columns.hidden: true
+          columns.width: 12
+          columns.alignment: right
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
 ebpfParams:
   all_files:
     key: all-files

--- a/gadgets/top_file/program.bpf.c
+++ b/gadgets/top_file/program.bpf.c
@@ -36,6 +36,8 @@ struct file_id {
 
 struct file_stat {
 	gadget_mntns_id mntns_id;
+	__u32 uid;
+	__u32 gid;
 	__u64 reads;
 	__u64 rbytes;
 	__u64 writes;
@@ -76,6 +78,7 @@ static void get_file_path(struct file *file, __u8 *buf, size_t size)
 static int probe_entry(struct pt_regs *ctx, struct file *file, size_t count,
 		       enum op op)
 {
+	__u64 uid_gid;
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 pid = pid_tgid >> 32;
 	__u32 tid = (__u32)pid_tgid;
@@ -116,6 +119,9 @@ static int probe_entry(struct pt_regs *ctx, struct file *file, size_t count,
 		} else {
 			valuep->t_raw = O;
 		}
+		uid_gid = bpf_get_current_uid_gid();
+		valuep->uid = uid_gid;
+		valuep->gid = uid_gid >> 32;
 	}
 	if (op == READ) {
 		valuep->reads++;

--- a/gadgets/top_file/test/top_file_test.go
+++ b/gadgets/top_file/test/top_file_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type topFileEntry struct {
+	eventtypes.CommonData
+
+	MntNsID uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+	Uid  uint32 `json:"uid"`
+	Gid  uint32 `json:"gid"`
+
+	Reads      uint64 `json:"reads"`
+	Writes     uint64 `json:"writes"`
+	ReadBytes  uint64 `json:"rbytes"`
+	WriteBytes uint64 `json:"wbytes"`
+
+	FileType  string `json:"t"`
+	FileName  string `json:"file"`
+	FileInode uint64 `json:"inode"`
+	FileDev   uint64 `json:"dev"`
+}
+
+func TestTopFile(t *testing.T) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+	containerName := "test-top-file"
+	containerImage := "docker.io/library/busybox:latest"
+
+	var ns string
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(containerImage),
+		containers.WithStartAndStop(),
+	}
+
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		ns = utils.GenerateTestNamespaceName(t, "test-top-file")
+		containerOpts = append(containerOpts, containers.WithContainerNamespace(ns))
+	}
+
+	testContainer := containerFactory.NewContainer(
+		containerName,
+		"while true; do echo -n foo > bar ; sleep 1; done",
+		containerOpts...,
+	)
+
+	testContainer.Start(t)
+	t.Cleanup(func() {
+		testContainer.Stop(t)
+	})
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+	commonDataOpts := []utils.CommonDataOption{
+		utils.WithContainerImageName(containerImage),
+		utils.WithContainerID(testContainer.ID()),
+	}
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-r=%s", utils.Runtime),
+				fmt.Sprintf("-c=%s", containerName),
+			),
+		)
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns)))
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
+	}
+
+	runnerOpts = append(runnerOpts,
+		igrunner.WithStartAndStop(),
+		igrunner.WithValidateOutput(
+			func(t *testing.T, output string) {
+				expectedEntry := &topFileEntry{
+					CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
+
+					// Workload writes "foo" with "echo" (so "sh") command into
+					// a regular file ('R') named "bar" once per second. The
+					// gadget runs every second, so we expect 1 write operation
+					// with 3 bytes.
+					Comm:       "sh",
+					FileType:   "R",
+					FileName:   "bar",
+					Writes:     1,
+					WriteBytes: 3,
+
+					// Nothing is read
+					Reads:     0,
+					ReadBytes: 0,
+
+					// Check the existence of the following fields
+					MntNsID:   utils.NormalizedInt,
+					Pid:       utils.NormalizedInt,
+					Tid:       utils.NormalizedInt,
+					FileInode: utils.NormalizedInt,
+
+					// Manually normalize fields that might contain 0, so we
+					// can't use NormalizedInt and NormalizeInt()
+					// TODO: Support checking for the presence of a field, even if it's 0
+					Uid:     0,
+					Gid:     0,
+					FileDev: 0,
+				}
+
+				normalize := func(e *topFileEntry) {
+					utils.NormalizeCommonData(&e.CommonData)
+					utils.NormalizeInt(&e.MntNsID)
+					utils.NormalizeInt(&e.Pid)
+					utils.NormalizeInt(&e.Tid)
+					utils.NormalizeInt(&e.FileInode)
+
+					// Manually normalize fields that might contain 0
+					e.Uid = 0
+					e.Gid = 0
+					e.FileDev = 0
+				}
+
+				match.MatchEntries(t, match.JSONMultiArrayMode, output, normalize, expectedEntry)
+			},
+		),
+	)
+
+	topFileCmd := igrunner.New("top_file", runnerOpts...)
+
+	igtesting.RunTestSteps([]igtesting.TestStep{topFileCmd}, t, testingOpts...)
+}

--- a/include/gadget/macros.h
+++ b/include/gadget/macros.h
@@ -35,12 +35,6 @@
 	const void *gadget_tracer_##name##___##map_name##___##event_type __attribute__((unused)); \
 	const struct event_type *__gadget_tracer_type_##name __attribute__((unused));
 
-// GADGET_TOPPER is used to define a topper. Currently only one topper per eBPF object is allowed.
-// name is the topper's name
-// map_name is the name of the hash map used to send events to user space
-#define GADGET_TOPPER(name, map_name) \
-	const void *gadget_topper_##name##___##map_name __attribute__((unused));
-
 // GADGET_PARAM is used to indicate that a given variable is used as a parameter.
 // Users of Inspektor Gadget can set these values from userspace
 #define GADGET_PARAM(name) \

--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -255,6 +255,10 @@ func validateSnapshotterPrograms(spec *ebpf.CollectionSpec, programs []string) e
 }
 
 func populateDatasourceFields(ds *metadatav1.DataSource, btfStruct *btf.Struct) error {
+	if ds.Fields == nil {
+		ds.Fields = make(map[string]metadatav1.Field)
+	}
+
 	existingFields := make(map[string]struct{})
 	for name := range ds.Fields {
 		existingFields[name] = struct{}{}


### PR DESCRIPTION
# Update top_file gadget to use map iterators instead of toppers

Use map iterators datasource introduced in https://github.com/inspektor-gadget/inspektor-gadget/pull/3182 to run top_file gadget.

Ref https://github.com/inspektor-gadget/inspektor-gadget/issues/1924

## Testing done

Tests where implemented using new testing framework.

## TODO (In follow-up PRs)

- [ ] It's still missing to merge outcomes from nodes (combiner operator): https://github.com/inspektor-gadget/inspektor-gadget/pull/3068
- [ ] `--max-rows` support is still missing (new operator or probably in the combiner)
- [ ] Once agree on this implementation, implement other toppers based on this.