### PR TITLE
gadgets: Standardize common information

### DIFF
--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -16,26 +16,37 @@ datasources:
         annotations:
           description: Mount namespace inode id
           template: ns
-      comm:
+      proc:
+        annotations:
+          columns.hidden: true
+      proc.user:
+        annotations:
+          columns.hidden: true
+      proc.comm:
         annotations:
           description: Process name
           template: comm
-      pid:
+          columns.alias: comm
+      proc.pid:
         annotations:
           description: Process ID
           template: pid
-      tid:
+          columns.alias: pid
+      proc.tid:
         annotations:
           description: Thread ID
           template: pid
-      uid:
+          columns.alias: tid
+      proc.user.uid:
         annotations:
           description: User ID
           template: uid
-      gid:
+          columns.alias: uid
+      proc.user.gid:
         annotations:
           description: Group ID
           template: uid
+          columns.alias: gid
       flags_raw:
         annotations:
           columns.hidden: true
@@ -62,6 +73,27 @@ datasources:
         annotations:
           columns.width: 32
           columns.minwidth: 24
+      # Hide backward compatibility fields.
+      comm:
+        annotations:
+          columns.hidden: true
+          deprecated: true
+      uid:
+        annotations:
+          columns.hidden: true
+          deprecated: true
+      gid:
+        annotations:
+          columns.hidden: true
+          deprecated: true
+      pid:
+        annotations:
+          columns.hidden: true
+          deprecated: true
+      tid:
+        annotations:
+          columns.hidden: true
+          deprecated: true
 params:
   ebpf:
     targ_failed:

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -10,6 +10,7 @@
 #include <gadget/macros.h>
 #include <gadget/mntns_filter.h>
 #include <gadget/types.h>
+#include <gadget/common.h>
 
 #define TASK_RUNNING 0
 #define NAME_MAX 255
@@ -25,6 +26,9 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
+	struct process proc;
+
+	// TODO: These are kept for backward compatibility, drop them when ready.
 	char comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
 	__u32 pid;
@@ -157,11 +161,13 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 	}
 
 	/* event data */
-	event->pid = pid_tgid >> 32;
-	event->tid = (__u32)pid_tgid;
-	event->uid = (u32)uid_gid;
-	event->gid = (u32)(uid_gid >> 32);
-	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+	gadget_fill_current_process(&event->proc);
+	event->pid = event->proc.pid;
+	event->tid = event->proc.tid;
+	event->uid = event->proc.user.uid;
+	event->gid = event->proc.user.gid;
+	__builtin_memcpy(event->comm, event->proc.comm, sizeof(event->comm));
+
 	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
 	event->flags_raw = ap->flags;
 	event->mode_raw = ap->mode;

