### PR TITLE
gadgets: update sourceURL and documentationURL

### DIFF
--- a/gadgets/audit_seccomp/gadget.yaml
+++ b/gadgets/audit_seccomp/gadget.yaml
@@ -1,8 +1,8 @@
 name: audit seccomp
 description: Audit syscalls according to the seccomp profile
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/audit_seccomp
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/audit_seccomp
 datasources:
   seccomp:
     fields:

--- a/gadgets/profile_blockio/gadget.yaml
+++ b/gadgets/profile_blockio/gadget.yaml
@@ -1,8 +1,8 @@
 name: profile blockio
 description: TODO
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/profile_blockio
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/profile_blockio
 dataSources:
   blockio:
     annotations:

--- a/gadgets/snapshot_process/gadget.yaml
+++ b/gadgets/snapshot_process/gadget.yaml
@@ -1,8 +1,8 @@
 name: snapshot process
 description: Show running processes
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/snapshot_process
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/snapshot_process
 datasources:
   processes:
     fields:

--- a/gadgets/snapshot_socket/gadget.yaml
+++ b/gadgets/snapshot_socket/gadget.yaml
@@ -1,8 +1,8 @@
 name: snapshot socket
 description: Show TCP and UDP sockets
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/snapshot_socket
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/snapshot_socket
 datasources:
   sockets:
     fields:

--- a/gadgets/top_file/gadget.yaml
+++ b/gadgets/top_file/gadget.yaml
@@ -1,8 +1,8 @@
 name: top file
 description: Periodically report read/write activity by file
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/top_file
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_file
 datasources:
   file:
     annotations:

--- a/gadgets/top_tcp/gadget.yaml
+++ b/gadgets/top_tcp/gadget.yaml
@@ -1,8 +1,8 @@
 name: top tcp
 description: Periodically report tcp send receive activity by connection
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/top_tcp
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_tcp
 datasources:
   tcp:
     annotations:

--- a/gadgets/trace_bind/gadget.yaml
+++ b/gadgets/trace_bind/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace bind
 description: Trace socket bindings
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_bind
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_bind
 datasources:
   bind:
     fields:

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace capabilities
 description: trace security capabilitiy checks
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_capabilities
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_capabilities
 datasources:
   capabilities:
     fields:

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace dns
 description: trace dns requests and responses
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs/latest/
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_dns
 datasources:
   dns:
     fields:

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace exec
 description: trace process executions
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_exec
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_exec
 datasources:
   exec:
     fields:

--- a/gadgets/trace_lsm/gadget.yaml
+++ b/gadgets/trace_lsm/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace lsm
 description: a strace for LSM tracepoints
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_lsm
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_lsm
 datasources:
   lsm:
     fields:

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace malloc
 description: use uprobe to trace malloc and free in libc.so
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_malloc
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_malloc
 datasources:
   malloc:
     fields:

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace mount
 description: trace mount syscalls
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_mount
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_mount
 datasources:
   mount:
     fields:

--- a/gadgets/trace_oomkill/gadget.yaml
+++ b/gadgets/trace_oomkill/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace oomkill
 description: trace OOM killer
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_oomkill
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_oomkill
 datasources:
   events:
     fields:

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace open
 description: trace open files
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_open
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_open
 datasources:
   open:
     fields:

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace signal
 description: trace signal
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_signal
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_signal
 datasources:
   signal:
     fields:

--- a/gadgets/trace_sni/gadget.yaml
+++ b/gadgets/trace_sni/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace sni
 description: trace sni
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_sni
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_sni
 datasources:
   sni:
     fields:

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -2,8 +2,8 @@ name: trace ssl
 description: Captures data on read/recv or write/send functions of OpenSSL, GnuTLS,
   NSS and Libcrypto
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_ssl
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_ssl
 datasources:
   ssl:
     fields:

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace tcp
 description: monitor connect, accept and close events of TCP connections
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_tcp
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_tcp
 datasources:
   tracetcp:
     fields:

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace tcpconnect
 description: trace tcp connections
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_tcpconnect
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_tcpconnect
 datasources:
   tcpconnect:
     fields:

--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace tcpdrop
 description: trace TCP packets dropped by the kernel
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_tcpdrop
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_tcpdrop
 datasources:
   tcpdrop:
     fields:

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -1,8 +1,8 @@
 name: trace tcpretrans
 description: trace TCP retransmissions
 homepageURL: https://inspektor-gadget.io/
-documentationURL: https://inspektor-gadget.io/docs
-sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_tcpretrans
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_tcpretrans
 datasources:
   tcpretrans:
     fields:


### PR DESCRIPTION
I used the following command:
```
for i in $(git grep sourceURL -- gadgets/|cut -d: -f1|grep -v /ci/) ; do
    sed -i 's|^sourceURL:.*$|sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/'$(echo $i|cut -d/ -f2)'|g' $i
    sed -i 's|^documentationURL:.*$|documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/'$(echo $i|cut -d/ -f2)'|g' $i
    git add $i
done
```

See https://github.com/inspektor-gadget/inspektor-gadget/pull/3218#discussion_r1719813402