### PR TITLE
gadgets: add gadget to trace mutex locks/unlocks

### DIFF
--- a/docs/gadgets/deadlock.mdx
+++ b/docs/gadgets/deadlock.mdx
@@ -1,0 +1,1 @@
+../../gadgets/deadlock/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -13,6 +13,7 @@ COSIGN ?= cosign
 
 GADGETS = \
 	audit_seccomp \
+	deadlock \
 	fsnotify \
 	profile_blockio \
 	profile_tcprtt \

--- a/gadgets/deadlock/README.md
+++ b/gadgets/deadlock/README.md
@@ -1,0 +1,5 @@
+# deadlock
+
+Use uprobe to trace pthread_mutex_lock and pthread_mutex_unlock in libc.so and detect potential deadlocks.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/deadlock

--- a/gadgets/deadlock/README.mdx
+++ b/gadgets/deadlock/README.mdx
@@ -1,0 +1,71 @@
+---
+title: deadlock
+sidebar_position: 20
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# deadlock
+
+Use uprobe to trace pthread_mutex_lock and pthread_mutex_unlock in libc.so and detect potential deadlocks.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/deadlock:latest [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:latest [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+No flags.
+
+## Guide
+
+To generate mutex lock/unlock events, you can run a `test` program in another container.
+
+For this example, we use a [test C++ program](https://github.com/iovisor/bcc/blob/master/tools/deadlock_example.txt#L187) (from BCC) with lock inversions that can cause a potential deadlock.
+
+The deadlock gadget can trace all mutex lock/unlock events in the following way:
+```bash
+$ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:latest
+RUNTIME.CONTAINERNAME      COMM                  PID        TID MUTEX_ADDR        OPERATION
+hungry_turing              test                23148      23148 0x7FED1243EA58    lock
+hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
+hungry_turing              test                23148      23237 0x5612ABB33160    lock
+hungry_turing              test                23148      23237 0x5612ABB331A0    lock
+hungry_turing              test                23148      23237 0x5612ABB331A0    unlock
+hungry_turing              test                23148      23237 0x5612ABB33160    unlock
+hungry_turing              test                23148      23148 0x7FED1243EA58    lock
+hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
+hungry_turing              test                23148      23239 0x5612ABB331A0    lock
+hungry_turing              test                23148      23239 0x5612ABB331E0    lock
+hungry_turing              test                23148      23239 0x5612ABB331E0    unlock
+hungry_turing              test                23148      23239 0x5612ABB331A0    unlock
+hungry_turing              test                23148      23148 0x7FED1243EA58    lock
+hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
+hungry_turing              test                23148      23240 0x5612ABB331E0    lock
+hungry_turing              test                23148      23240 0x7FFDC68BEB80    lock
+hungry_turing              test                23148      23240 0x7FFDC68BEB80    unlock
+hungry_turing              test                23148      23240 0x5612ABB331E0    unlock
+hungry_turing              test                23148      23148 0x7FED1243EA58    lock
+hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
+hungry_turing              test                23148      23241 0x7FFDC68BEB80    lock
+hungry_turing              test                23148      23241 0x5612ABB33160    lock
+hungry_turing              test                23148      23241 0x5612ABB33160    unlock
+hungry_turing              test                23148      23241 0x7FFDC68BEB80    unlock
+hungry_turing              test                23148      23148 0x7FED1243EA08    lock
+hungry_turing              test                23148      23148 0x7FED1243EA08    unlock
+```

--- a/gadgets/deadlock/artifacthub-pkg.yml
+++ b/gadgets/deadlock/artifacthub-pkg.yml
@@ -1,0 +1,29 @@
+# Artifact Hub package metadata file
+version: v0.32.0
+name: "deadlock"
+category: monitoring-logging
+displayName: "deadlock"
+createdAt: "2024-09-21T19:37:40Z"
+digest: 2024-09-21T19:37:40Z
+description: "use uprobe to trace pthread_mutex_lock and pthread_mutex_unlock in libc.so and detect potential deadlocks"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/deadlock"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/deadlock:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/deadlock"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/deadlock/gadget.yaml
+++ b/gadgets/deadlock/gadget.yaml
@@ -1,0 +1,42 @@
+name: deadlock
+description: use uprobe to trace pthread_mutex_lock and pthread_mutex_unlock in libc.so
+  and detect potential deadlocks
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/deadlock
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/deadlock
+datasources:
+  deadlock:
+    fields:
+      comm:
+        annotations:
+          description: Process name
+          template: comm
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+          template: ns
+      mutex_addr:
+        annotations:
+          columns.hex: "true"
+          columns.width: "20"
+          description: address of mutex lock/unlock operations
+      operation:
+        annotations:
+          description: mutex operation type
+      operation_raw:
+        annotations:
+          columns.hidden: "true"
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      tid:
+        annotations:
+          description: Thread ID
+          template: pid
+      timestamp:
+        annotations:
+          template: timestamp
+      timestamp_raw:
+        annotations:
+          columns.hidden: "true"

--- a/gadgets/deadlock/program.bpf.c
+++ b/gadgets/deadlock/program.bpf.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2024 The Inspektor Gadget authors */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+
+enum operation { lock, unlock };
+
+struct event {
+	gadget_timestamp timestamp_raw;
+	gadget_mntns_id mntns_id;
+
+	char comm[TASK_COMM_LEN];
+	__u32 pid;
+	__u32 tid;
+
+	__u64 mutex_addr;
+
+	enum operation operation_raw;
+};
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER(deadlock, events, event);
+
+static __always_inline int
+gen_mutex_event(struct pt_regs *ctx, enum operation operation, u64 mutex_addr)
+{
+	u64 mntns_id;
+	struct event *event;
+	u64 pid_tgid;
+	u32 tid;
+
+	mntns_id = gadget_get_mntns_id();
+	if (gadget_should_discard_mntns_id(mntns_id))
+		return 0;
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	pid_tgid = bpf_get_current_pid_tgid();
+	tid = (u32)pid_tgid;
+
+	event->mntns_id = mntns_id;
+	event->pid = pid_tgid >> 32;
+	event->tid = tid;
+	event->mutex_addr = mutex_addr;
+	bpf_get_current_comm(event->comm, sizeof(event->comm));
+	event->operation_raw = operation;
+	event->timestamp_raw = bpf_ktime_get_ns();
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+	return 0;
+}
+
+/* mutex acquisition */
+SEC("uprobe/libc:pthread_mutex_lock")
+int BPF_UPROBE(trace_uprobe_mutex_lock, void *mutex_addr)
+{
+	return gen_mutex_event(ctx, lock, (u64)mutex_addr);
+}
+
+/* mutex release */
+SEC("uprobe/libc:pthread_mutex_unlock")
+int BPF_UPROBE(trace_uprobe_mutex_unlock, void *mutex_addr)
+{
+	return gen_mutex_event(ctx, unlock, (u64)mutex_addr);
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/gadgets/fsnotify/README.mdx
+++ b/gadgets/fsnotify/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: fsnotify
-sidebar_position: 20
+sidebar_position: 30
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/profile_blockio/README.mdx
+++ b/gadgets/profile_blockio/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: profile_blockio
-sidebar_position: 30
+sidebar_position: 40
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/profile_tcprtt/README.mdx
+++ b/gadgets/profile_tcprtt/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: profile_tcprtt
-sidebar_position: 40
+sidebar_position: 50
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/snapshot_process/README.mdx
+++ b/gadgets/snapshot_process/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: snapshot_process
-sidebar_position: 50
+sidebar_position: 60
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/snapshot_socket/README.mdx
+++ b/gadgets/snapshot_socket/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: snapshot_socket
-sidebar_position: 60
+sidebar_position: 70
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/top_file/README.mdx
+++ b/gadgets/top_file/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: top_file
-sidebar_position: 70
+sidebar_position: 80
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/top_tcp/README.mdx
+++ b/gadgets/top_tcp/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: top_tcp
-sidebar_position: 80
+sidebar_position: 90
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_bind/README.mdx
+++ b/gadgets/trace_bind/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_bind
-sidebar_position: 90
+sidebar_position: 100
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_capabilities/README.mdx
+++ b/gadgets/trace_capabilities/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_capabilities
-sidebar_position: 100
+sidebar_position: 110
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_dns/README.mdx
+++ b/gadgets/trace_dns/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_dns
-sidebar_position: 110
+sidebar_position: 120
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_exec/README.mdx
+++ b/gadgets/trace_exec/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_exec
-sidebar_position: 120
+sidebar_position: 130
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_lsm/README.mdx
+++ b/gadgets/trace_lsm/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace lsm
-sidebar_position: 130
+sidebar_position: 140
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_malloc/README.mdx
+++ b/gadgets/trace_malloc/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace malloc
-sidebar_position: 140
+sidebar_position: 150
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_mount/README.mdx
+++ b/gadgets/trace_mount/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_mount
-sidebar_position: 150
+sidebar_position: 160
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_oomkill/README.mdx
+++ b/gadgets/trace_oomkill/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_oomkill
-sidebar_position: 160
+sidebar_position: 170
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_open/README.mdx
+++ b/gadgets/trace_open/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_open
-sidebar_position: 170
+sidebar_position: 180
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_signal/README.mdx
+++ b/gadgets/trace_signal/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace signal
-sidebar_position: 180
+sidebar_position: 190
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_sni/README.mdx
+++ b/gadgets/trace_sni/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_sni
-sidebar_position: 190
+sidebar_position: 200
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_ssl/README.mdx
+++ b/gadgets/trace_ssl/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace ssl
-sidebar_position: 200
+sidebar_position: 210
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_tcp/README.mdx
+++ b/gadgets/trace_tcp/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_tcp
-sidebar_position: 210
+sidebar_position: 220
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_tcpconnect/README.mdx
+++ b/gadgets/trace_tcpconnect/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace tcpconnect
-sidebar_position: 220
+sidebar_position: 230
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_tcpdrop/README.mdx
+++ b/gadgets/trace_tcpdrop/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_tcpdrop
-sidebar_position: 230
+sidebar_position: 240
 ---
 
 import Tabs from '@theme/Tabs';

--- a/gadgets/trace_tcpretrans/README.mdx
+++ b/gadgets/trace_tcpretrans/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: trace_tcpretrans
-sidebar_position: 240
+sidebar_position: 250
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
# Gadget to trace mutex locks/unlocks

Adds a basic gadget that traces mutex acquisitions and releases. This gadget will be extended to detect potential deadlocks.

## How to use

1. Run the gadget using `ig`.
2. Run a simple script that uses the `pthread_mutex_lock` and `pthread_mutex_unlock` methods, in a container.
3. Observe trace.

## Testing done

Followed the above steps with the following `test` [script](https://github.com/iovisor/bcc/blob/master/tools/deadlock_example.txt#L187).

**Output**:

![image](https://github.com/user-attachments/assets/a856a030-ae90-4a84-98d7-0783a1012114)
