### PR TITLE
treewide: Bump golang to 1.22.5.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2,7 +2,7 @@ name: Inspektor Gadget CI
 env:
   REGISTRY: ghcr.io
   CONTAINER_REPO: ${{ github.repository }}
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.22.5
   # controller-gen with go >1.21 panics, but we can't update controller-gen itself
   GO_VERSION_DOC_CHECK: 1.21.3
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ output:
   sort-results: true
 
 run:
-  go: "1.22"
+  go: "1.22.5"
   timeout: 10m
   build-tags:
   - docs

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module examples
 
-go 1.22.2
+go 1.22.5
 
 require (
 	github.com/cilium/ebpf v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/inspektor-gadget/inspektor-gadget
 
-go 1.22.0
+go 1.22.5
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/tools/testjson2md/go.mod
+++ b/tools/testjson2md/go.mod
@@ -1,6 +1,6 @@
 module github.com/inspektor-gadget/inspektor-gadget/tools/testjson2md
 
-go 1.22
+go 1.22.5
 
 require github.com/medyagh/gopogh v0.27.0
 


### PR DESCRIPTION
Hi.

This is needed by https://github.com/inspektor-gadget/inspektor-gadget/pull/3312 and I think this is better to a open a dedicated PR for this.

Best regards.