### PR TITLE
tree-wide: Mark image-based gadgets as non experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ Available Commands:
   advise      Recommend system configurations based on collected information
   audit       Audit a subsystem
   completion  Generate the autocompletion script for the specified shell
-  config      Configuration commands (experimental)
+  config      Configuration commands
   deploy      Deploy Inspektor Gadget on the cluster
   help        Help about any command
   profile     Profile different subsystems
   prometheus  Expose metrics using prometheus
-  run         Run a gadget (experimental)
+  run         Run a gadget
   snapshot    Take a snapshot of a subsystem and print it
   sync        Synchronize gadget information with server
   top         Gather, sort and periodically report events according to a given criteria

--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
@@ -205,9 +204,9 @@ func NewConfigCmd(runtime runtime.Runtime, rootFlags *pflag.FlagSet) *cobra.Comm
 		return nil
 	}
 
-	cmd.AddCommand(utils.MarkExperimental(defaultCmd))
-	cmd.AddCommand(utils.MarkExperimental(viewCmd))
+	cmd.AddCommand(defaultCmd)
+	cmd.AddCommand(viewCmd)
 	AddConfigFlag(cmd)
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -39,7 +39,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -112,7 +111,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.btfgen, "btfgen", false, "Enable btfgen")
 	cmd.Flags().StringVar(&opts.btfhubarchive, "btfhub-archive", "", "Path to the location of the btfhub-archive files")
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }
 
 func runBuild(cmd *cobra.Command, opts *cmdOpts) error {

--- a/cmd/common/image/export.go
+++ b/cmd/common/image/export.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -43,5 +42,5 @@ func NewExportCmd() *cobra.Command {
 		},
 	}
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/image.go
+++ b/cmd/common/image/image.go
@@ -16,8 +16,6 @@ package image
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 )
 
 func NewImageCmd() *cobra.Command {
@@ -35,5 +33,5 @@ func NewImageCmd() *cobra.Command {
 	cmd.AddCommand(NewListCmd())
 	cmd.AddCommand(NewRemoveCmd())
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/import.go
+++ b/cmd/common/image/import.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -44,5 +43,5 @@ func NewImportCmd() *cobra.Command {
 		},
 	}
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -95,5 +95,5 @@ func NewListCmd() *cobra.Command {
 		fmt.Sprintf("Output mode, possible values are, %s", strings.Join(outputModes, ", ")),
 	)
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/pull.go
+++ b/cmd/common/image/pull.go
@@ -44,5 +44,5 @@ func NewPullCmd() *cobra.Command {
 		},
 	}
 	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/push.go
+++ b/cmd/common/image/push.go
@@ -44,5 +44,5 @@ func NewPushCmd() *cobra.Command {
 		},
 	}
 	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/remove.go
+++ b/cmd/common/image/remove.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -44,5 +43,5 @@ func NewRemoveCmd() *cobra.Command {
 		},
 	}
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/image/tag.go
+++ b/cmd/common/image/tag.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -43,5 +42,5 @@ func NewTagCmd() *cobra.Command {
 		},
 	}
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/login.go
+++ b/cmd/common/login.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -46,5 +45,5 @@ func NewLoginCmd() *cobra.Command {
 	loginFlagSet := auth.GetLoginFlags(&o.loginOpts)
 	loginFlagSet.Lookup("authfile").Value.Set(oci.DefaultAuthFile)
 	cmd.Flags().AddFlagSet(loginFlagSet)
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/logout.go
+++ b/cmd/common/logout.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 
-	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 )
 
@@ -44,5 +43,5 @@ func NewLogoutCmd() *cobra.Command {
 	logoutFlagSet := auth.GetLogoutFlags(&o.logoutOpts)
 	logoutFlagSet.Lookup("authfile").Value.Set(oci.DefaultAuthFile)
 	cmd.Flags().AddFlagSet(logoutFlagSet)
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -234,5 +234,5 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		AddFlags(cmd, operatorParams, nil, runtime)
 	}
 
