### PR TITLE
Add top_blockio

### DIFF
--- a/docs/gadgets/top_blockio.mdx
+++ b/docs/gadgets/top_blockio.mdx
@@ -1,0 +1,1 @@
+../../gadgets/top_blockio/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -33,6 +33,7 @@ GADGETS = \
 	trace_tcpconnect \
 	trace_tcpdrop \
 	trace_tcpretrans \
+	top_blockio \
 	top_file \
 	top_tcp \
 	snapshot_process \

--- a/gadgets/top_blockio/README.md
+++ b/gadgets/top_blockio/README.md
@@ -1,0 +1,5 @@
+# top_blockio
+
+The top blockio gadget provides a periodic list of input/output block device activity. This gadget requires Linux Kernel Version 6.5+.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/top_blockio

--- a/gadgets/top_blockio/README.mdx
+++ b/gadgets/top_blockio/README.mdx
@@ -1,0 +1,94 @@
+---
+title: top_blockio
+sidebar_position: 55
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# top_blockio
+
+The top_blockio gadget provides a periodic list of input/output block device activity.
+This gadget requires Linux Kernel Version 6.5+.
+
+Note: If you have an encrpyted disk some block IO operations will not be shown, since device mappers are in between these operations to operate transparently. See https://docs.kernel.org/admin-guide/device-mapper/dm-crypt.html
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_blockio:latest
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_blockio:latest
+        ```
+    </TabItem>
+</Tabs>
+
+## Guide
+
+Run a pod / container:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl run --restart=Never --image=busybox test-top-blockio -- sh -c 'while true; do dd if=/dev/zero of=/tmp/test count=4096; sync; sleep 0.2; done'
+        pod/test-top-blockio created
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker run --name test-top-blockio -d busybox /bin/sh -c 'while true; do dd if=/dev/zero of=/tmp/test count=4096; sync; sleep 0.2; done'
+        ...
+        ```
+    </TabItem>
+</Tabs>
+
+Then, run the gadget and see how it shows the sync process:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run top_blockio:latest
+        K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME          PID MAJOR      MINOR      COMM       BYTES      US        IO        RW 
+        minikube            default             test-top-blockio    test-top-blockio          8086 8          0          sync       81920      45        1         wr…
+        minikube            default             test-top-blockio    test-top-blockio          8055 8          0          sync       606208     547       3         wr…
+        minikube            default             test-top-blockio    test-top-blockio          8082 8          0          sync       65536      95        2         wr…
+        minikube            default             test-top-blockio    test-top-blockio          8084 8          0          sync       147456     95        2         wr…
+        ...
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run top_blockio:latest -c test-top-blockio
+        RUNTIME.CONTAINERNAME                                PID MAJOR       MINOR       COMM             BYTES                US                   IO         RW     
+        test-top-blockio                                   11723 8           0           sync             212992               747                  3          write  
+        test-top-blockio                                   11727 8           0           sync             65536                75                   1          write  
+        ...
+        ```
+    </TabItem>
+</Tabs>
+
+Finally, clean the system:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl delete pod test-top-blockio
+```
+</TabItem>
+
+<TabItem value="ig" label="ig">
+```bash
+$ docker rm -f test-top-blockio
+```
+</TabItem>
+</Tabs>

--- a/gadgets/top_blockio/artifacthub-pkg.yml
+++ b/gadgets/top_blockio/artifacthub-pkg.yml
@@ -1,0 +1,29 @@
+# Artifact Hub package metadata file
+version: v0.32.0
+name: "top blockio"
+category: monitoring-logging
+displayName: "top blockio"
+createdAt: "2024-08-01T09:22:04Z"
+digest: "2024-08-01T13:58:59Z"
+description: "Periodically report input/output block device activity. This gadget requires Linux Kernel Version 6.5+"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/top_blockio"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/top_blockio:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_blockio"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/top_blockio:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/top_blockio/gadget.yaml
+++ b/gadgets/top_blockio/gadget.yaml
@@ -1,0 +1,49 @@
+name: top blockio
+description: Periodically report input/output block device activity.
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/top_blockio
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_blockio
+datasources:
+  blockio:
+    annotations:
+      cli.clear-screen-before: "true"
+    fields:
+      bytes:
+        annotations:
+          description: Amount of bytes read or written
+      io:
+        annotations:
+          description: Amount of io operations
+      major:
+        annotations:
+          description: Major device number
+      minor:
+        annotations:
+          description: Minor device number
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      comm:
+        annotations:
+          description: Command name
+          template: comm
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+          columns.hidden: true
+      rw_raw:
+        annotations:
+          columns.hidden: true
+      rw:
+        annotations:
+          description: Indicates if the operation was a read or a write
+          columns.width: 5
+      us:
+        annotations:
+          description: Time spent in microseconds

