### PR TITLE
Container enrichment: add container PID

### DIFF
--- a/docs/legacy/crds/gadgets/ebpftop.md
+++ b/docs/legacy/crds/gadgets/ebpftop.md
@@ -8,7 +8,7 @@ ebpftop shows cpu time used by ebpf programs.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,k8s.owner.kind,k8s.owner.name,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerPid,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,k8s.owner.kind,k8s.owner.name,progid,type,name,runtime,runcount,cumulruntime,cumulruncount,totalruntime,totalRunCount,mapmemory,mapcount,totalcpu,percpu). (default -runtime,-runcount)
 
 ### Example CR
 

--- a/docs/legacy/crds/gadgets/filetop.md
+++ b/docs/legacy/crds/gadgets/filetop.md
@@ -8,7 +8,7 @@ filetop shows reads and writes by file, with container details.
 The following parameters are supported:
  - interval: Output interval, in seconds. (default 1)
  - max_rows: Maximum rows to print. (default 20)
- - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,k8s.owner.kind,k8s.owner.name,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
+ - sort_by: The field to sort the results by (runtime.runtimeName,runtime.containerId,runtime.containerName,runtime.containerPid,runtime.containerImageName,runtime.containerImageDigest,runtime.containerStartedAt,k8s.node,k8s.namespace,k8s.podName,k8s.labels,k8s.containerName,k8s.hostnetwork,k8s.owner.kind,k8s.owner.name,mntns,pid,tid,comm,reads,writes,rbytes,wbytes,T,file). (default -reads,-writes,-rbytes,-wbytes)
  - all-files: Show all files. (default false, i.e. show regular files only)
 
 ### Example CR

