### PR TITLE
oci: Set artifactType in all cases

### DIFF
--- a/docs/spec/oci.md
+++ b/docs/spec/oci.md
@@ -23,6 +23,13 @@ architectures are supported:
 - amd64
 - arm64
 
+## ArtifactType
+
+Media type: `application/vnd.gadget.v1+binary`
+
+This indicates the manifest is a Gadget. It follows the guidelines in:
+https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage.
+
 ## Gadget metadata
 
 Media type: `application/vnd.gadget.config.v1+yaml`

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -42,6 +42,7 @@ const (
 )
 
 const (
+	artifactType        = "application/vnd.gadget.v1+binary"
 	eBPFObjectMediaType = "application/vnd.gadget.ebpf.program.v1+binary"
 	wasmObjectMediaType = "application/vnd.gadget.wasm.program.v1+binary"
 	btfgenMediaType     = "application/vnd.gadget.btfgen.v1+binary"
@@ -225,10 +226,6 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 	}
 
 	var defDesc ocispec.Descriptor
-	// artifactType must be only set when the config.mediaType is set to
-	// MediaTypeEmptyJSON. In our case, when the metadata file is not provided:
-	// https://github.com/opencontainers/image-spec/blob/f5f87016de46439ccf91b5381cf76faaae2bc28f/manifest.md?plain=1#L170
-	var artifactType string
 
 	if _, err := os.Stat(metadataFilePath); err == nil {
 		// Read the metadata file into a byte array
@@ -243,7 +240,6 @@ func createManifestForTarget(ctx context.Context, target oras.Target, metadataFi
 		if err != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("creating empty descriptor: %w", err)
 		}
-		artifactType = eBPFObjectMediaType
 
 		// Even without metadata, we can still set some annotations
 		defDesc.Annotations = map[string]string{


### PR DESCRIPTION
The documentation in [0] states we can set the artifactType in all cases, do it to simplify the logic.

[0]: https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage
See https://github.com/inspektor-gadget/inspektor-gadget/pull/2572#discussion_r1752171717

### Discussion

I still don't think `application/vnd.gadget.ebpf.program.v1+binary` is right. IMO it should be something like `application/vnd.gadget+binary` as the manifest refers to the whole gadget, not a single layer. 
See previous discussion on https://github.com/inspektor-gadget/inspektor-gadget/pull/2177#discussion_r1370713366 too.