--- a/gadgets/top_blockio/program.bpf.c
+++ b/gadgets/top_blockio/program.bpf.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022 Francis Laniel <flaniel@linux.microsoft.com>
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/maps.bpf.h>
+#include <gadget/macros.h>
+#include <gadget/types.h>
+#include <gadget/core_fixes.bpf.h>
+#include <gadget/mntns_filter.h>
+
+#define REQ_OP_BITS 8
+#define REQ_OP_MASK ((1 << REQ_OP_BITS) - 1)
+
+#define TASK_COMM_LEN 16
+
+enum rw_type : u8 {
+	read,
+	write,
+};
+
+// for saving the timestamp and __data_len of each request
+struct start_req_t {
+	__u64 ts;
+	__u64 data_len;
+};
+
+// for saving process info by request
+struct who_t {
+	gadget_mntns_id mntns_id;
+	__u32 pid;
+	__u32 tid;
+	char comm[TASK_COMM_LEN];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, struct request *);
+	__type(value, struct start_req_t);
+} start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, struct request *);
+	__type(value, struct who_t);
+} whobyreq SEC(".maps");
+
+// the key for the output summary
+struct info_t {
+	gadget_mntns_id mntns_id;
+	__u32 pid;
+	__u32 tid;
+	enum rw_type rw_raw;
+	int major;
+	int minor;
+	char comm[TASK_COMM_LEN];
+};
+
+// the value of the output summary
+struct val_t {
+	__u64 bytes;
+	__u64 us;
+	__u32 io;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, struct info_t);
+	__type(value, struct val_t);
+} counts SEC(".maps");
+
+GADGET_MAPITER(blockio, counts);
+
+static __always_inline int trace_start(struct request *req)
+{
+	__u64 mntns_id;
+	__u64 pid_tgid;
+
+	mntns_id = gadget_get_mntns_id();
+
+	if (gadget_should_discard_mntns_id(mntns_id))
+		return 0;
+
+	struct who_t who = {};
+
+	// cache PID and comm by-req
+	bpf_get_current_comm(&who.comm, sizeof(who.comm));
+	pid_tgid = bpf_get_current_pid_tgid();
+	who.pid = pid_tgid >> 32;
+	who.tid = (__u32)pid_tgid;
+
+	who.mntns_id = mntns_id;
+	bpf_map_update_elem(&whobyreq, &req, &who, 0);
+
+	return 0;
+}
+
+SEC("kprobe/blk_mq_start_request")
+int BPF_KPROBE(ig_topio_req, struct request *req)
+{
+	/* time block I/O */
+	struct start_req_t start_req;
+	u64 mntns_id;
+
+	mntns_id = gadget_get_mntns_id();
+
+	if (gadget_should_discard_mntns_id(mntns_id))
+		return 0;
+
+	start_req.ts = bpf_ktime_get_ns();
+	start_req.data_len = BPF_CORE_READ(req, __data_len);
+
+	bpf_map_update_elem(&start, &req, &start_req, 0);
+	return 0;
+}
+
+static __always_inline int trace_done(struct request *req)
+{
+	struct val_t *valp, zero = {};
+	struct info_t info = {};
+
+	struct start_req_t *startp;
+	unsigned int req_op_flags;
+	struct gendisk *disk;
+	struct who_t *whop;
+	u64 delta_us;
+
+	/* fetch timestamp and calculate delta */
+	startp = bpf_map_lookup_elem(&start, &req);
+	if (!startp)
+		return 0; /* missed tracing issue */
+
+	delta_us = (bpf_ktime_get_ns() - startp->ts) / 1000;
+
+	/* setup info_t key */
+	disk = get_disk(req);
+	info.major = BPF_CORE_READ(disk, major);
+	info.minor = BPF_CORE_READ(disk, first_minor);
+	req_op_flags = BPF_CORE_READ(req, cmd_flags) & REQ_OP_MASK;
+	if (req_op_flags == REQ_OP_WRITE)
+		info.rw_raw = write;
+	else if (req_op_flags == REQ_OP_READ)
+		info.rw_raw = read;
+	else
+		goto end;
+
+	whop = bpf_map_lookup_elem(&whobyreq, &req);
+	if (whop) {
+		info.pid = whop->pid;
+		info.tid = whop->tid;
+		info.mntns_id = whop->mntns_id;
+		__builtin_memcpy(&info.comm, whop->comm, sizeof(info.comm));
+	}
+
+	valp = bpf_map_lookup_or_try_init(&counts, &info, &zero);
+
+	if (valp) {
+		/* save stats */
+		valp->us += delta_us;
+		valp->bytes += startp->data_len;
+		valp->io++;
+	}
+
+end:
+	bpf_map_delete_elem(&start, &req);
+	bpf_map_delete_elem(&whobyreq, &req);
+
+	return 0;
+}
+
+SEC("tp_btf/block_io_start")
+int BPF_PROG(ig_topio_start, struct request *req)
+{
+	return trace_start(req);
+}
+
+SEC("tp_btf/block_io_done")
+int BPF_PROG(ig_topio_done, struct request *req)
+{
+	return trace_done(req);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/top_blockio/test/top_blockio_test.go
+++ b/gadgets/top_blockio/test/top_blockio_test.go
@@ -1,0 +1,156 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/moby/moby/pkg/parsers/kernel"
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type topBlockioEntry struct {
+	eventtypes.CommonData
+
+	MntNsID uint64 `json:"mntns_id"`
+
+	Comm string `json:"comm"`
+	Pid  uint32 `json:"pid"`
+	Tid  uint32 `json:"tid"`
+
+	Bytes uint64 `json:"bytes"`
+	Io    uint32 `json:"io"`
+	Major int    `json:"major"`
+	Minor int    `json:"minor"`
+	Rw    string `json:"rw"`
+	Us    uint64 `json:"us"`
+}
+
+func TestTopBlockio(t *testing.T) {
+	version, err := kernel.GetKernelVersion()
+	require.Nil(t, err, "Failed to get kernel version: %s", err)
+	v6_5 := kernel.VersionInfo{Kernel: 6, Major: 5, Minor: 0}
+	if kernel.CompareKernelVersion(*version, v6_5) < 0 {
+		t.Skip("Skip running top_blockio on kernel versions lower than 6.5")
+	}
+
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+	containerName := "test-top-blockio"
+	containerImage := "docker.io/library/busybox:latest"
+
+	var ns string
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(containerImage),
+	}
+
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		ns = utils.GenerateTestNamespaceName(t, "test-top-blockio")
+		containerOpts = append(containerOpts, containers.WithContainerNamespace(ns))
+	}
+
+	testContainer := containerFactory.NewContainer(
+		containerName,
+		"while true; do dd if=/dev/zero of=/tmp/test count=4096; sleep 0.2; done",
+		containerOpts...,
+	)
+
+	testContainer.Start(t)
+	t.Cleanup(func() {
+		testContainer.Stop(t)
+	})
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+	commonDataOpts := []utils.CommonDataOption{
+		utils.WithContainerImageName(containerImage),
+		utils.WithContainerID(testContainer.ID()),
+	}
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-r=%s", utils.Runtime),
+				fmt.Sprintf("-c=%s", containerName),
+			),
+		)
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns)))
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
+	}
+
+	runnerOpts = append(runnerOpts,
+		igrunner.WithStartAndStop(),
+		igrunner.WithValidateOutput(
+			func(t *testing.T, output string) {
+				expectedEntry := &topBlockioEntry{
+					CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
+
+					Comm: "dd",
+					// bytes manipulated by dd are given by count * bs
+					// where bs is 512 by default and we set 4096 for count
+					Bytes: 512 * 4096,
+					Rw:    "write",
+
+					// Check the existence of the following fields
+					MntNsID: utils.NormalizedInt,
+					Pid:     utils.NormalizedInt,
+					Tid:     utils.NormalizedInt,
+					Us:      utils.NormalizedInt,
+					Io:      utils.NormalizedInt,
+
+					// Manually normalize fields that might contain 0, so we
+					// can't use NormalizedInt and NormalizeInt()
+					// TODO: Support checking for the presence of a field, even if it's 0
+					Major: 0,
+					Minor: 0,
+				}
+
+				normalize := func(e *topBlockioEntry) {
+					utils.NormalizeCommonData(&e.CommonData)
+					utils.NormalizeInt(&e.MntNsID)
+					utils.NormalizeInt(&e.Pid)
+					utils.NormalizeInt(&e.Tid)
+					utils.NormalizeInt(&e.Us)
+					utils.NormalizeInt(&e.Io)
+
+					// Manually normalize fields that might contain 0
+					e.Major = 0
+					e.Minor = 0
+				}
+
+				match.MatchEntries(t, match.JSONMultiArrayMode, output, normalize, expectedEntry)
+			},
+		),
+	)
+
+	topBlockioCmd := igrunner.New("top_blockio", runnerOpts...)
+
+	igtesting.RunTestSteps([]igtesting.TestStep{topBlockioCmd}, t, testingOpts...)
+}

