### PR TITLE
ig: Add optional further K8s enrichment (Ownertype and Ownername in this PR)

### DIFF
--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -49,7 +49,7 @@ func NewListContainersCmd() *cobra.Command {
 				return err
 			}
 
-			igmanager, err := igmanager.NewManager(commonFlags.RuntimeConfigs)
+			igmanager, err := igmanager.NewManager(commonFlags.RuntimeConfigs, nil)
 			if err != nil {
 				return commonutils.WrapInErrManagerInit(err)
 			}

--- a/docs/reference/ig.md
+++ b/docs/reference/ig.md
@@ -187,6 +187,21 @@ $ kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/insp
 This requires Kubernetes v1.30.0.
 It is also working on older versions as long as kubectl (client) is v1.30.0 or greater.
 
+#### Usage with flag `--enrich-with-k8s-apiserver`
+
+In order to use `--enrich-with-k8s-apiserver`, the spawned debug pod has to have permissions to list all Pods, Services, DaemonSets and more.
+This can be done with giving it the `cluster-admin` role:
+
+```bash
+$ kubectl create serviceaccount -n kube-system ig
+
+$ kubectl create clusterrolebinding ig \
+  --clusterrole=cluster-admin \
+  --serviceaccount=kube-system:ig
+
+$ kubectl debug -n kube-system --as system:serviceaccount:kube-system:ig --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig trace exec --enrich-with-k8s-apiserver -o columns=k8s.owner.kind,k8s.owner.name,pid,comm,args
+```
+
 ### Using ig as a daemon
 
 `ig` can also be run as a daemon. You can then use `gadgetctl` to connect to it as an unprivileged user.

--- a/pkg/ig-manager/ig-manager.go
+++ b/pkg/ig-manager/ig-manager.go
@@ -74,7 +74,7 @@ func (l *IGManager) RemoveMountNsMap(id string) error {
 	return l.tracerCollection.RemoveTracer(id)
 }
 
-func NewManager(runtimes []*containerutilsTypes.RuntimeConfig) (*IGManager, error) {
+func NewManager(runtimes []*containerutilsTypes.RuntimeConfig, additionalOpts []containercollection.ContainerCollectionOption) (*IGManager, error) {
 	l := &IGManager{}
 
 	var err error
@@ -102,6 +102,7 @@ func NewManager(runtimes []*containerutilsTypes.RuntimeConfig) (*IGManager, erro
 		containercollection.WithTracerCollection(l.tracerCollection),
 		containercollection.WithProcEnrichment(),
 	}
+	opts = append(opts, additionalOpts...)
 
 	if !log.IsLevelEnabled(log.DebugLevel) && isDefaultContainerRuntimeConfig(runtimes) {
 		warnings := []containercollection.ContainerCollectionOption{containercollection.WithDisableContainerRuntimeWarnings()}

--- a/pkg/ig-manager/ig-manager_test.go
+++ b/pkg/ig-manager/ig-manager_test.go
@@ -43,7 +43,7 @@ const (
 func TestBasic(t *testing.T) {
 	utilstest.RequireRoot(t)
 
-	igManager, err := NewManager(nil)
+	igManager, err := NewManager(nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to start ig manager: %s", err)
 	}
@@ -53,7 +53,7 @@ func TestBasic(t *testing.T) {
 func TestContainersMap(t *testing.T) {
 	utilstest.RequireRoot(t)
 
-	igManager, err := NewManager(nil)
+	igManager, err := NewManager(nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to start ig manager: %s", err)
 	}
@@ -67,7 +67,7 @@ func TestContainersMap(t *testing.T) {
 func TestMountNsMap(t *testing.T) {
 	utilstest.RequireRoot(t)
 
-	igManager, err := NewManager(nil)
+	igManager, err := NewManager(nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to start ig manager: %s", err)
 	}
@@ -136,7 +136,7 @@ func TestClose(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	for i := 0; i < 4; i++ {
-		igManager, err := NewManager([]*containerutilsTypes.RuntimeConfig{{Name: "docker"}})
+		igManager, err := NewManager([]*containerutilsTypes.RuntimeConfig{{Name: "docker"}}, nil)
 		if err != nil {
 			t.Fatalf("Failed to start ig manager: %s", err)
 		}

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -244,7 +244,7 @@ partsLoop:
 	//   namespace ID to bet set.
 	l.fakeContainer = &containercollection.Container{Pid: pidOne, Mntns: mntns}
 
-	igManager, err := igmanager.NewManager(l.rc)
+	igManager, err := igmanager.NewManager(l.rc, nil)
 	if err != nil {
 		log.Warnf("Failed to create container-collection")
 		log.Debugf("Failed to create container-collection: %s", err)


### PR DESCRIPTION
# ig: Add optional further K8s enrichment

Two new flags are added:
1. `--with-k8s-apiserver` to enable this optional enrichment
2. `kubeconfig` to point to a kubeconfig file if it isn't in the default path(s) (Split into #3370)

One has to supply a `kubeconfig` file with is allowed to query `DaemonSets`, ...

This works for builtin gadgets and image based gadgets.
```json
$ ig trace exec -o json --with-k8s-apiserver --kubeconfig /minikube.conf
{
  "args": "/usr/sbin/iptables -w 5 -W 100000 -S KUBE-PROXY-CANARY -t mangle",
  "comm": "iptables",
 ....
  "k8s": {
    "containerName": "kube-proxy",
    "hostnetwork": true,
    "namespace": "kube-system",
    "node": "",
    "owner": {
      "kind": "DaemonSet",
      "name": "kube-proxy"
    },
    "podName": "kube-proxy-9zf67"
  },
 ....
}
{
  "args": "/bin/gadgettracermanager -liveness",
  "comm": "gadgettracerman",
 ....
  "k8s": {
    "containerName": "gadget",
    "hostnetwork": false,
    "namespace": "gadget",
    "node": "",
    "owner": {
      "kind": "DaemonSet",
      "name": "gadget"
    },
    "podName": "gadget-mdwnx"
  },
 ....
  }
```

Resolves #3260