### PR TITLE
feat: add verifier debug output when running faulty ebpf gadget

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -19,6 +19,7 @@ package ebpfoperator
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -631,6 +632,11 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 	}
 	collection, err := ebpf.NewCollectionWithOptions(i.collectionSpec, opts)
 	if err != nil {
+		var verifierErr *ebpf.VerifierError
+		if errors.As(err, &verifierErr) {
+			gadgetCtx.Logger().Debugf("running gadget: verifier error: %+v\n", verifierErr)
+		}
+
 		return fmt.Errorf("creating eBPF collection: %w", err)
 	}
 	i.collection = collection


### PR DESCRIPTION
# Add verifier output when running faulty ebpf gadget

When running a faulty gadget containing ebpf code that gets rejected by the verifier, now the full 
verifier log is printed.

Fixes #3462

## How to use

Pass `-v` flag to `ig run`. 

## Testing done

Run `sudo ig run -v ...` with a gadget rejected by the ebpf verifier.
