### PR TITLE
 Remove --max-rows Flag from Snapshot Gadgets

### DIFF
--- a/pkg/gadgets/params.go
+++ b/pkg/gadgets/params.go
@@ -25,7 +25,8 @@ import (
 const (
 	ParamInterval = "interval"
 	ParamSortBy   = "sort"
-	ParamMaxRows  = "max-rows"
+
+// ParamMaxRows  = "max-rows"
 )
 
 const (
@@ -80,14 +81,6 @@ func SortableParams(gadget GadgetDesc, parser parser.Parser) params.ParamDescs {
 	}
 
 	return params.ParamDescs{
-		{
-			Key:          ParamMaxRows,
-			Title:        "Max Rows",
-			Alias:        "m",
-			DefaultValue: "50",
-			TypeHint:     params.TypeUint32,
-			Description:  "Maximum number of rows to return",
-		},
 		{
 			Key:          ParamSortBy,
 			Title:        "Sort By",

--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -322,7 +322,6 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 
 func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
 

--- a/pkg/gadgets/top/ebpf/tracer/tracer.go
+++ b/pkg/gadgets/top/ebpf/tracer/tracer.go
@@ -475,7 +475,6 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 
 func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
 

--- a/pkg/gadgets/top/file/tracer/tracer.go
+++ b/pkg/gadgets/top/file/tracer/tracer.go
@@ -283,7 +283,7 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 
 func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
+	//t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
 	t.config.AllFiles = params.Get(types.AllFilesParam).AsBool()

--- a/pkg/gadgets/top/tcp/tracer/tracer.go
+++ b/pkg/gadgets/top/tcp/tracer/tracer.go
@@ -296,7 +296,7 @@ func (g *GadgetDesc) NewInstance() (gadgets.Gadget, error) {
 
 func (t *Tracer) init(gadgetCtx gadgets.GadgetContext) error {
 	params := gadgetCtx.GadgetParams()
-	t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
+	//t.config.MaxRows = params.Get(gadgets.ParamMaxRows).AsInt()
 	t.config.SortBy = params.Get(gadgets.ParamSortBy).AsStringSlice()
 	t.config.Interval = time.Second * time.Duration(params.Get(gadgets.ParamInterval).AsInt())
 	t.config.TargetFamily, _ = types.ParseFilterByFamily(params.Get(types.FamilyParam).AsString())


### PR DESCRIPTION
#2173   Remove --max-rows Flag from Snapshot Gadgets 

This PR addresses the issue of the --max-rows flag not having any effect on the snapshot process and snapshot socket commands. The flag has been removed to prevent confusion and ensure the commands operate as expected without unused options.

## How to use

To validate this PR, reviewers should build the inspektor-gadget executable and run the snapshot process and snapshot socket commands to ensure they work correctly without the --max-rows flag.

## Testing done

1. Built the inspektor-gadget executable.
2. Ran the snapshot process and snapshot socket commands to ensure they function without the --max-rows flag.
3. Confirmed the commands produce the expected output without any errors.
