### PR TITLE
ci: Automatically update website on push

### DIFF
--- a/.github/workflows/update-website.yaml
+++ b/.github/workflows/update-website.yaml
@@ -1,0 +1,19 @@
+name: Trigger Website Update
+on:
+  push:
+    paths:
+    - 'docs/**'
+    branches:
+    - main
+permissions:
+  contents: read
+jobs:
+  trigger_website_update:
+    name: Trigger Website Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger via gh
+        env:
+          GH_TOKEN: ${{ secrets.IG_WEBSITE_TOKEN }}
+        run: |
+           gh workflow run -R inspektor-gadget/website azure-static-web-apps-polite-mushroom-00d947803.yml


### PR DESCRIPTION
## Testing

I forced pushed this branch before adding the path filter and removing the citest/** branch and the workflow was executed in https://github.com/inspektor-gadget/website/actions/runs/10359315537. 

### TODO
- Should it replace https://github.com/inspektor-gadget/website/blob/main/.github/workflows/update-inspektor-gadget-release.yaml? (i.e. run this also when a release is done)
