### PR TITLE
gha: Remove unneeded strategy on workflow file

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -732,8 +732,6 @@ jobs:
       # in case of public fork repo/packages permissions will always be read
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
     outputs:
       image-digest: ${{ steps.publish-manifest-list.outputs.image-digest }}
     steps:


### PR DESCRIPTION
## Fixes #3275 

## Title: describe the change in one sentence

This PR removes the `strategy` section from the `.github/workflows/inspektor-gadget.yml` file. The `strategy: fail-fast: false` lines were causing issues with the workflow execution, specifically triggering a "Missing property 'matrix'" error.

## How to use

Review the changes in the .github/workflows/inspektor-gadget.yml file.
