### PR TITLE
treewide: Add back --verify-gadgets.

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -47,15 +47,7 @@ runs:
           # Inspektor-Gadget container image is loaded into the cluster using "minikube image load" instead of pushing the container image to a registry.
           EXTRA_FLAGS='--image-pull-policy=Never'
         fi
-
-        # This is needed by dependabot, as the gadgets would not be signed in
-        # this case as the bot does not have access to the secrets.
-        # So let's deactivate the verifying.
-        if [ "${{ inputs.gadget_verify_image }}" == 'false' ]; then
-          EXTRA_FLAGS="${EXTRA_FLAGS} --gadgets-public-keys="
-        fi
-
-        ./kubectl-gadget deploy $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
+        ./kubectl-gadget deploy --verify-gadgets=${{ inputs.gadget_verify_image }} $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
     - name: Integration tests
       id: integration-tests
       shell: bash

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1434,18 +1434,10 @@ jobs:
       shell: bash
       run: |
           set -o pipefail
-
-          # This is needed by dependabot, as the gadgets would not be signed in
-          # this case as the bot does not have access to the secrets.
-          # So let's deactivate the verifying.
-          if [ ${{ needs.check-secrets.outputs.cosign }} == 'false' ]; then
-            public_keys_flag='--public-keys='
-          fi
-
           make \
           GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
           GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \
-          IG_FLAGS="${public_keys_flag}" \
+          IG_FLAGS="--verify-image=${{ needs.check-secrets.outputs.cosign }}" \
           IG_RUNTIME=${{ matrix.runtime }} \
           -C gadgets/ test-local -o build |& tee gadgets-tests.log & wait $!
     - name: Prepare and publish test reports
@@ -1510,19 +1502,8 @@ jobs:
       shell: bash
       run: |
         set -o pipefail
-
-        # This is needed by dependabot, as the gadgets would not be signed in
-        # this case as the bot does not have access to the secrets.
-        # So let's deactivate the verifying.
-        if [ "${{ needs.check-secrets.outputs.cosign }}" == 'false' ]; then
-          gadgets_public_keys_flag='--gadgets-public-keys=""'
-          echo "Public key verification deactivated"
-        fi
-
-        echo "gadgets_public_keys_flag: ${gadgets_public_keys_flag}"
-
         tar zxvf /home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget-linux-amd64.tar.gz
-        ./kubectl-gadget deploy ${gadgets_public_keys_flag} --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        ./kubectl-gadget deploy --verify-gadgets=${{ needs.check-secrets.outputs.cosign }} --image-pull-policy=Never --debug --experimental --image=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         make \
         GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }} \
         GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }} \

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
 		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
-	./kubectl-gadget deploy $(if $(findstring false,$(VERIFY_GADGETS)),--gadgets-public-keys=) --liveness-probe=$(LIVENESS_PROBE) \
+	./kubectl-gadget deploy --verify-gadgets=$(VERIFY_GADGETS) --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -19,4 +19,5 @@ data:
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
       operator:
         oci:
+          verify-image: {{ .Values.config.verifyGadgets }}
           public-keys:{{ toYaml $.Values.config.gadgetsPublicKeys | nindent 12 }}

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -106,6 +106,7 @@ var (
 	verifyImage         bool
 	publicKey           string
 	strLevels           []string
+	verifyGadgets       bool
 	gadgetsPublicKeys   string
 )
 
@@ -233,12 +234,15 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(
 		&publicKey,
 		"public-key", "", resources.InspektorGadgetPublicKey, "Public key used to verify the container image")
