### PR TITLE
dependabot: Fix groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,8 @@ updates:
           - "k8s.io/*"
       docker:
         patterns:
-          - "github.com/docker/docker/*"
-          - "github.com/moby/moby/*"
+          - "github.com/docker/*"
+          - "github.com/moby/*"
       otel:
         patterns:
           - "go.opentelemetry.io/*"


### PR DESCRIPTION
Update rules to match at the org level for docker and moby.

Hopefully this will fix this error message:

updater | 2024/08/28 03:32:00 WARN <job_875214778> Please check your configuration as there are groups where no dependencies match:
- docker

This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project

And actually group those PRs.


--- 

For instance, the following PRs should be grouped after this change:
- #3409  
- #3407 
- #3408 