### PR TITLE
pkg/operators/filter: Update docs to talk about fields and not just columns

### DIFF
--- a/docs/reference/operators/filter.md
+++ b/docs/reference/operators/filter.md
@@ -19,13 +19,13 @@ output to entries that meet certain criteria.
 The filter syntax supports the following operations:
 
 ```bash
-- `columnName==value`: Matches if the content of `columnName` equals exactly `value`.
-- `columnName!=value`: Matches if the content of `columnName` does not equal exactly `value`.
-- `columnName>=value`: Matches if the content of `columnName` is greater than or equal to `value`.
-- `columnName>value`: Matches if the content of `columnName` is greater than `value`.
-- `columnName<=value`: Matches if the content of `columnName` is less than or equal to `value`.
-- `columnName<value`: Matches if the content of `columnName` is less than `value`.
-- `columnName~value`: Matches if the content of `columnName` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
+- `field==value`: Matches if the content of `field` equals exactly `value`.
+- `field!=value`: Matches if the content of `field` does not equal exactly `value`.
+- `field>=value`: Matches if the content of `field` is greater than or equal to `value`.
+- `field>value`: Matches if the content of `field` is greater than `value`.
+- `field<=value`: Matches if the content of `field` is less than or equal to `value`.
+- `field<value`: Matches if the content of `field` is less than `value`.
+- `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 ```
 
 Fully qualified name: `operators.filter.filter`

--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -120,13 +120,13 @@ The `--filter` flag allows you to filter events based on specific field values p
 The filter syntax supports the following operations:
 
 ```bash
-- `columnName==value`: Matches if the content of `columnName` equals exactly `value`.
-- `columnName!=value`: Matches if the content of `columnName` does not equal exactly `value`.
-- `columnName>=value`: Matches if the content of `columnName` is greater than or equal to `value`.
-- `columnName>value`: Matches if the content of `columnName` is greater than `value`.
-- `columnName<=value`: Matches if the content of `columnName` is less than or equal to `value`.
-- `columnName<value`: Matches if the content of `columnName` is less than `value`.
-- `columnName~value`: Matches if the content of `columnName` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
+- `field==value`: Matches if the content of `field` equals exactly `value`.
+- `field!=value`: Matches if the content of `field` does not equal exactly `value`.
+- `field>=value`: Matches if the content of `field` is greater than or equal to `value`.
+- `field>value`: Matches if the content of `field` is greater than `value`.
+- `field<=value`: Matches if the content of `field` is less than or equal to `value`.
+- `field<value`: Matches if the content of `field` is less than `value`.
+- `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 ```
 
 #### Examples:

--- a/pkg/operators/filter/filter.go
+++ b/pkg/operators/filter/filter.go
@@ -64,14 +64,14 @@ func (f *filterOperator) InstanceParams() api.Params {
 	return api.Params{&api.Param{
 		Key: ParamFilter,
 		Description: `Filter rules
-  A filter can match any column using the following syntax
-    columnName==value     - matches, if the content of columnName equals exactly value
-    columnName!=value     - matches, if the content of columnName does not equal exactly value
-    columnName>=value     - matches, if the content of columnName is greater than or equal to the value
-    columnName>value      - matches, if the content of columnName is greater than the value
-    columnName<=value     - matches, if the content of columnName is less than or equal to the value
-    columnName<value      - matches, if the content of columnName is less than the value
-    columnName~value      - matches, if the content of columnName matches the regular expression 'value'
+  A filter can match any field using the following syntax:
+    field==value     - matches, if the content of field equals exactly value
+    field!=value     - matches, if the content of field does not equal exactly value
+    field>=value     - matches, if the content of field is greater than or equal to the value
+    field>value      - matches, if the content of field is greater than the value
+    field<=value     - matches, if the content of field is less than or equal to the value
+    field<value      - matches, if the content of field is less than the value
+    field~value      - matches, if the content of field matches the regular expression 'value'
                  see [https://github.com/google/re2/wiki/Syntax] for more information on the syntax
         `,
 		Alias: "F",


### PR DESCRIPTION
# Update docs to talk about fields and not just columns in filter operator

Filtering is applied regardless the output format (columns, JSON, etc.),
so update the documentation to talk about fields in a generic way and
not just about columns.
