### PR TITLE
Columns header is printed twice Fixed

### DIFF
--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -259,10 +259,14 @@ func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 				}
 			}
 			headerFuncs = append(headerFuncs, printHeader)
-
+			
+			printedHeader := false
 			for _, headerFunc := range headerFuncs {
-				headerFunc()
-			}
+				if !printedHeader {
+					headerFunc()
+					printedHeader = true
+				}
+			}			
 
 			switch ds.Type() {
 			case datasource.TypeSingle:


### PR DESCRIPTION
## Fixes #3264 

## describe the change in one sentence

The update fixes an issue where column headers were printed twice. A printedHeader variable was added to ensure headers are only printed once by tracking if the header has already been output.

## How to use

Reviewers should run the affected commands to confirm that column headers are now printed correctly and only once.

## Testing done

Commands tested:

- $ ./kubectl-gadget run snapshot_process:latest
- $ sudo -E gadgetctl run snapshot_process:latest
- $ sudo -E ig run snapshot_process:latest
