### PR TITLE
treewide: Remove unused verify-gadgets flag and adapt CI jobs to dependabot

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -47,7 +47,15 @@ runs:
           # Inspektor-Gadget container image is loaded into the cluster using "minikube image load" instead of pushing the container image to a registry.
           EXTRA_FLAGS='--image-pull-policy=Never'
         fi
-        ./kubectl-gadget deploy --verify-gadgets=${{ inputs.gadget_verify_image }} $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
+
+        # This is needed by dependabot, as the gadgets would not be signed in
+        # this case as the bot does not have access to the secrets.
+        # So let's deactivate the verifying.
+        if [ "${{ inputs.gadget_verify_image }}" == 'false' ]; then
+          EXTRA_FLAGS="${EXTRA_FLAGS} --gadgets-public-keys=''"
+        fi
+
+        ./kubectl-gadget deploy $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
     - name: Integration tests
       id: integration-tests
       shell: bash

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1400,6 +1400,7 @@ jobs:
       - build-ig
       - build-helper-images
       - build-and-push-gadgets
+      - check-secrets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1433,9 +1434,18 @@ jobs:
       shell: bash
       run: |
           set -o pipefail
+
+          # This is needed by dependabot, as the gadgets would not be signed in
+          # this case as the bot does not have access to the secrets.
+          # So let's deactivate the verifying.
+          if [ ${{ needs.check-secrets.outputs.cosign }} == 'false' ]; then
+            public_keys_flag='--public-keys=""'
+          fi
+
           make \
           GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
           GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
+          IG_FLAGS="${public_keys_flag}" \
           IG_RUNTIME=${{ matrix.runtime }} \
           -C gadgets/ test-local -o build |& tee gadgets-tests.log & wait $!
     - name: Prepare and publish test reports
@@ -1500,8 +1510,16 @@ jobs:
       shell: bash
       run: |
         set -o pipefail
+
+        # This is needed by dependabot, as the gadgets would not be signed in
+        # this case as the bot does not have access to the secrets.
+        # So let's deactivate the verifying.
+        if [ "${{ needs.check-secrets.outputs.cosign }}" == 'false' ]; then
+          gadgets_public_keys_flag='--gadgets-public-keys=""'
+        fi
+
         tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-        ./kubectl-gadget deploy --verify-gadgets=${{ needs.check-secrets.outputs.cosign }} --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        ./kubectl-gadget deploy ${gadgets_public_keys_flag} --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         make \
         GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
         GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
 		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
-	./kubectl-gadget deploy --verify-gadgets=$(VERIFY_GADGETS) --liveness-probe=$(LIVENESS_PROBE) \
+	./kubectl-gadget deploy $(if $(findstring false,$(VERIFY_GADGETS)),--gadgets-public-keys='') --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -106,7 +106,6 @@ var (
 	verifyImage         bool
 	publicKey           string
 	strLevels           []string
-	verifyGadgets       bool
 	gadgetsPublicKeys   string
 )
 
@@ -234,17 +233,12 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(
 		&publicKey,
 		"public-key", "", resources.InspektorGadgetPublicKey, "Public key used to verify the container image")
-	deployCmd.PersistentFlags().BoolVarP(
-		&verifyGadgets,
-		"verify-gadgets", "",
-		true,
-		"verify gadgets using the provided public key")
 	// WARNING For now, use StringVar() instead of StringSliceVar() as only the
 	// first line of the file will be taken when used with
 	// --gadgets-public-keys="$(cat inspektor-gadget.pub),$(cat your-key.pub)"
 	deployCmd.PersistentFlags().StringVar(
 		&gadgetsPublicKeys,
-		"gadgets-public-keys", resources.InspektorGadgetPublicKey, "Public keys used to verify the gadgets")
+		"gadgets-public-keys", resources.InspektorGadgetPublicKey, "Public keys used to verify the gadgets. If empty, verification will not occur.")
 	rootCmd.AddCommand(deployCmd)
 }
 

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -62,7 +62,7 @@ func (o *ociHandler) GlobalParams() api.Params {
 		{
 			Key:          publicKeys,
 			Title:        "Public keys",
-			Description:  "Public keys used to verify the gadget",
+			Description:  "Public keys used to verify the gadget. If empty, verification will not occur.",
 			DefaultValue: resources.InspektorGadgetPublicKey,
 			TypeHint:     api.TypeStringSlice,
 		},


### PR DESCRIPTION
The verify-gadgets was not used, so this commit removes it. Also, dependabot does not have access to signing related secrets, so this commit introduces a way to skip verification if these secrets cannot be accessed.

Fixes: f51ff0eb2ec8 ("treewide: Allow to have several public keys.")