### PR TITLE
pkg/gadgets: Fix tracepoint for top block-io.

### DIFF
--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -145,7 +145,7 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("attaching kprobe: %w", err)
 	}
 
-	t.ioStartLink, err = link.AttachTracing(link.TracingOptions{
+	t.doneLink, err = link.AttachTracing(link.TracingOptions{
 		Program:    t.objs.IgTopioDoneTp,
 		AttachType: ebpf.AttachTraceRawTp,
 	})


### PR DESCRIPTION
Fixes: df44b47b082a ("pkg/gadgets: Use tp_btf for top block-io.")
