### PR TITLE
pkg/datasource: Use FullName to look for fields in config

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -483,7 +483,7 @@ func (ds *dataSource) applyFieldConfig(newFields ...*field) {
 			continue
 		}
 
-		fieldConfig := fields.Sub(field.Name)
+		fieldConfig := fields.Sub(field.FullName)
 		if fieldConfig == nil {
 			continue
 		}


### PR DESCRIPTION
# Use FullName to look for fields in config

Similar to https://github.com/inspektor-gadget/inspektor-gadget/pull/3293 and https://github.com/inspektor-gadget/inspektor-gadget/pull/3271, we are not using the `FullName` to look for fields. This prevents us from correctly annotating fields.

## Testing done

Try to annotate fields with parent like this:

```bash
diff --git a/gadgets/top_tcp/gadget.yaml b/gadgets/top_tcp/gadget.yaml
index d942a1aa51c6..dcd89c74c7bd 100644
--- a/gadgets/top_tcp/gadget.yaml
+++ b/gadgets/top_tcp/gadget.yaml
@@ -8,6 +8,9 @@ datasources:
     annotations:
       cli.clear-screen-before: "true"
     fields:
+      runtime.containername:
+        annotations:
+          columns.hidden: true
       mntns_id:
         annotations:
           description: Mount namespace inode id
```

Then, build and push the gadget:

```bash
$ go run ./cmd/ig/... image build -t $LOCAL_REPO/top_tcp:no-run-container gadgets/top_tcp/
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:993dd2ee641faaf7a038df4534c893023a0a94edd24b9ba127c2eb70a00ea33a
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Successfully built ghcr.io/blanquicet/top_tcp:no-run-container@sha256:ac0e605d9600f9220249b91dec3f314fa087923b5c6302d9b6a401d2d105dbf7
```

```bash
$ go run ./cmd/ig/... image push $LOCAL_REPO/top_tcp:no-run-container
Pushing ghcr.io/blanquicet/top_tcp:no-run-container...
Successfully pushed ghcr.io/blanquicet/top_tcp:no-run-container@sha256:ac0e605d9600f9220249b91dec3f314fa087923b5c6302d9b6a401d2d105dbf7
```

Then, run the same gadget with and without this PR:

- **Before this PR:** Annotation is not applied:

```bash
$ go run --exec "sudo -E" ./cmd/ig/... run $LOCAL_REPO/top_tcp:no-run-container --verify-image=false
RUNTIME.CONTAINERNAME         PID SRC                         DST                         COMM        SENT       RECEIVED
RUNTIME.CONTAINERNAME         PID SRC                         DST                         COMM        SENT       RECEIVED
RUNTIME.CONTAINERNAME         PID SRC                         DST                         COMM        SENT       RECEIVED
```

- **After this PR:** Annotation is applied:

```bash
go run --exec "sudo -E" ./cmd/ig/... run $LOCAL_REPO/top_tcp:no-run-container --verify-image=false
       PID SRC                                DST                                COMM           SENT          RECEIVED
```



