### PR TITLE
treewide: Replace allowed-digests and allowed-registries by allowed-gadgets

### DIFF
--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -21,5 +21,4 @@ data:
         oci:
           verify-image: {{ .Values.config.verifyGadgets }}
           public-keys:{{ toYaml $.Values.config.gadgetsPublicKeys | nindent 12 }}
-          allowed-digests:{{ toYaml .Values.config.allowedDigests | nindent 12 }}
-          allowed-registries:{{toYaml .Values.config.allowedRegistries | nindent 12 }}
+          allowed-gadgets:{{ toYaml .Values.config.allowedGadgets | nindent 12 }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -38,11 +38,8 @@ config:
       Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
       -----END PUBLIC KEY-----
 
-  # -- List of allowed gadgets digests.
-  allowedDigests: []
-
-  # -- List of allowed registries.
-  allowedRegistries: []
+  # -- List of allowed gadgets.
+  allowedGadgets: []
 
   # -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from private registry
   mountPullSecret: false

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -108,8 +108,7 @@ var (
 	strLevels           []string
 	verifyGadgets       bool
 	gadgetsPublicKeys   string
-	allowedDigests      []string
-	allowedRegistries   []string
+	allowedGadgets      []string
 	insecureRegistries  []string
 )
 
@@ -247,11 +246,8 @@ func init() {
 		&gadgetsPublicKeys,
 		"gadgets-public-keys", resources.InspektorGadgetPublicKey, "Public keys used to verify the gadgets")
 	deployCmd.PersistentFlags().StringSliceVar(
-		&allowedDigests,
-		"allowed-digests", []string{}, "List of allowed digests, if image digest is not part of it, execution will be denied. By default, all digests are allowed.")
-	deployCmd.PersistentFlags().StringSliceVar(
-		&allowedRegistries,
-		"allowed-registries", []string{}, "List of allowed registries, if image-based gadget is not from one of these registries, execution will be denied. By default, all registries are allowed")
+		&allowedGadgets,
+		"allowed-gadgets", []string{}, "List of allowed gadgets, if gadget is not part of it, execution will be denied. By default, all gadgets are allowed.")
 	deployCmd.PersistentFlags().StringSliceVar(
 		&insecureRegistries,
 		"insecure-registries",
@@ -757,8 +753,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 			opOciCfg[gadgettracermanagerconfig.VerifyImage] = verifyGadgets
 			opOciCfg[gadgettracermanagerconfig.PublicKeys] = strings.Split(gadgetsPublicKeys, ",")
-			opOciCfg[gadgettracermanagerconfig.AllowedDigests] = allowedDigests
-			opOciCfg[gadgettracermanagerconfig.AllowedRegistries] = allowedRegistries
+			opOciCfg[gadgettracermanagerconfig.AllowedGadgets] = allowedGadgets
 			opOciCfg[gadgettracermanagerconfig.InsecureRegistries] = insecureRegistries
 
 			data, err := yaml.Marshal(cfg)

--- a/docs/guides/run.md
+++ b/docs/guides/run.md
@@ -135,12 +135,12 @@ For more information about the configuration file, check the [configuration guid
 
 ### Restricting gadget images (by registry or digest)
 
-This is possible to restrict the executed gadgets by using the `--allowed-digests` and `--allowed-regisitries`.
-By default, all gadgets digests and gadgets from all regisitries are allowed.
+This is possible to restrict the executed gadgets by using the `--allowed-gadgets` flag.
+By default, all gadgets are allowed.
 You can specify these options only at deploy time:
 
 ```bash
-$ kubectl gadget deploy --gadgets-public-keys="$(cat inspektor-gadget.pub),$(cat your-key.pub)" --allowed-digests='sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,sha256:digest_of_your_gadget' --allowed-registries='ghcr.io/inspektor-gadget/gadget,ghcr.io/your-repo/gadget'
+$ kubectl gadget deploy --gadgets-public-keys="$(cat inspektor-gadget.pub),$(cat your-key.pub)" --allowed-gadgets='ghcr.io/inspektor-gadget/gadget@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/your-repo/gadget@sha256:digest_of_your_gadget'
 ...
 Inspektor Gadget successfully deployed
 $ kubectl gadget run trace_exec
@@ -149,7 +149,7 @@ gadget           gadget-fdpxp     gadget           gadgettr…    131299   13129
 gadget           gadget-fdpxp     gadget           gadgettr…    131298   131298 runc       131280 /bin/ga… minikub…    2024-07-25T08:22:…
 ^C
 $ kubectl gadget run trace_open
-Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: image digest not allowed: "sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d" not in "sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f, sha256:digest_of_your_gadget"
+Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: trace_open is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f, ghcr.io/your-repo/gadget@sha256:digest_of_your_gadget
 $ kubectl gadget run ghcr./io/your-repo/gadget/your_gadget
 K8S.NAMESPACE  K8S.PODNAME    K8S.CONTAINER… TIMEST… PID     UID     GID     MNTNS_… ERR     FD      FLAGS   MODE    COMM   FNAME  K8S.N…
 gadget         gadget-8rcdz   gadget         500159… 134426  0       0       402653… 0       5       0       0       runc:… /sys/… minik…
@@ -206,20 +206,20 @@ mycontainer3                                        122110  cat              0  
 We also offer this possibility with `ig` by using the same flags at run time:
 
 ```bash
-$ sudo -E ig run --allowed-digests='sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' --allowed-registries='ghcr.io/inspektor-gadget/gadget' trace_exec
+$ sudo -E ig run --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' trace_exec
 RUNTIME.CONTAINERNAME    COMM                    PID           TID PCOMM                PPID ARGS         ER… TIMESTAMP
 minikube-docker          iptables             137722        137722 kubelet             11713 /usr/sbin/i…     2024-07-25T10:30:21.902064…
 minikube-docker          ip6tables            137723        137723 kubelet             11713 /usr/sbin/i…     2024-07-25T10:30:21.904561…
 ^C
-$ sudo -E ig run --allowed-digests='sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' --allowed-registries='ghcr.io/inspektor-gadget/gadget' trace_open
+$ sudo -E ig run ---allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' trace_open
 RUNTIME.CONTAINER… COMM              PID       TID       UID       GID  FD FNAME                    MODE      ERROR  TIMESTAMP
 minikube-docker    kubelet         11713     11715         0         0  20 /sys/fs/cgroup/kubepods… --------…        2024-07-25T10:30:44…
 minikube-docker    kubelet         11713     11715         0         0  20 /proc/2136/fd            --------…        2024-07-25T10:30:44…
 ^C
-$ sudo -E ig run --allowed-digests='sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' --allowed-registries='ghcr.io/inspektor-gadget/gadget' trace_signal
-Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: image digest not allowed: "sha256:bd5acefb4372832ca30fe3814b6bace8141882ee8e20c661d82cb3c5a64bc48a" not in "sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f, sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d"
-$ sudo -E ig run --allowed-digests='sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' --allowed-registries='ghcr.io/inspektor-gadget/gadget' ghcr.io/your-repo/gadget/your-gadget
-Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/your-repo/gadget/your-gadget:latest not originating from allowed registries: ghcr.io/inspektor-gadget/gadget
+$ sudo -E ig run --allowed-gadgetss='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' trace_signal
+Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: trace_signal is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f, ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d
+$ sudo -E ig run --allowed-gadgetss='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d' ghcr.io/your-repo/gadget/your-gadget
+Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/your-repo/gadget/your-gadget is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f, ghcr.io/inspektor-gadget/gadget/trace_open@sha256:be8dd66efc69a14f2812b7d5472b378b095a2002ef89fa7aa1e33b7133da762d
 ```
 
 ## Environment Variables

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -28,7 +28,6 @@ const (
 	Oci                    = "oci"
 	VerifyImage            = "verify-image"
 	PublicKeys             = "public-keys"
-	AllowedDigests         = "allowed-digests"
-	AllowedRegistries      = "allowed-registries"
+	AllowedGadgets         = "allowed-gadgets"
 	InsecureRegistries     = "insecure-registries"
 )

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -41,8 +41,7 @@ const (
 	pullSecret              = "pull-secret"
 	verifyImage             = "verify-image"
 	publicKeys              = "public-keys"
-	allowedDigests          = "allowed-digests"
-	allowedRegistries       = "allowed-registries"
+	allowedGadgets          = "allowed-gadgets"
 )
 
 type ociHandler struct {
@@ -75,15 +74,9 @@ func (o *ociHandler) GlobalParams() api.Params {
 			TypeHint:     api.TypeStringSlice,
 		},
 		{
-			Key:         allowedDigests,
-			Title:       "Allowed Digests",
-			Description: "List of allowed digests, if image digest is not part of it, execution will be denied. By default, all digests are allowed",
-			TypeHint:    api.TypeStringSlice,
-		},
-		{
-			Key:         allowedRegistries,
-			Title:       "Allowed registries",
-			Description: "List of allowed registries, if image-based gadget is not from one of these registries, execution will be denied. By default, all registries are allowed",
+			Key:         allowedGadgets,
+			Title:       "Allowed Gadgets",
+			Description: "List of allowed gadgets, if gadget is not part of it, execution will be denied. By default, all digests are allowed",
 			TypeHint:    api.TypeStringSlice,
 		},
 		{
@@ -208,11 +201,8 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 			VerifyPublicKey: o.ociParams.Get(verifyImage).AsBool(),
 			PublicKeys:      o.ociParams.Get(publicKeys).AsStringSlice(),
 		},
-		AllowedDigestsOptions: oci.AllowedDigestsOptions{
-			AllowedDigests: o.ociParams.Get(allowedDigests).AsStringSlice(),
-		},
-		AllowedRegistriesOptions: oci.AllowedRegistriesOptions{
-			AllowedRegistries: o.ociParams.Get(allowedRegistries).AsStringSlice(),
+		AllowedGadgetsOptions: oci.AllowedGadgetsOptions{
+			AllowedGadgets: o.ociParams.Get(allowedGadgets).AsStringSlice(),
 		},
 		Logger: gadgetCtx.Logger(),
 	}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -36,9 +36,7 @@ data:
               MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
               Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
               -----END PUBLIC KEY-----
-          allowed-digests:
-            []
-          allowed-registries:
+          allowed-gadgets:
             []
 ---
 # Source: gadget/templates/clusterrole.yaml


### PR DESCRIPTION
Hi!

This new arguments combines the two previous and extend them. It is possible to filter by the following:
1. By gadget: by giving the exact name of the gadget like ghcr.io/inspektor-gadget/gadget/trace_exec
2. By digest: by giving the digest of the gadget like ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:trace_exec_digest
3. By suffix: by using a star at the end of the word like ghcr.io/inspektor-gadget/gadget/*

```bash
$ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/*' ghcr.io/inspektor-gadget/gadget/trace_exec
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAINERNAME    COMM                    PID           TID PCOMM                PPID ARGS         ER… TIMESTAMP                  
^C%                                                                                                                                      $ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/*' ghcr.io/eiffel-fl/gadget/trace_exec       
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/eiffel-fl/gadget/trace_exec is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/*
$ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/*,ghcr.io/eiffel-fl/gadget/*' ghcr.io/mqasimsarfraz/gadget/trace_open:latest       
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/mqasimsarfraz/gadget/trace_open:latest is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/*, ghcr.io/eiffel-fl/gadget/*
$ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/trace_exec:latest,ghcr.io/inspektor-gadget/gadget/trace_open:v0.29.0' ghcr.io/inspektor-gadget/gadget/trace_exec:v0.29.0
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/inspektor-gadget/gadget/trace_exec:v0.29.0 is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/trace_exec:latest, ghcr.io/inspektor-gadget/gadget/trace_open:v0.29.0
$ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/trace_exec:latest,ghcr.io/inspektor-gadget/gadget/trace_open:v0.29.0' ghcr.io/inspektor-gadget/gadget/trace_open:v0.29.0
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAINERN… TIMESTAMP  PID        UID        GID        MNTNS_ID   ERR        FD         FLAGS      MODE      COMM      FNAME    
^C%
$ sudo -E ./ig run --allowed-gadgets 'ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:b03315bdbe30c153494c0e0f051c731f8082f4f39cf68aeff4e7fa4df105be84,ghcr.io/inspektor-gadget/gadget/trace_open@sha256:a404ad37bc9a80a43267697d1a9a67a2688bf5575f011e45f02787f21051769b' ghcr.io/inspektor-gadget/gadget/trace_exec:v0.29.0
INFO[0000] Experimental features enabled                
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock" 
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock" 
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: ghcr.io/inspektor-gadget/gadget/trace_exec:v0.29.0 is not part of allowed gadgets: ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:b03315bdbe30c153494c0e0f051c731f8082f4f39cf68aeff4e7fa4df105be84, ghcr.io/inspektor-gadget/gadget/trace_open@sha256:a404ad37bc9a80a43267697d1a9a67a2688bf5575f011e45f02787f21051769b
```

Best regards.