### PR TITLE
gadgets/top_tcp: Mark received and sent fields as metric counters

### DIFF
--- a/gadgets/top_tcp/program.bpf.c
+++ b/gadgets/top_tcp/program.bpf.c
@@ -32,8 +32,8 @@ struct ip_key_t {
 };
 
 struct traffic_t {
-	size_t sent;
-	size_t received;
+	gadget_counter__u32 sent;
+	gadget_counter__u32 received;
 };
 
 struct {


### PR DESCRIPTION
# Mark received and sent fields as metric counters for top_tcp gadget

Given that the `sent` and `received` fields act already as counters, let's use the `gadget_counter__u32` type to make Inspektor Gadget manage them as metric counters. Doing so, we simplify the users' life because they will just need to select the key to make Inspektor Gadget start exporting the metrics for the `tcp` datasource.

Once we agree it's fine, I'll do the same for other top gadgets.

## How to use

This change has no impact if metrics collection is disable.

## Testing done

All the testing was done on top of https://github.com/inspektor-gadget/inspektor-gadget/pull/3468.

Build gadget:

```bash
ig image build -t $CUSTOM_REPO/top_tcp:metrics-export gadgets/top_tcp
ig image push $CUSTOM_REPO/top_tcp:metrics-export
```

Start daemon with metrics listener enabled:

```bash
sudo ig daemon -H tcp://$IG_TARGET:9999 \
			--otel-metrics-listen=true \
			--verify-image=false"
```

Run `top_tcp` gadget and export `sent` and `received` as counter and `comm` as key:

- **Without this PR**
```bash
gadgetctl --remote-address tcp://$IG_TARGET:9999 \
			run ghcr.io/inspektor-gadget/gadget/top_tcp:latest \
			--annotate=tcp:metrics.collect=true,tcp.comm:metrics.type=key,tcp.received:metrics.type=counter,tcp.sent:metrics.type=counter \
			--otel-metrics-name tcp:demotcp
```

- **With this PR**:
```bash
gadgetctl --remote-address tcp://$IG_TARGET:9999 \
			run $CUSTOM_REPO/top_tcp:metrics-export \
			--annotate=tcp:metrics.collect=true,tcp.comm:metrics.type=key \
			--otel-metrics-name tcp:demotcp
```

Now, verify that metrics were exported after running a couple of `wget` and `apt` commands on a container:

```
$ curl http://192.168.56.2:2224/metrics -s | grep "demotcp"
otel_scope_info{otel_scope_name="demotcp",otel_scope_version=""} 1
received_total{comm="http",otel_scope_name="demotcp",otel_scope_version=""} 253456
received_total{comm="wget",otel_scope_name="demotcp",otel_scope_version=""} 9.12388876e+08
sent_total{comm="http",otel_scope_name="demotcp",otel_scope_version=""} 852
sent_total{comm="wget",otel_scope_name="demotcp",otel_scope_version=""} 1322
```


