### PR TITLE
pkg/operators/otel-metrics: don't automatically apply metrics type based on role tag

### DIFF
--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -618,9 +618,6 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 					metricsType = MetricTypeCounter
 				} else if f.HasAnyTagsOf("type:gadget_gauge__u32", "type:gadget_gauge__u64") {
 					metricsType = MetricTypeGauge
-				} else if f.HasAnyTagsOf("role:key") {
-					// This is probably coming from the key of an eBPF map
-					metricsType = MetricTypeKey
 				}
 			}
 


### PR DESCRIPTION
Before this change, the operator would automatically flag every member of a map key as metrics.type=key. That however also affected types that were not suited for being a metrics key and thus led to an error. After this change, keys have to be explicitly set.
