### PR TITLE
image-based gadgets: add support for profiler gadgets

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -32,6 +32,7 @@ import (
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
 )
@@ -141,6 +142,12 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 					continue
 				}
 				param := apihelpers.ParamToParamDesc(p).ToParam()
+
+				// Skip duplicate params (can happen if an operator is running on both client + server)
+				if _, ok := paramLookup[p.Prefix+p.Key]; ok {
+					continue
+				}
+
 				paramLookup[p.Prefix+p.Key] = param
 				gadgetParams.Add(param)
 			}

--- a/examples/gadgets/operators/otel_metrics/main.go
+++ b/examples/gadgets/operators/otel_metrics/main.go
@@ -45,7 +45,7 @@ func do() error {
 			if err != nil {
 				return err
 			}
-			ds.AddAnnotation(otelmetrics.AnnotationMetricsExport, "true")
+			ds.AddAnnotation(otelmetrics.AnnotationMetricsCollect, "true")
 
 			// The node name will be used as key
 			node, err := ds.AddField(
@@ -140,7 +140,7 @@ func do() error {
 
 	// Initialize operator with default settings
 	globalParams := apihelpers.ToParamDescs(otelmetrics.Operator.GlobalParams()).ToParams()
-	globalParams.Set(otelmetrics.ParamOtelMetricsEnabled, "true")
+	globalParams.Set(otelmetrics.ParamOtelMetricsListen, "true")
 	otelmetrics.Operator.Init(globalParams)
 
 	l := logger.DefaultLogger()

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -13,6 +13,7 @@ COSIGN ?= cosign
 
 GADGETS = \
 	audit_seccomp \
+	profile_blockio \
 	trace_bind \
 	trace_capabilities \
 	trace_dns \

--- a/gadgets/profile_blockio/gadget.yaml
+++ b/gadgets/profile_blockio/gadget.yaml
@@ -1,0 +1,17 @@
+name: profile blockio
+description: TODO
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://inspektor-gadget.io/docs
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+dataSources:
+  blockio:
+    annotations:
+      cli.output: "none"
+      metrics.print: "true"
+    fields:
+      latency:
+        annotations:
+          metrics.unit: µs
+  renderedmetrics:
+    annotations:
+      cli.clear-screen-before: "true"

--- a/gadgets/profile_blockio/program.bpf.c
+++ b/gadgets/profile_blockio/program.bpf.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include <gadget/bits.bpf.h>
+#include <gadget/core_fixes.bpf.h>
+#include <gadget/types.h>
+#include <gadget/macros.h>
+
+#ifndef PROFILER_MAX_SLOTS
+#define PROFILER_MAX_SLOTS 27
+#endif /* !PROFILER_MAX_SLOTS */
+
+#define MAX_ENTRIES 10240
+#define DISK_NAME_LEN 32
+
+#define MINORBITS 20
+#define MINORMASK ((1U << MINORBITS) - 1)
+
+#define MKDEV(ma, mi) (((ma) << MINORBITS) | (mi))
+
+const volatile bool filter_cg = false;
+const volatile bool targ_per_disk = false;
+const volatile bool targ_per_flag = false;
+const volatile bool targ_queued = false;
+const volatile bool targ_ms = false;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = 0;
+
+extern int LINUX_KERNEL_VERSION __kconfig;
+
+struct hist_key {
+	__u32 cmd_flags;
+	__u32 dev;
+};
+
+// hist_value is used as value for profiler hash map.
+struct hist_value {
+	gadget_histogram_slot__u32 latency[PROFILER_MAX_SLOTS];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct hist_key);
+	__type(value, struct hist_value);
+} hists SEC(".maps");
+
+GADGET_MAPITER(blockio, hists);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_CGROUP_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, 1);
+} cgroup_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct request *);
+	__type(value, u64);
+} start SEC(".maps");
+
+static struct hist_value initial_hist;
+
+static __always_inline int trace_rq_start(struct request *rq, int issue)
+{
+	if (issue && targ_queued && BPF_CORE_READ(rq, q, elevator))
+		return 0;
+
+	u64 ts = bpf_ktime_get_ns();
+
+	if (filter_dev) {
+		struct gendisk *disk = get_disk(rq);
+		u32 dev;
+
+		dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
+				   BPF_CORE_READ(disk, first_minor)) :
+			     0;
+		if (targ_dev != dev)
+			return 0;
+	}
+	bpf_map_update_elem(&start, &rq, &ts, 0);
+	return 0;
+}
+
+// https://github.com/torvalds/linux/commit/a54895fa057c67700270777f7661d8d3c7fda88a
+// -       TP_PROTO(struct request_queue *q, struct request *rq),
+// +       TP_PROTO(struct request *rq),
+
+// struct request and struct request_queue are likely different in the current
+// kernel and in vmlinux.h. We don't need recursive compatibility checks on
+// each field of the struct because we only use this to check the prototype of
+// the tracepoints. We use empty structs so none of the fields are checked by
+// bpf_core_type_matches().
+struct request___empty {};
+struct request_queue___empty {};
+
+typedef void (*btf_trace_block_rq_insert___new)(void *,
+						struct request___empty *);
+typedef void (*btf_trace_block_rq_insert___old)(void *,
+						struct request_queue___empty *q,
+						struct request___empty *);
+typedef void (*btf_trace_block_rq_issue___new)(void *,
+					       struct request___empty *);
+typedef void (*btf_trace_block_rq_issue___old)(void *,
+					       struct request_queue___empty *q,
+					       struct request___empty *);
+
+SEC("raw_tp/block_rq_insert")
+int ig_profio_ins(u64 *ctx)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	if (bpf_core_type_matches(btf_trace_block_rq_insert___new)) {
+		// After commit a54895fa (v5.11-rc1)
+		return trace_rq_start((void *)ctx[0], false);
+	} else if (bpf_core_type_matches(btf_trace_block_rq_insert___old)) {
+		// Before commit a54895fa (v5.11-rc1)
+		return trace_rq_start((void *)ctx[1], false);
+	} else {
+		// Couldn't detect block/block_rq_insert tracepoint
+		bpf_core_unreachable();
+		return 0;
+	}
+}
+
+SEC("raw_tp/block_rq_issue")
+int ig_profio_iss(u64 *ctx)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	if (bpf_core_type_matches(btf_trace_block_rq_issue___new)) {
+		// After commit a54895fa (v5.11-rc1)
+		return trace_rq_start((void *)ctx[0], true);
+	} else if (bpf_core_type_matches(btf_trace_block_rq_issue___old)) {
+		// Before commit a54895fa (v5.11-rc1)
+		return trace_rq_start((void *)ctx[1], true);
+	} else {
+		// Couldn't detect block/block_rq_issue tracepoint
+		bpf_core_unreachable();
+		return 0;
+	}
+}
+
+SEC("raw_tp/block_rq_complete")
+int BPF_PROG(ig_profio_done, struct request *rq, int error,
+	     unsigned int nr_bytes)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	u64 slot, *tsp, ts = bpf_ktime_get_ns();
+	struct hist_key hkey = {};
+	struct hist_value *histp;
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&start, &rq);
+	if (!tsp)
+		return 0;
+	delta = (s64)(ts - *tsp);
+	if (delta < 0)
+		goto cleanup;
+
+	if (targ_per_disk) {
+		struct gendisk *disk = get_disk(rq);
+
+		hkey.dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
+					BPF_CORE_READ(disk, first_minor)) :
+				  0;
+	}
+	if (targ_per_flag)
+		hkey.cmd_flags = BPF_CORE_READ(rq, cmd_flags);
+
+	histp = bpf_map_lookup_elem(&hists, &hkey);
+	if (!histp) {
+		bpf_map_update_elem(&hists, &hkey, &initial_hist, 0);
+		histp = bpf_map_lookup_elem(&hists, &hkey);
+		if (!histp)
+			goto cleanup;
+	}
+
+	if (targ_ms)
+		delta /= 1000000U;
+	else
+		delta /= 1000U;
+	slot = log2l(delta);
+	if (slot >= PROFILER_MAX_SLOTS)
+		slot = PROFILER_MAX_SLOTS - 1;
+	__sync_fetch_and_add(&histp->latency[slot], 1);
+
+cleanup:
+	bpf_map_delete_elem(&start, &rq);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -59,4 +59,12 @@ typedef __u64 gadget_syscall;
 
 typedef __u32 gadget_kernel_stack;
 
