### PR TITLE
docs/op: Add UidGidResolver documentation

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -285,6 +285,25 @@ Symbolize the kernel stack from `gadget_get_kernel_stack(ctx)` (see [kernel-stac
 
 - `ebpf.formatter.kstack`: Name of the new field. If the annotation is not set and the source field name has a `_raw` suffix, the target name will be set to the source name without that suffix.
 
+### `gadget_uid` and `gadget_gid`
+
+The `uid` and `gid` saved to these types will be resolved to the corresponding username and groupname on the host system:
+
+```c
+struct event {
+	gadget_uid user_raw;
+};
+```
+
+```json
+  "user": "root",
+  "user_raw": 0,
+```
+
+#### Annotations
+
+- `uidgidresolver.target`: Name of the new field. If the annotation is not set and the source field name has a `_raw` suffix, the target name will be set to the source name without that suffix.
+
 ### Enumerations
 
 Inspektor Gadget supports enums already defined on the kernel or enums defined

--- a/docs/reference/operators/uidgidresolver.mdx
+++ b/docs/reference/operators/uidgidresolver.mdx
@@ -1,0 +1,11 @@
+---
+title: UidGidResolver
+sidebar_position: 10
+---
+
+# UidGidResolver
+
+The `UidGidResolver` data operator resolves `uid` and `gid` (user and group identifiers) values to the corresponding user and group names.
+It does this by monitoring the `/etc/passwd` and `/etc/group` files on the host.
+This leads to the restrictions that user and groupnames inside the guest might not be correctly resolved.
+It means the events are enriched with the user and group names from the host, so the ones for the container are ignored.


### PR DESCRIPTION
# docs/op: Add UidGidResolver documentation

Is this the way we want to document the dataoperators?