### PR TITLE
operators/ebpf: Do not add ebpf objects to context

### DIFF
--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -61,9 +61,6 @@ func (i *ebpfInstance) populateMap(t btf.Type, varName string) error {
 
 	i.vars[varName] = newVar
 
-	// Set variable to nil pointer to map, so it's present
-	var nilVal *ebpf.Map
-	i.gadgetCtx.SetVar(varName, nilVal)
 	return nil
 }
 

--- a/pkg/operators/ebpf/vars.go
+++ b/pkg/operators/ebpf/vars.go
@@ -58,6 +58,5 @@ func (i *ebpfInstance) populateVar(t btf.Type, varName string) error {
 	}
 
 	i.gadgetCtx.Logger().Debugf("variable %q %v %+v", varName, refType, t)
-	i.gadgetCtx.SetVar(varName, reflect.New(refType).Elem().Interface())
 	return nil
 }


### PR DESCRIPTION
Adding ebpf objects like maps and variables to the context is not needed. This commit removes that to allow users of the API to pass their own mount ns map, for instance, for testing purposes.

```
	filterMap := utilstest.CreateMntNsFilterMap(t, runner.Info.MountNsID)
	gadgetCtx.SetVar(gadgets.MntNsFilterMapName, filterMap)
	gadgetCtx.SetVar(gadgets.FilterByMntNsName, true)
```


Will be used in #3502 later on.