-	return utils.MarkExperimental(cmd)
+	return cmd
 }

--- a/cmd/common/registry.go
+++ b/cmd/common/registry.go
@@ -672,12 +672,6 @@ func buildCommandFromGadget(
 		AddFlags(cmd, operatorParams, skipParams, runtime)
 	}
 
-	if exp, ok := gadgetDesc.(gadgets.GadgetExperimental); ok {
-		if exp.Experimental() {
-			utils.MarkExperimental(cmd)
-		}
-	}
-
 	return cmd
 }
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -53,7 +53,7 @@ readmes: $(GADGETS_README)
 .PHONY: $(GADGETS)
 $(GADGETS):
 	@echo "Building $@"
-	@sudo -E IG_EXPERIMENTAL=true \
+	@sudo -E \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -76,27 +76,26 @@ $(GADGETS_README):
 push: build
 	@echo "Pushing all gadgets"
 	for GADGET in $(GADGETS); do \
-		sudo -E IG_EXPERIMENTAL=true $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
+		sudo -E $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
 	done
 
 sign: push
 	@echo "Signing all gadgets"
 	for GADGET in $(GADGETS); do \
-		digest=$$(sudo -E IG_EXPERIMENTAL=true $(IG) image list --no-trunc | grep "$$GADGET " | awk '{ print $$3 }') ; \
+		digest=$$(sudo -E $(IG) image list --no-trunc | grep "$$GADGET " | awk '{ print $$3 }') ; \
 		cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$$GADGET@$$digest || exit 1 ; \
 	done
 
 .PHONY:
 clean:
 	for GADGET in $(GADGETS); do \
-		sudo -E IG_EXPERIMENTAL=true $(IG) image remove $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
 	done
 
 .PHONY:
 test: build
 	IG_PATH=$(IG_PATH) \
 	CGO_ENABLED=0 \
-	IG_EXPERIMENTAL=true \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \

--- a/gadgets/audit_seccomp/artifacthub-pkg.yml
+++ b/gadgets/audit_seccomp/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/audit_seccomp:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/audit_seccomp:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/snapshot_process/artifacthub-pkg.yml
+++ b/gadgets/snapshot_process/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/snapshot_process:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_process:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/snapshot_socket/artifacthub-pkg.yml
+++ b/gadgets/snapshot_socket/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/top_file/artifacthub-pkg.yml
+++ b/gadgets/top_file/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/top_file:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/top_file:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/top_tcp/artifacthub-pkg.yml
+++ b/gadgets/top_tcp/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/top_tcp:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/top_tcp:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_capabilities/artifacthub-pkg.yml
+++ b/gadgets/trace_capabilities/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_dns/artifacthub-pkg.yml
+++ b/gadgets/trace_dns/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_dns:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_dns:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_exec/artifacthub-pkg.yml
+++ b/gadgets/trace_exec/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_lsm/artifacthub-pkg.yml
+++ b/gadgets/trace_lsm/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_lsm:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_lsm:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_malloc/artifacthub-pkg.yml
+++ b/gadgets/trace_malloc/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_malloc:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_malloc:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_mount/artifacthub-pkg.yml
+++ b/gadgets/trace_mount/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_mount:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_mount:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_oomkill/artifacthub-pkg.yml
+++ b/gadgets/trace_oomkill/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_open/artifacthub-pkg.yml
+++ b/gadgets/trace_open/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_open:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_signal/artifacthub-pkg.yml
+++ b/gadgets/trace_signal/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_signal:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_signal:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_sni/artifacthub-pkg.yml
+++ b/gadgets/trace_sni/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_sni:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_sni:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_ssl/artifacthub-pkg.yml
+++ b/gadgets/trace_ssl/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_ssl:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_ssl:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_tcp/artifacthub-pkg.yml
+++ b/gadgets/trace_tcp/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_tcpconnect/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpconnect/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_tcpdrop/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpdrop/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/gadgets/trace_tcpretrans/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpretrans/artifacthub-pkg.yml
@@ -23,7 +23,7 @@ links:
 install: |
     # Run
     ```bash
-    sudo IG_EXPERIMENTAL=true ig run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest
     ```
 provider:
     name: Inspektor Gadget

