### PR TITLE
treewide: Fix usage of empty public keys.

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -52,7 +52,7 @@ runs:
         # this case as the bot does not have access to the secrets.
         # So let's deactivate the verifying.
         if [ "${{ inputs.gadget_verify_image }}" == 'false' ]; then
-          EXTRA_FLAGS="${EXTRA_FLAGS} --gadgets-public-keys=''"
+          EXTRA_FLAGS="${EXTRA_FLAGS} --gadgets-public-keys="
         fi
 
         ./kubectl-gadget deploy $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1439,7 +1439,7 @@ jobs:
           # this case as the bot does not have access to the secrets.
           # So let's deactivate the verifying.
           if [ ${{ needs.check-secrets.outputs.cosign }} == 'false' ]; then
-            public_keys_flag='--public-keys=""'
+            public_keys_flag='--public-keys='
           fi
 
           make \
@@ -1515,7 +1515,7 @@ jobs:
         # this case as the bot does not have access to the secrets.
         # So let's deactivate the verifying.
         if [ "${{ needs.check-secrets.outputs.cosign }}" == 'false' ]; then
-          gadgets_public_keys_flag='--gadgets-public-keys=""'
+          gadgets_public_keys_flag='--gadgets-public-keys='
         fi
 
         tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
 		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
-	./kubectl-gadget deploy $(if $(findstring false,$(VERIFY_GADGETS)),--gadgets-public-keys='') --liveness-probe=$(LIVENESS_PROBE) \
+	./kubectl-gadget deploy $(if $(findstring false,$(VERIFY_GADGETS)),--gadgets-public-keys=) --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"

--- a/docs/getting-started/verify.md
+++ b/docs/getting-started/verify.md
@@ -215,11 +215,11 @@ RUNTIME.CONTAINERNAME  PID          UID          GID          MNTNS_ID RET FL…
 ...
 ```
 
-You can also skip verifying image-based gadget signature with `--public-keys=''`.
+You can also skip verifying image-based gadget signature with `--public-keys=`.
 Note that we do not recommend using this:
 
 ```bash
-$ sudo -E ig run --public-keys='' ghcr.io/your-repo/gadget/trace_open
+$ sudo -E ig run --public-keys= ghcr.io/your-repo/gadget/trace_open
 ...
 WARN[0000] image signature verification is disabled because no public keys were provided
 WARN[0000] image signature verification is disabled because no public keys were provided
@@ -269,7 +269,7 @@ gadget      gadge…hbh8n gadget      40265… 22867… 53387  53369  0      0  
 You can also skip verification at deploy time, note that we do not recommend doing so:
 
 ```bash
-$ kubectl gadget deploy --gadgets-public-keys=''
+$ kubectl gadget deploy --gadgets-public-keys=
 ...
 Inspektor Gadget successfully deployed
 $ kubectl gadget run trace_exec -A


### PR DESCRIPTION
Fixes: c71d05d54f04 ("treewide: Remove unused verify-gadgets flag and adapt CI jobs to dependabot.")
Fixes: f51ff0eb2ec8 ("treewide: Allow to have several public keys.")