+	deployCmd.PersistentFlags().BoolVar(
+		&verifyGadgets,
+		"verify-gadgets", true, "Verify gadgets using the provided public keys")
 	// WARNING For now, use StringVar() instead of StringSliceVar() as only the
 	// first line of the file will be taken when used with
 	// --gadgets-public-keys="$(cat inspektor-gadget.pub),$(cat your-key.pub)"
 	deployCmd.PersistentFlags().StringVar(
 		&gadgetsPublicKeys,
-		"gadgets-public-keys", resources.InspektorGadgetPublicKey, "Public keys used to verify the gadgets. If empty, verification will not occur.")
+		"gadgets-public-keys", resources.InspektorGadgetPublicKey, "Public keys used to verify the gadgets")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -736,6 +740,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("%s.%s not found in config.yaml", gadgettracermanagerconfig.Operator, gadgettracermanagerconfig.Oci)
 			}
 
+			opOciCfg[gadgettracermanagerconfig.VerifyImage] = verifyGadgets
 			opOciCfg[gadgettracermanagerconfig.PublicKeys] = strings.Split(gadgetsPublicKeys, ",")
 
 			data, err := yaml.Marshal(cfg)

--- a/docs/devel/hello-world-gadget-wasm.md
+++ b/docs/devel/hello-world-gadget-wasm.md
@@ -67,11 +67,11 @@ $ sudo -E ig image build . -t mygadget:latest
 and run it:
 
 ```bash
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
+WARN[0000] image signature verification is disabled due to using corresponding option
 INFO[0000] init: hello from wasm
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
+WARN[0000] image signature verification is disabled due to using corresponding option
 INFO[0000] init: hello from wasm
 RUNTIME.CONTAINERNAME        MNTNS_ID            PID            COMM           FILENAME
 INFO[0001] start: hello from wasm
@@ -132,11 +132,11 @@ $ sudo -E ig image build . -t mygadget:latest
 ...
 
 
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
+WARN[0000] image signature verification is disabled due to using corresponding option
 INFO[0000] init: hello from wasm
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
+WARN[0000] image signature verification is disabled due to using corresponding option
 INFO[0000] init: hello from wasm
 RUNTIME.CONTAINERNAME        MNTNS_ID            PID            COMM           FILENAME
 INFO[0001] start: hello from wasm
@@ -221,7 +221,7 @@ output from it:
 $ sudo -E ig image build . -t mygadget:latest
 ...
 
-$ sudo -E ig run mygadget:latest --public-keys='' -o jsonpretty
+$ sudo -E ig run mygadget:latest --verify-image=false -o jsonpretty
 {
   "comm": "cat",
   "filename": "/home/***/xxx.txt",

--- a/docs/devel/hello-world-gadget.md
+++ b/docs/devel/hello-world-gadget.md
@@ -209,7 +209,7 @@ Successfully pushed ghcr.io/my-org/mygadget:latest@sha256:dd3f5c357983bb863ef869
 Once you have pushed your gadget image to a container registry, it's highly recommended to sign it for security reasons.
 Tools like [cosign](https://docs.sigstore.dev/signing/signing_with_containers/) can be used for this purpose.
 Signed images ensure integrity and authenticity, adding an extra layer of trust.
-By default, Inspektor Gadget forbids running unsigned gadget images, but you can skip the verification using the `--public-keys=''` flag at your own risks.
+By default, Inspektor Gadget forbids running unsigned gadget images, but you can skip the verification using the `--verify-image=false` flag at your own risks.
 
 For more details on the verification process, refer to the [verification documentation](../getting-started/verify.md#verify-image-based-gadgets).
 
@@ -218,7 +218,7 @@ For more details on the verification process, refer to the [verification documen
 We're now all set to run our gadget for the first time.
 
 ```bash
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
 PID
 1113
