### PR TITLE
pkg/datasource: Use FullName to add field.

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -209,7 +209,7 @@ func NewFromAPI(in *api.DataSource) (DataSource, error) {
 	for _, f := range in.Fields {
 		ds.fields = append(ds.fields, (*field)(f))
 		if !FieldFlagUnreferenced.In(f.Flags) {
-			ds.fieldMap[f.Name] = (*field)(f)
+			ds.fieldMap[f.FullName] = (*field)(f)
 		}
 	}
 	if in.Flags&api.DataSourceFlagsBigEndian != 0 {


### PR DESCRIPTION
We mark the field as being replace with its FullName, so we need to use it here too.

```bash
$ ./kubectl-gadget run trace_bind           francis/fix-missing-endpoints-kubelct % u=
INFO[0000] Experimental features enabled                
K8S.NAMESPACE  K8S.PODNAME    K8S.CONTAINER… ADDR            COMM        PID     TID      UID      GID BOU… K8S.NO… ERROR TIMESTAMP      
default        test-pod       test-pod       :::4242         nc       167030  167030        0        0 0    miniku…       2024-08-01T14:…
^C%
```