### PR TITLE
columns: add support for displaying event data in Hex format

### DIFF
--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -67,6 +67,8 @@ type Attributes struct {
 	FixedWidth bool `yaml:"fixed_width"`
 	// Precision defines how many decimals should be shown on float values, default: 2
 	Precision int `yaml:"precision"`
+	// Hex defines whether the value should be shown as a hexadecimal number
+	Hex bool `yaml:"hex"`
 	// Description can hold a short description of the field that can be used to aid the user
 	Description string `yaml:"description"`
 	// Order defines the default order in which columns are shown
@@ -189,6 +191,11 @@ func (ci *Column[T]) parseTagInfo(tagInfo []string) error {
 			default:
 				return fmt.Errorf("invalid ellipsis value %q for field %q", params[1], ci.Name)
 			}
+		case "hex":
+			if paramsLen != 1 {
+				return fmt.Errorf("parameter hex on field %q must not have a value", ci.Name)
+			}
+			ci.Hex = true
 		case "fixed":
 			if paramsLen != 1 {
 				return fmt.Errorf("parameter fixed on field %q must not have a value", ci.Name)

--- a/pkg/columns/columns.go
+++ b/pkg/columns/columns.go
@@ -109,6 +109,7 @@ func (c *Columns[T]) AddFields(fields []DynamicField, base func(*T) unsafe.Point
 				Alignment:    c.options.DefaultAlignment,
 				Visible:      true,
 				Precision:    2,
+				Hex:          false,
 				Order:        len(c.ColumnMap) * 10,
 			}
 		}
@@ -239,6 +240,7 @@ func (c *Columns[T]) iterateFields(t reflect.Type, sub []subField, offset uintpt
 				Alignment:    c.options.DefaultAlignment,
 				Visible:      true,
 				Precision:    2,
+				Hex:          false,
 				Order:        len(c.ColumnMap) * 10,
 			},
 			offset: offset + f.Offset,
@@ -571,7 +573,7 @@ func SetFieldFunc[OT any, T any](column ColumnInternals) func(entry *T, val OT) 
 	}
 }
 
-func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatPrecision int) func(entry *T) string {
+func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatPrecision int, hex bool) func(entry *T) string {
 	switch column.(*Column[T]).Kind() {
 	case reflect.Int,
 		reflect.Int8,
@@ -580,6 +582,9 @@ func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatP
 		reflect.Int64:
 		ff := GetFieldAsNumberFunc[int64, T](column)
 		return func(entry *T) string {
+			if hex {
+				return "0x" + strings.ToUpper(strconv.FormatInt(ff(entry), 16))
+			}
 			return strconv.FormatInt(ff(entry), 10)
 		}
 	case reflect.Uint,
@@ -589,6 +594,9 @@ func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatP
 		reflect.Uint64:
 		ff := GetFieldAsNumberFunc[uint64, T](column)
 		return func(entry *T) string {
+			if hex {
+				return "0x" + strings.ToUpper(strconv.FormatUint(ff(entry), 16))
+			}
 			return strconv.FormatUint(ff(entry), 10)
 		}
 	case reflect.Float32, reflect.Float64:
@@ -662,7 +670,7 @@ func GetFieldAsStringExt[T any](column ColumnInternals, floatFormat byte, floatP
 }
 
 func GetFieldAsString[T any](column ColumnInternals) func(entry *T) string {
-	return GetFieldAsStringExt[T](column, 'E', -1)
+	return GetFieldAsStringExt[T](column, 'E', -1, false)
 }
 
 // GetFieldAsNumberFunc returns a helper function to access a field of struct T as a number.

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (tf *TextColumnsFormatter[T]) setFormatter(column *Column[T]) {
-	ff := columns.GetFieldAsStringExt[T](column.col, 'f', column.col.Precision)
+	ff := columns.GetFieldAsStringExt[T](column.col, 'f', column.col.Precision, column.col.Hex)
 	column.formatter = func(entry *T) string {
 		return tf.buildFixedString(ff(entry), column.calculatedWidth, column.col.EllipsisType, column.col.Alignment)
 	}

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -39,6 +39,7 @@ const (
 	ColumnsEllipsisAnnotation  = "columns.ellipsis"
 	ColumnsHiddenAnnotation    = "columns.hidden"
 	ColumnsFixedAnnotation     = "columns.fixed"
+	ColumnsHexAnnotation       = "columns.hex"
 
 	DescriptionAnnotation = "description"
 	TemplateAnnotation    = "template"
@@ -134,6 +135,10 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 			case ColumnsFixedAnnotation:
 				if v == "true" {
 					attributes.FixedWidth = true
+				}
+			case ColumnsHexAnnotation:
+				if v == "true" {
+					attributes.Hex = true
 				}
 			}
 		}
@@ -261,6 +266,9 @@ var annotationsTemplates = map[string]map[string]string{
 	"gid": {
 		ColumnsMinWidthAnnotation:  "8",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+	},
+	"address": {
+		ColumnsHexAnnotation: "true",
 	},
 	"ns": {
 		ColumnsHiddenAnnotation:    "true",


### PR DESCRIPTION
# Adds support for displaying event data (like addresses) in Hexadecimal format

![image](https://github.com/user-attachments/assets/c4c0f54f-d792-4729-883a-ba6269b9934c)

- Adds `columns.hex` annotation field for datasources in `gadget.yaml` configuration.
- Adds `address` template with `columns.hex: true`. I wasn't sure, what other annotations to include for *address* columns for better formatting so suggestions are welcome
- Enabling this formats integer type entries to hexadecimal in the format `0x{hex_addr}` (as shown in the image above).

## How to use

- Add the `columns.hex` annotation to any integer type datasource in any gadget's yaml configuration.
- Build and run the gadget.
- Validate the column entries.

## Testing done

The above steps were used to validate the PR.