### PR TITLE
pkg/testing/ig: Support more than one flag on IG_FLAGS env variable

### DIFF
--- a/pkg/testing/ig/ig.go
+++ b/pkg/testing/ig/ig.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
@@ -105,7 +106,8 @@ func New(image string, opts ...Option) igtesting.TestStep {
 	// append IG_FLAGS flags separately to ensure
 	// one from the option aren't overwritten
 	if flags, ok := os.LookupEnv("IG_FLAGS"); ok {
-		factoryRunner.flags = append(factoryRunner.flags, flags)
+		split := strings.Split(flags, " ")
+		factoryRunner.flags = append(factoryRunner.flags, split...)
 	}
 
 	factoryRunner.createCmd()


### PR DESCRIPTION
# Support more than one flag on IG_FLAGS env variable in ig testing framework

## How to use

#### Without this PR (Fails)

```bash
$ IG_PATH=ig IG_EXPERIMENTAL=true GADGET_REPOSITORY=$LOCAL_REPO GADGET_TAG=latest IG_FLAGS='--insecure --public-keys=' IG_RUNTIME=docker go test -exec 'sudo -E' -v ./...
=== RUN   TestTraceExec
    command.go:111: Start command(Run_trace_exec)
    docker.go:152: Container "test-trace-exec" output:
    command.go:128: Stop command(Run_trace_exec)
    command.go:130: Command returned(Run_trace_exec):
        time="2024-07-24T18:43:55+02:00" level=info msg="Experimental features enabled"
        Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "127.0.0.1:5000/trace_exec:latest": getting signing information: getting signature: getting signature bytes: Get "https://127.0.0.1:5000/v2/trace_exec/manifests/sha256-e53472850099542387144b7e4a08cb5bcee9a1391c77c23731a64563fc0ec673.sig": http: server gave HTTP response to HTTPS client

        [...]
```


#### With this PR (Works)

```bash
$ IG_PATH=ig IG_EXPERIMENTAL=true GADGET_REPOSITORY=$LOCAL_REPO GADGET_TAG=latest IG_FLAGS='--insecure --public-keys=' IG_RUNTIME=docker go test -exec 'sudo -E' -v ./...
=== RUN   TestTraceExec
    command.go:111: Start command(Run_trace_exec)
    docker.go:152: Container "test-trace-exec" output:
    command.go:128: Stop command(Run_trace_exec)
    command.go:130: Command returned(Run_trace_exec):
        time="2024-07-24T18:43:10+02:00" level=info msg="Experimental features enabled"
        time="2024-07-24T18:43:11+02:00" level=warning msg="image signature verification is disabled because no public keys were provided"
        time="2024-07-24T18:43:11+02:00" level=warning msg="image signature verification is disabled because no public keys were provided"

        [...]
```
