### PR TITLE
docs: Use constants to point to correct versions in docs

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -52,6 +52,11 @@ jobs:
       run: |
         make manifests generate generate-documentation
         git diff --exit-code HEAD --
+    - name: Replace tag constant
+      run: |
+        # Replace tag and branch constants to be able to check links
+        find docs/ -type f -exec sed -i 's/%IG_BRANCH%/main/g' {} +
+        find docs/ -type f -exec sed -i 's/%IG_TAG%/latest/g' {} +
     - name: Check that there are not broken links
       uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
       with:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Check [Installing on Kubernetes](https://www.inspektor-gadget.io/docs/latest/ref
 We can use [kubectl node debug](https://kubernetes.io/docs/tasks/debug/debug-cluster/kubectl-node-debug/) to run `ig` on a Kubernetes node:
 
 ```bash
-kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig run trace_open:latest
+kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig:latest -- ig run trace_open:latest
 ```
 
 For more information on how to use `ig` without installation on Kubernetes, please refer to the [ig documentation](https://www.inspektor-gadget.io/docs/latest/reference/ig#using-ig-with-kubectl-debug-node).
@@ -85,7 +85,7 @@ Check [Installing on Linux](https://www.inspektor-gadget.io/docs/latest/referenc
 #### Run in a Container
 
 ```bash
-docker run -ti --rm --privileged -v /:/host --pid=host ghcr.io/inspektor-gadget/ig run trace_open:latest
+docker run -ti --rm --privileged -v /:/host --pid=host ghcr.io/inspektor-gadget/ig:latest run trace_open:latest
 ```
 
 For more information on how to use `ig` without installation on Linux, please check [Using ig in a container](https://www.inspektor-gadget.io/docs/latest/reference/ig#using-ig-in-a-container).

--- a/docs/api/golang.md
+++ b/docs/api/golang.md
@@ -6,7 +6,7 @@ description: 'Reference documentation for Inspektor Gadget Golang API'
 
 It's possible to run gadgets and consume their output directly from a Golang
 application. This documentation is still WIP, so please check
-https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
+https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/examples/gadgets
 to get more information.
 
 TODO: Complete documentation.

--- a/docs/api/grpc.md
+++ b/docs/api/grpc.md
@@ -8,12 +8,12 @@ TODO
 
 ## api.proto
 
-[pkg/gadget-service/api/api.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/gadget-service/api/api.proto)
-
 TODO
+
+[pkg/gadget-service/api/api.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/pkg/gadget-service/api/api.proto)
 
 ## gadgettracermanager.proto
 
-[pkg/gadgettracermanager/api/gadgettracermanager.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/gadgettracermanager/api/gadgettracermanager.proto)
+[pkg/gadgettracermanager/api/gadgettracermanager.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/pkg/gadgettracermanager/api/gadgettracermanager.proto)
 
 TODO

--- a/docs/devel/ci.md
+++ b/docs/devel/ci.md
@@ -286,7 +286,7 @@ You can see the guide [here](https://cloud.google.com/kubernetes-engine/docs/how
 ## Benchmarks
 
 Inspektor Gadget has
-[benchmark tests](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/internal/benchmarks/benchmarks_test.go)
+[benchmark tests](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/internal/benchmarks/benchmarks_test.go)
 that are automatically executed and published by
 [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark). You can see the results on:
 

--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -12,7 +12,7 @@ life easier when implementing gadgets.
 ## Container enrichment
 
 To make use of container enrichment, gadgets must include
-[gadget/mntns.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/include/gadget/mntns.h):
+[gadget/mntns.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/include/gadget/mntns.h):
 
 ```C
 #include <gadget/mntns.h>
@@ -65,7 +65,7 @@ and the container runtime (docker, cri-o, containerd, etc.).
 ## Container filtering
 
 To make use of container filtering, gadgets must include
-[gadget/mntns_filter.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/include/gadget/mntns_filter.h):
+[gadget/mntns_filter.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/include/gadget/mntns_filter.h):
 
 ```C
 #include <gadget/mntns_filter.h>
@@ -82,7 +82,7 @@ if (gadget_should_discard_mntns_id(mntns_id))
 ## Socket enrichment
 
 To make use of socket enrichment, gadgets must include
-[gadget/sockets-map.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/include/gadget/sockets-map.h).
+[gadget/sockets-map.h](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/include/gadget/sockets-map.h).
 
 For eBPF programs of type socket filter:
 

--- a/docs/gadget-devel/gadget-intro.md
+++ b/docs/gadget-devel/gadget-intro.md
@@ -56,8 +56,8 @@ GADGET_TRACER(name, mapname, structname);
 - structname: Name of the structure defining the gadget's event
 
 Examples of Gadgets that use this kind of data sources are
-[trace_open](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_open),
-[trace_exec](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_exec),
+[trace_open](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets/trace_open),
+[trace_exec](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets/trace_exec),
 etc.
 
 ### Map Iterators
@@ -94,7 +94,7 @@ GADGET_MAPITER(name, mapname)
 - name: Name of the data source
 - mapname: Name of the hash map used to store the data
 
-[top_file](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_file)
+[top_file](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets/top_file)
 is an example of a gadget using this data source.
 
 ### Snapshotters

--- a/docs/gadget-devel/testing.md
+++ b/docs/gadget-devel/testing.md
@@ -7,7 +7,7 @@ description: 'Testing a Gadget'
 :::warning
 
 This document is slighty outdated, please check the [existing
-gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets)
+gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets)
 to learn how they implement the tests.
 
 :::

--- a/docs/gadgets/index.mdx
+++ b/docs/gadgets/index.mdx
@@ -8,7 +8,7 @@ import DocCardList from '@theme/DocCardList';
 
 This section provides documentation for *some* of the Gadgets that are hosted in
 the
-[gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets)
+[gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets)
 folder of the Inspektor Gadget source tree. Check [Artifact
 HUB](https://artifacthub.io/packages/search?kind=22) to get a more complete list
 of Gadgets.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ using the [`ig image build`](./gadget-devel/building.md) command.
 You can find a growing collection of Gadgets on [Artifact
 HUB](https://artifacthub.io/packages/search?kind=22). This includes both in-tree
 Gadgets (hosted in this git repository in the
-[gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets)
+[gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets)
 directory and third-party Gadgets).
 
 See the [Gadget documentation](./gadgets/) for more information.

--- a/docs/legacy/prometheus.md
+++ b/docs/legacy/prometheus.md
@@ -418,7 +418,7 @@ We can see how the counter for `mycontainer` is increased in http://localhost:90
 #### Grafana
 
 It's possible to visualize the metrics in Grafana. As an example we will plot a histogram for DNS requests latency. We
-can use the [docker compose file](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/tools/monitoring/docker-compose.yml) to prepare the environment:
+can use the [docker compose file](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/tools/monitoring/docker-compose.yml) to prepare the environment:
 
 ```bash
 $ pushd tools/monitoring

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -34,7 +34,7 @@ commands.
 ```bash
 kubectl krew install gadget
 kubectl gadget deploy
-kubectl gadget run trace_open:latest
+kubectl gadget run trace_open:%IG_TAG%
 ```
 
 Check [Installing on Kubernetes](./reference/install-kubernetes.md) to learn more about different options.
@@ -44,7 +44,7 @@ Check [Installing on Kubernetes](./reference/install-kubernetes.md) to learn mor
 We can use [kubectl node debug](https://kubernetes.io/docs/tasks/debug/debug-cluster/kubectl-node-debug/) to run `ig` on a Kubernetes node:
 
 ```bash
-kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig run trace_open:latest
+kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig:%IG_TAG% -- ig run trace_open:%IG_TAG%
 ```
 
 For more information on how to use `ig` without installation on Kubernetes, please refer to the [ig documentation](./reference/ig.md#using-ig-with-kubectl-debug-node).
@@ -61,7 +61,7 @@ IG_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gad
 
 curl -sL https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${IG_VERSION}/ig-linux-${IG_ARCH}-${IG_VERSION}.tar.gz | sudo tar -C /usr/local/bin -xzf - ig
 
-sudo ig run trace_open:latest
+sudo ig run trace_open:%IG_TAG%
 ```
 
 Check [Installing on Linux](./reference/install-linux.md) to learn more.
@@ -69,7 +69,7 @@ Check [Installing on Linux](./reference/install-linux.md) to learn more.
 #### Run in a Container
 
 ```bash
-docker run -ti --rm --privileged -v /:/host --pid=host ghcr.io/inspektor-gadget/ig run trace_open:latest
+docker run -ti --rm --privileged -v /:/host --pid=host ghcr.io/inspektor-gadget/ig:%IG_TAG% run trace_open:%IG_TAG%
 ```
 
 For more information on how to use `ig` without installation on Linux, please check [Using ig in a container](./reference/ig.md#using-ig-in-a-container).
@@ -90,7 +90,7 @@ Download the `gadgetctl` tools for MacOS
 
 
 ```bash
-gadgetctl run trace_open:latest --remote-address=tcp://$IP:1234
+gadgetctl run trace_open:%IG_TAG% --remote-address=tcp://$IP:1234
 ```
 
 ***The above demonstrates the simplest command. To learn how to filter, export, etc. please consult the documentation for the [run](./reference/run.mdx) command***.

--- a/docs/reference/ig.md
+++ b/docs/reference/ig.md
@@ -330,10 +330,10 @@ List of flags:
 
 ### Using ig in a Kubernetes pod
 
-In order to run `ig` in a Kubernetes pod use [pod-ig.yaml](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/docs/examples/pod-ig.yaml).
+In order to run `ig` in a Kubernetes pod use [pod-ig.yaml](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/docs/examples/pod-ig.yaml).
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/main/docs/examples/pod-ig.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/%IG_BRANCH%/docs/examples/pod-ig.yaml
 $ kubectl logs ig
 RUNTIME.CONTAINERNAME          RUNTIME.CONTAIN… PID              PPID             COMM             RET ARGS
 kube-proxy                     k8s.gcr.io/kube… 3985376          3024961          ip6tables        0   /usr/sbin/ip6tables -w 5 -W 100000 -S K…
@@ -361,10 +361,10 @@ you use the appropriate `--platforms` flag of `docker buildx build` (see
 [Docker documentation about multi-platform images](https://docs.docker.com/build/building/multi-platform/#example)).
 
 You can then run your image locally or in a Kubernetes pod.
-Here is an example using a Kubernetes DaemonSet: [ds-ig.yaml](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/docs/examples/ds-ig.yaml):
+Here is an example using a Kubernetes DaemonSet: [ds-ig.yaml](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/docs/examples/ds-ig.yaml):
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/main/docs/examples/ds-ig.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/%IG_BRANCH%/docs/examples/ds-ig.yaml
 $ kubectl exec -ti $(kubectl get pod -o name -l name=example-ig | head -1) -- sh
 / # ig trace exec
 ```

--- a/docs/spec/operators/oci.md
+++ b/docs/spec/operators/oci.md
@@ -26,7 +26,7 @@ Public keys used to verify the gadgets. Check [Verify image-based
 gadgets](../../reference/verify-assets.mdx#verify-image-based-gadgets) to learn more.
 
 Default: [Inspektor Gadget public
-key](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/resources/inspektor-gadget.pub).
+key](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/pkg/resources/inspektor-gadget.pub).
 
 ### `allowed-gadgets`
 

--- a/gadgets/audit_seccomp/README.mdx
+++ b/gadgets/audit_seccomp/README.mdx
@@ -21,13 +21,13 @@ one of these two conditions:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/audit_seccomp:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/audit_seccomp:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/audit_seccomp:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/audit_seccomp:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -137,7 +137,7 @@ Then, start the audit_seccomp gadget and observe how it logs the `unshare` sysca
 <TabItem value="kubectl-gadget" label="kubectl gadget">
 
 ```bash
-$ kubectl gadget run audit_seccomp:latest
+$ kubectl gadget run audit_seccomp:%IG_TAG%
 K8S.NODE          K8S.NAMESPACE   K8S.PODNAME     K8S.CONTAINERN… COMM          PID     TID      UID      GID CODE      SYSCALL
 minikube-docker   default         mypod           container1      mkdir       60482   60482        0        0 …_RET_LOG SYS_MKDIR
 minikube-docker   default         mypod           container1      unshare     60483   60483        0        0 …L_THREAD SYS_UNSH…
@@ -151,7 +151,7 @@ minikube-docker   default         mypod           container1      unshare     60
 <TabItem value="ig" label="ig">
 
 ```bash
-$ sudo -E ig run audit_seccomp:latest
+$ sudo -E ig run audit_seccomp:%IG_TAG%
 RUNTIME.CONTAINERNAME COMM                  PID         TID         UID         GID CODE          SYSCALL
 test-audit-seccomp    unshare            485855      485855           0           0 …_KILL_THREAD SYS_UNSHARE
 test-audit-seccomp    unshare            485865      485865           0           0 …_KILL_THREAD SYS_UNSHARE

--- a/gadgets/deadlock/README.mdx
+++ b/gadgets/deadlock/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/deadlock:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/deadlock:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -40,7 +40,7 @@ For this example, we use a [test C++ program](https://github.com/iovisor/bcc/blo
 
 The deadlock gadget can trace all mutex lock/unlock events in the following way:
 ```bash
-$ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:latest
+$ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:%IG_TAG%
 RUNTIME.CONTAINERNAME      COMM                  PID        TID MUTEX_ADDR        OPERATION
 hungry_turing              test                23148      23148 0x7FED1243EA58    lock
 hungry_turing              test                23148      23148 0x7FED1243EA58    unlock

--- a/gadgets/fsnotify/README.mdx
+++ b/gadgets/fsnotify/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/fsnotify:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/fsnotify:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -75,7 +75,7 @@ touch /tmp/ABCDE
 
 The fsnotify gadget can observe and enrich the inotify events in the following way:
 ```bash
-$ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:latest --inotify-only --fields=tracer_comm,tracee_comm,i_mask,name
+$ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:%IG_TAG% --inotify-only --fields=tracer_comm,tracee_comm,i_mask,name
 TRACER_COMM    TRACEE_COMM   I_MASK      NAME
 inotifywatch   touch         0x8000020   ABCDE
 inotifywatch   touch         0x8000004   ABCDE
@@ -98,7 +98,7 @@ docker run -ti --rm busybox date
 
 The fsnotify gadget can observe and enrich the fanotify events in the following way:
 ```bash
-$ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:latest --fanotify-only --fields=tracer_comm,tracee_comm,type,fa_type,fa_response,name
+$ sudo ig run ghcr.io/inspektor-gadget/gadget/fsnotify:%IG_TAG% --fanotify-only --fields=tracer_comm,tracee_comm,type,fa_type,fa_response,name
 TRACER_COMM  TRACEE_COMM      TYPE       FA_TYPE                         FA_RESPONSE   NAME
 ig           containerd-shim  fanotify   FANOTIFY_EVENT_TYPE_PATH_PERM   na            /usr/bin/runc
 ig           containerd-shim  fa_resp    FANOTIFY_EVENT_TYPE_PATH_PERM   allow         /usr/bin/runc

--- a/gadgets/profile_blockio/README.mdx
+++ b/gadgets/profile_blockio/README.mdx
@@ -35,13 +35,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_blockio:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_blockio:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_blockio:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_blockio:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -53,7 +53,7 @@ Running the gadget:
         Run the gadget in a terminal:
 
         ```bash
-        $ kubectl gadget run profile_blockio:latest --node minikube-docker
+        $ kubectl gadget run profile_blockio:%IG_TAG% --node minikube-docker
         ```
 
         It will start to display the I/O latency distribution as follows:
@@ -110,7 +110,7 @@ Running the gadget:
 
         ```bash
         # Run the gadget again
-        $ kubectl gadget run profile_blockio:latest --node minikube-docker
+        $ kubectl gadget run profile_blockio:%IG_TAG% --node minikube-docker
         latency
               µs               : count    distribution
                0 -> 1          : 0        |                                        |
@@ -150,7 +150,7 @@ Running the gadget:
         Run the gadget in a terminal:
 
         ```bash
-        $ sudo ig run profile_blockio:latest
+        $ sudo ig run profile_blockio:%IG_TAG%
         ```
 
         It will start to display the I/O latency distribution as follows:
@@ -196,7 +196,7 @@ Running the gadget:
         Run the gadget to observe the I/O latency distribution:
 
         ```bash
-        $ sudo ig run profile_blockio:latest
+        $ sudo ig run profile_blockio:%IG_TAG%
         latency
               µs               : count    distribution
                0 -> 1          : 0        |                                        |

--- a/gadgets/profile_tcprtt/README.mdx
+++ b/gadgets/profile_tcprtt/README.mdx
@@ -31,13 +31,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_tcprtt:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_tcprtt:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_tcprtt:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_tcprtt:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -49,7 +49,7 @@ Running the gadget:
         Run the gadget in a terminal:
 
         ```bash
-        $ kubectl gadget run profile_tcprtt:latest --node minikube-docker
+        $ kubectl gadget run profile_tcprtt:%IG_TAG% --node minikube-docker
         ```
 
         It will start to display the TCP RTT latency distribution as follows:

--- a/gadgets/snapshot_process/README.mdx
+++ b/gadgets/snapshot_process/README.mdx
@@ -15,13 +15,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/snapshot_process:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/snapshot_process:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_process:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_process:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -59,7 +59,7 @@ Then, run the gadget and see how it shows the sleep process:
 <Tabs groupId="env">
 <TabItem value="kubectl-gadget" label="kubectl gadget">
 ```bash
-$ kubectl gadget run snapshot_process:latest
+$ kubectl gadget run snapshot_process:%IG_TAG%
 K8S.NODE            K8S.NAMESPACE       K8S.PODNAME         K8S.CONTAINERNAME   COMM              PID        TID        UID        GID       PPID
 minikube-docker     default             test-snap…t-process test-snapshot-proce sh             530932     530932          0          0     530911
 ^C
@@ -69,7 +69,7 @@ minikube-docker     default             test-snap…t-process test-snapshot-proc
 
 <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run snapshot_process:latest -c test-snapshot-process
+$ sudo ig run snapshot_process:%IG_TAG% -c test-snapshot-process
 RUNTIME.CONTAINERNAME           COMM                            PID               TID              UID              GID             PPID
 test-snapshot-process           sh                           524665            524665                0                0           524645
 ^C

--- a/gadgets/snapshot_socket/README.mdx
+++ b/gadgets/snapshot_socket/README.mdx
@@ -15,13 +15,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/snapshot_socket:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_socket:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_socket:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -51,7 +51,7 @@ Then, run the gadget and see how it shows the sockets used by nginx:
 <Tabs groupId="env">
 <TabItem value="kubectl-gadget" label="kubectl gadget">
 ```bash
-$ kubectl gadget run snapshot_socket:latest
+$ kubectl gadget run snapshot_socket:%IG_TAG%
 K8S.NODE            K8S.NAMESPACE         K8S.PODNAME           K8S.CONTAINERNAME     SRC                        DST                        STATE
 minikube-docker     default               test-snapshot-socket  test-snapshot-socket  :::80                      :::0                       10
 minikube-docker     default               test-snapshot-socket  test-snapshot-socket  0.0.0.0:80                 0.0.0.0:0                  10
@@ -62,7 +62,7 @@ minikube-docker     default               test-snapshot-socket  test-snapshot-so
 
 <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run snapshot_socket:latest -c test-snapshot-socket
+$ sudo ig run snapshot_socket:%IG_TAG% -c test-snapshot-socket
 RUNTIME.CONTAINERNAME              SRC                                           DST                                          STATE
 test-snapshot-socket               :::80                                         :::0                                         10
 test-snapshot-socket               0.0.0.0:80                                    0.0.0.0:0                                    10

--- a/gadgets/top_file/README.mdx
+++ b/gadgets/top_file/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_file:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_file:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_file:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_file:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -53,14 +53,14 @@ captures all the events from the beginning:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run top_file:latest --pod mypod
+        $ kubectl gadget run top_file:%IG_TAG% --pod mypod
         K8S.NODE     K8S.NAMESPACE          K8S.PODNAME            K8S.CONTAINERNAME               PID  READS RBYT… WRIT… WBYT… FILE                  COMM             T
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run top_file:latest --containername test-top-file
+        $ sudo ig run top_file:%IG_TAG% --containername test-top-file
         RUNTIME.CONTAINERNAME                                 PID      READS     RBYTES    WRITES    WBYTES FILE                                COMM             T
         ```
     </TabItem>
@@ -88,34 +88,34 @@ clone the linux source code:
 </Tabs>
 
 We can see how the `top_file` terminal shows the files that are read and written
-by the application. The `File` field shows the absolute path of the file being 
+by the application. The `File` field shows the absolute path of the file being
 accessed. For instance, `http`, `apt-get` and `apt-config` are reading a lot
 of files when updating the packages list and installing packages:
 
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-		K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME                       PID    READS  RBYTES  WRITES  WBYTES FILE                       COMM            K8S.NODE      
-        default                     mypod                       mypod                               1786428       64  262144       0       0 /var/lib/apt/lists/archiv… apt-get         minikube      
-        default                     mypod                       mypod                               1786428       10  589883       0       0 /var/lib/apt/lists/securi… apt-get         minikube      
-        default                     mypod                       mypod                               1786428        2  110977       0       0 /var/lib/apt/lists/securi… apt-get         minikube      
-        default                     mypod                       mypod                               1786428        6   24576       0       0 /etc/group                 apt-get         minikube      
-        default                     mypod                       mypod                               1786730        3    2400       0       0 /usr/lib/x86_64-linux-gnu… dpkg            minikube      
-        default                     mypod                       mypod                               1786428     1494 977912…       0       0 /var/lib/apt/lists/archiv… apt-get         minikube      
-        default                     mypod                       mypod                               1786608        3   21287       0       0 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786730        1     832       0       0 /usr/lib/x86_64-linux-gnu… dpkg            minikube      
-        default                     mypod                       mypod                               1786730        2    8192       0       0 /etc/dpkg/dpkg.cfg         dpkg            minikube      
-        default                     mypod                       mypod                               1786608        0       0      28  722475 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608        0       0      28  589765 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608       74  602300       0       0 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608     2049 167783…       0       0 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608        0       0       2   17989 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608        0       0      40  973998 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786608        4   32284       0       0 /var/lib/apt/lists/partia… store           minikube      
-        default                     mypod                       mypod                               1786729        3    2400       0       0 /usr/lib/x86_64-linux-gnu… rm              minikube      
-        default                     mypod                       mypod                               1786428       10  649015       0       0 /var/lib/apt/lists/archiv… apt-get         minikube      
-        default                     mypod                       mypod                               1786428        4  197340       0       0 /var/lib/apt/lists/archiv… apt-get         minikube      
-        default                     mypod                       mypod                               1786428      188 123166…       0       0 /var/lib/apt/lists/archiv… apt-get         minikube 
+		K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME                       PID    READS  RBYTES  WRITES  WBYTES FILE                       COMM            K8S.NODE
+        default                     mypod                       mypod                               1786428       64  262144       0       0 /var/lib/apt/lists/archiv… apt-get         minikube
+        default                     mypod                       mypod                               1786428       10  589883       0       0 /var/lib/apt/lists/securi… apt-get         minikube
+        default                     mypod                       mypod                               1786428        2  110977       0       0 /var/lib/apt/lists/securi… apt-get         minikube
+        default                     mypod                       mypod                               1786428        6   24576       0       0 /etc/group                 apt-get         minikube
+        default                     mypod                       mypod                               1786730        3    2400       0       0 /usr/lib/x86_64-linux-gnu… dpkg            minikube
+        default                     mypod                       mypod                               1786428     1494 977912…       0       0 /var/lib/apt/lists/archiv… apt-get         minikube
+        default                     mypod                       mypod                               1786608        3   21287       0       0 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786730        1     832       0       0 /usr/lib/x86_64-linux-gnu… dpkg            minikube
+        default                     mypod                       mypod                               1786730        2    8192       0       0 /etc/dpkg/dpkg.cfg         dpkg            minikube
+        default                     mypod                       mypod                               1786608        0       0      28  722475 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608        0       0      28  589765 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608       74  602300       0       0 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608     2049 167783…       0       0 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608        0       0       2   17989 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608        0       0      40  973998 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786608        4   32284       0       0 /var/lib/apt/lists/partia… store           minikube
+        default                     mypod                       mypod                               1786729        3    2400       0       0 /usr/lib/x86_64-linux-gnu… rm              minikube
+        default                     mypod                       mypod                               1786428       10  649015       0       0 /var/lib/apt/lists/archiv… apt-get         minikube
+        default                     mypod                       mypod                               1786428        4  197340       0       0 /var/lib/apt/lists/archiv… apt-get         minikube
+        default                     mypod                       mypod                               1786428      188 123166…       0       0 /var/lib/apt/lists/archiv… apt-get         minikube
         ...
         ```
     </TabItem>
@@ -157,8 +157,8 @@ to store the repository being cloned.
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME                       PID    READS  RBYTES  WRITES  WBYTES FILE                                      COMM            K8S.NODE      
-        default                     mypod                       mypod                               1799742      266   81944       0       0 /linux/.git/objects/pack/tmp_pack_dzzrva  git             minikube      
+        K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME                       PID    READS  RBYTES  WRITES  WBYTES FILE                                      COMM            K8S.NODE
+        default                     mypod                       mypod                               1799742      266   81944       0       0 /linux/.git/objects/pack/tmp_pack_dzzrva  git             minikube
 	    ```
     </TabItem>
 
@@ -179,13 +179,13 @@ with the following values, the gadget will run for 10 seconds in total, printing
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        kubectl gadget run top_file:latest --map-fetch-count 5 --map-fetch-interval 2s
+        kubectl gadget run top_file:%IG_TAG% --map-fetch-count 5 --map-fetch-interval 2s
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        sudo ig run top_file:latest --map-fetch-count 5 --map-fetch-interval 2s
+        sudo ig run top_file:%IG_TAG% --map-fetch-count 5 --map-fetch-interval 2s
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/top_tcp/README.mdx
+++ b/gadgets/top_tcp/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_tcp:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_tcp:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_tcp:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_tcp:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -49,7 +49,7 @@ Default value: "0"
         First, we need to create one pod for us to play with:
 
         ```bash
-        kubectl run mypod --image busybox:latest sleep inf
+        kubectl run mypod --image busybox:%IG_TAG% sleep inf
         ```
     </TabItem>
 
@@ -57,7 +57,7 @@ Default value: "0"
         First, we need to create a container for us to play with:
 
         ```bash
-        docker run -d --name mycontainer busybox:latest sleep inf
+        docker run -d --name mycontainer busybox:%IG_TAG% sleep inf
         ```
     </TabItem>
 </Tabs>
@@ -67,14 +67,14 @@ You can now use the gadget, but output will be empty:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run top_tcp:latest --pod mypod
+        $ kubectl gadget run top_tcp:%IG_TAG% --pod mypod
         K8S.NODE     K8S.NAMESPACE          K8S.PODNAME            K8S.CONTAINERNAME               PID SRC                                 DST                                COMM          SENT          RECEIVED
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run top_tcp:latest --containername mycontainer
+        $ sudo ig run top_tcp:%IG_TAG% --containername mycontainer
         RUNTIME.CONTAINERNAME                 PID SRC                                 DST                                COMM          SENT          RECEIVED
         ```
     </TabItem>

--- a/gadgets/trace_bind/README.mdx
+++ b/gadgets/trace_bind/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_bind:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_bind:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_bind:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_bind:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -65,7 +65,7 @@ Then, let's run the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run trace_bind:latest --podname mypod
+        $ kubectl gadget run trace_bind:%IG_TAG% --podname mypod
         K8S.NODE            K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        ADDR                       COMM                    PID           TID          UID          GID BOUND_… ERROR
         minikube-docker     default                  mypod                    mypod                    :::4242                    nc                   635160        635160            0            0 0
         minikube-docker     default                  mypod                    mypod                    :::4242                    nc                   635213        635213            0            0 0
@@ -77,7 +77,7 @@ Then, let's run the gadget:
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run trace_bind:latest --containername test-trace-bind
+        $ sudo ig run trace_bind:%IG_TAG% --containername test-trace-bind
         WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME               ADDR                                  COMM                            PID                TID                UID                GID BOUND_DEV_… ERROR
         test-trace-bind                     :::4242                               nc                           647422             647422                  0                  0 0

--- a/gadgets/trace_capabilities/README.mdx
+++ b/gadgets/trace_capabilities/README.mdx
@@ -28,13 +28,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_capabilities:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -113,7 +113,7 @@ Default value: "false"
         We can see the same checks but this time with the `CAPABLE` column set to `true`:
 
         ```bash
-        $ kubectl gadget run trace_capabilities --selector name=set-priority-1
+        $ kubectl gadget run trace_capabilities:%IG_TAG% --selector name=set-priority-1
         K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        COMM                    PID          TID          UID          GID CAPABLE AUDIT    CAP          SYSCALL
         minikube-docker          default                  set-priority-1           set-priority-1           nice                 225549       225549            0            0 true    1        CAP_SYS_NICE SYS_SETPRIORITY
         minikube-docker          default                  set-priority-1           set-priority-1           nice                 225615       225615            0            0 true    1        CAP_SYS_NICE SYS_SETPRIORITY
@@ -125,7 +125,7 @@ Default value: "false"
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run trace_capabilities:latest --containername test-trace-capabilities
+        $ sudo ig run trace_capabilities:%IG_TAG% --containername test-trace-capabilities
         WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         ...
         ```

--- a/gadgets/trace_dns/README.mdx
+++ b/gadgets/trace_dns/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_dns:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_dns:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_dns:%IG_TAG% [flags]
         ```
     </TabItem>
 
@@ -84,7 +84,7 @@ Running the gadget:
         Run the gadget in a terminal, in this case we are only focused on DNS requests/response in `demo` namespace for pod `mypod`:
 
         ```bash
-        kubectl gadget run trace_dns:latest -n demo -p mypod
+        kubectl gadget run trace_dns:%IG_TAG% -n demo -p mypod
         ```
 
         Run a pod in a different terminal:
@@ -115,7 +115,7 @@ Running the gadget:
         Let's try to expand the scope and see what happens to the DNS request at CoreDNS pod. Restart the gadget as:
 
         ```bash
-        kubectl gadget run trace_dns:latest -n demo,kube-system -F "k8s.podName~mypod|coredns-.*" -F "name==inspektor-gadget.io." --fields=k8s.node,k8s.namespace,k8s.podname,id,src,dst,qr,name,rcode,timestamp
+        kubectl gadget run trace_dns:%IG_TAG% -n demo,kube-system -F "k8s.podName~mypod|coredns-.*" -F "name==inspektor-gadget.io." --fields=k8s.node,k8s.namespace,k8s.podname,id,src,dst,qr,name,rcode,timestamp
         ```
 
         This will filter the DNS request/response for pods `mypod` and  CoreDNS pods. See how are able to choose different fields via `--fields`.
@@ -143,7 +143,7 @@ Running the gadget:
         At this point we already have the idea about what is happening to the request at different stages. In order to include context related to the OS, we can restart the gadget and don't filter by pod names:
 
         ```bash
-        kubectl gadget run trace_dns:latest -n demo,kube-system  -F "name==inspektor-gadget.io." --fields=k8s.node,k8s.namespace,k8s.podname,id,pky_type,src,dst,qr,name,rcode,latency_ns,timestamp
+        kubectl gadget run trace_dns:%IG_TAG% -n demo,kube-system  -F "name==inspektor-gadget.io." --fields=k8s.node,k8s.namespace,k8s.podname,id,pky_type,src,dst,qr,name,rcode,latency_ns,timestamp
         ```
 
         :::note
@@ -178,7 +178,7 @@ Running the gadget:
         Start the gadget in a terminal:
 
         ```bash
-        $ sudo ig run trace_dns:latest --containername test-trace-dns
+        $ sudo ig run trace_dns:%IG_TAG% --containername test-trace-dns
         RUNTIME.CONTAINERNAME       SRC                                 DST                                 COMM                      PID QR QTYPE          NAME                       RCODE    ADDRESSES
         ```
 

--- a/gadgets/trace_exec/README.mdx
+++ b/gadgets/trace_exec/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_exec:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_exec:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -81,7 +81,7 @@ Then, let's run the gadget:
         `minikube-docker` where `myapp1-pod` and `myapp2-pod` are running:
 
         ```bash
-        $ kubectl gadget run trace_exec --selector role=demo --node minikube-docker
+        $ kubectl gadget run trace_exec:%IG_TAG% --selector role=demo --node minikube-docker
         K8S.NODE            K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME           COMM                        PID            TID PCOMM                    PPID ARGS           ERR… USER           LOGINUSER      GROUP
         minikube-docker     default                     myapp1-pod                  myapp1-pod                  true                    2957112        2957112 sh                    2589510 /bin/true           root           uid:4294967295 root
         minikube-docker     default                     myapp1-pod                  myapp1-pod                  date                    2957113        2957113 sh                    2589510 /bin/date           root           uid:4294967295 root
@@ -114,7 +114,7 @@ Then, let's run the gadget:
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run trace_exec:latest --containername test-trace-exec
+        $ sudo ig run trace_exec:%IG_TAG% --containername test-trace-exec
         WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME           COMM                            PID              TID PCOMM                        PPID ARGS             ERROR USER             LOGINUSER        GROUP
         test-trace-exec                 true                        2920998          2920998 sh                        2920573 /bin/true              root             uid:4294967295   root

--- a/gadgets/trace_lsm/README.mdx
+++ b/gadgets/trace_lsm/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_lsm:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_lsm:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_lsm:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_lsm:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/trace_malloc/README.mdx
+++ b/gadgets/trace_malloc/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_malloc:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_malloc:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_malloc:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_malloc:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/trace_mount/README.mdx
+++ b/gadgets/trace_mount/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_mount:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_mount:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_mount:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_mount:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -63,7 +63,7 @@ Then, let's run the gadget:
         thus tracing on all nodes for a pod called `mypod`:
 
         ```bash
-        $ kubectl gadget run trace_mount:latest --podname mypod
+        $ kubectl gadget run trace_mount:%IG_TAG% --podname mypod
         K8S.NODE          K8S.NAMESPACE              K8S.PODNAME                K8S.CONTAINERNAME          COMM                      PID           TID  DELTA FLAGS         CALL                        ERROR
         minikube-docker   default                    mypod                      mypod                      mount                   36469         36469   3318 MS_SILENT     mount("/mnt", "/mnt", "ext… ENOENT
         minikube-docker   default                    mypod                      mypod                      mount                   36469         36469   1321 MS_SILENT     mount("/mnt", "/mnt", "ext… ENOENT
@@ -82,7 +82,7 @@ Then, let's run the gadget:
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run trace_mount:latest --containername test-trace-mount
+        $ sudo ig run trace_mount:%IG_TAG% --containername test-trace-mount
         WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME                    COMM                               PID                   TID       DELTA FLAGS                CALL                                      ERROR
         test-trace-mount                         mount                            51158                 51158        3460 MS_SILENT            mount("/bar", "/foo", "ext3", MS_SILENT,… ENOENT

--- a/gadgets/trace_oomkill/README.mdx
+++ b/gadgets/trace_oomkill/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_oomkill:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_oomkill:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_oomkill:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -53,7 +53,7 @@ Running the gadget:
         Run the gadget in a terminal:
 
         ```bash
-        $ kubectl gadget run trace_oomkill:latest --namespace oomkill-demo
+        $ kubectl gadget run trace_oomkill:%IG_TAG% --namespace oomkill-demo
         K8S.NODE           K8S.NAMESPACE             K8S.PODNAME               K8S.CONTAINERNAME         MNTNS_ID      FPID          FUID          FGID          TPID          PAGES        FCOMM        TCOMM
         ```
 
@@ -76,7 +76,7 @@ Running the gadget:
         Start the gadget in a terminal:
 
         ```bash
-        $ sudo ig run trace_oomkill:latest --containername test-trace-oomkill
+        $ sudo ig run trace_oomkill:%IG_TAG% --containername test-trace-oomkill
         RUNTIME.CONTAINERNAME               MNTNS_ID            FPID                FUID                FGID                TPID                PAGES              FCOMM              TCOMM
         ```
 

--- a/gadgets/trace_open/README.mdx
+++ b/gadgets/trace_open/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
   <TabItem value="kubectl-gadget" label="kubectl gadget">
 ```bash
-$ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_open:latest [flags]
+$ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_open:%IG_TAG% [flags]
 ```
   </TabItem>
 
   <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:latest [flags]
+$ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:%IG_TAG% [flags]
 ```
   </TabItem>
 </Tabs>
@@ -77,7 +77,7 @@ We can simply filter for the pod "mypod" and omit specifying the node,
 thus tracing on all nodes for a pod called "mypod":
 
 ```bash
-$ kubectl gadget run trace_open:latest --podname mypod
+$ kubectl gadget run trace_open:%IG_TAG% --podname mypod
 K8S.NODE           K8S.NAMESPACE K8S.PODNAME   K8S.CONTAINE… COMM        PID     TID      UID      GID  FD FNAME                    MODE    ERROR
 minikube-docker    default       mypod         mypod         true     511559  511559        0        0   0 /etc/ld.so.cache         ------… ENOEN
 minikube-docker    default       mypod         mypod         true     511559  511559        0        0   0 /lib/x86_64-linux-gnu/g… ------… ENOEN
@@ -106,7 +106,7 @@ We can stop the gadget by hitting Ctrl-C.
 
   <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run trace_open:latest --containername test-trace-open
+$ sudo ig run trace_open:%IG_TAG% --containername test-trace-open
 WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
 WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
 RUNTIME.CONTAINERNA… COMM                PID         TID         UID        GID  FD FNAME                    MODE       ERROR   TIMESTAMP

--- a/gadgets/trace_signal/README.mdx
+++ b/gadgets/trace_signal/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_signal:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_signal:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_signal:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_signal:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/trace_sni/README.mdx
+++ b/gadgets/trace_sni/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_sni:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_sni:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_sni:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_sni:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -35,7 +35,7 @@ Running the gadget:
         Run the gadget in a terminal:
 
         ```bash
-        $ kubectl gadget run trace_sni:latest
+        $ kubectl gadget run trace_sni:%IG_TAG%
         K8S.NODE          K8S.NAMESPACE               K8S.PODNAME                 K8S.CONTAINERNAME           COMM                      PID            TID           UID           GID NAME
         ```
 
@@ -68,7 +68,7 @@ Running the gadget:
         Start the gadget in a terminal:
 
         ```bash
-        $ sudo ig run trace_sni:latest --containername test-trace-sni
+        $ sudo ig run trace_sni:%IG_TAG% --containername test-trace-sni
         RUNTIME.CONTAINERNAME                      COMM                                PID                    TID                    UID                   GID NAME
         ```
 

--- a/gadgets/trace_ssl/README.mdx
+++ b/gadgets/trace_ssl/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_ssl:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_ssl:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_ssl:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_ssl:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/trace_tcp/README.mdx
+++ b/gadgets/trace_tcp/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcp:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -55,7 +55,7 @@ Default value: ""
         You can now use the gadget, but output will be empty:
 
         ```bash
-        $ kubectl gadget run trace_tcp:latest
+        $ kubectl gadget run trace_tcp:%IG_TAG%
         K8S.NODE          K8S.NAMESPACE         K8S.PODNAME           K8S.CONTAINERNAME     SRC                          DST                          COMM                PID         TID         UID        GID TYPE
         ```
 
@@ -83,7 +83,7 @@ Default value: ""
         Start the gadget in a terminal:
 
         ```bash
-        $ sudo ig run trace_tcp:latest --containername test-trae-tcp
+        $ sudo ig run trace_tcp:%IG_TAG% --containername test-trae-tcp
         RUNTIME.CONTAINERNAME        SRC                                   DST                                   COMM                        PID            TID            UID            GID TYPE
         ```
 

--- a/gadgets/trace_tcpconnect/README.mdx
+++ b/gadgets/trace_tcpconnect/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpconnect:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>

--- a/gadgets/trace_tcpdrop/README.mdx
+++ b/gadgets/trace_tcpdrop/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpdrop:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -35,7 +35,7 @@ Running the gadget:
         In terminal 1, start the trace tcpdrop gadget:
 
         ```bash
-        $ kubectl gadget run trace_tcpdrop:latest
+        $ kubectl gadget run trace_tcpdrop:%IG_TAG%
         K8S.NODE                 K8S.NAMESPACE                                  K8S.PODNAME                                    K8S.CONTAINERNAME                              SRC                                                  DST                                                  MOUNT_NS_ID               COMM                                   PID                      TID STATE                    TCPFLAGS                 REASON
         ```
 
@@ -74,7 +74,7 @@ Running the gadget:
         In terminal 1, start the trace tcpdrop gadget:
 
         ```bash
-        $ sudo ig run trace_tcpdrop:latest --containername test-trace-tcpdrop
+        $ sudo ig run trace_tcpdrop:%IG_TAG% --containername test-trace-tcpdrop
         RUNTIME.CONTAINERNAME      SRC                                DST                                MOUNT_NS_ID    COMM                      PID            TID STATE         TCPFLAGS      REASON
         ```
 

--- a/gadgets/trace_tcpretrans/README.mdx
+++ b/gadgets/trace_tcpretrans/README.mdx
@@ -17,13 +17,13 @@ Running the gadget:
 <Tabs groupId="env">
     <TabItem value="kubectl-gadget" label="kubectl gadget">
         ```bash
-        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest [flags]
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:%IG_TAG% [flags]
         ```
     </TabItem>
 
     <TabItem value="ig" label="ig">
         ```bash
-        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:latest [flags]
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_tcpretrans:%IG_TAG% [flags]
         ```
     </TabItem>
 </Tabs>
@@ -35,7 +35,7 @@ Running the gadget:
         In terminal 1, start the trace_tcpretrans gadget:
 
         ```bash
-        $ kubectl gadget run trace_tcpretrans:latest
+        $ kubectl gadget run trace_tcpretrans:%IG_TAG%
         K8S.NODE          K8S.NAMESPACE            K8S.PODNAME              K8S.CONTAINERNAME        SRC                              DST                              COMM                    PID           TID STATE         REASON        TCPFLAGS     TYPE
         ```
 
@@ -66,7 +66,7 @@ Running the gadget:
         In terminal 1, start the trace_tcpretrans gadget:
 
         ```bash
-        $ sudo ig run trace_tcpretrans:latest --containername test-trace-tcpretrans
+        $ sudo ig run trace_tcpretrans:%IG_TAG% --containername test-trace-tcpretrans
         RUNTIME.CONTAINERNAME            SRC                                         DST                                         COMM                            PID               TID STATE            REASON           TCPFLAGS         TYPE
         ```
 


### PR DESCRIPTION
use the %IG_BRANCH% and %IG_TAG% constants what will be replaced by the correct versions when building the docs.

:loudspeaker: : This has to be used with https://github.com/inspektor-gadget/website/pull/96 

### Testing 

I tested it by pushing a new tag to my fork and changing config.yaml on the website repo:

```diff
$ git diff
diff --git a/config.yaml b/config.yaml
index b30390f..c481f7d 100644
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,10 @@ params:
     - crds
     - design
     external_docs:
+    - repo: https://github.com/mauriciovasquezbernal/inspektor-gadget.git
+      name: v0.99.0
+      branch: v0.99.0
+      dir: docs
     - repo: https://github.com/inspektor-gadget/inspektor-gadget.git
       name: v0.32.0
       branch: v0.32.0
```

Then run the following inside the website folder:

```bash
$ make docs && npm install && npm run dev
```

The version was correctly shown on the rendered docs:

![image](https://github.com/user-attachments/assets/f4c99368-f0e6-47ae-aaa2-811daca122a4)

Fixes #3492