### PR TITLE
gadgets/top_tcp: fix typo in date

### DIFF
--- a/gadgets/top_tcp/artifacthub-pkg.yml
+++ b/gadgets/top_tcp/artifacthub-pkg.yml
@@ -3,8 +3,8 @@ version: 0.30.0
 name: "top tcp"
 category: monitoring-logging
 displayName: "top tcp"
-createdAt: "2024-07-026T09:22:04Z"
-digest: "2024-07-026T09:22:04Z"
+createdAt: "2024-07-26T09:22:04Z"
+digest: "2024-07-26T09:22:04Z"
 description: Periodically report tcp send receive activity by connection
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""


### PR DESCRIPTION
Fixes: 7cdb3c733e7a ("gadgets: Add top_tcp as image based gadget")

The date was invalid and was causing the following error in artifact hub:

> error getting package metadata (path: /tmp/artifact-hub3521047503/gadgets/top_tcp): error validating package metadata file: 1 error occurred:
>	* invalid metadata: invalid createdAt (RFC3339 expected): parsing time "2024-07-026T09:22:04Z" as "2006-01-02T15:04:05Z07:00": cannot parse "6T09:22:04Z" as "T"