--- a/gadgets/top_file/test/top_file_test.go
+++ b/gadgets/top_file/test/top_file_test.go
@@ -63,7 +63,6 @@ func TestTopFile(t *testing.T) {
 	var ns string
 	containerOpts := []containers.ContainerOption{
 		containers.WithContainerImage(containerImage),
-		containers.WithStartAndStop(),
 	}
 
 	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {

--- a/gadgets/top_tcp/test/top_tcp_test.go
+++ b/gadgets/top_tcp/test/top_tcp_test.go
@@ -59,7 +59,6 @@ func TestTopTcp(t *testing.T) {
 	var ns string
 	containerOpts := []containers.ContainerOption{
 		containers.WithContainerImage(containerImage),
-		containers.WithStartAndStop(),
 	}
 
 	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {

--- a/gadgets/trace_capabilities/test/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/trace_capabilities_test.go
@@ -65,7 +65,6 @@ func TestTraceCapabilities(t *testing.T) {
 	var ns string
 	containerOpts := []containers.ContainerOption{
 		containers.WithContainerImage(containerImage),
-		containers.WithStartAndStop(),
 	}
 
 	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -32,6 +32,7 @@ const (
 	iterPrefix      = "iter/"
 	fentryPrefix    = "fentry/"
 	fexitPrefix     = "fexit/"
+	tpBtfPrefix     = "tp_btf/"
 	uprobePrefix    = "uprobe/"
 	uretprobePrefix = "uretprobe/"
 	usdtPrefix      = "usdt/"
@@ -91,6 +92,12 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 			return link.AttachTracing(link.TracingOptions{
 				Program:    prog,
 				AttachType: ebpf.AttachTraceFExit,
+			})
+		case strings.HasPrefix(p.SectionName, tpBtfPrefix):
+			i.logger.Debugf("Attaching tp_btf %q to %q", p.Name, p.AttachTo)
+			return link.AttachTracing(link.TracingOptions{
+				Program:    prog,
+				AttachType: ebpf.AttachTraceRawTp,
 			})
 		}
 		return nil, fmt.Errorf("unsupported section name %q for program %q as type ebpf.Tracing", p.SectionName, p.Name)


### PR DESCRIPTION
This PR adds `top_blockio` as image based gadgets

Our builtin gadget supports kernel versions `<5.17` and `>6.5`. This is done through trying to attach the tracepoints/kprobes. Currently this can't be done with image based gadgets (#3274)

Fixes #2989

EDIT:
When having an encrpyted disk with `ig` it seems that the `--host` flag is needed. The event also shows up like the following:
```
RUNTIME.CONTAINERNAME      PID MAJOR        MINOR        COMM             BYTES              US                 IO                 RW   
                           485 259          0            dmcrypt_write/2  397312             8152               10                 write
                             0 259          0                             0                  2124               1                  read
```