### PR TITLE
image build: allow alternative tinygo

### DIFF
--- a/cmd/common/image/Makefile.build
+++ b/cmd/common/image/Makefile.build
@@ -1,6 +1,7 @@
 # This makefile is used by the build command, don't execute it manually
 
 CLANG ?= clang
+TINYGO ?= tinygo
 LLVM_STRIP ?= llvm-strip
 BASECFLAGS = -target bpf -Wall -g -O2
 CFLAGS ?=
@@ -24,7 +25,7 @@ wasm:
 	# No wasm file found. Nothing to do.
 else ifeq (go,$(patsubst %.go,go,$(WASM)))
 wasm: $(WASM)
-	tinygo build -o $(OUTPUTDIR)/program.wasm -target=wasi --no-debug $^
+	$(TINYGO) build -o $(OUTPUTDIR)/program.wasm -target=wasi --no-debug $^
 else ifeq (wasm,$(patsubst %.wasm,wasm,$(WASM)))
 wasm:
 	# Wasm file already compiled. Nothing to do.


### PR DESCRIPTION
Local builds ("ig image build -l") can fail if tinygo or go is too old.

On Fedora 38, I only have tinygo 0.30.0 and go 1.21.10 and those versions are not working.

With this patch, I can successfully build gadgets locally ("-l"). Example of commands:
```
sudo -E TINYGO=/home/alban/programs/tinygo/tinygo/bin/tinygo GOROOT=/home/alban/programs/golang/go ../ig image build trace_open -l
make  trace_open GADGET_BUILD_PARAMS="-l" TINYGO=/home/alban/programs/tinygo/tinygo/bin/tinygo GOROOT=/home/alban/programs/golang/go
```
