### PR TITLE
columns template: add max size on some fields

### DIFF
--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -259,14 +259,17 @@ var annotationsTemplates = map[string]map[string]string{
 	},
 	"pid": {
 		ColumnsMinWidthAnnotation:  "7",
+		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"uid": {
 		ColumnsMinWidthAnnotation:  "8",
+		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"gid": {
 		ColumnsMinWidthAnnotation:  "8",
+		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"ns": {


### PR DESCRIPTION
Before this patch, a gadget could show the following:
```
$ sudo ig run mygadget --fields=pcomm,ppid,comm,pid,name
PCOMM                                                             PPID COMM                                                              PID NAME
sh                                                             1795261 wget                                                          2137524 www.wikipedia.org.
```

After this patch, it shows:
```
$ sudo ig run mygadget --fields=pcomm,ppid,comm,pid,name
PCOMM                  PPID COMM                    PID NAME
sh                  1795261 wget                2144726 www.wikipedia.org.
```

Tested while working on #2684.