### PR TITLE
container-collection: Add OwnerKind and OwnerName to K8sEnrichment

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -226,3 +226,13 @@ func (c *Container) RuntimeMetadata() *types.BasicRuntimeMetadata {
 func (c *Container) UsesHostNetwork() bool {
 	return c.HostNetwork
 }
+
+func (c *Container) K8sOwnerReference() *types.K8sOwnerReference {
+	if c.K8s.ownerReference == nil {
+		return &types.K8sOwnerReference{}
+	}
+	return &types.K8sOwnerReference{
+		Kind: c.K8s.ownerReference.Kind,
+		Name: c.K8s.ownerReference.Name,
+	}
+}

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -517,64 +517,69 @@ func WithKubernetesEnrichment(nodeName string, kubeconfig *rest.Config) Containe
 
 		// Future containers
 		cc.containerEnrichers = append(cc.containerEnrichers, func(container *Container) bool {
-			// Skip enriching if all k8s fields are already known.
+			// Skip enriching if basic k8s fields are already known.
 			// This is an optimization and to make sure to avoid erasing the fields in case of error.
-			if runtimeclient.IsEnrichedWithK8sMetadata(container.K8s.BasicK8sMetadata) {
-				return true
-			}
-
-			var pod *corev1.Pod
-			var err error
-			if container.K8s.PodName == "" || container.K8s.Namespace == "" {
-				pod, err = getPodByCgroups(clientset, nodeName, container)
-				if err != nil {
-					log.Errorf("kubernetes enricher (from UID): cannot find pod for container %s: %s", container.Runtime.ContainerName, err)
-					return false
-				}
-			} else {
-				pod, err = clientset.CoreV1().Pods(container.K8s.Namespace).Get(context.TODO(), container.K8s.PodName, metav1.GetOptions{})
-				if err != nil {
-					log.Errorf("kubernetes enricher (from ns/podname): cannot find pod %s/%s: %s", container.K8s.Namespace, container.K8s.PodName, err)
-					return false
-				}
-			}
-
-			if container.K8s.ContainerName == "" {
-				var containerName string
-				uid := string(pod.ObjectMeta.UID)
-				containerNames := []string{}
-				for _, c := range pod.Spec.Containers {
-					containerNames = append(containerNames, c.Name)
-				}
-				for _, c := range pod.Spec.InitContainers {
-					containerNames = append(containerNames, c.Name)
-				}
-				for _, c := range pod.Spec.EphemeralContainers {
-					containerNames = append(containerNames, c.Name)
-				}
-			outerLoop:
-				for _, name := range containerNames {
-					for _, m := range container.OciConfig.Mounts {
-						pattern := fmt.Sprintf("pods/%s/containers/%s/", uid, name)
-						if strings.Contains(m.Source, pattern) {
-							containerName = name
-							break outerLoop
-						}
+			if !runtimeclient.IsEnrichedWithK8sMetadata(container.K8s.BasicK8sMetadata) {
+				var pod *corev1.Pod
+				var err error
+				if container.K8s.PodName == "" || container.K8s.Namespace == "" {
+					pod, err = getPodByCgroups(clientset, nodeName, container)
+					if err != nil {
+						log.Errorf("kubernetes enricher (from UID): cannot find pod for container %s: %s", container.Runtime.ContainerName, err)
+						return false
+					}
+				} else {
+					pod, err = clientset.CoreV1().Pods(container.K8s.Namespace).Get(context.TODO(), container.K8s.PodName, metav1.GetOptions{})
+					if err != nil {
+						log.Errorf("kubernetes enricher (from ns/podname): cannot find pod %s/%s: %s", container.K8s.Namespace, container.K8s.PodName, err)
+						return false
 					}
 				}
-				container.K8s.ContainerName = containerName
+
+				if container.K8s.ContainerName == "" {
+					var containerName string
+					uid := string(pod.ObjectMeta.UID)
+					containerNames := []string{}
+					for _, c := range pod.Spec.Containers {
+						containerNames = append(containerNames, c.Name)
+					}
+					for _, c := range pod.Spec.InitContainers {
+						containerNames = append(containerNames, c.Name)
+					}
+					for _, c := range pod.Spec.EphemeralContainers {
+						containerNames = append(containerNames, c.Name)
+					}
+				outerLoop:
+					for _, name := range containerNames {
+						for _, m := range container.OciConfig.Mounts {
+							pattern := fmt.Sprintf("pods/%s/containers/%s/", uid, name)
+							if strings.Contains(m.Source, pattern) {
+								containerName = name
+								break outerLoop
+							}
+						}
+					}
+					container.K8s.ContainerName = containerName
+				}
+
+				container.K8s.Namespace = pod.ObjectMeta.Namespace
+				container.K8s.PodName = pod.ObjectMeta.Name
+				container.K8s.PodUID = string(pod.ObjectMeta.UID)
+				container.K8s.PodLabels = pod.ObjectMeta.Labels
+
+				// drop pause containers
+				if container.K8s.PodName != "" && container.K8s.ContainerName == "" {
+					return false
+				}
 			}
 
-			container.K8s.Namespace = pod.ObjectMeta.Namespace
-			container.K8s.PodName = pod.ObjectMeta.Name
-			container.K8s.PodUID = string(pod.ObjectMeta.UID)
-			container.K8s.PodLabels = pod.ObjectMeta.Labels
-
-			// drop pause containers
-			if container.K8s.PodName != "" && container.K8s.ContainerName == "" {
-				return false
+			if container.K8s.ownerReference == nil {
+				_, err = container.GetOwnerReference()
+				if err != nil {
+					log.Errorf("kubernetes enricher: failed to get owner reference for container %s: %s", container.Runtime.ContainerID, err)
+					// Don't drop the container. We just have problems getting the owner reference, but still want to trace the container.
+				}
 			}
-
 			return true
 		})
 		return nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -110,6 +110,7 @@ type Container interface {
 	K8sMetadata() *BasicK8sMetadata
 	RuntimeMetadata() *BasicRuntimeMetadata
 	UsesHostNetwork() bool
+	K8sOwnerReference() *K8sOwnerReference
 }
 
 type BasicRuntimeMetadata struct {
@@ -155,6 +156,11 @@ type BasicK8sMetadata struct {
 	ContainerName string            `json:"containerName,omitempty" column:"containerName,template:container"`
 }
 
+type K8sOwnerReference struct {
+	Kind string `json:"kind,omitempty" column:"kind,hide"`
+	Name string `json:"name,omitempty" column:"name,hide"`
+}
+
 func (b *BasicK8sMetadata) IsEnriched() bool {
 	return b.Namespace != "" && b.PodName != "" && b.ContainerName != "" && b.PodLabels != nil
 }
@@ -166,6 +172,8 @@ type K8sMetadata struct {
 
 	// HostNetwork is true if the container uses the host network namespace
 	HostNetwork bool `json:"hostNetwork,omitempty" column:"hostnetwork,hide"`
+
+	Owner K8sOwnerReference `json:"owner,omitempty" column:"owner,hide"`
 }
 
 type CommonData struct {
@@ -189,6 +197,7 @@ func (c *CommonData) SetPodMetadata(container Container) {
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace
 	c.K8s.PodLabels = k8s.PodLabels
+	c.K8s.Owner = *container.K8sOwnerReference()
 
 	// All containers in the same pod share the same container runtime
 	c.Runtime.RuntimeName = runtime.RuntimeName
@@ -202,6 +211,7 @@ func (c *CommonData) SetContainerMetadata(container Container) {
 	c.K8s.PodName = k8s.PodName
 	c.K8s.Namespace = k8s.Namespace
 	c.K8s.PodLabels = k8s.PodLabels
+	c.K8s.Owner = *container.K8sOwnerReference()
 
 	c.Runtime.RuntimeName = runtime.RuntimeName
 	c.Runtime.ContainerName = runtime.ContainerName


### PR DESCRIPTION
When using the `KubernetesEnrichment` resolve also the Owner Kind and Owner Name. Partially solves https://github.com/inspektor-gadget/inspektor-gadget/issues/3260

For `ig w/ K8s` we need to talk to the API server. This is still TODO, needs to be discussed and should be optional (either enrichment failing siliently or actived through flag)


## image based gadgets
```
./kubectl-gadget run trace_exec -n gadget --fields k8s.podname,k8s.owner.kind,k8s.owner.name,comm
K8S.PODNAME                        K8S.OWNER.KIND     K8S.OWNER.NAME     COMM            
gadget-mdwnx                       DaemonSet          gadget             gadgettracerman 
gadget-mdwnx                       DaemonSet          gadget             gadgettracerman 
```

## Built-in gadgets
```
./kubectl-gadget trace exec -n gadget -o columns=k8s.podname,k8s.owner.kind,k8s.owner.name,comm 
K8S.PODNAME                        K8S.OWNER.KIND     K8S.OWNER.NAME     COMM            
gadget-mdwnx                       DaemonSet          gadget             gadgettracerman 
gadget-mdwnx                       DaemonSet          gadget             gadgettracerman
```