### PR TITLE
charts: Fix INSPEKTOR_GADGET_VERSION env

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
             - name: GADGET_IMAGE
               value: "{{ .Values.image.repository }}"
             - name: INSPEKTOR_GADGET_VERSION
-              value: {{ include "gadget.image.tag" . | quote }}
+              value: {{ include "gadget.image.tag" . | trimPrefix "v" | quote }}
             - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
               value: {{ .Values.config.hookMode | quote }}
             - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER


### PR DESCRIPTION
It seems `INSPEKTOR_GADGET_VERSION` should be semver compliant (without `v` prefix). We are setting it correctly for `kubectl gadget deploy` but for helm-charts it seem to be broken with:

```
$ helm repo add gadget https://inspektor-gadget.github.io/charts
$ helm install gadget gadget/gadget --namespace=gadget --create-namespace
NAME: gadget
LAST DEPLOYED: Wed Sep 18 18:30:53 2024
NAMESPACE: gadget
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Inspektor Gadget "v0.32.0" installed successfully!

For usage details, visit https://www.inspektor-gadget.io
$ kubectl gadget version
Client version: v0.32.0
Server version: v
```

This PR trims the prefix so version is showed correctly! 


### Testing Done:

```
$ export IMAGE_TAG=v0.32.0
$ make -C charts install
$ kubectl gadget sync
$ kubectl gadget version
Client version: v0.32.0
Server version: v0.32.0
$ make -C charts uninstall

```