### PR TITLE
operators: Fix location of enriched fields

### DIFF
--- a/pkg/datasource/field.go
+++ b/pkg/datasource/field.go
@@ -94,6 +94,18 @@ type ParentedField interface {
 
 type FieldOption func(*field)
 
+func WithSameParentAs(otherField FieldAccessor) FieldOption {
+	return func(f *field) {
+		if otherField == nil {
+			return
+		}
+		if FieldFlagHasParent.In(otherField.(*fieldAccessor).Flags()) {
+			f.Parent = otherField.(*fieldAccessor).f.Parent
+			FieldFlagHasParent.AddTo(&f.Flags)
+		}
+	}
+}
+
 func WithTags(tags ...string) FieldOption {
 	return func(f *field) {
 		f.Tags = append(f.Tags, tags...)

--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -98,7 +98,7 @@ func (i *ebpfInstance) initEnumFormatter(gadgetCtx operators.GadgetContext) erro
 				continue
 			}
 
-			out, err := ds.AddField(targetName, api.Kind_String)
+			out, err := ds.AddField(targetName, api.Kind_String, datasource.WithSameParentAs(in))
 			if err != nil {
 				return err
 			}
@@ -180,7 +180,7 @@ func (i *ebpfInstance) initStackConverter(gadgetCtx operators.GadgetContext) err
 				i.logger.Warnf("Failed to get target name for enum field %q: %v", in.Name(), err)
 				continue
 			}
-			out, err := ds.AddField(targetName, api.Kind_String)
+			out, err := ds.AddField(targetName, api.Kind_String, datasource.WithSameParentAs(in))
 			if err != nil {
 				return err
 			}

--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -190,7 +190,7 @@ func (i *ebpfInstance) getFieldsFromMember(member btf.Member, fields *[]*Field, 
 
 	// Keep enums to convert them to strings
 	if en, ok := member.Type.(*btf.Enum); ok {
-		i.enums = append(i.enums, &enum{Enum: en, memberName: member.Name})
+		i.enums = append(i.enums, &enum{Enum: en, memberName: prefix + member.Name})
 	}
 
 	kind := getFieldKind(refType, tags)

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -212,7 +212,7 @@ var replacers = []replacer{
 				return nil, err
 			}
 
-			signalField, err := ds.AddField(outName, api.Kind_String)
+			signalField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(in))
 			if err != nil {
 				return nil, err
 			}
@@ -247,6 +247,7 @@ var replacers = []replacer{
 				datasource.WithAnnotations(map[string]string{
 					datasource.TemplateAnnotation: "errorString",
 				}),
+				datasource.WithSameParentAs(in),
 			}
 			errnoField, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {
@@ -282,8 +283,7 @@ var replacers = []replacer{
 			if err != nil {
 				return nil, err
 			}
-
-			syscallField, err := ds.AddField(outName, api.Kind_String)
+			syscallField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(in))
 			if err != nil {
 				return nil, err
 			}
@@ -326,6 +326,7 @@ var replacers = []replacer{
 				datasource.WithAnnotations(map[string]string{
 					datasource.TemplateAnnotation: "timestamp",
 				}),
+				datasource.WithSameParentAs(in),
 			}
 			out, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -236,11 +236,15 @@ func (m *UidGidResolverInstance) PreStart(gadgetCtx operators.GadgetContext) err
 			}, 1)
 		}
 	}
