### PR TITLE
cmd/common: allow to specify gadget runtime configuration using "-f"

### DIFF
--- a/cmd/common/runwithspec_test.go
+++ b/cmd/common/runwithspec_test.go
@@ -1,0 +1,258 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
+	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
+)
+
+type testMode int
+
+const (
+	testModeBoth testMode = iota
+	testModeInteractiveOnly
+	testModeDetachOnly
+)
+
+type testSpec struct {
+	Name           string
+	Manifest       string
+	Mode           testMode
+	AdditionalArgs []string
+	ExpectedParams api.ParamValues
+	ExpectedName   string
+	ExpectedID     string
+	ExpectedTags   []string
+	ExpectError    bool
+}
+
+type testRuntime struct {
+	grpcruntime.Runtime
+	t        *testing.T
+	testSpec *testSpec
+}
+
+func (r *testRuntime) Init(*params.Params) error {
+	return nil
+}
+
+func (r *testRuntime) Close() error {
+	return nil
+}
+
+func (r *testRuntime) GetGadgetInfo(gadgetCtx runtime.GadgetContext, runtimeParams *params.Params, paramValueMap api.ParamValues) (*api.GadgetInfo, error) {
+	panic("unimplemented")
+}
+
+func (r *testRuntime) RunGadget(gadgetCtx runtime.GadgetContext, runtimeParams *params.Params, paramValueMap api.ParamValues) error {
+	if r.testSpec.ExpectedID != "" {
+		assert.Equal(r.t, r.testSpec.ExpectedID, runtimeParams.Get(grpcruntime.ParamID).AsString())
+	}
+	if r.testSpec.ExpectedName != "" {
+		assert.Equal(r.t, r.testSpec.ExpectedName, runtimeParams.Get(grpcruntime.ParamName).AsString())
+	}
+	if r.testSpec.ExpectedTags != nil {
+		assert.Equal(r.t, r.testSpec.ExpectedTags, runtimeParams.Get(grpcruntime.ParamTags).AsStringSlice())
+	}
+	for k, v := range r.testSpec.ExpectedParams {
+		val, ok := paramValueMap[k]
+		require.True(r.t, ok, "expected paramValue exists for %q", k)
+		require.Equal(r.t, v, val)
+	}
+	return nil
+}
+
+func createTempManifest(t *testing.T, manifest string) (string, error) {
+	f, err := os.CreateTemp("", "manifest")
+	if err != nil {
+		return "", fmt.Errorf("creating temp manifest file: %w", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(f.Name())
+	})
+	_, err = f.WriteString(manifest)
+	if err != nil {
+		return "", fmt.Errorf("writing temp manifest: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func TestRunWithSpec(t *testing.T) {
+	tests := []*testSpec{
+		{
+			Name:           "specified image on command line",
+			ExpectError:    true,
+			AdditionalArgs: []string{"trace_exec"},
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: trace_exec
+`,
+		},
+		{
+			Name: "invalid version",
+			Manifest: `
+apiVersion: a`,
+			ExpectError: true,
+		},
+		{
+			Name: "invalid kind",
+			Manifest: `
+apiVersion: 1
+kind: yo`,
+			ExpectError: true,
+		},
+		{
+			Name: "one spec with id, name, tags and params",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+id: 00000000000000000000000000000000
+name: myinstancename
+tags:
+  - tag1
+  - tag2
+paramValues:
+  a: b
+  y: z
+  n: 1
+`,
+			ExpectedID:   "00000000000000000000000000000000",
+			ExpectedName: "myinstancename",
+			ExpectedTags: []string{"tag1", "tag2"},
+			ExpectedParams: map[string]string{
+				"a": "b",
+				"y": "z",
+				"n": "1",
+			},
+		},
+		{
+			Name: "multiple specs with detach",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+---
+apiVersion: 1
+kind: instance-spec
+image: demo
+`,
+			Mode: testModeDetachOnly,
+		},
+		{
+			Name: "multiple specs without detach",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+---
+apiVersion: 1
+kind: instance-spec
+image: demo
+`,
+			Mode:        testModeInteractiveOnly,
+			ExpectError: true,
+		},
+		{
+			Name: "multiple specs, one invalid",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+---
+apiVersion: x
+`,
+			Mode:        testModeInteractiveOnly,
+			ExpectError: true,
+		},
+		{
+			Name: "missing image",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+`,
+			ExpectError: true,
+		},
+		{
+			Name: "invalid id",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+id: 0
+`,
+			ExpectError: true,
+		},
+		{
+			Name: "invalid name",
+			Manifest: `
+apiVersion: 1
+kind: instance-spec
+image: demo
+name: invalid-#name*
+`,
+			ExpectError: true,
+		},
+	}
+
+	environment.Environment = environment.Local
+
+	for _, tt := range tests {
+		runTest := func(detach bool) func(t *testing.T) {
+			return func(t *testing.T) {
+				fn, err := createTempManifest(t, tt.Manifest)
+				require.NoError(t, err)
+				rt := &testRuntime{
+					t:        t,
+					testSpec: tt,
+				}
+				root := &cobra.Command{}
+
+				root.AddCommand(NewRunCommand(root, rt, []string{}, CommandModeRun))
+				args := []string{"run", "-f", fn}
+				if detach {
+					args = append(args, "--detach")
+				}
+				args = append(args, tt.AdditionalArgs...)
+				root.SetArgs(args)
+				err = root.Execute()
+				if tt.ExpectError {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			}
+		}
+		if tt.Mode == testModeInteractiveOnly || tt.Mode == testModeBoth {
+			t.Run(tt.Name, runTest(false))
+		}
+		if tt.Mode == testModeDetachOnly || tt.Mode == testModeBoth {
+			t.Run(tt.Name, runTest(true))
+		}
+	}
+}

--- a/docs/reference/manifests.mdx
+++ b/docs/reference/manifests.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Gadget Instance Manifests'
+sidebar_position: 305
+description: Running gadgets in a predefined way using manifests
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Instead of providing all the parameters from command line, you can also use the `-f` flag in combination with the `run`
+command to specify a manifest file to run gadgets from. A manifest file is a file in
+[YAML format](https://en.wikipedia.org/wiki/YAML), that can hold information about one or more gadget instances. Such a
+file could look like this:
+
+```yaml
+apiVersion: 1
+kind: instance-spec
+image: trace_exec
+name: my-gadget-1
+paramValues:
+  operator.LocalManager.host: true
+tags:
+  - mytag1
+  - mytag2
+---
+apiVersion: 1
+kind: instance-spec
+image: trace_open
+name: my-gadget-2
+```
+
+This example contains two gadget instance specifications that are divided by three dashes (`---`).
+
+The `apiVersion` and `kind` fields define the specification used. They are mandatory and currently we only support
+this version and kind as part of the manifest.
+
+Specifying an `image` is also mandatory, while the rest of the fields are optional.
+
+When specifying `paramValues`, please use the fully qualified parameter names provided with their respective
+documentations in the [operators section](../spec/operators) ([example](../spec/operators/filter#filter)).
+
+:::warning
+
+If a manifest contains multiple instance specs, it can only be run by additionally using `--detach`. This is however
+only available when using `gadgetctl`. The run command will then try to create instances for all given specs and return
+their IDs.
+
+:::
+
+## Running a single gadget interactively
+
+When running interactively, you are limited to one gadget instance spec per manifest. This applies to `ig` as well as
+`gadgetctl` without the `--detach` flag.
+
+<Tabs groupId="env">
+    <TabItem value="single" label="Running a single gadget">
+
+```bash
+$ sudo ig run -f gadget.yaml
+WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
+WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
+RUNTIME.CONTAINERNAME                       COMM                    PID        TID PCOMM                  PPID ARGS                       ERROR USER                   LOGINUSER              GROUP
+                                            cat                   22630      22630 bash                  16905                                  username               username               username
+^C
+```
+    </TabItem>
+    <TabItem value="gadget-yaml" label="gadget.yaml">
+
+```yaml
+apiVersion: 1
+kind: instance-spec
+image: trace_exec
+name: my-gadget-1
+paramValues:
+  operator.LocalManager.host: true
+tags:
+  - mytag1
+  - mytag2
+```
+    </TabItem>
+</Tabs>
+
+## Running multiple gadgets in Headless Mode
+
+When running in Headless Mode (with the `--detach` flag), you can specify several gadget instance specs. This only
+applies to `gadgetctl`.
+
+More information about the Headless Mode is available [here](headless.mdx).
+
+<Tabs groupId="env">
+    <TabItem value="multi" label="Running multiple gadgets">
+
+```bash
+$ gadgetctl run -f gadgets.yaml --detach
+INFO[0000] installed on node "local" as "1bfb2963fef8b6d046357c9c4081d62a"
+INFO[0000] installed on node "local" as "d32d70d4baca063e3a183f40ecdf2d0a"
+
+$ gadgetctl list
+ID           NAME                          TAGS                          GADGET
+1bfb2963fef8 my-gadget-1                   mytag1,mytag2                 trace_exec
+d32d70d4baca my-gadget-2                                                 trace_open
+```
+    </TabItem>
+    <TabItem value="gadgets-yaml" label="gadgets.yaml">
+
+```yaml
+apiVersion: 1
+kind: instance-spec
+image: trace_exec
+name: my-gadget-1
+paramValues:
+  operator.LocalManager.host: true
+tags:
+  - mytag1
+  - mytag2
+---
+apiVersion: 1
+kind: instance-spec
+image: trace_open
+name: my-gadget-2
+```
+    </TabItem>
+</Tabs>

--- a/gadgets/trace_fsslower/gadget.yaml
+++ b/gadgets/trace_fsslower/gadget.yaml
@@ -85,4 +85,3 @@ params:
       defaultValue: ext4
       description: 'Filesystem to trace. Possible values are: btrfs, ext4, fuse, nfs, nfts3 or xfs.'
       title: Filesystem
-      alias: f

--- a/gadgets/trace_fsslower/test/trace_fsslower_test.go
+++ b/gadgets/trace_fsslower/test/trace_fsslower_test.go
@@ -95,7 +95,7 @@ func TestTraceFSSlower(t *testing.T) {
 		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
 	}
 
-	runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-f=%s", fsType), "--min=0"))
+	runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("--filesystem=%s", fsType), "--min=0"))
 
 	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
 		func(t *testing.T, output string) {

--- a/pkg/gadget-manifest/instance-spec.go
+++ b/pkg/gadget-manifest/instance-spec.go
@@ -1,0 +1,86 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgetmanifest
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+const (
+	APIVersion       = 1
+	KindInstanceSpec = "instance-spec"
+)
+
+type InstanceSpec struct {
+	APIVersion  int               `json:"apiVersion" yaml:"apiVersion"`
+	Kind        string            `json:"kind" yaml:"kind"`
+	Image       string            `json:"image" yaml:"image"`
+	ID          string            `json:"id" yaml:"id"`
+	Name        string            `json:"name" yaml:"name"`
+	Tags        []string          `json:"tags" yaml:"tags"`
+	ParamValues map[string]string `json:"paramValues" yaml:"paramValues"`
+}
+
+func InstanceSpecsFromReader(r io.Reader) ([]*InstanceSpec, error) {
+	ydec := yaml.NewDecoder(r)
+	res := make([]*InstanceSpec, 0)
+	c := 0
+	for {
+		c++
+		spec := &InstanceSpec{}
+		err := ydec.Decode(&spec)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parsing gadget spec (entry %d): %w", c, err)
+		}
+		if spec == nil {
+			continue
+		}
+		if spec.Kind != KindInstanceSpec {
+			return nil, fmt.Errorf("expected kind %q for entry %d in manifest, got kind %q", KindInstanceSpec, c, spec.Kind)
+		}
+		if spec.APIVersion != APIVersion {
+			return nil, fmt.Errorf("expected apiVersion %d for entry %d in manifest, got apiVersion %d", APIVersion, c, spec.APIVersion)
+		}
+		if spec.ParamValues == nil {
+			spec.ParamValues = make(map[string]string)
+		}
+		if spec.ID != "" && !api.IsValidInstanceID(spec.ID) {
+			return nil, fmt.Errorf("invalid instance id %q in entry %d", spec.ID, c)
+		}
+		if spec.Name != "" && !api.IsValidInstanceName(spec.Name) {
+			return nil, fmt.Errorf("invalid instance name %q in entry %d", spec.Name, c)
+		}
+		for _, t := range spec.Tags {
+			if strings.Contains(t, ",") {
+				return nil, fmt.Errorf("invalid character \",\" in tag %q of entry %d", t, c)
+			}
+		}
+		if spec.Image == "" {
+			return nil, fmt.Errorf("no image specified in entry %d", c)
+		}
+		res = append(res, spec)
+	}
+	return res, nil
+}


### PR DESCRIPTION
This allows specifying a manifest file using the "-f" flag.

Gadget instance specs can look like this:

```yaml
version: 1
kind: instance-spec
imageName: trace_exec
name: yoyo
tags:
  - foo
  - bar
paramValues:
  operator.LocalManager.host: true
---
version: 1
kind: instance-spec
imageName: trace_exec
name: gagaga
tags:
  - second
paramValues:
  operator.oci.wasm.gadget_a: 1212
  operator.oci.ebpf.gadget_a: 1212
  operator.LocalManager.host: true
```

When defining multiple specs inside the file like that, this functionality can only be used in combination with `--detach`.