### PR TITLE
pkg/operators: Add limiter

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -31,6 +31,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/sort"

--- a/docs/reference/operators/limiter.md
+++ b/docs/reference/operators/limiter.md
@@ -1,0 +1,21 @@
+---
+title: Limiter
+---
+
+The Limiter operator limits the number of entries in each batch of data. This
+operator is only enabled for data sources of type array. A great scenario for
+this operator is when you are already sorting data within an array of data and
+you want to filter out the top `max-entries` entries.
+
+## Instance Parameters
+
+### `--max-entries`
+
+The maximum number of entries for each batch of data. If using multiple array
+data sources, prefix the value with 'datasourcename:' and separate with ','. If
+no array data source is specified, the value will be applied to all array data
+sources. Use -1 to disable the limiter.
+
+Fully qualified name: `operators.limiter.max-entries`
+
+Default value: `-1`

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/sort"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/uidgidresolver"

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -86,6 +86,20 @@ func (d *dataArray) Swap(i, j int) {
 	d.DataArray[i], d.DataArray[j] = d.DataArray[j], d.DataArray[i]
 }
 
+func (d *dataArray) Resize(size int) error {
+	if size < 0 {
+		return errors.New("resizing to an invalid size")
+	}
+	if size > len(d.DataArray) {
+		return errors.New("resizing to a larger size is not supported")
+	}
+	for i := size; i < len(d.DataArray); i++ {
+		d.Release(d.Get(i))
+	}
+	d.DataArray = d.DataArray[:size]
+	return nil
+}
+
 func (d *dataArray) New() Data {
 	return d.ds.newDataElement()
 }

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -68,6 +68,12 @@ type DataArray interface {
 
 	// Swap swaps two elements of the array by their index
 	Swap(i, j int)
+
+	// Resize resizes the array to the given size. If the new size is smaller
+	// than the current size, the array will be truncated and the elements
+	// beyond the new size will be released. Currently, it does not support
+	// resizing to a larger size.
+	Resize(int) error
 }
 
 type Packet interface {

--- a/pkg/gadget-service/api-helpers/aphelpers_test.go
+++ b/pkg/gadget-service/api-helpers/aphelpers_test.go
@@ -1,0 +1,215 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apihelpers provides some helper functions for the API package; these were extracted into this package
+// to avoid having additional dependencies on the API package itself
+package apihelpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStringValuesPerDataSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    map[string]string
+		expectedErr bool
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:     "valid without datasource",
+			input:    "50",
+			expected: map[string]string{"": "50"},
+		},
+		{
+			name:     "valid with datasource",
+			input:    "datasource1:10",
+			expected: map[string]string{"datasource1": "10"},
+		},
+		{
+			name:     "valid with multiple datasources",
+			input:    "datasource1:10,datasource2:20",
+			expected: map[string]string{"datasource1": "10", "datasource2": "20"},
+		},
+		{
+			name:     "valid with empty element",
+			input:    "datasource1:10,",
+			expected: map[string]string{"datasource1": "10"},
+		},
+		{
+			name:     "valid with empty string value",
+			input:    "datasource1:10,datasource2:",
+			expected: map[string]string{"datasource1": "10", "datasource2": ""},
+		},
+		{
+			name:     "valid with non-number value",
+			input:    "datasource1:foo",
+			expected: map[string]string{"datasource1": "foo"},
+		},
+		{
+			name:        "invalid mixing datasource and no datasource",
+			input:       "10,datasource1:20",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetStringValuesPerDataSource(test.input)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestGetIntValuesPerDataSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    map[string]int
+		expectedErr bool
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: map[string]int{},
+		},
+		{
+			name:     "valid without datasource",
+			input:    "50",
+			expected: map[string]int{"": 50},
+		},
+		{
+			name:     "valid with datasource",
+			input:    "datasource1:10",
+			expected: map[string]int{"datasource1": 10},
+		},
+		{
+			name:     "valid with multiple datasources",
+			input:    "datasource1:10,datasource2:20",
+			expected: map[string]int{"datasource1": 10, "datasource2": 20},
+		},
+		{
+			name:     "valid with empty element",
+			input:    "datasource1:10,",
+			expected: map[string]int{"datasource1": 10},
+		},
+		{
+			name:        "invalid with empty string value",
+			input:       "datasource1:10,datasource2:",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid with invalid number",
+			input:       "datasource1:foo",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid mixing datasource and no datasource",
+			input:       "10,datasource1:20",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetIntValuesPerDataSource(test.input)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestGetDurationValuesPerDataSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    map[string]time.Duration
+		expectedErr bool
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: map[string]time.Duration{},
+		},
+		{
+			name:     "valid without datasource",
+			input:    "50s",
+			expected: map[string]time.Duration{"": 50 * time.Second},
+		},
+		{
+			name:     "valid with datasource",
+			input:    "datasource1:10h",
+			expected: map[string]time.Duration{"datasource1": 10 * time.Hour},
+		},
+		{
+			name:     "valid with multiple datasources",
+			input:    "datasource1:10s,datasource2:20s",
+			expected: map[string]time.Duration{"datasource1": 10 * time.Second, "datasource2": 20 * time.Second},
+		},
+		{
+			name:     "valid with empty element",
+			input:    "datasource1:10h,",
+			expected: map[string]time.Duration{"datasource1": 10 * time.Hour},
+		},
+		{
+			name:        "invalid with empty string value",
+			input:       "datasource1:10,datasource2:",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid with invalid time duration (string)",
+			input:       "datasource1:foo",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid mixing datasource and no datasource",
+			input:       "10,datasource1:20",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid with invalid time duration (no unit)",
+			input:       "datasource1:10",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetDurationValuesPerDataSource(test.input)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/pkg/operators/limiter/limiter.go
+++ b/pkg/operators/limiter/limiter.go
@@ -1,0 +1,169 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package limiter is a data operator that limits the number of entries in each
+// batch of data. This operator is only enabled for data sources of type array.
+// A great scenario for this operator is when you are already sorting data
+// within an array of data and you want to filter out the top `X` entries.
+package limiter
+
+import (
+	"fmt"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const (
+	name            = "limiter"
+	ParamMaxEntries = "max-entries"
+	Priority        = 9600
+)
+
+type limiterOperator struct{}
+
+func (l *limiterOperator) Name() string {
+	return name
+}
+
+func (l *limiterOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (l *limiterOperator) GlobalParams() api.Params {
+	return nil
+}
+
+func (l *limiterOperator) InstanceParams() api.Params {
+	return api.Params{
+		{
+			Key:   ParamMaxEntries,
+			Title: "Max Entries",
+			Description: "The maximum number of entries for each batch of data. " +
+				"If using multiple array data sources, prefix the value with 'datasourcename:' and separate with ','. " +
+				"If no data source is specified, the value will be applied to all array data sources." +
+				"Use -1 to disable the limiter.",
+			DefaultValue: "-1",
+			TypeHint:     api.TypeString,
+		},
+	}
+}
+
+func (l *limiterOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	// When getting the GadgetInfo, InstantiateDataOperator is called with an
+	// empty instanceParamValues. In such cases, we don't need to validate the
+	// ParamMaxEntries parameter, but just return an instance if there is, at
+	// least, one array data source; otherwise return nil (disabling the
+	// operator).
+	maxEntries, ok := instanceParamValues[ParamMaxEntries]
+	if !ok {
+		for _, ds := range gadgetCtx.GetDataSources() {
+			if ds.Type() == datasource.TypeArray {
+				return &limiterOperatorInstance{}, nil
+			}
+		}
+		return nil, nil
+	}
+
+	// If ParamMaxEntries is set, it must be valid.
+	valuesPerDs, err := apihelpers.GetIntValuesPerDataSource(maxEntries)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s (%q): %w", ParamMaxEntries, maxEntries, err)
+	}
+	if len(valuesPerDs) == 0 {
+		return nil, fmt.Errorf("missing value for %s", ParamMaxEntries)
+	}
+
+	maxEntriesPerDs := make(map[datasource.DataSource]int)
+	for _, ds := range gadgetCtx.GetDataSources() {
+		var maxEntries int
+		if val, ok := valuesPerDs[""]; ok {
+			if ds.Type() != datasource.TypeArray {
+				continue
+			}
+			// Disable for all data sources
+			if val == -1 {
+				return nil, nil
+			}
+			maxEntries = val
+		} else if val, ok := valuesPerDs[ds.Name()]; ok {
+			if ds.Type() != datasource.TypeArray {
+				return nil, fmt.Errorf("%s can only be used on array data sources", ParamMaxEntries)
+			}
+			// Disable for this specific data source
+			if val == -1 {
+				continue
+			}
+			maxEntries = val
+		}
+
+		if maxEntries < -1 {
+			return nil, fmt.Errorf("invalid value for %s: %d", ParamMaxEntries, maxEntries)
+		}
+		maxEntriesPerDs[ds] = maxEntries
+	}
+
+	if len(maxEntriesPerDs) == 0 {
+		gadgetCtx.Logger().Infof("limiter: no array data sources need to be limited. Skipping operator")
+		return nil, nil
+	}
+
+	return &limiterOperatorInstance{
+		maxEntries: maxEntriesPerDs,
+	}, nil
+}
+
+func (l *limiterOperator) Priority() int {
+	return Priority
+}
+
+type limiterOperatorInstance struct {
+	maxEntries map[datasource.DataSource]int
+}
+
+func (l *limiterOperatorInstance) Name() string {
+	return name
+}
+
+func (l *limiterOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, maxEntries := range l.maxEntries {
+		ds.SubscribeArray(func(ds datasource.DataSource, data datasource.DataArray) error {
+			if data.Len() <= maxEntries {
+				return nil
+			}
+			if err := data.Resize(maxEntries); err != nil {
+				return fmt.Errorf("limiting data source %q to %d entries: %w", ds.Name(), maxEntries, err)
+			}
+			return nil
+		}, Priority)
+	}
+	return nil
+}
+
+func (l *limiterOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (l *limiterOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+var Operator = &limiterOperator{}
+
+func init() {
+	operators.RegisterDataOperator(Operator)
+}

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -145,10 +145,13 @@ func (m *otelMetricsOperator) InstanceParams() api.Params {
 
 func (m *otelMetricsOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
 	// extract name mappings; key will be old name (or empty), value the new name
-	mappings := apihelpers.GetStringValuesPerDataSource(instanceParamValues[ParamOtelMetricsName])
+	mappings, err := apihelpers.GetStringValuesPerDataSource(instanceParamValues[ParamOtelMetricsName])
+	if err != nil {
+		return nil, fmt.Errorf("parsing name mappings: %w", err)
+	}
 
 	params := apihelpers.ToParamDescs(m.InstanceParams()).ToParams()
-	err := params.CopyFromMap(instanceParamValues, "")
+	err = params.CopyFromMap(instanceParamValues, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Add limiter operator

This PR introduces the `Limiter` data operator which operates on array data sources by limiting the number of entries in each batch of data. A great scenario for this operator is when you are already sorting data within an array of data and you want to filter out the top `X` entries. 

This operator has lower priority than combiner (if it's enabled) and sorted (to limit after things are sorted).

Notice this functionality was known as `max-rows` in built-in gadgets. However, it was changed to `max-entries` as it also limit the number of entries in the JSON or any other kind of output.

Refer https://github.com/inspektor-gadget/inspektor-gadget/issues/1924

## TODOs for follow-up PRs

- [x] Limit also on server side to avoid wasting resources sending things that will be dropped on client.

