### PR TITLE
docs: Add missing symlink to render gadget documentation

### DIFF
--- a/docs/gadgets/trace_lsm.mdx
+++ b/docs/gadgets/trace_lsm.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_lsm/README.mdx

--- a/docs/gadgets/trace_malloc.mdx
+++ b/docs/gadgets/trace_malloc.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_malloc/README.mdx

--- a/docs/gadgets/trace_signal.mdx
+++ b/docs/gadgets/trace_signal.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_signal/README.mdx

--- a/docs/gadgets/trace_ssl.mdx
+++ b/docs/gadgets/trace_ssl.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_ssl/README.mdx

--- a/docs/gadgets/trace_tcpconnect.mdx
+++ b/docs/gadgets/trace_tcpconnect.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_tcpconnect/README.mdx


### PR DESCRIPTION
Fixes: f609533acb47 ("gadgets/readmes: update all gadgets documentation")

