### PR TITLE
snapshot_process: Sleep before starting the gadget

### DIFF
--- a/gadgets/snapshot_process/test/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/snapshot_process_test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -114,5 +115,5 @@ func TestSnapshotProcess(t *testing.T) {
 
 	snashotProcessCmd := igrunner.New("snapshot_process", runnerOpts...)
 
-	igtesting.RunTestSteps([]igtesting.TestStep{snashotProcessCmd}, t, testingOpts...)
+	igtesting.RunTestSteps([]igtesting.TestStep{utils.Sleep(5 * time.Second), snashotProcessCmd}, t, testingOpts...)
 }


### PR DESCRIPTION
This makes sure that our test container has already spawned and is running the command we want to see in the snapshot

We have many flaky CI failures on `snapshot_process`. This should fix it