### PR TITLE
operators/kubeipresolver: Improve memory consumption

### DIFF
--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -59,6 +59,28 @@ func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
 	return apiclientset, nil
 }
 
+// NewClientsetWithProtobuf creates a client to talk to the Kubernetes API
+// server using protobuf encoding.
+func NewClientsetWithProtobuf(kubeconfigPath string) (*kubernetes.Clientset, error) {
+	config, err := NewKubeConfig(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use protobuf instead of json as it's more efficient. This support was
+	// introduced in Kubernetes 1.3, released in July 2016, we can assume it's
+	// available.
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
+
+	apiclientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiclientset, nil
+}
+
 func NewClientsetFromConfigFlags(flags *genericclioptions.ConfigFlags) (*kubernetes.Clientset, error) {
 	config, err := flags.ToRESTConfig()
 	if err != nil {


### PR DESCRIPTION
The kubeipresolver needs to watch ALL pods and services in the cluster to be able to enrich network events with the service / pod information. The memory usage can become critical in clusters with thousands of pods. This commit optimizes it by doing two different things:
- Use protobuf instead of json: The protobuf encoding is more efficient than json. It's supported by the kube-apiserver from 8 years ago, so compability is not an issue.
- Define a SlimPod and SlimService structures: We only need few fields from the pod/service, define smaller structs to avoid storing a lot of data we don't care about. This uses the Transform() support from the shared informer.

## Testing 

This is only relevant in clusters with a lot of pods, so let's create a minikube cluster with 40k pods. (don't worry, we don't need all those pods in running state)

```bash 
$ minikube start ...

# deploy Inspektor Gadget here. 

# create a lot of pods
$ parallel -j 256 -i sh -c 'kubectl run pod-{} --image=ubuntu -- /bin/sh -c "while true; do sleep 3600000; done"' -- {1..40000}

$ kubectl get pods | wc -l
40001

# almost all pods are in pending state, but it doesn't matter for this test 
$ kubectl get pods | grep Pending | wc -l
39899
````

The kubeipresolver is only enabled when a gadget needs it, so we need to run a gadget that uses it (for now only built-in gadgets do)

```bash 
$ kubectl-gadget trace tcpconnect
... 
```

Then, check the memory consumption and compare this PR with main

I was initially testing with the metrics-server and grafana, but it's delay to update the memory usage from a pod confused me, so I decided to instrument the gadgettracermanager binary to print the memory usage to the terminal:

```diff
$ git diff -- gadget-container/
diff --git a/gadget-container/gadgettracermanager/main.go b/gadget-container/gadgettracermanager/main.go
index 70f8c1d04..19d7e0f6b 100644
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -23,11 +23,13 @@ import (
        "net"
        "os"
        "os/signal"
+       "runtime"
        "strconv"
        "strings"
        "syscall"
        "time"

+       "github.com/dustin/go-humanize"
        log "github.com/sirupsen/logrus"

        "google.golang.org/grpc"
@@ -112,6 +114,12 @@ func init() {
        flag.BoolVar(&fallbackPodInformer, "fallback-podinformer", true, "Use pod informer as a fallback for main hook")
 }

+func printMemory() {
+       var m runtime.MemStats
+       runtime.ReadMemStats(&m)
+       fmt.Printf("Alloc : %s, NumCG: %d\n", humanize.Bytes(m.Alloc), m.NumGC)
+}
+
 func main() {
        flag.Parse()

@@ -275,6 +283,14 @@ func main() {
        }

        if serve {
+
+               go func() {
+                       for {
+                               printMemory()
+                               time.Sleep(2 * time.Second)
+                       }
+               }()
+
                if experimental.Enabled() {
                        log.Info("Experimental features enabled")
                }
```

With the help of ChatGPT I plotted these data to compare. The spike around 15 seconds is when the `trace tcpconnect` gadget is run (i.e. the kubeipresolver is started), the release around 135 seconds happens when the garbage collector runs.

![image](https://github.com/user-attachments/assets/91c42fd4-c3ca-4334-bf32-26a23104628a)

It's clear how this PR reduces the memory usage around ~70% (after the GC is done)

## Q & A
- Q: Should we ignore pending pods?
A: Probably yes, however I don't expect it to be a huge optimization. However I'd prefer to make it in a following PR to avoid this PR becoming huge and difficult to review
- Q: Can we use the same shared informer for the podinformer (pkg/container-collection/podinformer.go)(see #3505) 
  A: Unfortunately I don't think so. There are two reasons:
  -  The podinformer only watches pods on the current node, in order to use the same factory we'll have to watch all pods on the cluster, it'll be very inefficient when the kubeipresolver is not needed.
  -  The pods informer needs additional information from the pod (contianers, etc.) compared to the kubeipresolver, it means we'll need to save that information for all pods in the cluster, but it's actually only needed for pods running on the current node.
- Q: Why do you need to watch all pods in the cluster?
  A: We use that information to enrich the IP Addresses of the events (instead of just showing the IP, we show the name of the pod/service where a packet is going to or coming from). We enrich the event on each node, hence we need to have that information available there. One possibility could be to enrich the events on a single node (like a proxy for enrichment), but we haven't explored this idea.

Reported in https://kubernetes.slack.com/archives/CSYL75LF6/p1726774473080999
/cc @matthyx 