@@ -271,7 +271,7 @@ Build and run the gadget again. Now it provides more information.
 ```bash
 $ sudo -E ig image build -t mygadget:latest .
 ....
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
 PID                      COMM                     FILENAME
 11305                    Chrome_ChildIOT          /dev/shm/.org.chromium.…
@@ -350,7 +350,7 @@ Now we can build and run the gadget again
 $ sudo -E ig image build . -t mygadget
 ...
 
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
               PID COMM              FILENAME
              1094 systemd-oomd      /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/memor…
              1094 systemd-oomd      /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/memor…
@@ -434,7 +434,7 @@ After adding the `gadget_mntns_id` field to the event structure, compiling and r
 Inspektor Gadget will automatically add the container name column to the output:
 
 ```bash
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
 RUNTIME.CONTAINERNAME        PID             COMM            FILENAME                        MNTNS_ID
 ```
@@ -450,7 +450,7 @@ Only events generated in containers are now printed, and they include the name o
 generating them.
 
 ```bash
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 RUNTIME.CONTAINERNAME MNTNS_ID            PID COMM        FILENAME
 mycontainer           4026536181       119341 runc:[2:IN… /proc/self/fd
 mycontainer           4026536181       119341 sh          /etc/ld.so.cache
@@ -476,7 +476,7 @@ events by container name.
 The following command doesn't show any event as there is no container with the specified name:
 
 ```bash
-$ sudo -E ig run mygadget:latest -c non_existing_container --public-keys=''
+$ sudo -E ig run mygadget:latest -c non_existing_container --verify-image=false
 INFO[0000] Experimental features enabled
 RUNTIME.CONTAINERNAME MNTNS_ID            PID COMM        FILENAME
 ```
@@ -573,7 +573,7 @@ Edit them, build and run the gadget again:
 $ sudo -E ig image build . -t mygadget --update-metadata -v
 ...
 
-$ sudo -E ig run mygadget:latest --public-keys=''
+$ sudo -E ig run mygadget:latest --verify-image=false
 INFO[0000] Experimental features enabled
 RUNTIME.CONTAINERN…        PID COMM       FILENAME                                       UID       GID
 ```

--- a/docs/getting-started/verify.md
+++ b/docs/getting-started/verify.md
@@ -215,14 +215,14 @@ RUNTIME.CONTAINERNAME  PID          UID          GID          MNTNS_ID RET FL…
 ...
 ```
 
-You can also skip verifying image-based gadget signature with `--public-keys=`.
+
+You can also skip verifying image-based gadget signature with `--verify-image=false`.
 Note that we do not recommend using this:
 
 ```bash
-$ sudo -E ig run --public-keys= ghcr.io/your-repo/gadget/trace_open
-...
-WARN[0000] image signature verification is disabled because no public keys were provided
-WARN[0000] image signature verification is disabled because no public keys were provided
+$ sudo -E ig run --verify-image=false ghcr.io/your-repo/gadget/trace_open
+WARN[0000] image signature verification is disabled due to using corresponding option
+WARN[0000] image signature verification is disabled due to using corresponding option
 RUNTIME.CONTAINERNAME  PID          UID          GID          MNTNS_ID RET FL… MODE        COMM        FNAME                  TIMESTAMP
 ```
 
@@ -233,6 +233,8 @@ Compared to `ig`, you cannot specify information with regard to verification whe
 ```bash
 $ kubectl gadget run --public-keys="$(cat your-key.pub)" trace_exec
 Error: unknown flag: --public-keys
+$ kubectl gadget run --verify-image=false trace_exec
+Error: unknown flag: --verify-image
 ```
 
 Instead, all these information are set once at deploy time.
@@ -273,7 +275,7 @@ $ kubectl gadget deploy --gadgets-public-keys=
 ...
 Inspektor Gadget successfully deployed
 $ kubectl gadget run trace_exec -A
-WARN[0001] minikube-docker      | image signature verification is disabled because no public keys were provided
+WARN[0001] minikube-docker      | image signature verification is disabled due to using corresponding option
 K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME          PID       PPID RE… COMM      ARGS      K8S.NODE  TIMESTAMP
 gadget              gadget-z55jq        gadget                   55376      55357   0 gadgettr… /bin/gad… minikube… 2024-07-17T07:39:07.…
 gadget              gadget-z55jq        gadget                   55375      55358   0 gadgettr… /bin/gad… minikube… 2024-07-17T07:39:07.…

--- a/docs/guides/run.md
+++ b/docs/guides/run.md
@@ -196,8 +196,8 @@ $ export INSPEKTOR_GADGET_OPERATOR_OCI_VERIFY_IMAGE=false
 $ sudo ig run trace_open
 INFO[0000] Experimental features enabled
 WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
-WARN[0000] image signature verification is disabled due to using corresponding CLI options
+WARN[0000] image signature verification is disabled due to using corresponding option
+WARN[0000] image signature verification is disabled due to using corresponding option
 ...
 ```
 

--- a/integration/k8s/run_insecure_test.go
+++ b/integration/k8s/run_insecure_test.go
@@ -67,9 +67,8 @@ func TestRunInsecure(t *testing.T) {
 	}
 
 	// TODO: Ideally it should not depend on a real gadget, but we don't have a "test gadget" available yet.
-	// As the image was not signed, we need to set --public-keys="" to deactivate
-	// image signature verification.
-	cmd := fmt.Sprintf("ig run --public-keys='' %s:5000/trace_open:%s -o json --insecure --timeout 2", registryIP, *gadgetTag)
+	// As the image was not signed, we need to set --verify-image=false.
+	cmd := fmt.Sprintf("ig run --verify-image=false %s:5000/trace_open:%s -o json --insecure --timeout 2", registryIP, *gadgetTag)
 
 	// run the gadget without verifying its output as we only need to check if it runs
 	traceOpenCmd := &Command{

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -26,5 +26,6 @@ const (
 	PodmanSocketPath       = "podman-socketpath"
 	Operator               = "operator"
 	Oci                    = "oci"
+	VerifyImage            = "verify-image"
 	PublicKeys             = "public-keys"
 )

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -39,6 +39,7 @@ const (
 	insecureParam         = "insecure"
 	pullParam             = "pull"
 	pullSecret            = "pull-secret"
+	verifyImage           = "verify-image"
 	publicKeys            = "public-keys"
 	allowedDigests        = "allowed-digests"
 	allowedRegistries     = "allowed-registries"
@@ -60,9 +61,16 @@ func (o *ociHandler) Init(params *params.Params) error {
 func (o *ociHandler) GlobalParams() api.Params {
 	return api.Params{
 		{
+			Key:          verifyImage,
+			Title:        "Verify image",
+			Description:  "Verify image using the provided public key",
+			DefaultValue: "true",
+			TypeHint:     api.TypeBool,
+		},
+		{
 			Key:          publicKeys,
 			Title:        "Public keys",
-			Description:  "Public keys used to verify the gadget. If empty, verification will not occur.",
+			Description:  "Public keys used to verify the gadgets",
 			DefaultValue: resources.InspektorGadgetPublicKey,
 			TypeHint:     api.TypeStringSlice,
 		},
@@ -198,7 +206,8 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 			Insecure:    o.ociParams.Get(insecureParam).AsBool(),
 		},
 		VerifyOptions: oci.VerifyOptions{
-			PublicKeys: o.ociParams.Get(publicKeys).AsStringSlice(),
+			VerifyPublicKey: o.ociParams.Get(verifyImage).AsBool(),
+			PublicKeys:      o.ociParams.Get(publicKeys).AsStringSlice(),
 		},
 		AllowedDigestsOptions: oci.AllowedDigestsOptions{
 			AllowedDigests: o.ociParams.Get(allowedDigests).AsStringSlice(),

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -29,6 +29,7 @@ data:
       podman-socketpath: /run/podman/podman.sock
       operator:
         oci:
+          verify-image: true
           public-keys:
             - |
               -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
This is easier to have two parameters:
1. --verify-gadgets: One the control the verification process.
2. --gadgets-public-keys: The other to specify the keys used to verify the gadgets.

Fixes: c71d05d54f04 ("treewide: Remove unused verify-gadgets flag and adapt CI jobs to dependabot.")
Fixes: f51ff0eb2ec8 ("treewide: Allow to have several public keys.")

With `kubectl-gadget`:

```bash
$ ./kubectl-gadget deploy --verify-gadgets=false --image-pull-policy=Never --debug --experimental
INFO[0000] Experimental features enabled                
WARN[0000] No policy controller found, the container image will not be verified 
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ConfigMap/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating DaemonSet/gadget...
W0725 15:28:49.088504  111716 warnings.go:70] spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/gadget]: deprecated since v1.30; use the "appArmorProfile" field instead
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Retrieving Gadget Catalog...
Inspektor Gadget successfully deployed
$ ./kubectl-gadget run trace_exec                    francis/resurect-verify-gadgets %
INFO[0000] Experimental features enabled                
WARN[0002] minikube-docker      | image signature verification is disabled due to using corresponding CLI options
K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNA… COMM            PID      TID PCOMM        PPID ARGS     K8S.NODE E… TIMESTAMP         
^C%
$ ./kubectl-gadget undeploy                          francis/resurect-verify-gadgets %
INFO[0000] Experimental features enabled                
Removing traces...
Removing CRD...
Removing cluster role binding...
Removing cluster role...
Removing namespace...
Waiting for namespace to be removed...
Inspektor Gadget successfully removed
$ ./kubectl-gadget deploy --gadgets-public-keys="$(cat pkg/resources/inspektor-gadget.pub),$(cat eiffel-fl.pub)" --image-pull-policy=Never --debug --experimental
INFO[0000] Experimental features enabled                
WARN[0000] No policy controller found, the container image will not be verified 
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ConfigMap/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating DaemonSet/gadget...
W0725 15:30:09.496238  112822 warnings.go:70] spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/gadget]: deprecated since v1.30; use the "appArmorProfile" field instead
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Retrieving Gadget Catalog...
Inspektor Gadget successfully deployed
$ ./kubectl-gadget run trace_exec                    francis/resurect-verify-gadgets %
INFO[0000] Experimental features enabled                
K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNA… COMM            PID      TID PCOMM        PPID ARGS     K8S.NODE E… TIMESTAMP         
^C%                                                                                                                                      $ ./kubectl-gadget run ghcr.io/eiffel-fl/gadget/trace_exec
INFO[0000] Experimental features enabled                
K8S.NAMESP… K8S.PODNAME K8S.CONTAI… MNTNS… TIMES… PID    PPID   UID    GID    LOGIN… SESSI… RETVAL ARGS_… UPPER… ARGS_… COMM  ARGS  K8S.…
^C%                                                                                                                                      
$ ./kubectl-gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:v0.23.0
INFO[0000] Experimental features enabled                
Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "ghcr.io/inspektor-gadget/gadget/trace_exec:v0.23.0": getting signing information: getting signature: getting signature bytes: ghcr.io/inspektor-gadget/gadget/trace_exec:sha256-2d4187d5045b4bf6ffac1c6a8a055a3280e9ab36c825532569fa351a2371b105.sig: not found
$ ./kubectl-gadget undeploy                          francis/resurect-verify-gadgets %
INFO[0000] Experimental features enabled                
Removing traces...
Removing CRD...
Removing cluster role binding...
Removing cluster role...
Removing namespace...
Waiting for namespace to be removed...
Inspektor Gadget successfully removed
$ ./kubectl-gadget deploy --image-pull-policy=Never --debug --experimental 
INFO[0000] Experimental features enabled                
WARN[0000] No policy controller found, the container image will not be verified 
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ConfigMap/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating DaemonSet/gadget...
W0725 15:31:57.383318  114578 warnings.go:70] spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/gadget]: deprecated since v1.30; use the "appArmorProfile" field instead
Creating CustomResourceDefinition/traces.gadget.kinvolk.io...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready
1/1 gadget pod(s) ready
Retrieving Gadget Catalog...
Inspektor Gadget successfully deployed
$ ./kubectl-gadget run trace_exec                    francis/resurect-verify-gadgets %
INFO[0000] Experimental features enabled                
K8S.NAMESPACE    K8S.PODNAME      K8S.CONTAINERNA… COMM            PID      TID PCOMM        PPID ARGS     K8S.NODE E… TIMESTAMP         
^C%                                                                                                                                      $ ./kubectl-gadget run ghcr.io/eiffel-fl/gadget/trace_exec               
INFO[0000] Experimental features enabled                
Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "ghcr.io/eiffel-fl/gadget/trace_exec": the image was not signed by the provided keys: invalid signature when validating ASN.1 encoded signature
```

With `ig`:

```bash
$ sudo -E ./ig run --verify-image=false ghcr.io/eiffel-fl/gadget/trace_exec
[sudo] Mot de passe de francis : 
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
WARN[0000] image signature verification is disabled due to using corresponding CLI options 
WARN[0000] image signature verification is disabled due to using corresponding CLI options 
RUNTIME.CONTAI… MNTNS_ID TIMESTA… PID      PPID     UID      GID      LOGINUID SESSION… RETVAL   ARGS_CO… UPPER_… ARGS_S… COMM    ARGS   
minikube-docker 4026535… 4214253… 90454    86187    0        0        4294967… 4294967… 0        1        false   20      bridge  /opt/c…
minikube-docker 4026535… 4214254… 90459    86187    0        0        4294967… 4294967… 0        1        false   21      portmap /opt/c…
minikube-docker 4026535… 4214255… 90464    86187    0        0        4294967… 4294967… 0        1        false   22      firewa… /opt/c…
minikube-docker 4026535… 4215210… 90470    87896    0        0        4294967… 4294967… 0        15       false   477     runc    /usr/b…
minikube-docker 4026535… 4215210… 90469    87896    0        0        4294967… 4294967… 0        15       false   477     runc    /usr/b…
minikube-docker 4026535… 4215215… 90484    90469    0        0        4294967… 4294967… 0        2        false   20      exe     /proc/…
minikube-docker 4026535… 4215215… 90485    90470    0        0        4294967… 4294967… 0        2        false   20      exe     /proc/…
^C%                                                                                                                                      $ sudo -E ./ig run --public-keys="$(cat pkg/resources/inspektor-gadget.pub),$(cat eiffel-fl.pub)" ghcr.io/eiffel-fl/gadget/trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAI… MNTNS_ID TIMESTA… PID      PPID     UID      GID      LOGINUID SESSION… RETVAL   ARGS_CO… UPPER_… ARGS_S… COMM    ARGS   
minikube-docker 4026535… 4244300… 90894    86187    0        0        4294967… 4294967… 0        1        false   20      bridge  /opt/c…
minikube-docker 4026535… 4244304… 90900    86187    0        0        4294967… 4294967… 0        1        false   21      portmap /opt/c…
minikube-docker 4026535… 4244305… 90905    86187    0        0        4294967… 4294967… 0        1        false   22      firewa… /opt/c…
^C%                                                                                                                                      $ sudo -E ./ig run --public-keys="$(cat pkg/resources/inspektor-gadget.pub),$(cat eiffel-fl.pub)" trace_exec                         
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAINERNAME    COMM                    PID           TID PCOMM                PPID ARGS         ER… TIMESTAMP                  
minikube-docker          bridge                91065         91065 cri-dockerd         86187 /opt/cni/bi…     2024-07-25T15:24:10.599121…
minikube-docker          portmap               91071         91071 cri-dockerd         86187 /opt/cni/bi…     2024-07-25T15:24:10.603444…
minikube-docker          firewall              91076         91076 cri-dockerd         86187 /opt/cni/bi…     2024-07-25T15:24:10.604583…
^C%
```
