### PR TITLE
 pkg/datasource/columns: Default MaxWith attribute based on field type (For int and bool)

### DIFF
--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -213,8 +213,16 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 			continue
 		}
 
-		if attributes.Width == 0 {
-			attributes.Width = columns.GetWidthFromType(f.ReflectType().Kind())
+		if attributes.Width == 0 || attributes.MaxWidth == 0 {
+			w := columns.GetWidthFromType(f.ReflectType().Kind())
+			if w > 0 {
+				if attributes.Width == 0 {
+					attributes.Width = w
+				}
+				if attributes.MaxWidth == 0 {
+					attributes.MaxWidth = w
+				}
+			}
 		}
 
 		df.Type = f.ReflectType()

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -289,17 +289,14 @@ var annotationsTemplates = map[string]map[string]string{
 	},
 	"pid": {
 		ColumnsMinWidthAnnotation:  "7",
-		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"uid": {
 		ColumnsMinWidthAnnotation:  "8",
-		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"gid": {
 		ColumnsMinWidthAnnotation:  "8",
-		ColumnsMaxWidthAnnotation:  "10",
 		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 	},
 	"ns": {


### PR DESCRIPTION
# Default MaxWith attribute based on field type (For int and bool)

After https://github.com/inspektor-gadget/inspektor-gadget/pull/3401, I propose to always set the maximum width to the maximum number of characters an integer and bool can use. 

This PR also adds support for "type" special value in the field annotations for the Width, MaxWidth and MinWidth field attributes.

## Testing done

Before and after this PR, the output for the following command is still the same:

```bash
$ go run --exec "sudo" ./cmd/ig/... run $MY_REPO/trace_exec --verify-image=false --insecure-registries=$LOCAL_REPO --pull always --fields=pcomm,ppid,comm,pid
PCOMM                  PPID COMM                    PID
```
