### PR TITLE
gadgets: Update READMEs and template to mention operators' flags

### DIFF
--- a/gadgets/README-flags.template
+++ b/gadgets/README-flags.template
@@ -1,3 +1,9 @@
+{{ $image := index (index (index (datasource "artifacthubpkg") "containersImages") 0) "image" -}}
+:::note
+Depending on the operators used to run the gadget, additional flags may be available.
+Check the [operators](../reference/operators) documentation for more information.
+Additionally, if you are using the CLI, you can execute `run {{ $image }} --help` to get the full list of flags available at runtime.
+:::
 {{ if has (ds "gadget") "ebpfParams" -}}
 {{ range $index, $flag := index (ds "gadget") "ebpfParams" }}
 ### `--{{ index $flag "key" }}`

--- a/gadgets/audit_seccomp/README.mdx
+++ b/gadgets/audit_seccomp/README.mdx
@@ -34,6 +34,12 @@ one of these two conditions:
 
 ## Flags
 
+:::note
+Depending on the operators used to run the gadget, additional flags may be available.
+Check the [operators](../reference/operators) documentation for more information.
+Additionally, if you are using the CLI, you can execute `run ghcr.io/inspektor-gadget/gadget/audit_seccomp:latest --help` to get the full list of flags available at runtime.
+:::
+
 No flags.
 
 ## Guide

--- a/gadgets/fsnotify/README.mdx
+++ b/gadgets/fsnotify/README.mdx
@@ -29,6 +29,12 @@ Running the gadget:
 </Tabs>
 ## Flags
 
+:::note
+Depending on the operators used to run the gadget, additional flags may be available.
+Check the [operators](../reference/operators) documentation for more information.
+Additionally, if you are using the CLI, you can execute `run ghcr.io/inspektor-gadget/gadget/fsnotify:latest --help` to get the full list of flags available at runtime.
+:::
+
 ### `--fanotify-only`
 
 Show only fanotify events


### PR DESCRIPTION
# Update READMEs and template to mention operators' flags

As agreed during latest [Dev Sync meeting](https://docs.google.com/document/d/1cbPYvYTsdRXd41PEDcwC89IZbcA8WneNt34oiu5s9VA/edit#heading=h.101qhjpkpvi), let's add a note to let users know that additional flags may be available based on operators.

## Testing

I check it was rendered correctly in the website:

![Screenshot from 2024-08-23 15-15-38](https://github.com/user-attachments/assets/39dcf2dd-2f05-40b8-8739-89ca78fc464b)

![image](https://github.com/user-attachments/assets/3c3236fc-cea1-4391-9556-153efc5ce0eb)


## TODO (Before merging)

- [ ] Update all READMEs once we agree on the text.