### PR TITLE
pkg: Add safeset package.

### DIFF
--- a/pkg/columns/formatter/json/json.go
+++ b/pkg/columns/formatter/json/json.go
@@ -25,6 +25,7 @@ import (
 	_ "unsafe"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeset"
 )
 
 type column[T any] struct {
@@ -329,7 +330,7 @@ func writeString(e *encodeState, s string) {
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
-			if safeSet[b] {
+			if safeset.SafeSet[b] {
 				i++
 				continue
 			}
@@ -396,8 +397,3 @@ func writeString(e *encodeState, s string) {
 }
 
 var hex = "0123456789abcdef"
-
-// use safeSet from encoding/json directly
-//
-//go:linkname safeSet encoding/json.safeSet
-var safeSet = [utf8.RuneSelf]bool{}

--- a/pkg/datasource/formatters/json/json.go
+++ b/pkg/datasource/formatters/json/json.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeset"
 )
 
 var (
@@ -480,7 +481,7 @@ func writeString(e *encodeState, s string) {
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
-			if safeSet[b] {
+			if safeset.SafeSet[b] {
 				i++
 				continue
 			}
@@ -547,8 +548,3 @@ func writeString(e *encodeState, s string) {
 }
 
 const hexChars = "0123456789abcdef"
-
-// use safeSet from encoding/json directly
-//
-//go:linkname safeSet encoding/json.safeSet
-var safeSet = [utf8.RuneSelf]bool{}

--- a/pkg/utils/safeset/safeset.go
+++ b/pkg/utils/safeset/safeset.go
@@ -1,0 +1,127 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safeset
+
+import "unicode/utf8"
+
+// SafeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+//
+// Taken from:
+// https://cs.opensource.google/go/go/+/release-branch.go1.23:src/encoding/json/tables.go;l=15-112.
+// This variable was never modified since its introduction in 2016:
+// https://cs.opensource.google/go/go/+/ed8f207940c8787d344664a43071b235e2ce5c68
+var SafeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}


### PR DESCRIPTION
Before this commit, we used the private variable safeSet available in encoding/json through linkname.
But, since golang 1.23, linkname is not authorized by default [1].

So, this commit introduces the safeset package which defines the SafeSet map. This map has the exact same value as encoding/json.safeSet [2]. It is also safe to add it in our sources, as this variable was not modified upstream since its introduction in 2016 [3].

This permits the whole project to be compiled using golang 1.23.

[1]: https://github.com/golang/go/issues/67401
[2]: https://cs.opensource.google/go/go/+/release-branch.go1.23:src/encoding/json/tables.go;l=15-112
[3]: https://cs.opensource.google/go/go/+/ed8f207940c8787d344664a43071b235e2ce5c68