--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -80,7 +80,7 @@ func publishEvent(c *containercollection.Container, reason, message string) {
 func callback(notif containercollection.PubSubEvent) {
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
-		fmt.Printf("Container added: %v pid %d\n", notif.Container.Runtime.ContainerID, notif.Container.Pid)
+		fmt.Printf("Container added: %v pid %d\n", notif.Container.Runtime.ContainerID, notif.Container.ContainerPid())
 		if notif.Container.OciConfig != nil {
 			config, err := json.Marshal(notif.Container.OciConfig)
 			if err != nil {
@@ -92,7 +92,7 @@ func callback(notif containercollection.PubSubEvent) {
 			publishEvent(notif.Container, "ContainerConfigNotFound", "")
 		}
 	case containercollection.EventTypeRemoveContainer:
-		fmt.Printf("Container removed: %v pid %d\n", notif.Container.Runtime.ContainerID, notif.Container.Pid)
+		fmt.Printf("Container removed: %v pid %d\n", notif.Container.Runtime.ContainerID, notif.Container.ContainerPid())
 	default:
 		return
 	}

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -56,6 +56,7 @@ func TestFilterByContainerName(t *testing.T) {
 				c.K8s.PodLabels = nil
 				c.K8s.PodUID = ""
 				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerPID = 0
 				c.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				c.Runtime.ContainerImageName = ""
@@ -124,6 +125,7 @@ func TestWatchContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = nil
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerPID = 0
 				e.Container.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Container.Runtime.ContainerImageName = ""

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -43,7 +43,6 @@ func TestFilterByContainerName(t *testing.T) {
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.Pid = 0
 				c.OciConfig = nil
 				c.Bundle = ""
 				c.Mntns = 0
@@ -111,7 +110,6 @@ func TestWatchContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.Pid = 0
 				e.Container.OciConfig = nil
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0

--- a/integration/ig/non-k8s/snapshot_process_test.go
+++ b/integration/ig/non-k8s/snapshot_process_test.go
@@ -53,6 +53,7 @@ func TestSnapshotProcess(t *testing.T) {
 				e.MountNsID = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerPID = 0
 				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -150,6 +150,7 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 				}
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerPID = 0
 				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""

--- a/integration/ig/non-k8s/trace_network_test.go
+++ b/integration/ig/non-k8s/trace_network_test.go
@@ -89,6 +89,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Gid = 0
 
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerPID = 0
 				e.Runtime.ContainerStartedAt = 0
 				// TODO: Handle once we support getting ContainerImageName from Docker
 				e.Runtime.ContainerImageName = ""

--- a/integration/k8s/audit_seccomp_test.go
+++ b/integration/k8s/audit_seccomp_test.go
@@ -201,6 +201,7 @@ EOF
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerPID = 0
 					e.Runtime.ContainerImageDigest = ""
 					e.Runtime.ContainerStartedAt = 0
 				}

--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -102,6 +102,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 
 				c.SandboxId = ""
 				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerPID = 0
 				c.Runtime.ContainerImageDigest = ""
 				c.Runtime.ContainerStartedAt = 0
 
@@ -177,6 +178,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 				e.Container.SandboxId = ""
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerPID = 0
 				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.Runtime.ContainerStartedAt = 0
 

--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -90,7 +90,6 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.Pid = 0
 				c.OciConfig = nil
 				c.Bundle = ""
 				c.Mntns = 0
@@ -164,7 +163,6 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.Pid = 0
 				e.Container.OciConfig = nil
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0

--- a/integration/k8s/integration_test.go
+++ b/integration/k8s/integration_test.go
@@ -60,6 +60,7 @@ func normalizeCommonData(e *eventtypes.CommonData, ns string) {
 	cn := "test-pod"
 
 	e.Runtime.ContainerID = ""
+	e.Runtime.ContainerPID = 0
 	e.Runtime.ContainerImageDigest = ""
 	e.Runtime.ContainerStartedAt = 0
 

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -66,7 +66,6 @@ func newListContainerTestStep(
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.Pid = 0
 				c.OciConfig = nil
 				c.Bundle = ""
 				c.Mntns = 0
@@ -200,7 +199,6 @@ func TestWatchCreatedContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.Pid = 0
 				e.Container.OciConfig = nil
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
@@ -297,7 +295,6 @@ func TestWatchDeletedContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.Pid = 0
 				e.Container.OciConfig = nil
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
@@ -397,7 +394,6 @@ func TestPodWithSecurityContext(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.Pid = 0
 				e.Container.OciConfig = nil
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -79,6 +79,7 @@ func newListContainerTestStep(
 				c.SandboxId = ""
 				c.K8s.PodLabels = addPodLabels(pod)
 				c.Runtime.ContainerID = ""
+				c.Runtime.ContainerPID = 0
 				c.Runtime.ContainerImageDigest = ""
 				c.Runtime.ContainerStartedAt = 0
 
@@ -214,6 +215,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = addPodLabels(pod)
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerPID = 0
 				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.Runtime.ContainerStartedAt = 0
 
@@ -310,6 +312,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 				e.Container.K8s.PodLabels = addPodLabels(pod)
 				e.Container.K8s.PodUID = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerPID = 0
 				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.Runtime.ContainerStartedAt = 0
 
@@ -407,6 +410,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 
 				e.Container.SandboxId = ""
 				e.Container.Runtime.ContainerID = ""
+				e.Container.Runtime.ContainerPID = 0
 				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.Runtime.ContainerStartedAt = 0
 				e.Container.K8s.PodLabels = addPodLabels(po)

--- a/integration/k8s/snapshot_socket_test.go
+++ b/integration/k8s/snapshot_socket_test.go
@@ -93,6 +93,7 @@ func TestSnapshotSocket(t *testing.T) {
 					e.Runtime.RuntimeName = ""
 					e.Runtime.ContainerName = ""
 					e.Runtime.ContainerID = ""
+					e.Runtime.ContainerPID = 0
 					e.Runtime.ContainerImageDigest = ""
 					e.Runtime.ContainerStartedAt = 0
 				}

--- a/integration/k8s/trace_network_test.go
+++ b/integration/k8s/trace_network_test.go
@@ -151,6 +151,7 @@ func TestTraceNetwork(t *testing.T) {
 				e.Uid = 0
 				e.Gid = 0
 				e.Runtime.ContainerID = ""
+				e.Runtime.ContainerPID = 0
 				e.Runtime.ContainerImageDigest = ""
 				e.Runtime.ContainerStartedAt = 0
 

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -213,12 +213,12 @@ func BenchmarkAllGadgetsWithContainers(b *testing.B) {
 				container := &containercollection.Container{
 					Runtime: containercollection.RuntimeMetadata{
 						BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-							ContainerID: fmt.Sprintf("container%d", i),
+							ContainerID:  fmt.Sprintf("container%d", i),
+							ContainerPID: uint32(runner.Info.Tid),
 						},
 					},
 					Mntns: runner.Info.MountNsID,
 					Netns: runner.Info.NetworkNsID,
-					Pid:   uint32(runner.Info.Tid),
 				}
 				containers = append(containers, container)
 			}

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -210,7 +210,6 @@ func (cc *ContainerCollection) AddContainer(container *Container) {
 		}
 	}
 
-	container.Runtime.ContainerPID = container.Pid
 	_, loaded := cc.containers.LoadOrStore(container.Runtime.ContainerID, container)
 	if loaded {
 		return
@@ -314,7 +313,7 @@ func (cc *ContainerCollection) LookupPIDByContainer(namespace, pod, container st
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
 		if namespace == c.K8s.Namespace && pod == c.K8s.PodName && container == c.K8s.ContainerName {
-			pid = c.Pid
+			pid = c.Runtime.ContainerPID
 			// container found, stop iterating
 			return false
 		}
@@ -331,7 +330,7 @@ func (cc *ContainerCollection) LookupPIDByPod(namespace, pod string) map[string]
 	cc.containers.Range(func(key, value interface{}) bool {
 		c := value.(*Container)
 		if namespace == c.K8s.Namespace && pod == c.K8s.PodName {
-			ret[c.K8s.ContainerName] = c.Pid
+			ret[c.K8s.ContainerName] = c.Runtime.ContainerPID
 		}
 		return true
 	})

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -210,6 +210,7 @@ func (cc *ContainerCollection) AddContainer(container *Container) {
 		}
 	}
 
+	container.Runtime.ContainerPID = container.Pid
 	_, loaded := cc.containers.LoadOrStore(container.Runtime.ContainerID, container)
 	if loaded {
 		return

--- a/pkg/container-collection/container-collection_test.go
+++ b/pkg/container-collection/container-collection_test.go
@@ -148,11 +148,11 @@ func TestWithTracerCollection(t *testing.T) {
 					RuntimeName:   types.RuntimeNameDocker,
 					ContainerName: fmt.Sprintf("name%d", i),
 					ContainerID:   fmt.Sprintf("id%d", i),
+					ContainerPID:  uint32(runner.Info.Pid),
 				},
 			},
 			Mntns: runner.Info.MountNsID,
 			Netns: runner.Info.NetworkNsID,
-			Pid:   uint32(runner.Info.Pid),
 			K8s: K8sMetadata{
 				BasicK8sMetadata: types.BasicK8sMetadata{
 					ContainerName: fmt.Sprintf("name%d", i),

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -38,9 +38,6 @@ type Container struct {
 	// K8s contains the Kubernetes metadata of the container.
 	K8s K8sMetadata `json:"k8s,omitempty" column:"k8s" columnTags:"kubernetes"`
 
-	// Pid is the process id of the container
-	Pid uint32 `json:"pid,omitempty" column:"pid,template:pid,hide"`
-
 	// Container's configuration is the config.json from the OCI runtime
 	// spec
 	OciConfig *ocispec.Spec `json:"ociConfig,omitempty"`
@@ -228,7 +225,7 @@ func (c *Container) UsesHostNetwork() bool {
 }
 
 func (c *Container) ContainerPid() uint32 {
-	return c.Pid
+	return c.Runtime.ContainerPID
 }
 
 func (c *Container) K8sOwnerReference() *types.K8sOwnerReference {

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -227,6 +227,10 @@ func (c *Container) UsesHostNetwork() bool {
 	return c.HostNetwork
 }
 
+func (c *Container) ContainerPid() uint32 {
+	return c.Pid
+}
+
 func (c *Container) K8sOwnerReference() *types.K8sOwnerReference {
 	if c.K8s.ownerReference == nil {
 		return &types.K8sOwnerReference{}

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -184,9 +184,16 @@ func (k *K8sClient) GetRunningContainers(pod *v1.Pod) []Container {
 
 		containerDef := Container{
 			Runtime: RuntimeMetadata{
-				BasicRuntimeMetadata: containerData.Runtime.BasicRuntimeMetadata,
+				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+					RuntimeName:          containerData.Runtime.RuntimeName,
+					ContainerID:          containerData.Runtime.ContainerID,
+					ContainerName:        containerData.Runtime.ContainerName,
+					ContainerPID:         uint32(pid),
+					ContainerImageName:   containerData.Runtime.ContainerImageName,
+					ContainerImageDigest: containerData.Runtime.ContainerImageDigest,
+					ContainerStartedAt:   containerData.Runtime.ContainerStartedAt,
+				},
 			},
-			Pid: uint32(pid),
 			K8s: K8sMetadata{
 				BasicK8sMetadata: types.BasicK8sMetadata{
 					Namespace:     pod.GetNamespace(),

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -195,11 +195,11 @@ func TestContainerResolver(t *testing.T) {
 		cc.AddContainer(&Container{
 			Runtime: RuntimeMetadata{
 				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-					ContainerID: fmt.Sprintf("abcde%d", i),
+					ContainerID:  fmt.Sprintf("abcde%d", i),
+					ContainerPID: uint32(100 + i),
 				},
 			},
 			Mntns:      55555 + uint64(i),
-			Pid:        uint32(100 + i),
 			CgroupPath: "/none",
 			CgroupID:   1,
 			K8s: K8sMetadata{

--- a/pkg/container-collection/networktracer/connect.go
+++ b/pkg/container-collection/networktracer/connect.go
@@ -62,7 +62,7 @@ func ConnectToContainerCollection[Event any](
 	base := config.Base
 
 	attachContainerFunc := func(container *containercollection.Container) {
-		err := tracer.Attach(container.Pid)
+		err := tracer.Attach(container.ContainerPid())
 		if err != nil {
 			msg := fmt.Sprintf("start tracing container %q: %s", container.K8s.ContainerName, err)
 			tracer.EventCallback(base(eventtypes.Err(msg)))
@@ -72,7 +72,7 @@ func ConnectToContainerCollection[Event any](
 	}
 
 	detachContainerFunc := func(container *containercollection.Container) {
-		err := tracer.Detach(container.Pid)
+		err := tracer.Detach(container.ContainerPid())
 		if err != nil {
 			msg := fmt.Sprintf("stop tracing container %q: %s", container.K8s.ContainerName, err)
 			tracer.EventCallback(base(eventtypes.Err(msg)))

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -158,6 +158,7 @@ func (c *ContainerdClient) GetContainerDetails(containerID string) (*runtimeclie
 	if task.pid == 0 {
 		return nil, fmt.Errorf("got zero pid")
 	}
+	containerData.Runtime.ContainerPID = task.pid
 
 	spec, err := container.Spec(c.ctx)
 	if err != nil {
@@ -320,14 +321,17 @@ func (c *ContainerdClient) buildContainerData(container containerd.Container, ta
 	// 2. We would need to get the Task for the Container. containerd needs to acquire a mutex
 	//    that is currently hold by the creating process, which we interrupted -> deadlock
 	taskState := runtimeclient.StateRunning
+	containerPid := uint32(0)
 	if task != nil {
 		taskState = task.status
+		containerPid = task.pid
 	}
 
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
 			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
 				ContainerID:          container.ID(),
+				ContainerPID:         containerPid,
 				ContainerName:        getContainerName(container, labels),
 				RuntimeName:          types.RuntimeNameContainerd,
 				ContainerImageName:   image.Name(),

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -428,14 +428,12 @@ func buildContainerData(runtimeName types.RuntimeName, container CRIContainer, p
 
 	containerData := &runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
-			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:          container.GetId(),
-				ContainerName:        strings.TrimPrefix(containerMetadata.GetName(), "/"),
-				RuntimeName:          runtimeName,
-				ContainerImageName:   image.GetImage(),
-				ContainerImageDigest: digestFromRef(imageRef),
-			},
-			State: containerStatusStateToRuntimeClientState(container.GetState()),
+			ContainerID:          container.GetId(),
+			ContainerName:        strings.TrimPrefix(containerMetadata.GetName(), "/"),
+			RuntimeName:          runtimeName,
+			ContainerImageName:   image.GetImage(),
+			ContainerImageDigest: digestFromRef(imageRef),
+			State:                containerStatusStateToRuntimeClientState(container.GetState()),
 		},
 	}
 

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -188,6 +188,7 @@ func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.C
 		c.getContainerImageDigest(containerJSON.Image),
 		containerJSON.State.Status,
 		containerJSON.Config.Labels)
+	containerData.Runtime.ContainerPID = uint32(containerJSON.State.Pid)
 
 	containerDetailsData := runtimeclient.ContainerDetailsData{
 		ContainerData: *containerData,

--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -188,7 +188,6 @@ func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.C
 		c.getContainerImageDigest(containerJSON.Image),
 		containerJSON.State.Status,
 		containerJSON.Config.Labels)
-	containerData.Runtime.ContainerPID = uint32(containerJSON.State.Pid)
 
 	containerDetailsData := runtimeclient.ContainerDetailsData{
 		ContainerData: *containerData,
@@ -319,14 +318,12 @@ func getContainerImageNamefromImage(image string) string {
 func buildContainerData(containerID string, containerName string, containerImage string, containerImageDigest string, state string, labels map[string]string) *runtimeclient.ContainerData {
 	containerData := runtimeclient.ContainerData{
 		Runtime: runtimeclient.RuntimeContainerData{
-			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-				ContainerID:          containerID,
-				ContainerName:        strings.TrimPrefix(containerName, "/"),
-				RuntimeName:          types.RuntimeNameDocker,
-				ContainerImageName:   getContainerImageNamefromImage(containerImage),
-				ContainerImageDigest: containerImageDigest,
-			},
-			State: containerStatusStateToRuntimeClientState(state),
+			ContainerID:          containerID,
+			ContainerName:        strings.TrimPrefix(containerName, "/"),
+			RuntimeName:          types.RuntimeNameDocker,
+			ContainerImageName:   getContainerImageNamefromImage(containerImage),
+			ContainerImageDigest: containerImageDigest,
+			State:                containerStatusStateToRuntimeClientState(state),
 		},
 	}
 

--- a/pkg/container-utils/podman/podman.go
+++ b/pkg/container-utils/podman/podman.go
@@ -89,12 +89,10 @@ func (p *PodmanClient) listContainers(containerID string) ([]*runtimeclient.Cont
 	for i, c := range containers {
 		ret[i] = &runtimeclient.ContainerData{
 			Runtime: runtimeclient.RuntimeContainerData{
-				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-					ContainerID:   c.ID,
-					ContainerName: c.Names[0],
-					RuntimeName:   types.RuntimeNamePodman,
-				},
-				State: containerStatusStateToRuntimeClientState(c.State),
+				ContainerID:   c.ID,
+				ContainerName: c.Names[0],
+				RuntimeName:   types.RuntimeNamePodman,
+				State:         containerStatusStateToRuntimeClientState(c.State),
 			},
 		}
 	}
@@ -148,13 +146,10 @@ func (p *PodmanClient) GetContainerDetails(containerID string) (*runtimeclient.C
 	return &runtimeclient.ContainerDetailsData{
 		ContainerData: runtimeclient.ContainerData{
 			Runtime: runtimeclient.RuntimeContainerData{
-				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-					ContainerID:   container.ID,
-					ContainerPID:  uint32(container.State.Pid),
-					ContainerName: container.Name,
-					RuntimeName:   types.RuntimeNamePodman,
-				},
-				State: containerStatusStateToRuntimeClientState(container.State.Status),
+				ContainerID:   container.ID,
+				ContainerName: container.Name,
+				RuntimeName:   types.RuntimeNamePodman,
+				State:         containerStatusStateToRuntimeClientState(container.State.Status),
 			},
 		},
 		Pid:         container.State.Pid,

--- a/pkg/container-utils/podman/podman.go
+++ b/pkg/container-utils/podman/podman.go
@@ -150,6 +150,7 @@ func (p *PodmanClient) GetContainerDetails(containerID string) (*runtimeclient.C
 			Runtime: runtimeclient.RuntimeContainerData{
 				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
 					ContainerID:   container.ID,
+					ContainerPID:  uint32(container.State.Pid),
 					ContainerName: container.Name,
 					RuntimeName:   types.RuntimeNamePodman,
 				},

--- a/pkg/container-utils/runtime-client/interface.go
+++ b/pkg/container-utils/runtime-client/interface.go
@@ -41,7 +41,14 @@ type K8sContainerData struct {
 }
 
 type RuntimeContainerData struct {
-	types.BasicRuntimeMetadata
+	// Almost like types.BasicRuntimeMetadata but don't use it because we
+	// don't need ContainerPID
+	RuntimeName          types.RuntimeName
+	ContainerID          string
+	ContainerName        string
+	ContainerImageName   string
+	ContainerImageDigest string
+	ContainerStartedAt   types.Time
 
 	// Current state of the container.
 	State string

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -27,7 +27,6 @@ import (
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
 	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 const (
@@ -68,14 +67,11 @@ func TestRuntimeClientInterface(t *testing.T) {
 					&runtimeclient.ContainerDetailsData{
 						ContainerData: runtimeclient.ContainerData{
 							Runtime: runtimeclient.RuntimeContainerData{
-								BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-									RuntimeName:        runtime,
-									ContainerName:      cn,
-									ContainerID:        c.ID(),
-									ContainerPID:       uint32(c.Pid()),
-									ContainerImageName: containerImageName,
-								},
-								State: runtimeclient.StateRunning,
+								RuntimeName:        runtime,
+								ContainerName:      cn,
+								ContainerID:        c.ID(),
+								ContainerImageName: containerImageName,
+								State:              runtimeclient.StateRunning,
 							},
 							K8s: runtimeclient.K8sContainerData{},
 						},
@@ -110,7 +106,7 @@ func TestRuntimeClientInterface(t *testing.T) {
 					found := false
 					for _, cData := range containers {
 						// ContainerImageDigest may vary among versions, so we do not check it for now
-						cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
+						cData.Runtime.ContainerImageDigest = ""
 						if cmp.Equal(*cData, eData.ContainerData) {
 							found = true
 							break
@@ -127,7 +123,7 @@ func TestRuntimeClientInterface(t *testing.T) {
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainer(eData.Runtime.ContainerID)
 					// ContainerImageDigest may vary among versions, so we do not check it for now
-					cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
+					cData.Runtime.ContainerImageDigest = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
 					require.True(t, cmp.Equal(*cData, eData.ContainerData),
@@ -141,7 +137,7 @@ func TestRuntimeClientInterface(t *testing.T) {
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainerDetails(eData.Runtime.ContainerID)
 					// ContainerImageDigest may vary among versions, so we do not check it for now
-					cData.Runtime.BasicRuntimeMetadata.ContainerImageDigest = ""
+					cData.Runtime.ContainerImageDigest = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
 

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -72,6 +72,7 @@ func TestRuntimeClientInterface(t *testing.T) {
 									RuntimeName:        runtime,
 									ContainerName:      cn,
 									ContainerID:        c.ID(),
+									ContainerPID:       uint32(c.Pid()),
 									ContainerImageName: containerImageName,
 								},
 								State: runtimeclient.StateRunning,

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -46,6 +46,7 @@ type EventWrapperBase struct {
 	containernameAccessor        datasource.FieldAccessor
 	runtimenameAccessor          datasource.FieldAccessor
 	containeridAccessor          datasource.FieldAccessor
+	containerpidAccessor         datasource.FieldAccessor
 	containerimagenameAccessor   datasource.FieldAccessor
 	containerimagedigestAccessor datasource.FieldAccessor
 	hostNetworkAccessor          datasource.FieldAccessor
@@ -238,7 +239,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		datasource.WithAnnotations(map[string]string{
 			metadatav1.TemplateAnnotation: "container",
 		}),
-		datasource.WithOrder(-26),
+		datasource.WithOrder(-27),
 	)
 	if err != nil {
 		return nil, err
@@ -251,7 +252,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 			metadatav1.ColumnsFixedAnnotation: "true",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
-		datasource.WithOrder(-25),
+		datasource.WithOrder(-26),
 	)
 	if err != nil {
 		return nil, err
@@ -264,6 +265,17 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 			metadatav1.ColumnsMaxWidthAnnotation: "64",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
+		datasource.WithOrder(-25),
+	)
+	if err != nil {
+		return nil, err
+	}
+	ev.containerpidAccessor, err = runtime.AddSubField(
+		"containerPid",
+		api.Kind_Uint32,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.TemplateAnnotation: "containerPid",
+		}),
 		datasource.WithOrder(-24),
 	)
 	if err != nil {
@@ -368,6 +380,10 @@ func (ev *EventWrapper) SetPodMetadata(container types.Container) {
 }
 
 func (ev *EventWrapper) SetContainerMetadata(container types.Container) {
+	if ev.containerpidAccessor.IsRequested() {
+		ev.containerpidAccessor.PutUint32(ev.Data, container.ContainerPid())
+	}
+
 	ev.SetPodMetadata(container)
 }
 

--- a/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
+++ b/pkg/gadget-collection/gadgets/snapshot/socket/gadget.go
@@ -112,7 +112,7 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 		if _, ok := visitedPods[key]; !ok {
 			// Make the whole gadget fail if there is a container without PID
 			// because it would be an inconsistency that has to be notified
-			if container.Pid == 0 {
+			if container.ContainerPid() == 0 {
 				trace.Status.OperationError = fmt.Sprintf("aborting! The following container does not have PID %+v", container)
 				return
 			}
@@ -122,9 +122,9 @@ func (t *Trace) Collect(trace *gadgetv1alpha1.Trace) {
 			visitedPods[key] = struct{}{}
 
 			log.Debugf("Gadget %s: Using PID %d to retrieve network namespace of Pod %q in Namespace %q",
-				trace.Spec.Gadget, container.Pid, container.K8s.PodName, container.K8s.Namespace)
+				trace.Spec.Gadget, container.ContainerPid(), container.K8s.PodName, container.K8s.Namespace)
 
-			podSockets, err := socketTracer.RunCollector(container.Pid, container.K8s.PodName,
+			podSockets, err := socketTracer.RunCollector(container.ContainerPid(), container.K8s.PodName,
 				container.K8s.Namespace, trace.Spec.Node)
 			if err != nil {
 				trace.Status.OperationError = err.Error()

--- a/pkg/gadgets/snapshot/socket/tracer/tracer.go
+++ b/pkg/gadgets/snapshot/socket/tracer/tracer.go
@@ -186,7 +186,7 @@ func (t *Tracer) AttachContainer(container *containercollection.Container) error
 	if _, ok := t.visitedNamespaces[container.Netns]; ok {
 		return nil
 	}
-	t.visitedNamespaces[container.Netns] = container.Pid
+	t.visitedNamespaces[container.Netns] = container.ContainerPid()
 	return nil
 }
 

--- a/pkg/gadgets/test/gadgets_test.go
+++ b/pkg/gadgets/test/gadgets_test.go
@@ -142,11 +142,11 @@ func TestContainerRemovalRaceCondition(t *testing.T) {
 			container := &containercollection.Container{
 				Runtime: containercollection.RuntimeMetadata{
 					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-						ContainerID: uuid.New().String(),
+						ContainerID:  uuid.New().String(),
+						ContainerPID: uint32(r.Info.Tid),
 					},
 				},
 				Mntns: r.Info.MountNsID,
-				Pid:   uint32(r.Info.Tid),
 				K8s: containercollection.K8sMetadata{
 					BasicK8sMetadata: types.BasicK8sMetadata{
 						ContainerName: name,
@@ -231,11 +231,11 @@ func TestEventEnrichmentRaceCondition(t *testing.T) {
 			container := &containercollection.Container{
 				Runtime: containercollection.RuntimeMetadata{
 					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
-						ContainerID: uuid.New().String(),
+						ContainerID:  uuid.New().String(),
+						ContainerPID: uint32(r.Info.Tid),
 					},
 				},
 				Mntns: r.Info.MountNsID,
-				Pid:   uint32(r.Info.Tid),
 				K8s: containercollection.K8sMetadata{
 					BasicK8sMetadata: types.BasicK8sMetadata{
 						ContainerName: name,

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -165,10 +165,10 @@ func (g *GadgetTracerManager) AddContainer(_ context.Context, containerDefinitio
 	container := containercollection.Container{
 		Runtime: containercollection.RuntimeMetadata{
 			BasicRuntimeMetadata: eventtypes.BasicRuntimeMetadata{
-				ContainerID: containerDefinition.Id,
+				ContainerID:  containerDefinition.Id,
+				ContainerPID: containerDefinition.Pid,
 			},
 		},
-		Pid: containerDefinition.Pid,
 		K8s: containercollection.K8sMetadata{
 			BasicK8sMetadata: eventtypes.BasicK8sMetadata{
 				Namespace:     containerDefinition.Namespace,

--- a/pkg/metadata/v1/annotations.go
+++ b/pkg/metadata/v1/annotations.go
@@ -53,6 +53,11 @@ var AnnotationsTemplates = map[string]map[string]string{
 	"containerImageName": {
 		ColumnsWidthAnnotation: "30",
 	},
+	"containerPid": {
+		ColumnsWidthAnnotation:     "6",
+		ColumnsHiddenAnnotation:    "true",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
 	"containerImageDigest": {
 		ColumnsWidthAnnotation: "30",
 	},

--- a/pkg/networktracer/tracer.go
+++ b/pkg/networktracer/tracer.go
@@ -305,11 +305,11 @@ func (t *Tracer[Event]) EventCallback(event any) {
 }
 
 func (t *Tracer[Event]) AttachContainer(container *containercollection.Container) error {
-	return t.Attach(container.Pid)
+	return t.Attach(container.ContainerPid())
 }
 
 func (t *Tracer[Event]) DetachContainer(container *containercollection.Container) error {
-	return t.Detach(container.Pid)
+	return t.Detach(container.ContainerPid())
 }
 
 func (t *Tracer[Event]) GetMap(name string) *ebpf.Map {

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -740,7 +740,7 @@ func (i *ebpfInstance) AttachContainer(container *containercollection.Container)
 	i.mu.Unlock()
 
 	for _, networkTracer := range i.networkTracers {
-		if err := networkTracer.Attach(container.Pid); err != nil {
+		if err := networkTracer.Attach(container.ContainerPid()); err != nil {
 			return err
 		}
 	}
@@ -768,7 +768,7 @@ func (i *ebpfInstance) DetachContainer(container *containercollection.Container)
 	i.mu.Unlock()
 
 	for _, networkTracer := range i.networkTracers {
-		if err := networkTracer.Detach(container.Pid); err != nil {
+		if err := networkTracer.Detach(container.ContainerPid()); err != nil {
 			return err
 		}
 	}

--- a/pkg/operators/ebpf/snapshotter.go
+++ b/pkg/operators/ebpf/snapshotter.go
@@ -167,7 +167,7 @@ func (i *ebpfInstance) runSnapshotters() error {
 					}
 					visitedNetNs[container.Netns] = struct{}{}
 
-					err := nsenter.NetnsEnter(int(container.Pid), func() error {
+					err := nsenter.NetnsEnter(int(container.ContainerPid()), func() error {
 						reader, err := l.link.Open()
 						if err != nil {
 							return err

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -268,7 +268,7 @@ func (m *KubeManagerInstance) PreGadgetRun() error {
 			m.attachedContainers[container.Runtime.ContainerID] = container
 
 			log.Debugf("tracer attached: container %q pid %d mntns %d netns %d",
-				container.K8s.ContainerName, container.Pid, container.Mntns, container.Netns)
+				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
 		}
 
 		detachContainerFunc := func(container *containercollection.Container) {
@@ -281,7 +281,7 @@ func (m *KubeManagerInstance) PreGadgetRun() error {
 				return
 			}
 			log.Debugf("tracer detached: container %q pid %d mntns %d netns %d",
-				container.K8s.ContainerName, container.Pid, container.Mntns, container.Netns)
+				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
 		}
 
 		m.subscribed = true

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -254,7 +254,14 @@ func (l *LocalManager) Init(operatorParams *params.Params) error {
 	//   own.
 	// * Others, like traceloop or advise seccomp-profile, need the mount
 	//   namespace ID to bet set.
-	l.fakeContainer = &containercollection.Container{Pid: pidOne, Mntns: mntns}
+	l.fakeContainer = &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+				ContainerPID: pidOne,
+			},
+		},
+		Mntns: mntns,
+	}
 
 	additionalOpts := []containercollection.ContainerCollectionOption{}
 	if operatorParams.Get(EnrichWithK8sApiserver).AsBool() {
@@ -382,7 +389,7 @@ func (l *localManagerTrace) PreGadgetRun() error {
 			l.attachedContainers[container] = struct{}{}
 
 			log.Debugf("tracer attached: container %q pid %d mntns %d netns %d",
-				container.K8s.ContainerName, container.Pid, container.Mntns, container.Netns)
+				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
 		}
 
 		detachContainerFunc := func(container *containercollection.Container) {
@@ -393,7 +400,7 @@ func (l *localManagerTrace) PreGadgetRun() error {
 				return
 			}
 			log.Debugf("tracer detached: container %q pid %d mntns %d netns %d",
-				container.K8s.ContainerName, container.Pid, container.Mntns, container.Netns)
+				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
 		}
 
 		if l.manager.igManager != nil {

--- a/pkg/tchandler/tracer.go
+++ b/pkg/tchandler/tracer.go
@@ -191,7 +191,7 @@ func (t *Handler) AttachContainer(container *containercollection.Container) erro
 		return nil
 	}
 
-	pid := container.Pid
+	pid := container.ContainerPid()
 
 	netns, err := containerutils.GetNetNs(int(pid))
 	if err != nil {
@@ -244,7 +244,7 @@ func (t *Handler) DetachContainer(container *containercollection.Container) erro
 		return nil
 	}
 
-	pid := container.Pid
+	pid := container.ContainerPid()
 
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -110,6 +110,8 @@ func NormalizeCommonData(e *eventtypes.CommonData) {
 	// ignore this field for now.
 	e.Runtime.ContainerImageDigest = ""
 
+	e.Runtime.ContainerPID = 0
+
 	if CurrentTestComponent == KubectlGadgetTestComponent {
 		e.K8s.Node = ""
 		// TODO: Verify container runtime and container name

--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -265,18 +265,19 @@ func (t *Tracer[Event]) AttachContainer(container *containercollection.Container
 		return errors.New("uprobetracer has been closed")
 	}
 
+	pid := container.ContainerPid()
 	if t.prog == nil {
-		_, exist := t.pendingContainerPids[container.Pid]
+		_, exist := t.pendingContainerPids[pid]
 		if exist {
-			return fmt.Errorf("container PID already exists: %d", container.Pid)
+			return fmt.Errorf("container PID already exists: %d", pid)
 		}
-		t.pendingContainerPids[container.Pid] = true
+		t.pendingContainerPids[pid] = true
 	} else {
-		_, exist := t.containerPid2Inodes[container.Pid]
+		_, exist := t.containerPid2Inodes[pid]
 		if exist {
-			return fmt.Errorf("container PID already exists: %d", container.Pid)
+			return fmt.Errorf("container PID already exists: %d", pid)
 		}
-		t.attach(container.Pid)
+		t.attach(pid)
 	}
 	return nil
 }
@@ -289,20 +290,21 @@ func (t *Tracer[Event]) DetachContainer(container *containercollection.Container
 		return nil
 	}
 
+	pid := container.ContainerPid()
 	if t.prog == nil {
 		// remove from pending list
-		_, exist := t.pendingContainerPids[container.Pid]
+		_, exist := t.pendingContainerPids[pid]
 		if !exist {
 			return errors.New("container has not been attached")
 		}
-		delete(t.pendingContainerPids, container.Pid)
+		delete(t.pendingContainerPids, pid)
 	} else {
 		// detach from container if attached
-		attachedRealInodes, exist := t.containerPid2Inodes[container.Pid]
+		attachedRealInodes, exist := t.containerPid2Inodes[pid]
 		if !exist {
 			return errors.New("container has not been attached")
 		}
-		delete(t.containerPid2Inodes, container.Pid)
+		delete(t.containerPid2Inodes, pid)
 
 		for _, realInodePtr := range attachedRealInodes {
 			keeper, exist := t.inodeRefCount[realInodePtr]


### PR DESCRIPTION
# Container enrichment: add container PID

- [X] Image-based gadgets :+1:
- [x] Builtin gadgets :+1:

## How to use

Read the `runtime.ContainerPid` field.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]


Tested with command:
```
$ docker run -ti --rm --name test ubuntu sh -c 'cat /dev/null'
```

Output for image-based gadgets:
```
$ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_exec:latest --fields runtime.ContainerName,runtime.ContainerPid,pid,comm,args -c test
RUNTIME.CONTAINERNAME     RUNTIME.CONTAINER…        PID COMM         ARGS
test                                 2911217    2911217 sh           /usr/bin/sh -c cat /dev/null
test                                 2911217    2911269 cat          /usr/bin/cat /dev/null
```

Output for builtin gadgets:
```
$ sudo ig trace exec -o columns=runtime.ContainerName,runtime.ContainerPid,pid,comm,args -c test
RUNTIME.CONTAINERNAME                                                                 RUNTIME.C… PID        COMM             ARGS
test                                                                                  33748      33748      sh               /usr/bin/sh -c cat /dev/null
test                                                                                  33748      33770      cat              /usr/bin/cat /dev/null
```

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/3467

