### PR TITLE
operators/oci: allow adding custom parameters from gadget.yaml

### DIFF
--- a/docs/gadget-devel/parameters.md
+++ b/docs/gadget-devel/parameters.md
@@ -4,6 +4,8 @@ sidebar_position: 610
 description: 'Gadget Parameters'
 ---
 
+## Parameters from eBPF programs
+
 A Gadget can expose parameters to the client from the eBPF program. Inspektor
 Gadget provides the mechanism to expose the parameters as CLI flags to the user
 and allow to set them from the configuration file.
@@ -30,3 +32,59 @@ params:
       defaultValue: "false"
       description: Description for the param
 ```
+
+## Customizable parameters
+
+Much of Inspektor Gadget's functionality is controlled by parameters and
+annotations. To give gadget authors more freedom, one can define new parameters
+that affect a group of other parameters, datasource and field annotations, operator's
+configuration or any other field in the metadata file. This works by patching the
+gadget metadata itself, depending on those custom parameters' values.
+
+In the `gadget.yaml`, create a new section called `custom` to `params` like this:
+
+```yaml
+params:
+  custom:
+    myCustomParam:
+      description: A parameter that will apply a patch based on one of the possible values.
+      defaultValue: "option1"
+      values:
+        option1:
+          patch:
+            datasources:
+              myDataSource:
+                annotations:
+                  columns.output: none
+    mySecondParam:
+      description: Another parameter. This will apply a patch globally, regardless of the actual value.
+      defaultValue: "default"
+      patch:
+        datasources:
+          myDataSource:
+            annotations:
+              my.annotation: >-
+                A template driven value, now {{call .getParamValue "custom.mySecondParam"}}.
+              my.second.annotation: >-
+                We can also access other configuration values, like the gadget name: {{call .getConfig "name"}}
+```
+
+All keys below `custom` will become new parameters that can be set by the user
+of the gadget. Depending on the parameters' value, a `patch` node will be applied
+to the gadget metadata itself. (See `myCustomParam` example above.)
+
+If no specific values are configured, a global `patch` section will be applied. (See
+`mySecondParam` example above.)
+
+Strings used can use templates (explained [here](https://pkg.go.dev/text/template)).
+Functions available to the templating engine are:
+
+### getParamValue(paramName)
+
+Can be used to get the value of any set parameter; paramName needs to be fully qualified, e.g.
+`custom.mySecondParam` or `operator.oci.ebpf.target_family`.
+
+### getConfig(key)
+
+Can be used to get the value of any metadata key like `name`,
+`params.custom.myCustomParam.description`, etc.

--- a/gadgets/top_process/gadget.yaml
+++ b/gadgets/top_process/gadget.yaml
@@ -11,3 +11,13 @@ datasources:
   processes:
     annotations:
       cli.clear-screen-before: "true"
+params:
+  custom:
+    interval:
+      description: "interval to re-read statistics"
+      defaultValue: 3s
+      patch:
+        operator:
+          process:
+            interval: >-
+              {{call .getParamValue "custom.interval"}}

--- a/pkg/gadget-context/context_test.go
+++ b/pkg/gadget-context/context_test.go
@@ -16,8 +16,10 @@ package gadgetcontext
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -113,4 +115,378 @@ paramDefaults:
 	}
 
 	t.Fatalf("param not found")
+}
+
+func TestProcessCustomParams(t *testing.T) {
+	tests := []struct {
+		name                    string
+		metadata                string
+		paramValues             map[string]string
+		expectedParams          []string
+		expectedError           bool
+		expectedMetadataChanges map[string]interface{}
+	}{
+		{
+			name:                    "no custom params",
+			metadata:                `name: test-gadget`,
+			paramValues:             nil,
+			expectedParams:          []string{},
+			expectedError:           false,
+			expectedMetadataChanges: nil,
+		},
+		{
+			name: "single custom param with no values and no patch",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      defaultValue: "default"
+      alias: "m"`,
+			paramValues:             nil,
+			expectedParams:          []string{},
+			expectedError:           false, // It doesn't fail here but it should fail at build time (TODO)
+			expectedMetadataChanges: nil,
+		},
+		{
+			name: "single custom param with values but no paramValues (simulating GetGadgetInfo path)",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      defaultValue: "verbose"
+      alias: "m"
+      values:
+        verbose:
+          patch:
+            debug: true
+        quiet:
+          patch:
+            debug: false`,
+			paramValues:             nil,
+			expectedParams:          []string{"mode"},
+			expectedError:           false,
+			expectedMetadataChanges: nil, // No changes expected as paramValues are not provided
+		},
+		{
+			name: "single custom param with empty patch",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      defaultValue: "verbose"
+      alias: "m"
+      values:
+        verbose:
+          patch:
+        quiet:
+          patch:
+            debug: false`,
+			paramValues:             map[string]string{"custom.mode": "verbose"},
+			expectedParams:          []string{"mode"},
+			expectedError:           false, // Shouldn't this fail?
+			expectedMetadataChanges: nil,   // No changes expected as patch is empty
+		},
+		{
+			name: "custom param with global patch fallback",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      defaultValue: "verbose"
+      patch:
+        global: true
+      values:
+        verbose:
+          # No patch here, should use global fallback (global: true)
+        quiet:
+          patch:
+            debug: false`,
+			paramValues:             map[string]string{"custom.mode": "verbose"},
+			expectedParams:          []string{"mode"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"global": true},
+		},
+		{
+			name: "custom param with simple patch",
+			metadata: `
+params:
+  custom:
+    target:
+      description: "Target specification"
+      defaultValue: "local"
+      values:
+        local:
+          patch:
+            target.host: "localhost"
+            target.port: "8080"`,
+			paramValues:             map[string]string{"custom.target": "local"},
+			expectedParams:          []string{"target"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"target.host": "localhost", "target.port": "8080"},
+		},
+		{
+			name: "invalid template syntax",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      values:
+        verbose:
+          patch:
+            target: "{{.invalidTemplate"`,
+			paramValues:             map[string]string{"custom.mode": "verbose"},
+			expectedParams:          []string{"mode"},
+			expectedError:           true,
+			expectedMetadataChanges: nil,
+		},
+		{
+			name: "template execution error",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      values:
+        verbose:
+          patch:
+            target: "{{call .nonExistentFunction \"test\"}}"`,
+			paramValues:             map[string]string{"custom.mode": "verbose"},
+			expectedParams:          []string{"mode"},
+			expectedError:           true,
+			expectedMetadataChanges: nil,
+		},
+		{
+			name: "template execution error with invalid function arguments",
+			metadata: `
+params:
+  custom:
+    mode:
+      description: "Operating mode"
+      values:
+        verbose:
+          patch:
+            target: "{{call .getConfig}}"`, // Missing required argument
+			paramValues:             map[string]string{"custom.mode": "verbose"},
+			expectedParams:          []string{"mode"},
+			expectedError:           true,
+			expectedMetadataChanges: nil,
+		},
+		{
+			name: "template using getConfig function",
+			metadata: `
+name: test-gadget
+target:
+  host: "default-host"
+  port: 8080
+params:
+  custom:
+    connection:
+      description: "Connection configuration"
+      defaultValue: "default"
+      values:
+        default:
+          patch:
+            connection:
+              url: "http://{{call .getConfig \"target.host\"}}:{{call .getConfig \"target.port\"}}/api"
+        custom:
+          patch:
+            connection:
+              url: "http://custom-host:9090/api"`,
+			paramValues:             map[string]string{"custom.connection": "default"},
+			expectedParams:          []string{"connection"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"connection.url": "http://default-host:8080/api"},
+		},
+		{
+			name: "template using getParamValue function",
+			metadata: `
+name: test-gadget
+params:
+  ebpf:
+    debug:
+      key: debug
+      defaultValue: "false"
+      description: "Enable debug mode for eBPF program"
+  custom:
+    target_env:
+      description: "Target environment"
+      defaultValue: "production"
+      values:
+        production:
+          patch:
+            deployment:
+              environment: "production"
+              debug: "{{call .getParamValue \"ebpf.debug\"}}"
+              replicas: 3
+        development:
+          patch:
+            deployment:
+              environment: "development"
+              debug: "{{call .getParamValue \"ebpf.debug\"}}"
+              replicas: 1`,
+			paramValues:             map[string]string{"custom.target_env": "development", "ebpf.debug": "true"},
+			expectedParams:          []string{"target_env"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"deployment.environment": "development", "deployment.debug": "true", "deployment.replicas": 1},
+		},
+		{
+			name: "patch datasource annotations",
+			metadata: `
+name: test-gadget
+datasources:
+  processes:
+    annotations:
+      cli.clear-screen-before: "false"
+params:
+  custom:
+    clear_screen:
+      description: "Clear screen before output"
+      defaultValue: "enabled"
+      values:
+        enabled:
+          patch:
+            datasources:
+              processes:
+                annotations:
+                  cli.clear-screen-before: "true"
+        disabled:
+          patch:
+            datasources:
+              processes:
+                annotations:
+                  cli.clear-screen-before: "false"`,
+			paramValues:             map[string]string{"custom.clear_screen": "enabled"},
+			expectedParams:          []string{"clear_screen"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"datasources.processes.annotations.cli.clear-screen-before": "true"},
+		},
+		{
+			name: "patch field annotations",
+			metadata: `
+name: test-gadget
+datasources:
+  events:
+    fields:
+      pid:
+        annotations:
+          columns.width: "8"
+params:
+  custom:
+    pid_width:
+      description: "Width of PID column"
+      defaultValue: "normal"
+      values:
+        normal:
+          patch:
+            datasources:
+              events:
+                fields:
+                  pid:
+                    annotations:
+                      columns.width: "8"
+        wide:
+          patch:
+            datasources:
+              events:
+                fields:
+                  pid:
+                    annotations:
+                      columns.width: "12"`,
+			paramValues:             map[string]string{"custom.pid_width": "wide"},
+			expectedParams:          []string{"pid_width"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"datasources.events.fields.pid.annotations.columns.width": "12"},
+		},
+		{
+			name: "patch operator configuration and patching multiple fields",
+			metadata: `
+name: test-gadget
+operator:
+  process:
+    interval: 1s
+params:
+  custom:
+    interval:
+      description: "Interval to re-read statistics"
+      defaultValue: "3s"
+      values:
+        fast:
+          patch:
+            operator:
+              process:
+                interval: "1s"
+                anotherConfig: true
+        slow:
+          patch:
+            operator:
+              process:
+                interval: "10s"
+                anotherConfig: false`,
+			paramValues:             map[string]string{"custom.interval": "fast"},
+			expectedParams:          []string{"interval"},
+			expectedError:           false,
+			expectedMetadataChanges: map[string]interface{}{"operator.process.interval": "1s", "operator.process.anotherConfig": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new gadget context with a mock logger
+			ctx := New(context.Background(), "test-image")
+
+			// Set up viper with the test configuration
+			v := viper.New()
+			v.SetConfigType("yaml")
+			err := v.ReadConfig(strings.NewReader(tt.metadata))
+			require.NoError(t, err)
+
+			// Store the original viper for comparison
+			originalViper := v
+
+			// Call the function under test
+			err = ctx.processCustomParams(v, tt.paramValues)
+
+			// Check error expectations
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Check the parameters were added to the context
+			params := ctx.Params()
+			assert.Len(t, params, len(tt.expectedParams))
+
+			// Check that the expected keys (params' name) are present
+			actualKeys := make([]string, len(params))
+			for i, p := range params {
+				// Verify the prefix is always "custom."
+				assert.Equal(t, "custom.", p.Prefix)
+				actualKeys[i] = p.Key
+			}
+			for _, expectedKey := range tt.expectedParams {
+				assert.Contains(t, actualKeys, expectedKey)
+			}
+
+			// Validate configuration changes
+			currentViper := v
+			if len(tt.expectedMetadataChanges) == 0 {
+				// Configuration should remain completely unchanged
+				assert.Equal(t, originalViper.AllSettings(), currentViper.AllSettings(), "Configuration should not have changed")
+			} else {
+				// Configuration should contain exactly the expected changes and nothing more
+				// Apply expected changes to original config
+				for key, value := range tt.expectedMetadataChanges {
+					originalViper.Set(key, value)
+				}
+				assert.Equal(t, originalViper.AllSettings(), currentViper.AllSettings(), "Configuration should contain exactly the expected changes")
+			}
+		})
+	}
 }

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -226,6 +226,9 @@ func (c *GadgetContext) Run(paramValues api.ParamValues) error {
 		}
 	}()
 
+	// keep a copy - currently only used for custom params in SetMetadata()
+	c.paramValues = paramValues
+
 	metricAttribs := attribute.NewSet(
 		attribute.KeyValue{Key: "gadget_image", Value: attribute.StringValue(c.imageName)},
 	)

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -287,7 +287,6 @@ func constructTempConfig(ann string) (map[string]any, int, error) {
 				},
 			},
 		}
-		viper.Set("a", "b")
 		return tmpConfig, 1, nil
 
 	case 2:
@@ -390,8 +389,11 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 	}
 	r.Close()
 
-	// Store metadata for serialization
-	gadgetCtx.SetMetadata(metadata)
+	// Store metadata
+	err = gadgetCtx.SetMetadata(metadata)
+	if err != nil {
+		return fmt.Errorf("setting metadata: %w", err)
+	}
 
 	cfg, ok := gadgetCtx.GetVar("config")
 	if !ok {

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Inspektor Gadget authors
+// Copyright 2022-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ type GadgetContext interface {
 	GetVar(string) (any, bool)
 	Params() []*api.Param
 	SetParams([]*api.Param)
-	SetMetadata([]byte)
+	SetMetadata([]byte) error
 	OrasTarget() oras.ReadOnlyTarget
 	IsRemoteCall() bool
 	IsClient() bool

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The Inspektor Gadget authors
+// Copyright 2022-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ type GadgetContext interface {
 	LoadGadgetInfo(info *api.GadgetInfo, paramValues api.ParamValues, run bool, extraInfo *api.ExtraInfo) error
 	StopLocalOperators()
 	Params() []*api.Param
-	SetMetadata([]byte)
+	SetMetadata([]byte) error
 	SetParams([]*api.Param)
 	DataOperators() []operators.DataOperator
 	OrasTarget() oras.ReadOnlyTarget


### PR DESCRIPTION
This adds support to create custom parameters in the manifest (`gadget.yaml`) that can then apply parameters, annotations and such to the base metadata. This allows easy creation of presets of configurations by the gadget author.

It uses [template/text](https://pkg.go.dev/text/template) for template logic and has access to the configuration (gadget params) and the metadata itself.

If the gadget developer needs even more logic, the fallback should be to use a WASM module for it (#3449, #3475), which will of course require the gadget author to be familiar with Go (or whatever language is used to compile to WASM in that case).

```
$ ig run mygadget --help
Run a gadget

Usage:
  ig run [flags]

Flags:
...
      --mycustomparam string                   Description for the param [option1] (default "option1")
      --mysecondparam string                    (default "")
```

When running a gadget, you can now set:
```sh
$ ig run mygadget --myCustomParam=option1 --mysecondparam foobar
```

Which would lead to these annotations being set:
```
myDataSource:columns.output=none
myDataSource:my.annotation=A template driven value, now foobar.
myDataSource:my.second.annotation=We can also access other configuration values, like the gadget name: mygadget
```

Basically, everything under `patch` will be used to patch the gadget metadata.