### PR TITLE
Add a second map to get pods and svcs by IP without GetCmp

### DIFF
--- a/pkg/cachedmap/cachedmap.go
+++ b/pkg/cachedmap/cachedmap.go
@@ -160,6 +160,9 @@ func (c *cachedMap[Key, T]) Get(key Key) (T, bool) {
 	return zeroValue, false
 }
 
+// GetCmp returns the first object for which the cmp function returns true
+// The cmp function is applied to both current and old objects until a match is found
+// This is an expensive operation and should be used with caution
 func (c *cachedMap[Key, T]) GetCmp(cmp func(T) bool) (T, bool) {
 	c.RLock()
 	defer c.RUnlock()


### PR DESCRIPTION
# Add a second map to get pods and svcs by IP without GetCmp

Checking pprof on big clusters (45k Pods) led to discover that a lot of CPU was wasted iterating over the map to run a func, which is the current method to match Pod IP addresses in the cache.

This PR proposes a second map indexed directly on IP addresses to fix that.

## Testing done

Was tried in kubescape's node-agent https://github.com/kubescape/node-agent/pull/362 and deployed on that huge cluster where we checked the better performance of the tracers.
