### PR TITLE
docs: Use GitHub instead of elixir

### DIFF
--- a/docs/gadget-devel/program-types.md
+++ b/docs/gadget-devel/program-types.md
@@ -80,4 +80,4 @@ The section name must use the `usdt/<file_path>:<providerName>:<probeName>` form
 ### Tracing with Linux Security Modules (LSM)
 
 The section name must use the `lsm/<hook>` format.
-The hook points could be found in [`<include/linux/lsm_hook_defs.h>`](https://elixir.bootlin.com/linux/latest/source/include/linux/lsm_hook_defs.h).
+The hook points could be found in [`<include/linux/lsm_hook_defs.h>`](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hook_defs.h).

--- a/docs/gadgets/builtin/profile/tcprtt.md
+++ b/docs/gadgets/builtin/profile/tcprtt.md
@@ -8,7 +8,7 @@ description: >
 The profile tcprtt gadget generates a histogram distribution of the TCP
 connections' Round-Trip Time (RTT). The RTT values used to create the histogram
 are collected from [the smoothed
-RTT](https://elixir.bootlin.com/linux/v5.11.22/source/include/linux/tcp.h#L258)
+RTT](https://github.com/torvalds/linux/blob/v5.11/include/linux/tcp.h#L258)
 information already provided by the Linux kernel for the TCP sockets.
 
 The histogram considers only the TCP connections that have been already


### PR DESCRIPTION
The broken link job fails often with elixir:

https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/10391104393/job/28773219330


