### PR TITLE
gadgets: Fix headless test

### DIFF
--- a/gadgets/zz_daemon/daemon_test.go
+++ b/gadgets/zz_daemon/daemon_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,12 +62,17 @@ func TestDaemonHeadless(t *testing.T) {
 		}
 	}
 
+	igDaemonFlags := []string{"daemon"}
+	flags := os.Getenv("IG_FLAGS")
+	if flags != "" {
+		igDaemonFlags = append(igDaemonFlags, strings.Split(flags, " ")...)
+	}
 	igtesting.RunTestSteps([]igtesting.TestStep{
 		&command.Command{
 			Name:           "Start Daemon",
 			ValidateOutput: nil,
 			StartAndStop:   true,
-			Cmd:            exec.Command(igCmd, "daemon"),
+			Cmd:            exec.Command(igCmd, igDaemonFlags...),
 		},
 		utils.Sleep(time.Second * 5),
 		&command.Command{


### PR DESCRIPTION
The cosign key is not available when running the tests on the CI for external contributors or dependabot, it means that this test will fail because the signature can't be found.

Introduce logic to pass IG_FLAGS to "ig daemon" to disable the image verification when needed.

Fixes: c837450e4e4b ("add tests for ig --daemon in headless mode")

See #3514

cc @flyth @burak-ok 