### PR TITLE
clioperator: Add support for adding / removing fields with --fields

### DIFF
--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -469,6 +469,34 @@ mycontainer                      wget           477678            44591
 </TabItem>
 </Tabs>
 
+It's possible to hide and show some fields by prefixing them with +/-, for instance
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl gadget run trace_exec:latest --fields=-error,-timestamp
+COMM  PID  TID  PCOMM  PPID  ARGS  K8S.NODE  K8S.NAMESPACE  K8S.PODNAME  K8S.CONTAINERNAME  USER  LOGINUSER  GROUP
+
+$ kubectl gadget run trace_exec:latest --fields=+uid,+pid
+COMM  PID  TID  PCOMM  PPID  ARGS  K8S.NODE  K8S.NAMESPACE  K8S.PODNAME  K8S.CONTAINERNAME  ERROR  USER  LOGINUSER  GROUP  UID
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ sudo ig run trace_exec:latest --fields=-error,-timestamp
+RUNTIME.CONTAINERNAME  COMM  PID  TID  PCOMM  PPID  ARGS  USER  LOGINUSER  GROUP
+
+$ sudo ig run trace_exec:latest --fields=+uid,+pid
+RUNTIME.CONTAINERNAME  COMM  TID  PCOMM  PPID  ARGS  TIMESTAMP  USER  LOGINUSER  GROUP  UID  PID
+```
+
+</TabItem>
+</Tabs>
+
 ## Run for a specific amount of time
 
 Many gadgets will run forever, printing the gathered output until we press

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -17,6 +17,7 @@ package clioperator
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -179,6 +180,47 @@ func (o *cliOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api
 	return api.Params{fields, mode}
 }
 
+func parseFields(fieldsString string, defaultFields []string) []string {
+	fields := strings.Split(fieldsString, ",")
+
+	addedFields := make([]string, 0, len(fields))
+	deletedFields := make([]string, 0, len(fields))
+	explicitFields := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		switch field[0] {
+		case '+':
+			addedFields = append(addedFields, field[1:])
+		case '-':
+			deletedFields = append(deletedFields, field[1:])
+		default:
+			if !slices.Contains(explicitFields, field) {
+				explicitFields = append(explicitFields, field)
+			}
+		}
+	}
+
+	result := defaultFields
+	if len(explicitFields) > 0 {
+		result = explicitFields
+	}
+
+	for _, field := range addedFields {
+		if !slices.Contains(result, field) {
+			result = append(result, field)
+		}
+	}
+
+	for _, field := range deletedFields {
+		result = slices.DeleteFunc(result, func(s string) bool { return s == field })
+	}
+	return result
+}
+
 func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
 	params := apihelpers.ToParamDescs(o.ExtraParams(gadgetCtx)).ToParams()
 	params.CopyFromMap(o.paramValues, "")
@@ -237,7 +279,8 @@ func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 			formatter := p.GetTextColumnsFormatter()
 
 			if hasFields {
-				err := formatter.SetShowColumns(strings.Split(fields, ","))
+				parsedFields := parseFields(fields, defCols)
+				err = formatter.SetShowColumns(parsedFields)
 				if err != nil {
 					return fmt.Errorf("setting fields: %w", err)
 				}


### PR DESCRIPTION
# clioperator: Enhance field management with '--fields' tag. Refactored the CLI operator to allow adding and removing fields using the '--fields' tag.

Now able to remove fields,  when specified like this `sudo -E ./ig run trace_exec:latest --fields=-timestamp`

## Testing done
Yes, I've recreated ig binary and tested it locally.
fixes: #3267