--- a/integration/components/image/image_test.go
+++ b/integration/components/image/image_test.go
@@ -32,9 +32,6 @@ import (
 )
 
 func TestImage(t *testing.T) {
-	// ensure that experimental is enabled
-	os.Setenv("IG_EXPERIMENTAL", "true")
-
 	// start registry
 	r := StartRegistry(t, "test-image-registry")
 	t.Cleanup(func() {
@@ -272,9 +269,6 @@ func runCmd(t *testing.T, cmd *cobra.Command, args []string) {
 }
 
 func TestExportDeterministic(t *testing.T) {
-	// ensure that experimental is enabled
-	os.Setenv("IG_EXPERIMENTAL", "true")
-
 	testImage := "test-image-export"
 	tmpFolder := t.TempDir()
 	gadgetSrcFolder := path.Join(tmpFolder, "gadget")

--- a/integration/k8s/run_insecure_test.go
+++ b/integration/k8s/run_insecure_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	. "github.com/inspektor-gadget/inspektor-gadget/integration"
@@ -61,11 +60,6 @@ func TestRunInsecure(t *testing.T) {
 	}
 	RunTestSteps(orasCpCmds, t)
 
-	err := os.Setenv("IG_EXPERIMENTAL", "true")
-	if err != nil {
-		t.Fatalf("setting IG_EXPERIMENTAL: %v\n", err)
-	}
-
 	// TODO: Ideally it should not depend on a real gadget, but we don't have a "test gadget" available yet.
 	// As the image was not signed, we need to set --verify-image=false.
 	cmd := fmt.Sprintf("ig run --verify-image=false %s/trace_open:%s -o json --insecure-registries %s --timeout 2",
@@ -77,9 +71,4 @@ func TestRunInsecure(t *testing.T) {
 		Cmd:  cmd,
 	}
 	RunTestSteps([]TestStep{traceOpenCmd}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
-
-	err = os.Setenv("IG_EXPERIMENTAL", "false")
-	if err != nil {
-		t.Fatalf("resetting IG_EXPERIMENTAL: %v\n", err)
-	}
 }

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -168,8 +168,3 @@ type GadgetInstantiate interface {
 	// should not run any code that depends on cleanup
 	NewInstance() (Gadget, error)
 }
-
-// GadgetExperimental allows to mark a gadget as experimental.
-type GadgetExperimental interface {
-	Experimental() bool
-}

--- a/pkg/operators/wasm/testdata/Makefile
+++ b/pkg/operators/wasm/testdata/Makefile
@@ -11,16 +11,10 @@ all: $(TEST_ARTIFACTS)
 .PHONY: $(TEST_ARTIFACTS)
 $(TEST_ARTIFACTS):
 	@echo "Building $@"
-	@sudo -E IG_EXPERIMENTAL=true \
-		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) \
-		ig image build \
-		-t $@:latest \
-		$@
-	@sudo -E IG_EXPERIMENTAL=true \
-		ig image export $@:latest $@.tar
+	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) ig image build -t $@:latest $@
+	@sudo ig image export $@:latest $@.tar
 	# TODO: This fails with "Error: removing gadget image: unable to reload index:"
-	#@sudo -E IG_EXPERIMENTAL=true \
-	#	ig image remove $@:latest
+	#@sudo ig image remove $@:latest
 
 .PHONY:
 clean:


### PR DESCRIPTION
This PR marks image-based gadgets a non experimental.

The support for experimental isn't removed by the PR, we can discuss later on if we want to maintain it or not.

Fixes #2997

