### PR TITLE
Use JSON args to prevent unintended behavior related to OS signals

### DIFF
--- a/examples/kube-container-collection/Dockerfile
+++ b/examples/kube-container-collection/Dockerfile
@@ -10,4 +10,4 @@ RUN cd /gadget/examples/kube-container-collection && make kube-container-collect
 
 FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 COPY --from=builder /gadget/examples/kube-container-collection/kube-container-collection-static /bin/kube-container-collection
-CMD /bin/kube-container-collection
+CMD ["/bin/kube-container-collection"]

--- a/examples/runc-hook/Dockerfile
+++ b/examples/runc-hook/Dockerfile
@@ -10,4 +10,4 @@ RUN cd /gadget/examples/runc-hook && make runc-hook-static
 
 FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 COPY --from=builder /gadget/examples/runc-hook/runc-hook-static /bin/runc-hook
-ENTRYPOINT /bin/runc-hook
+ENTRYPOINT ["/bin/runc-hook"]


### PR DESCRIPTION
We had 2 warnings shown inside Github regarding this:
![image](https://github.com/user-attachments/assets/ae1cb879-ebdd-4c59-9b1a-766d0742c2ae)
