### PR TITLE
Add link to v0.31.0 post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 Inspektor Gadget is a set of tools and framework for data collection and system inspection on Kubernetes clusters and Linux hosts using [eBPF](https://ebpf.io/). It manages the packaging, deployment and execution of Gadgets (eBPF programs encapsulated in [OCI images](https://opencontainers.org/)) and provides mechanisms to customize and extend Gadget functionality.
 
+**Note**: Major new functionality was released in v0.31.0. Please read the [blog post for a detailed overview](https://inspektor-gadget.io/blog/2024/08/empowering-observability_the_advent_of_image_based_gadgets).
+
 ## Features
 
 * Build and package eBPF programs into OCI images called Gadgets


### PR DESCRIPTION
We want to let users know about the new changes and vision of the project. So, adding a link to the README for the blog post explaining that.