+// typedefs used for metrics
+typedef __u32 gadget_counter__u32;
+typedef __u64 gadget_counter__u64;
+typedef __u32 gadget_gauge__u32;
+typedef __u64 gadget_gauge__u64;
+typedef __u32 gadget_histogram_slot__u32;
+typedef __u64 gadget_histogram_slot__u64;
+
 #endif /* __TYPES_H */

--- a/pkg/datasource/accessors.go
+++ b/pkg/datasource/accessors.go
@@ -101,6 +101,15 @@ type FieldAccessor interface {
 	// Flags returns the flags of the field
 	Flags() uint32
 
+	// Tags returns all tags of the field
+	Tags() []string
+
+	// HasAllTagsOf checks whether the field has all given tags
+	HasAllTagsOf(tags ...string) bool
+
+	// HasAnyTagsOf checks whether the field has any of the given tags; if tags is empty, it returns false
+	HasAnyTagsOf(tags ...string) bool
+
 	// Annotations returns stored annotations of the field
 	Annotations() map[string]string
 
@@ -377,6 +386,28 @@ func (a *fieldAccessor) IsRequested() bool {
 
 func (a *fieldAccessor) Flags() uint32 {
 	return a.f.Flags
+}
+
+func (a *fieldAccessor) Tags() []string {
+	return slices.Clone(a.f.Tags)
+}
+
+func (a *fieldAccessor) HasAllTagsOf(tags ...string) bool {
+	for _, tag := range tags {
+		if !slices.Contains(a.f.Tags, tag) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *fieldAccessor) HasAnyTagsOf(tags ...string) bool {
+	for _, tag := range tags {
+		if slices.Contains(a.f.Tags, tag) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *fieldAccessor) Annotations() map[string]string {

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -189,6 +189,19 @@ func (c *GadgetContext) DataOperators() []operators.DataOperator {
 	return slices.Clone(c.dataOperators)
 }
 
+func (c *GadgetContext) IsRemoteCall() bool {
+	val := c.ctx.Value(remoteKey)
+	if val == nil {
+		return false
+	}
+	bVal, ok := val.(bool)
+	if !ok {
+		c.logger.Errorf("invalid type of variable %s on context, expected bool, got %T", remoteKey, val)
+		return false
+	}
+	return bVal
+}
+
 func (c *GadgetContext) RegisterDataSource(t datasource.Type, name string) (datasource.DataSource, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/gadget-context/options.go
+++ b/pkg/gadget-context/options.go
@@ -15,6 +15,7 @@
 package gadgetcontext
 
 import (
+	"context"
 	"slices"
 	"time"
 
@@ -22,6 +23,12 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+)
+
+type contextKey string
+
+const (
+	remoteKey contextKey = "gadgetRemote"
 )
 
 type Option func(gadgetCtx *GadgetContext)
@@ -47,5 +54,11 @@ func WithTimeout(timeout time.Duration) Option {
 func WithOrasReadonlyTarget(ociStore oras.ReadOnlyTarget) Option {
 	return func(c *GadgetContext) {
 		c.orasTarget = ociStore
+	}
+}
+
+func WithAsRemoteCall(val bool) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.ctx = context.WithValue(gadgetCtx.ctx, remoteKey, val)
 	}
 }

--- a/pkg/gadget-service/api/consts.go
+++ b/pkg/gadget-service/api/consts.go
@@ -34,6 +34,18 @@ const (
 )
 
 const (
+	KindFlagArray Kind = 0x10000000
+)
+
+func ArrayOf(kind Kind) Kind {
+	return kind | KindFlagArray
+}
+
+func IsArrayKind(kind Kind) bool {
+	return kind&KindFlagArray != 0
+}
+
+const (
 	GadgetServicePort = 8080
 	DefaultDaemonPath = "unix:///var/run/ig/ig.socket"
 )

--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -69,7 +69,12 @@ func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoReque
 		ops = append(ops, op)
 	}
 
-	gadgetCtx := gadgetcontext.New(ctx, req.ImageName, gadgetcontext.WithDataOperators(ops...))
+	gadgetCtx := gadgetcontext.New(
+		ctx,
+		req.ImageName,
+		gadgetcontext.WithDataOperators(ops...),
+		gadgetcontext.WithAsRemoteCall(true),
+	)
 
 	gi, err := s.runtime.GetGadgetInfo(gadgetCtx, s.runtime.ParamDescs().ToParams(), req.ParamValues)
 	if err != nil {
@@ -233,6 +238,7 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 		gadgetcontext.WithLogger(logger),
 		gadgetcontext.WithDataOperators(ops...),
 		gadgetcontext.WithTimeout(time.Duration(ociRequest.Timeout)),
+		gadgetcontext.WithAsRemoteCall(true),
 	)
 
 	runtimeParams := s.runtime.ParamDescs().ToParams()

--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -123,8 +123,13 @@ func getFieldKind(typ reflect.Type, tags []string) api.Kind {
 		if typ.Elem().Kind() == reflect.Int8 && slices.Contains(tags, "type:char") {
 			return api.Kind_CString
 		}
+		kind := getFieldKind(typ.Elem(), tags)
+		if api.IsArrayKind(kind) {
+			// we don't support arrays of arrays for now
+			return api.Kind_Invalid
+		}
+		return api.ArrayOf(kind)
 	}
-
 	return api.Kind_Invalid
 }
 

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -48,6 +48,7 @@ type GadgetContext interface {
 	SetParams([]*api.Param)
 	SetMetadata([]byte)
 	OrasTarget() oras.ReadOnlyTarget
+	IsRemoteCall() bool
 }
 
 type (

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package otelmetrics implements an operator that can export data sources to OpenTelemetry metrics.
 package otelmetrics
 
 import (
@@ -20,17 +21,22 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/prometheus"
+	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"golang.org/x/exp/constraints"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
@@ -38,27 +44,34 @@ import (
 const (
 	name = "otel-metrics"
 
-	Priority                      = 50000
-	ParamOtelMetricsEnabled       = "otel-metrics-enabled"
+	Priority                      = 9995 // slightly before CLI so we can reroute output there
+	ParamOtelMetricsListen        = "otel-metrics-listen"
 	ParamOtelMetricsListenAddress = "otel-metrics-listen-address"
 	ParamOtelMetricsName          = "otel-metrics-name"
+	ParamOtelMetricsPrintInterval = "otel-metrics-print-interval"
 
 	MetricTypeKey       = "key"
 	MetricTypeCounter   = "counter"
 	MetricTypeGauge     = "gauge"
 	MetricTypeHistogram = "histogram"
 
-	AnnotationMetricsExport      = "metrics.export"
+	AnnotationMetricsCollect     = "metrics.collect"
+	AnnotationMetricsPrint       = "metrics.print"
 	AnnotationMetricsType        = "metrics.type"
 	AnnotationMetricsDescription = "metrics.description"
 	AnnotationMetricsUnit        = "metrics.unit"
 	AnnotationMetricsBoundaries  = "metrics.boundaries"
+
+	PrintDataSourceName = "renderedmetrics"
+	PrintFieldName      = "text"
+
+	MinPrintInterval = time.Millisecond * 25
 )
 
 type otelMetricsOperator struct {
-	exporter      *prometheus.Exporter
+	// exporter is the global exporter instance
+	exporter      *otelprometheus.Exporter
 	meterProvider metric.MeterProvider
-	initialized   bool
 
 	// if skipListen is set to true, it will not expose the metrics using http
 	// this is used mainly for unit tests (you can still use the meterProvider & exporter)
@@ -70,21 +83,19 @@ func (m *otelMetricsOperator) Name() string {
 }
 
 func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
-	if m.initialized {
+	if !globalParams.Get(ParamOtelMetricsListen).AsBool() {
 		return nil
 	}
 
-	if !globalParams.Get(ParamOtelMetricsEnabled).AsBool() {
-		return nil
-	}
-
-	exporter, err := prometheus.New()
+	// create a global prometheus collector/exporter; this will be exposed using an HTTP endpoint, if activated
+	exporter, err := otelprometheus.New()
 	if err != nil {
 		return fmt.Errorf("initializing otel metrics exporter: %w", err)
 	}
 	m.exporter = exporter
 	m.meterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
 
+	// Start HTTP listener for the global exporter
 	if !m.skipListen {
 		go func() {
 			mux := http.NewServeMux()
@@ -96,22 +107,22 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 			}
 		}()
 	}
-
-	m.initialized = true
 	return nil
 }
 
 func (m *otelMetricsOperator) GlobalParams() api.Params {
 	return api.Params{
 		{
-			Key:          ParamOtelMetricsEnabled,
+			Key:          ParamOtelMetricsListen,
 			DefaultValue: "false",
 			TypeHint:     api.TypeBool,
+			Description:  "enable OpenTelemetry metrics listener (Prometheus compatible) endpoint",
 		},
 		{
 			Key:          ParamOtelMetricsListenAddress,
 			DefaultValue: "0.0.0.0:2224",
 			TypeHint:     api.TypeString,
+			Description:  "address and port to create the OpenTelemetry metrics listener (Prometheus compatible) on",
 		},
 	}
 }
@@ -123,34 +134,37 @@ func (m *otelMetricsOperator) InstanceParams() api.Params {
 			TypeHint:    api.TypeString,
 			Description: "override name of the exported datasource; use a comma-separated list with datasource:newname to specify more than one name",
 		},
+		{
+			Key:          ParamOtelMetricsPrintInterval,
+			TypeHint:     api.TypeDuration,
+			Description:  "interval to use when printing metrics; minimum is 25ms",
+			DefaultValue: "1000ms",
+		},
 	}
 }
 
 func (m *otelMetricsOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
-	if !m.initialized {
-		return nil, nil
-	}
-
 	// extract name mappings; key will be old name (or empty), value the new name
-	mappings := make(map[string]string)
-	for _, m := range strings.Split(instanceParamValues[ParamOtelMetricsName], ",") {
-		names := strings.SplitN(m, ":", 2)
-		from := ""
-		to := names[0]
-		if len(names) == 2 {
-			from = to
-			to = names[1]
-		}
-		mappings[from] = to
+	mappings := apihelpers.GetStringValuesPerDataSource(instanceParamValues[ParamOtelMetricsName])
+
+	params := apihelpers.ToParamDescs(m.InstanceParams()).ToParams()
+	err := params.CopyFromMap(instanceParamValues, "")
+	if err != nil {
+		return nil, err
+	}
+	printInterval := params.Get(ParamOtelMetricsPrintInterval).AsDuration()
+	if printInterval < MinPrintInterval {
+		return nil, fmt.Errorf("parsing print interval: expected at least %s, got %s", MinPrintInterval, printInterval)
 	}
 
 	instance := &otelMetricsOperatorInstance{
-		op:           m,
-		collectors:   make(map[datasource.DataSource]*metricsCollector),
-		nameMappings: mappings,
+		op:            m,
+		collectors:    make(map[datasource.DataSource]*metricsCollector),
+		nameMappings:  mappings,
+		printInterval: printInterval,
 	}
 
-	err := instance.init(gadgetCtx)
+	err = instance.init(gadgetCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -162,9 +176,12 @@ func (m *otelMetricsOperator) Priority() int {
 }
 
 type otelMetricsOperatorInstance struct {
-	op           *otelMetricsOperator
-	collectors   map[datasource.DataSource]*metricsCollector
-	nameMappings map[string]string
+	op            *otelMetricsOperator
+	collectors    map[datasource.DataSource]*metricsCollector
+	nameMappings  map[string]string
+	outputDS      datasource.DataSource
+	outputField   datasource.FieldAccessor
+	printInterval time.Duration
 }
 
 func (m *otelMetricsOperatorInstance) Name() string {
@@ -172,9 +189,14 @@ func (m *otelMetricsOperatorInstance) Name() string {
 }
 
 type metricsCollector struct {
-	meter  metric.Meter
-	keys   []func(datasource.Data) attribute.KeyValue
-	values []func(context.Context, datasource.Data, attribute.Set)
+	meter             metric.Meter
+	keys              []func(datasource.Data) attribute.KeyValue
+	values            []func(context.Context, datasource.Data, attribute.Set)
+	mappedName        string
+	output            bool
+	exporter          *otelprometheus.Exporter
+	meterProvider     *sdkmetric.MeterProvider
+	useGlobalProvider bool
 }
 
 func asInt64Func[T constraints.Integer](extract func(datasource.Data) (T, error)) func(datasource.Data) int64 {
@@ -231,7 +253,7 @@ func (mc *metricsCollector) addKeyFunc(f datasource.FieldAccessor) error {
 	name := f.Name()
 	switch f.Type() {
 	default:
-		return fmt.Errorf("unsupported field type for metrics collector: %s", f.Type())
+		return fmt.Errorf("unsupported field type for metrics key: %s", f.Type())
 	case api.Kind_String, api.Kind_CString:
 		mc.keys = append(mc.keys, func(data datasource.Data) attribute.KeyValue {
 			val, _ := f.String(data)
@@ -355,7 +377,7 @@ func listToVals[T int64 | float64](list string, conv func(string) (T, error)) ([
 	return res, nil
 }
 
-func (mc *metricsCollector) addValHistFunc(f datasource.FieldAccessor) error {
+func (mc *metricsCollector) addValHistFunc(ds datasource.DataSource, f datasource.FieldAccessor) error {
 	options := make([]metric.HistogramOption, 0)
 	if buckets := f.Annotations()[AnnotationMetricsBoundaries]; buckets != "" {
 		boundaries, err := listToVals[float64](buckets, toFloat64)
@@ -374,6 +396,56 @@ func (mc *metricsCollector) addValHistFunc(f datasource.FieldAccessor) error {
 	switch f.Type() {
 	default:
 		return fmt.Errorf("unsupported field type for metrics value %q: %s", f.Name(), f.Type())
+	case api.ArrayOf(api.Kind_Uint32), api.ArrayOf(api.Kind_Uint64):
+		// Calc buckets
+		typeLen := 4
+		var extractor func(b []byte) uint64
+		switch f.Type() {
+		case api.ArrayOf(api.Kind_Uint64):
+			typeLen = 8
+			extractor = ds.ByteOrder().Uint64
+		case api.ArrayOf(api.Kind_Uint32):
+			typeLen = 4
+			extractor = func(b []byte) uint64 { return uint64(ds.ByteOrder().Uint32(b)) }
+		default:
+			return fmt.Errorf("expected array of uint32 or uint64, got %v", f.Type())
+		}
+		alen := int(f.Size()) / typeLen
+
+		bucketVals := make([]int64, alen)
+		bucketValsFloat := make([]float64, alen)
+		for i := range bucketVals {
+			bucketVals[i] = int64(1 << i)
+			bucketValsFloat[i] = float64(bucketVals[i])
+		}
+
+		options = append(options, metric.WithExplicitBucketBoundaries(bucketValsFloat...))
+		hOptions := make([]metric.Int64HistogramOption, len(options))
+		for i, option := range options {
+			hOptions[i] = option
+		}
+
+		hist, err := mc.meter.Int64Histogram(f.Name(), hOptions...)
+		if err != nil {
+			return fmt.Errorf("adding metric histogram for %q: %w", f.Name(), err)
+		}
+		mc.values = append(mc.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+			b := f.Get(data)
+			if len(b)%typeLen != 0 {
+				return
+			}
+			for i := 0; i < alen; i++ {
+				val := extractor(b[i*typeLen:])
+				// This looks counterintuitive - and it is. For every entry in our sources bucket, we have to emit
+				// a `hist.Record()` with a value from the given bucket, to replicate the entry count in that bucket.
+				// We sadly have no direct access to the underlying bucket to optimize this, but we should look into
+				// alternative (more optimized) solutions.
+				for range val {
+					hist.Record(ctx, bucketVals[i], metric.WithAttributeSet(set))
+				}
+			}
+		})
+		return nil
 	case api.Kind_Uint8,
 		api.Kind_Uint16,
 		api.Kind_Uint32,
@@ -423,28 +495,109 @@ func (mc *metricsCollector) Collect(ctx context.Context, data datasource.Data) {
 	}
 }
 
+func (m *otelMetricsOperatorInstance) shutdown() {
+	ctx := context.Background()
+	for _, collector := range m.collectors {
+		if collector.meterProvider != nil {
+			collector.meterProvider.Shutdown(ctx)
+			collector.meterProvider = nil
+		}
+		if collector.exporter != nil {
+			collector.exporter.Shutdown(ctx)
+			collector.exporter = nil
+		}
+	}
+}
+
 func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
+	needsOutputDS := false
 	for _, ds := range gadgetCtx.GetDataSources() {
 		annotations := ds.Annotations()
-		if annotations[AnnotationMetricsExport] != "true" {
+		if annotations[AnnotationMetricsCollect] != "true" && annotations[AnnotationMetricsPrint] != "true" {
+			continue
+		}
+
+		// we only use the global instance if there's an explicit name mapping available; otherwise we'll fallback
+		// to using a dedicated local registry/collector instance
+		useGlobal := false
+
+		output := false
+		// We only allow printing if the gadget is _not_ running remotely
+		if !gadgetCtx.IsRemoteCall() {
+			output = annotations[AnnotationMetricsPrint] == "true"
+			if output {
+				gadgetCtx.Logger().Debugf("enabling print for %s", ds.Name())
+				needsOutputDS = true
+			}
+		}
+
+		if !output && annotations[AnnotationMetricsCollect] != "true" {
+			// Not collecting AND not printing, so we don't need to collect
 			continue
 		}
 
 		metricsName := ds.Name()
+
+		// if there's an explicit mapping set for the datasource, we will export it using the global exporter
+		// (if that is available)
 		mappedName, ok := m.nameMappings[metricsName]
-		if !ok {
-			// try empty (unspecified)
-			mappedName = m.nameMappings[""]
+		if ok && m.op.exporter != nil {
+			useGlobal = true
+		} else if ok {
+			gadgetCtx.Logger().Warnf("global exporter not configured, using local metric instance")
 		}
 
+		// If mapped name is empty, it hasn't been explicitly set (or set to empty), so we will use the data source name
 		if mappedName == "" {
-			gadgetCtx.Logger().Warnf("no name found for metric %q, skipping export", metricsName)
-			continue
+			mappedName = ds.Name()
 		}
 
-		meter := m.op.meterProvider.Meter(mappedName)
+		gadgetCtx.Logger().Debugf("collecting metrics for data source %q as %q", ds.Name(), mappedName)
 
-		collector := &metricsCollector{meter: meter}
+		m.collectors[ds] = &metricsCollector{
+			output:            output,
+			mappedName:        mappedName,
+			useGlobalProvider: useGlobal,
+		}
+	}
+
+	if needsOutputDS {
+		gadgetCtx.Logger().Debugf("creating output data source for metrics")
+		ods, err := gadgetCtx.RegisterDataSource(datasource.TypeSingle, PrintDataSourceName)
+		if err != nil {
+			return fmt.Errorf("registering %q: %w", PrintDataSourceName, err)
+		}
+		if ods.Annotations()["cli.output"] == "" {
+			ods.AddAnnotation("cli.output", "raw")
+		}
+		f, err := ods.AddField("text", api.Kind_String, datasource.WithAnnotations(map[string]string{"content-type": "text/plain"}))
+		if err != nil {
+			return fmt.Errorf("adding field %q: %w", PrintFieldName, err)
+		}
+		m.outputDS = ods
+		m.outputField = f
+	}
+	return nil
+}
+
+func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, collector := range m.collectors {
+		if collector.useGlobalProvider {
+			gadgetCtx.Logger().Debugf("using global metric provider for collector %q", collector.mappedName)
+			// using the global meter provider to export to Prometheus
+			collector.meter = m.op.meterProvider.Meter(collector.mappedName)
+		} else {
+			// Initialize a local instance
+			gadgetCtx.Logger().Debugf("using local metric provider for collector %q", collector.mappedName)
+			registry := prometheus.NewRegistry()
+			exporter, err := otelprometheus.New(otelprometheus.WithRegisterer(registry))
+			if err != nil {
+				return fmt.Errorf("creating prometheus registry: %w", err)
+			}
+			collector.exporter = exporter
+			collector.meterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+			collector.meter = collector.meterProvider.Meter(collector.mappedName)
+		}
 
 		hasValueFields := false
 
@@ -452,6 +605,22 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 		for _, f := range fields {
 			fieldName := f.Name()
 			metricsType := f.Annotations()[AnnotationMetricsType]
+
+			// Try to auto-apply metricsType from tags
+			if metricsType == "" {
+				// tbd: should we rather handle this mapping in the eBPF operator to keep the types there?
+				if f.HasAnyTagsOf("type:gadget_histogram_slot__u32", "type:gadget_histogram_slot__u64") {
+					metricsType = MetricTypeHistogram
+				} else if f.HasAnyTagsOf("type:gadget_counter__u32", "type:gadget_counter__u64") {
+					metricsType = MetricTypeCounter
+				} else if f.HasAnyTagsOf("type:gadget_gauge__u32", "type:gadget_gauge__u64") {
+					metricsType = MetricTypeGauge
+				} else if f.HasAnyTagsOf("role:key") {
+					// This is probably coming from the key of an eBPF map
+					metricsType = MetricTypeKey
+				}
+			}
+
 			switch metricsType {
 			default:
 				continue
@@ -467,7 +636,7 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 				}
 				hasValueFields = true
 			case MetricTypeHistogram:
-				err := collector.addValHistFunc(f)
+				err := collector.addValHistFunc(ds, f)
 				if err != nil {
 					return fmt.Errorf("adding histogram for %q: %w", fieldName, err)
 				}
@@ -476,15 +645,10 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 			gadgetCtx.Logger().Debugf("registered field %q as type %q", fieldName, metricsType)
 		}
 		if !hasValueFields {
+			gadgetCtx.Logger().Debugf("no value fields found for metrics %q", collector.mappedName)
 			continue
 		}
-		m.collectors[ds] = collector
-	}
-	return nil
-}
 
-func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
-	for ds, collector := range m.collectors {
 		err := ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
 			collector.Collect(gadgetCtx.Context(), data)
 			return nil
@@ -493,7 +657,91 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 			return err
 		}
 	}
+
+	// If we registered an output datasource, use it
+	if m.outputDS != nil && m.printInterval > 0 {
+		// Start printer
+		go m.PrintMetrics(gadgetCtx)
+	}
 	return nil
+}
+
+func (m *otelMetricsOperatorInstance) PrintMetrics(gadgetCtx operators.GadgetContext) {
+	// Periodically print using the fetch interval
+	ticker := time.NewTicker(m.printInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-gadgetCtx.Context().Done():
+			return
+		case <-ticker.C:
+			// collect metrics
+			md := make(map[*otelprometheus.Exporter]*metricdata.ResourceMetrics)
+
+			var out strings.Builder
+			for _, collector := range m.collectors {
+				exporter := m.op.exporter
+				if collector.exporter != nil {
+					exporter = collector.exporter
+				}
+				if exporter == nil {
+					continue
+				}
+
+				rm, ok := md[exporter]
+				if !ok {
+					// Not yet collected, so collect
+					rm = &metricdata.ResourceMetrics{}
+					err := exporter.Collect(gadgetCtx.Context(), rm)
+					if err != nil {
+						gadgetCtx.Logger().Errorf("collecting metrics: %v", err)
+						return
+					}
+					md[exporter] = rm
+				}
+
+				// Find metric in ResourceMetrics
+				for _, sm := range rm.ScopeMetrics {
+					if sm.Scope.Name != collector.mappedName {
+						continue
+					}
+
+					for _, metric := range sm.Metrics {
+						fmt.Fprintln(&out, metric.Name)
+						switch t := metric.Data.(type) {
+						case metricdata.Histogram[int64]:
+							for _, dp := range t.DataPoints {
+								last := uint64(0)
+								v := make([]histogram.Interval, 0, len(dp.Bounds))
+								for bucket, high := range dp.Bounds {
+									v = append(v, histogram.Interval{
+										Count: dp.BucketCounts[bucket],
+										Start: last,
+										End:   uint64(high),
+									})
+									last = uint64(high)
+								}
+								h := histogram.Histogram{
+									Unit:      histogram.Unit(metric.Unit),
+									Intervals: v,
+								}
+								fmt.Fprintln(&out, h.String())
+							}
+						}
+					}
+					break
+				}
+			}
+
+			ps, err := m.outputDS.NewPacketSingle()
+			if err != nil {
+				gadgetCtx.Logger().Errorf("error creating packet: %v", err)
+				return
+			}
+			m.outputField.PutString(ps, out.String())
+			m.outputDS.EmitAndRelease(ps)
+		}
+	}
 }
 
 func (m *otelMetricsOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
@@ -501,7 +749,13 @@ func (m *otelMetricsOperatorInstance) Start(gadgetCtx operators.GadgetContext) e
 }
 
 func (m *otelMetricsOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	m.shutdown()
+	gadgetCtx.Logger().Debug("shutting down metrics")
 	return nil
 }
 
 var Operator = &otelMetricsOperator{}
+
+func init() {
+	operators.RegisterDataOperator(Operator)
+}

--- a/pkg/operators/otel-metrics/otel-metrics_test.go
+++ b/pkg/operators/otel-metrics/otel-metrics_test.go
@@ -34,11 +34,9 @@ import (
 func TestMetricsCounterAndGauge(t *testing.T) {
 	o := &otelMetricsOperator{skipListen: true}
 	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
-	globalParams.Set(ParamOtelMetricsEnabled, "true")
+	globalParams.Set(ParamOtelMetricsListen, "true")
 	err := o.Init(globalParams)
 	require.NoError(t, err)
-
-	require.True(t, o.initialized)
 
 	var ds datasource.DataSource
 	var ctr datasource.FieldAccessor
@@ -51,7 +49,7 @@ func TestMetricsCounterAndGauge(t *testing.T) {
 		var err error
 		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "metrics")
 		require.NoError(t, err)
-		ds.AddAnnotation(AnnotationMetricsExport, "true")
+		ds.AddAnnotation(AnnotationMetricsCollect, "true")
 
 		ctr, err = ds.AddField("ctr", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
 			AnnotationMetricsType: MetricTypeCounter,
@@ -125,11 +123,9 @@ func TestMetricsCounterAndGauge(t *testing.T) {
 func TestMetricsHistogram(t *testing.T) {
 	o := &otelMetricsOperator{skipListen: true}
 	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
-	globalParams.Set(ParamOtelMetricsEnabled, "true")
+	globalParams.Set(ParamOtelMetricsListen, "true")
 	err := o.Init(globalParams)
 	require.NoError(t, err)
-
-	require.True(t, o.initialized)
 
 	var ds datasource.DataSource
 	var value datasource.FieldAccessor
@@ -143,7 +139,7 @@ func TestMetricsHistogram(t *testing.T) {
 		var err error
 		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "metrics")
 		require.NoError(t, err)
-		ds.AddAnnotation(AnnotationMetricsExport, "true")
+		ds.AddAnnotation(AnnotationMetricsCollect, "true")
 		value, err = ds.AddField("duration", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
 			AnnotationMetricsType: MetricTypeHistogram,
 		}))

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -61,6 +61,7 @@ type GadgetContext interface {
 	SetParams([]*api.Param)
 	DataOperators() []operators.DataOperator
 	OrasTarget() oras.ReadOnlyTarget
+	IsRemoteCall() bool
 
 	Run(paramValues api.ParamValues) error
 	PrepareGadgetInfo(paramValues api.ParamValues) error


### PR DESCRIPTION
This implements support for profiler gadgets as image-based gadgets. It is based on top of the map iterators introduced in #3182.

Additionally, the otel-metrics operator has been updated to support histograms from int/float arrays (which also have been added to the datasources package in this PR).

As an example, the `profile_blockio` gadget has been translated (thanks to @eiffel-fl for covering almost all of it). Please take a look at the attached `gadget.yaml` file to see annotations that help achieving the original behavior of that gadget. In this specific case, the gadget will not export metrics to a Prometheus endpoint, but rather - only on the client side - render the metrics to a human-readable format, which is then picked up by the CLI operator to actually be printed. For that to work, a new output-mode called `raw` has been added to the CLI operator. Please note that the implementation of the renderer is incomplete - for now it only supports histograms. Also, the rendering itself will most likely change in the future. One big change to the legacy gadget is that until now you would start the gadget, press Ctrl+C and then get the histogram - the new image-based gadget updates the histogram every second by default until you cancel it. Thus you can watch the results over time.

There are many ways in which one can use the metrics collection, and this implementation tries to cover most of those cases:

* if you're collecting metrics using Prometheus, data is usually exported and collected from the collecting node (otel listener on the server)
* if you're doing ad-hoc debugging in a client/server environment, data has to be accumulated by the client (servers send their data to the client, the client accumulates the data and _only then_ renders it to a human-readable format)
* if you're doing ad-hoc debugging using ig directly, all of that has to happen on the same machine
* a third party application might still want all of that data in JSON

In order to react differently in client/server scenarios, the gadget context now has a `IsRemoteCall()` member, which returns true, if we're on the server and the call has been initiated through gRPC.

### Todo

* [x] Clean-up
* [x] more documentation

### Follow-up

* [ ] profile_tcprtt gadget