--- a/gadgets/trace_open/test/trace_open_test.go
+++ b/gadgets/trace_open/test/trace_open_test.go
@@ -35,11 +35,7 @@ type traceOpenEvent struct {
 	Timestamp string `json:"timestamp"`
 	MntNsID   uint64 `json:"mntns_id"`
 
-	Comm string `json:"comm"`
-	Pid  uint32 `json:"pid"`
-	Tid  uint32 `json:"tid"`
-	Uid  uint32 `json:"uid"`
-	Gid  uint32 `json:"gid"`
+	Proc eventtypes.Process `json:"proc"`
 
 	Fd    uint32 `json:"fd"`
 	Error string `json:"error"`
@@ -93,27 +89,31 @@ func TestTraceOpen(t *testing.T) {
 		func(t *testing.T, output string) {
 			expectedEntry := &traceOpenEvent{
 				CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
-				Comm:       "cat",
-				FName:      "/dev/null",
-				Fd:         3,
-				Error:      "",
-				Uid:        1000,
-				Gid:        1111,
-				Flags:      "O_RDONLY",
-				Mode:       "----------",
+				Proc: eventtypes.Process{
+					Comm: "cat",
+					Pid:  utils.NormalizedInt,
+					Tid:  utils.NormalizedInt,
+					User: eventtypes.User{
+						Uid: 1000,
+						Gid: 1111,
+					},
+				},
+				FName: "/dev/null",
+				Fd:    3,
+				Error: "",
+				Flags: "O_RDONLY",
+				Mode:  "----------",
 
 				// Check the existence of the following fields
 				Timestamp: utils.NormalizedStr,
-				Pid:       utils.NormalizedInt,
-				Tid:       utils.NormalizedInt,
 				MntNsID:   utils.NormalizedInt,
 			}
 
 			normalize := func(e *traceOpenEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Timestamp)
-				utils.NormalizeInt(&e.Pid)
-				utils.NormalizeInt(&e.Tid)
+				utils.NormalizeInt(&e.Proc.Pid)
+				utils.NormalizeInt(&e.Proc.Tid)
 				utils.NormalizeInt(&e.MntNsID)
 			}
 

--- a/include/gadget/common.h
+++ b/include/gadget/common.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __COMMON_H
+#define __COMMON_H
+
+#include <bpf/bpf_helpers.h>
+
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+struct user {
+	__u32 uid;
+	__u32 gid;
+};
+
+struct process {
+	char comm[TASK_COMM_LEN];
+	__u32 pid;
+	__u32 tid;
+
+	struct user user;
+};
+
+// gadget_fill_current_process fills the given process struct with the current
+// process information.
+void static __always_inline gadget_fill_current_process(struct process *p) {
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u64 uid_gid = bpf_get_current_uid_gid();
+
+	p->pid = pid_tgid >> 32;
+	p->tid = pid_tgid;
+	bpf_get_current_comm(p->comm, sizeof(p->comm));
+
+	p->user.uid = uid_gid;
+	p->user.gid = uid_gid >> 32;
+}
+
+#endif

--- a/pkg/columns/columninfo.go
+++ b/pkg/columns/columninfo.go
@@ -49,6 +49,8 @@ type Attributes struct {
 	Name string `yaml:"name"`
 	// Name of the columns without inherited prefixes
 	RawName string `yaml:"raw_name"`
+	// Alias is an alternative shorter name to be used for header of the column; if not set, the Name will be used
+	Alias string `yaml:"alias"`
 	// Width to reserve for this column
 	Width int `yaml:"width"`
 	// MinWidth will be the minimum width this column will be scaled to when using auto-scaling

--- a/pkg/columns/formatter/textcolumns/output.go
+++ b/pkg/columns/formatter/textcolumns/output.go
@@ -77,6 +77,9 @@ func (tf *TextColumnsFormatter[T]) FormatHeader() string {
 			row.WriteString(tf.options.ColumnDivider)
 		}
 		name := column.col.Name
+		if column.col.Alias != "" {
+			name = column.col.Alias
+		}
 		switch tf.options.HeaderStyle {
 		case HeaderStyleUppercase:
 			name = strings.ToUpper(name)

--- a/pkg/columns/formatter/textcolumns/textcolumns.go
+++ b/pkg/columns/formatter/textcolumns/textcolumns.go
@@ -99,11 +99,22 @@ func (tf *TextColumnsFormatter[T]) SetShowColumns(columns []string) error {
 		return nil
 	}
 
+	aliasLookup := make(map[string]string)
+	for _, c := range tf.columns {
+		if c.col.Alias != "" {
+			aliasLookup[strings.ToLower(c.col.Alias)] = strings.ToLower(c.col.Name)
+		}
+	}
+
 	newColumns := make([]*Column[T], 0)
 	for _, c := range columns {
 		column, ok := tf.columns[strings.ToLower(c)]
 		if !ok {
-			return fmt.Errorf("column %q is invalid", strings.ToLower(c))
+			// Check if there is an alias
+			column, ok = tf.columns[aliasLookup[strings.ToLower(c)]]
+			if !ok {
+				return fmt.Errorf("column %q is invalid", strings.ToLower(c))
+			}
 		}
 
 		newColumns = append(newColumns, column)

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -40,6 +40,7 @@ const (
 	ColumnsHiddenAnnotation    = "columns.hidden"
 	ColumnsFixedAnnotation     = "columns.fixed"
 	ColumnsHexAnnotation       = "columns.hex"
+	ColumnsAliasAnnotation     = "columns.alias"
 
 	DescriptionAnnotation = "description"
 	TemplateAnnotation    = "template"
@@ -162,6 +163,8 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				if v == "true" {
 					attributes.Hex = true
 				}
+			case ColumnsAliasAnnotation:
+				attributes.Alias = v
 			}
 		}
 

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -42,6 +42,7 @@ const (
 	ColumnsHexAnnotation       = "columns.hex"
 	ColumnsAliasAnnotation     = "columns.alias"
 
+	DeprecatedAnnotation  = "deprecated"
 	DescriptionAnnotation = "description"
 	TemplateAnnotation    = "template"
 )

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -154,7 +154,11 @@ func (o *cliOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "  %q (data source):\n", ds.Name())
 		for _, f := range availableFields {
-			fmt.Fprintf(&sb, "    %s\n", f.FullName)
+			if _, ok := f.Annotations[datasource.DeprecatedAnnotation]; ok {
+				fmt.Fprintf(&sb, "    %s (deprecated)\n", f.FullName)
+			} else {
+				fmt.Fprintf(&sb, "    %s\n", f.FullName)
+			}
 			if desc, ok := f.Annotations[datasource.DescriptionAnnotation]; ok {
 				fmt.Fprintf(&sb, "      %s\n", desc)
 			}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -176,6 +176,18 @@ type K8sMetadata struct {
 	Owner K8sOwnerReference `json:"owner,omitempty" column:"owner,hide"`
 }
 
+type User struct {
+	Uid uint32 `json:"uid,omitempty"`
+	Gid uint32 `json:"gid,omitempty"`
+}
+
+type Process struct {
+	Comm string `json:"comm,omitempty"`
+	Pid  uint32 `json:"pid,omitempty"`
+	Tid  uint32 `json:"tid,omitempty"`
+	User User   `json:"user,omitempty"`
+}
+
 type CommonData struct {
 	// Runtime contains the container runtime metadata of the container
 	// that generated the event


### PR DESCRIPTION
Fixes #1567

This PR introduces some types and helpers to easy the gadget development process. By using the new `struct process`, and the `gadget_fill_current_process` helper, gadgets can provide all information related to processes without having to duplicate the same logic in all of them. 

Specifically, this PR:
- Extends the metadata generation to include subfields for structs 
- Adds support for column alias: This is needed to avoid printing long names like `proc.user.uid`
- Support for deprecated annotation: How to tell the user a column is deprecated 
- Ports the trace_open gadget to discus the whole approach 

The purpose of this draft PR is to gather feedback on the approach and to discuss how to handle backward compatibility 

## Implementation

To avoid breaking users, this gadget keeps the old fields. This is the json output with the old and new fields available:

```json
{
  "comm": "bash",
  "error": "",
  "error_raw": 0,
  "fd": 3,
  "flags": "O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC",
  "flags_raw": 591872,
  "fname": ".",
  "gid": 0,
  "k8s": {
    "containerName": "",
    "hostnetwork": false,
    "namespace": "",
    "node": "",
    "owner": {
      "kind": "",
      "name": ""
    },
    "podName": ""
  },
  "mntns_id": 4026534323,
  "mode": "----------",
  "mode_raw": 0,
  "pid": 163367,
  "proc": {
    "comm": "bash",
    "pid": 163367,
    "tid": 163367,
    "user": {
      "gid": 0,
      "uid": 0
    }
  },
  "runtime": {
    "containerId": "04051f5e0d174d371cf20980cb516c73f4220c27924f08096e0856cd789564e1",
    "containerImageDigest": "sha256:58b87898e82351c6cf9cf5b9f3c20257bb9e2dcf33af051e12ce532d7f94e3fe",
    "containerImageName": "ubuntu:22.04",
    "containerName": "quirky_meninsky",
    "runtimeName": "docker"
  },
  "tid": 163367,
  "timestamp": "2024-09-20T16:42:20.216070372-05:00",
  "timestamp_raw": 1726868540216070400,
  "uid": 0
}
``` 

The columns output is the same as before as new fields have aliases.

Old fields will be removed in the next 2 - 3 releases.

## TODO
- [ ] Add helpers for socket enricher (enrich process information fron an skb)
- [ ] Port missing gadgets
- [ ] Document annotations 
- [ ] Release note 
- [ ] Fix #3459
- [ ] Understand how to handle the mount namespace id. Should it go to the process?