### PR TITLE
Improve insecure registries support

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -149,11 +149,11 @@ func AddRegistryAuthVariablesAndFlags(cmd *cobra.Command, authOptions *oci.AuthO
 	viper.BindPFlag("registry.auth_file", cmd.Flags().Lookup("authfile"))
 	viper.BindEnv("registry.auth_file", "REGISTRY_AUTH_FILE")
 
-	cmd.Flags().BoolVar(
-		&authOptions.Insecure,
-		"insecure",
-		false,
-		"Allow connections to HTTP only registries",
+	cmd.Flags().StringSliceVar(
+		&authOptions.InsecureRegistries,
+		"insecure-registries",
+		[]string{},
+		"List of registries to access over plain HTTP",
 	)
 }
 

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -110,6 +110,7 @@ var (
 	gadgetsPublicKeys   string
 	allowedDigests      []string
 	allowedRegistries   []string
+	insecureRegistries  []string
 )
 
 var supportedHooks = []string{"auto", "crio", "podinformer", "nri", "fanotify", "fanotify+ebpf"}
@@ -251,6 +252,12 @@ func init() {
 	deployCmd.PersistentFlags().StringSliceVar(
 		&allowedRegistries,
 		"allowed-registries", []string{}, "List of allowed registries, if image-based gadget is not from one of these registries, execution will be denied. By default, all registries are allowed")
+	deployCmd.PersistentFlags().StringSliceVar(
+		&insecureRegistries,
+		"insecure-registries",
+		[]string{},
+		"List of registries to access over plain HTTP",
+	)
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -752,6 +759,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			opOciCfg[gadgettracermanagerconfig.PublicKeys] = strings.Split(gadgetsPublicKeys, ",")
 			opOciCfg[gadgettracermanagerconfig.AllowedDigests] = allowedDigests
 			opOciCfg[gadgettracermanagerconfig.AllowedRegistries] = allowedRegistries
+			opOciCfg[gadgettracermanagerconfig.InsecureRegistries] = insecureRegistries
 
 			data, err := yaml.Marshal(cfg)
 			if err != nil {

--- a/docs/core-concepts/images.md
+++ b/docs/core-concepts/images.md
@@ -276,9 +276,9 @@ Usage:
   ig image pull IMAGE [flags]
 
 Flags:
-      --authfile string   Path of the authentication file. This overrides the REGISTRY_AUTH_FILE environment variable (default "/var/lib/ig/config.json")
-  -h, --help              help for pull
-      --insecure          Allow connections to HTTP only registries
+      --authfile string               Path of the authentication file. This overrides the REGISTRY_AUTH_FILE environment variable (default "/var/lib/ig/config.json")
+  -h, --help                          help for pull
+      --insecure-registries strings   List of registries to access over plain HTTP
 ```
 
 ```bash
@@ -301,9 +301,9 @@ Usage:
   ig image push IMAGE [flags]
 
 Flags:
-      --authfile string   Path of the authentication file. This overrides the REGISTRY_AUTH_FILE environment variable (default "/var/lib/ig/config.json")
-  -h, --help              help for push
-      --insecure          Allow connections to HTTP only registrie
+      --authfile string               Path of the authentication file. This overrides the REGISTRY_AUTH_FILE environment variable (default "/var/lib/ig/config.json")
+  -h, --help                          help for push
+      --insecure-registries strings   List of registries to access over plain HTTP
 ```
 
 ```bash

--- a/integration/components/image/image_test.go
+++ b/integration/components/image/image_test.go
@@ -117,7 +117,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "push",
 			cmd:  commonImage.NewPushCmd(),
-			args: []string{testRegistryImage, "--insecure"},
+			args: []string{testRegistryImage, "--insecure-registries", registryAddr},
 			expectedStdout: []string{
 				fmt.Sprintf("Successfully pushed %s", testRegistryImage),
 			},
@@ -125,7 +125,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "push-invalid-image",
 			cmd:  commonImage.NewPushCmd(),
-			args: []string{"unknown", "--insecure"},
+			args: []string{"unknown", "--insecure-registries", registryAddr},
 			expectedStderr: []string{
 				"failed to resolve ghcr.io/inspektor-gadget/gadget/unknown:latest: not found",
 			},
@@ -133,7 +133,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "push-unknown-tag",
 			cmd:  commonImage.NewPushCmd(),
-			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure"},
+			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure-registries", registryAddr},
 			expectedStderr: []string{
 				fmt.Sprintf("%s/%s:%s: not found", registryAddr, testRepo, "unknown"),
 			},
@@ -168,7 +168,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "pull",
 			cmd:  commonImage.NewPullCmd(),
-			args: []string{testRegistryImage, "--insecure"},
+			args: []string{testRegistryImage, "--insecure-registries", registryAddr},
 			expectedStdout: []string{
 				fmt.Sprintf("Successfully pulled %s", testRegistryImage),
 			},
@@ -185,7 +185,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "pull-invalid-image",
 			cmd:  commonImage.NewPullCmd(),
-			args: []string{"unknown", "--insecure"},
+			args: []string{"unknown", "--insecure-registries", registryAddr},
 			expectedStderr: []string{
 				"failed to resolve ghcr.io/inspektor-gadget/gadget/unknown:latest",
 			},
@@ -193,7 +193,7 @@ func TestImage(t *testing.T) {
 		{
 			name: "pull-unknown-tag",
 			cmd:  commonImage.NewPullCmd(),
-			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure"},
+			args: []string{fmt.Sprintf("%s/%s:%s", registryAddr, testRepo, "unknown"), "--insecure-registries", registryAddr},
 			expectedStderr: []string{
 				fmt.Sprintf("%s/%s:%s: not found", registryAddr, testRepo, "unknown"),
 			},

--- a/integration/k8s/run_insecure_test.go
+++ b/integration/k8s/run_insecure_test.go
@@ -46,7 +46,7 @@ func TestRunInsecure(t *testing.T) {
 		RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
 
-	registryIP := GetTestPodIP(t, ns, "registry")
+	registry := GetTestPodIP(t, ns, "registry") + ":5000"
 
 	// copy gadget image to insecure registry
 	orasCpCmds := []TestStep{
@@ -55,7 +55,7 @@ func TestRunInsecure(t *testing.T) {
 			"copy",
 			"--to-plain-http",
 			fmt.Sprintf("%s/trace_open:%s", *gadgetRepository, *gadgetTag),
-			fmt.Sprintf("%s:5000/trace_open:%s", registryIP, *gadgetTag),
+			fmt.Sprintf("%s/trace_open:%s", registry, *gadgetTag),
 		),
 		WaitUntilJobCompleteCommand(ns, "copier"),
 	}
@@ -68,7 +68,8 @@ func TestRunInsecure(t *testing.T) {
 
 	// TODO: Ideally it should not depend on a real gadget, but we don't have a "test gadget" available yet.
 	// As the image was not signed, we need to set --verify-image=false.
-	cmd := fmt.Sprintf("ig run --verify-image=false %s:5000/trace_open:%s -o json --insecure --timeout 2", registryIP, *gadgetTag)
+	cmd := fmt.Sprintf("ig run --verify-image=false %s/trace_open:%s -o json --insecure-registries %s --timeout 2",
+		registry, *gadgetTag, registry)
 
 	// run the gadget without verifying its output as we only need to check if it runs
 	traceOpenCmd := &Command{

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -30,4 +30,5 @@ const (
 	PublicKeys             = "public-keys"
 	AllowedDigests         = "allowed-digests"
 	AllowedRegistries      = "allowed-registries"
+	InsecureRegistries     = "insecure-registries"
 )

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -56,7 +56,9 @@ import (
 type AuthOptions struct {
 	AuthFile    string
 	SecretBytes []byte
-	Insecure    bool
+	// InsecureRegistries is a list of registries that should be accessed over
+	// plain HTTP.
+	InsecureRegistries []string
 }
 
 type VerifyOptions struct {
@@ -823,8 +825,12 @@ func newRepository(image reference.Named, authOpts *AuthOptions) (*remote.Reposi
 	if err != nil {
 		return nil, fmt.Errorf("creating remote repository: %w", err)
 	}
-	repo.PlainHTTP = authOpts.Insecure
-	if !authOpts.Insecure {
+
+	registryDomain := reference.Domain(image)
+	insecure := slices.Contains(authOpts.InsecureRegistries, registryDomain)
+
+	repo.PlainHTTP = insecure
+	if !insecure {
 		client, err := newAuthClient(image.Name(), authOpts)
 		if err != nil {
 			return nil, fmt.Errorf("creating auth client: %w", err)

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -34,15 +34,15 @@ import (
 )
 
 const (
-	validateMetadataParam = "validate-metadata"
-	authfileParam         = "authfile"
-	insecureParam         = "insecure"
-	pullParam             = "pull"
-	pullSecret            = "pull-secret"
-	verifyImage           = "verify-image"
-	publicKeys            = "public-keys"
-	allowedDigests        = "allowed-digests"
-	allowedRegistries     = "allowed-registries"
+	validateMetadataParam   = "validate-metadata"
+	authfileParam           = "authfile"
+	insecureRegistriesParam = "insecure-registries"
+	pullParam               = "pull"
+	pullSecret              = "pull-secret"
+	verifyImage             = "verify-image"
+	publicKeys              = "public-keys"
+	allowedDigests          = "allowed-digests"
+	allowedRegistries       = "allowed-registries"
 )
 
 type ociHandler struct {
@@ -86,6 +86,12 @@ func (o *ociHandler) GlobalParams() api.Params {
 			Description: "List of allowed registries, if image-based gadget is not from one of these registries, execution will be denied. By default, all registries are allowed",
 			TypeHint:    api.TypeStringSlice,
 		},
+		{
+			Key:         insecureRegistriesParam,
+			Title:       "Insecure registries",
+			Description: "List of registries to access over plain HTTP",
+			TypeHint:    api.TypeStringSlice,
+		},
 	}
 }
 
@@ -104,13 +110,6 @@ func (o *ociHandler) InstanceParams() api.Params {
 			Title:        "Validate metadata",
 			Description:  "Validate the gadget metadata before running the gadget",
 			DefaultValue: "true",
-			TypeHint:     api.TypeBool,
-		},
-		{
-			Key:          insecureParam,
-			Title:        "Insecure connection",
-			Description:  "Allow connections to HTTP only registries",
-			DefaultValue: "false",
 			TypeHint:     api.TypeBool,
 		},
 		{
@@ -201,9 +200,9 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 
 	imgOpts := &oci.ImageOptions{
 		AuthOptions: oci.AuthOptions{
-			AuthFile:    o.ociParams.Get(authfileParam).AsString(),
-			SecretBytes: secretBytes,
-			Insecure:    o.ociParams.Get(insecureParam).AsBool(),
+			AuthFile:           o.ociParams.Get(authfileParam).AsString(),
+			SecretBytes:        secretBytes,
+			InsecureRegistries: o.ociParams.Get(insecureRegistriesParam).AsStringSlice(),
 		},
 		VerifyOptions: oci.VerifyOptions{
 			VerifyPublicKey: o.ociParams.Get(verifyImage).AsBool(),


### PR DESCRIPTION
- Allow list of registries instead of global on / off flag
- Move argument to be global (configurable only by admins)
- Add support in kubectl-gadget deploy

### Testing 

An insecure registry can be created on the local host by running 

```bash 
 docker run -d -p 5000:5000 --restart always --name registry registry:2
```

Build / tag an image and push it to this registry

```bash 
 sudo -E ig image push 192.168.1.16:5000/trace_open:latest --insecure-registries="192.168.1.16:5000"
```

### ig 

```bash 
$ sudo -E ig run 192.168.1.16:5000/trace_open:latest --verify-image=false --insecure-registries="192.168.1.16:5000" --pull=always
# -> works 

$ sudo -E ig run 192.168.1.16:5000/trace_open:latest --verify-image=false --insecure-registries="192.168.1.16:5000,foo.com" --pull=always
# -> works 

$ sudo -E ig run 192.168.1.16:5000/trace_open:latest --verify-image=false --pull=always
INFO[0000] Experimental features enabled
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: pulling image (always) "192.168.1.16:5000/trace_open:latest": copying to remote repository: failed to resolve 192.168.1.16:5000/trace_open:latest: Get "https://192.168.1.16:5000/v2/trace_open/manifests/latest": http: server gave HTTP response to HTTPS client

$ sudo -E ig run 192.168.1.16:5000/trace_open:latest --verify-image=false --insecure-registries="192.168.1.16:5001" --pull=always
INFO[0000] Experimental features enabled
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: pulling image (always) "192.168.1.16:5000/trace_open:latest": copying to remote repository: failed to resolve 192.168.1.16:5000/trace_open:latest: Get "https://192.168.1.16:5000/v2/trace_open/manifests/latest": http: server gave HTTP response to HTTPS client
```

### kubectl-gadget 

```bash 
$ kubectl-gadget deploy --experimental --insecure-registries=192.168.1.16:5000 --verify-gadgets=false
...

$ kubectl-gadget run 192.168.1.16:5000/trace_open:latest --pull=always
# -> works
```