-	return nil
+
+	// We need to start the cache here because it's too late to start it in
+	// Start() as other operators could be started before and generate events
+	// that need the cache
+	return m.uidGidCache.Start()
 }
 
 func (m *UidGidResolverInstance) Start(gadgetCtx operators.GadgetContext) error {
-	return m.uidGidCache.Start()
+	return nil
 }
 
 func (m *UidGidResolverInstance) Stop(gadgetCtx operators.GadgetContext) error {

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -123,10 +123,10 @@ func (k *UidGidResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			for _, uid := range uids {
 				outName, err := annotations.GetTargetNameFromAnnotation(logger, "uidgidresolver.uid", uid, "uidgidresolver.target")
 				if err != nil {
-					return nil, err
+					logger.Warnf("failed to get target name for uid: %s", err)
+					continue
 				}
-
-				uidStrField, err := ds.AddField(outName, api.Kind_String)
+				uidStrField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(uid))
 				if err != nil {
 					return nil, err
 				}
@@ -142,10 +142,10 @@ func (k *UidGidResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			for _, gid := range gids {
 				outName, err := annotations.GetTargetNameFromAnnotation(logger, "uidgidresolver.gid", gid, "uidgidresolver.target")
 				if err != nil {
-					return nil, err
+					logger.Warnf("failed to get target name for gid: %s", err)
+					continue
 				}
-
-				gidStrField, err := ds.AddField(outName, api.Kind_String)
+				gidStrField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(gid))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Before this commit operators were creating the enriched field in the root of the data source. This commit fixes that by creating the enriched fields in the same node of the "raw" one.

### Testing 

I used the following gadget to test it:

```c
#include <vmlinux.h>
#include <bpf/bpf_helpers.h>
#include <gadget/buffer.h>
#include <gadget/macros.h>
#include <gadget/types.h>

enum myenum {
	ONE = 1,
	TWO = 2,
	THREE = 3,
};

// Just to show inner fields
struct inner {
	gadget_uid inner_user_raw;
	gadget_gid inner_group_raw;
	gadget_syscall inner_syscall_raw;
	gadget_errno inner_errno_raw;
	enum myenum inner_enum_raw;
};

struct event {
	__u32 pid;

	gadget_uid user_raw;
	gadget_gid group_raw;
	gadget_syscall syscall_raw;
	gadget_errno errno_raw;
	enum myenum enum_raw;

	struct inner inner;
};

GADGET_TRACER_MAP(open_events, 1024 * 256);
GADGET_TRACER(open, open_events, event);

SEC("tracepoint/syscalls/sys_enter_openat")
int enter_openat(struct trace_event_raw_sys_enter *ctx)
{
	struct event *event;

	event = gadget_reserve_buf(&open_events, sizeof(*event));
	if (!event)
		return 0;

	u64 uid_gid = bpf_get_current_uid_gid();

	event->pid = bpf_get_current_pid_tgid() >> 32;

	event->user_raw = (u32)uid_gid;
	event->group_raw = (u32)(uid_gid >> 32);
	event->syscall_raw = 50; // any number just for testing
	event->errno_raw = 15;
	event->enum_raw = TWO;

	event->inner.inner_user_raw = event->user_raw;
	event->inner.inner_group_raw = event->group_raw;
	event->inner.inner_syscall_raw = event->syscall_raw;
	event->inner.inner_errno_raw = event->errno_raw;
	event->inner.inner_enum_raw = event->enum_raw;

	gadget_submit_buf(ctx, &open_events, event, sizeof(*event));

	return 0;
}

char LICENSE[] SEC("license") = "GPL";
```

#### Before 

Note: It's possible that you need to avoid running the command multiple types until it works because of the race condition fixed by the first commit of this PR 

```json
{
  "enum": "TWO",
  "enum_raw": 2,
  "errno": "ENOTBLK",
  "errno_raw": 15,
  "group": "systemd-oom",
  "group_raw": 117,
  "inner": {
    "inner_enum_raw": 2,
    "inner_errno_raw": 15,
    "inner_group_raw": 117,
    "inner_syscall_raw": 50,
    "inner_user_raw": 108
  },
  "inner_errno": "ENOTBLK",
  "inner_group": "systemd-oom",
  "inner_syscall": "SYS_LISTEN",
  "inner_user": "systemd-oom",
  "pid": 1182,
  "syscall": "SYS_LISTEN",
  "syscall_raw": 50,
  "user": "systemd-oom",
  "user_raw": 108
}
```

Notice hwo the enriched inner... fields are wrongly added to the root node .

### after 

```json
{
  "enum": "TWO",
  "enum_raw": 2,
  "errno": "ENOTBLK",
  "errno_raw": 15,
  "group": "systemd-oom",
  "group_raw": 117,
  "inner": {
    "inner_enum": "TWO",
    "inner_enum_raw": 2,
    "inner_errno": "ENOTBLK",
    "inner_errno_raw": 15,
    "inner_group": "systemd-oom",
    "inner_group_raw": 117,
    "inner_syscall": "SYS_LISTEN",
    "inner_syscall_raw": 50,
    "inner_user": "systemd-oom",
    "inner_user_raw": 108
  },
  "pid": 1182,
  "syscall": "SYS_LISTEN",
  "syscall_raw": 50,
  "user": "systemd-oom",
  "user_raw": 108
}
```

Fields are now added to the correct node

Fixes #3459

## TODO

Issues to discuss later on

- [ ] We need a `Close()` method on the operator interface to clean up resources allocated in PreStart()
- [ ] We need to test the formatters (or extend them for this case). Perhaps the gadget I provided here can be the base for a new integration test?
- [ ] Perhaps it makes sense to define a root node for all objects and make Parent() return it instead of nil.
