### PR TITLE
gadgets/deadlock: add deadlock detection using cycles in mutex wait di-graph

### DIFF
--- a/gadgets/deadlock/README.mdx
+++ b/gadgets/deadlock/README.mdx
@@ -38,34 +38,16 @@ To generate mutex lock/unlock events, you can run a `test` program in another co
 
 For this example, we use a [test C++ program](https://github.com/iovisor/bcc/blob/master/tools/deadlock_example.txt#L187) (from BCC) with lock inversions that can cause a potential deadlock.
 
-The deadlock gadget can trace all mutex lock/unlock events in the following way:
+The deadlock gadget traces all potential deadlocks:
 ```bash
 $ sudo ig run ghcr.io/inspektor-gadget/gadget/deadlock:%IG_TAG%
-RUNTIME.CONTAINERNAME      COMM                  PID        TID MUTEX_ADDR        OPERATION
-hungry_turing              test                23148      23148 0x7FED1243EA58    lock
-hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
-hungry_turing              test                23148      23237 0x5612ABB33160    lock
-hungry_turing              test                23148      23237 0x5612ABB331A0    lock
-hungry_turing              test                23148      23237 0x5612ABB331A0    unlock
-hungry_turing              test                23148      23237 0x5612ABB33160    unlock
-hungry_turing              test                23148      23148 0x7FED1243EA58    lock
-hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
-hungry_turing              test                23148      23239 0x5612ABB331A0    lock
-hungry_turing              test                23148      23239 0x5612ABB331E0    lock
-hungry_turing              test                23148      23239 0x5612ABB331E0    unlock
-hungry_turing              test                23148      23239 0x5612ABB331A0    unlock
-hungry_turing              test                23148      23148 0x7FED1243EA58    lock
-hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
-hungry_turing              test                23148      23240 0x5612ABB331E0    lock
-hungry_turing              test                23148      23240 0x7FFDC68BEB80    lock
-hungry_turing              test                23148      23240 0x7FFDC68BEB80    unlock
-hungry_turing              test                23148      23240 0x5612ABB331E0    unlock
-hungry_turing              test                23148      23148 0x7FED1243EA58    lock
-hungry_turing              test                23148      23148 0x7FED1243EA58    unlock
-hungry_turing              test                23148      23241 0x7FFDC68BEB80    lock
-hungry_turing              test                23148      23241 0x5612ABB33160    lock
-hungry_turing              test                23148      23241 0x5612ABB33160    unlock
-hungry_turing              test                23148      23241 0x7FFDC68BEB80    unlock
-hungry_turing              test                23148      23148 0x7FED1243EA08    lock
-hungry_turing              test                23148      23148 0x7FED1243EA08    unlock
+RUNTIME.CONTAINERNAME                                  PID NODES   STACK_IDS                                           COMM
+hungry_montalcini                                    39046 3       [77, 13], [149, 42], [11, 109]                      test
+hungry_montalcini                                    39046 4       [51, 208], [87, 52], [239, 71], [175, 35]           test
 ```
+
+### Notes
+
+- This gadget detects "potential" deadlocks and not just actual deadlocks as a deadlock that didn't happen during the trace could happen in the future.
+A deadlock occurring depends on various factors such as thread scheduling and order of mutex acquisitions/releases, and hence it makes sense to report mutex lock order inversions as potentially unsafe resource management.
+- Tracing with `--host` will slow down the gadget due to too many events.

--- a/gadgets/deadlock/build.yaml
+++ b/gadgets/deadlock/build.yaml
@@ -1,0 +1,1 @@
+wasm: go/program.go

--- a/gadgets/deadlock/gadget.yaml
+++ b/gadgets/deadlock/gadget.yaml
@@ -5,16 +5,28 @@ homepageURL: https://inspektor-gadget.io/
 documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/deadlock
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/deadlock
 datasources:
+  mutex:
+    annotations:
+      description: Edges of the mutex-wait directed graph
   deadlock:
+    annotations:
+      description: Potential deadlocks
     fields:
-      mutex_addr:
+      pid:
         annotations:
-          columns.hex: "true"
-          columns.width: "20"
-          description: address of mutex lock/unlock operations
-      operation:
+          description: Process ID
+          template: pid
+      nodes:
         annotations:
-          description: mutex operation type
-      operation_raw:
+          description: Number of mutexes involved in the deadlock
+      stack_ids:
+        annoations:
+          description: Stack IDs of all mutexes involved in the deadlock
+      mntns_id:
         annotations:
+          description: Mount namespace inode id
           columns.hidden: "true"
+      comm:
+        annotations:
+          description: Process name
+          template: comm

--- a/gadgets/deadlock/go/digraph/cycles.go
+++ b/gadgets/deadlock/go/digraph/cycles.go
@@ -1,0 +1,160 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package digraph provides a directed graph implementation and methods for cycle detection.
+package digraph
+
+// StronglyConnectedComponents finds all strongly connected components in the graph.
+func StronglyConnectedComponents(g *DiGraph) []map[uint64]struct{} {
+	preorder := make(map[uint64]int)
+	lowlink := make(map[uint64]int)
+	sccFound := make(map[uint64]bool)
+	sccQueue := []uint64{}
+	var sccs []map[uint64]struct{}
+	i := 0
+
+	var strongConnect func(v uint64)
+	strongConnect = func(v uint64) {
+		i++
+		preorder[v] = i
+		lowlink[v] = i
+		sccQueue = append(sccQueue, v)
+
+		for _, w := range g.Neighbors(v) {
+			if _, ok := preorder[w]; !ok {
+				strongConnect(w)
+				lowlink[v] = min(lowlink[v], lowlink[w])
+			} else if !sccFound[w] {
+				lowlink[v] = min(lowlink[v], preorder[w])
+			}
+		}
+		if lowlink[v] == preorder[v] {
+			scc := make(map[uint64]struct{})
+			for {
+				u := sccQueue[len(sccQueue)-1]
+				sccQueue = sccQueue[:len(sccQueue)-1]
+				scc[u] = struct{}{}
+				sccFound[u] = true
+				if u == v {
+					break
+				}
+			}
+			sccs = append(sccs, scc)
+		}
+	}
+	for _, v := range g.Nodes() {
+		if _, ok := preorder[v]; !ok {
+			strongConnect(v)
+		}
+	}
+	return sccs
+}
+
+// SimpleCycles finds all simple cycles in the graph.
+func SimpleCycles(g *DiGraph) [][]uint64 {
+	var cycles [][]uint64
+
+	unblock := func(node uint64, blocked map[uint64]bool, B map[uint64]map[uint64]struct{}) {
+		stack := []uint64{node}
+		for len(stack) > 0 {
+			n := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if blocked[n] {
+				blocked[n] = false
+				for m := range B[n] {
+					stack = append(stack, m)
+				}
+				delete(B, n)
+			}
+		}
+	}
+	subG := g.Subgraph(g.Nodes())
+	sccs := StronglyConnectedComponents(subG)
+	for len(sccs) > 0 {
+		scc := sccs[len(sccs)-1]
+		sccs = sccs[:len(sccs)-1]
+
+		var startNode uint64
+		for node := range scc {
+			startNode = node
+			break
+		}
+		path := []uint64{startNode}
+		blocked := make(map[uint64]bool)
+		closed := make(map[uint64]bool)
+		blocked[startNode] = true
+		B := make(map[uint64]map[uint64]struct{})
+		stack := [][2]uint64{{startNode, 0}}
+
+		for len(stack) > 0 {
+			thisNode, prevNode := stack[len(stack)-1][0], stack[len(stack)-1][1]
+			stack = stack[:len(stack)-1]
+			if prevNode != 0 {
+				path = append(path, thisNode)
+			}
+			done := true
+			for _, nextNode := range subG.Neighbors(thisNode) {
+				if nextNode == startNode {
+					cycles = append(cycles, append(path, startNode))
+					closed[startNode] = true
+				} else if !blocked[nextNode] {
+					stack = append(stack, [2]uint64{nextNode, thisNode})
+					blocked[nextNode] = true
+					done = false
+				}
+			}
+			if done {
+				if closed[thisNode] {
+					unblock(thisNode, blocked, B)
+				} else {
+					for _, nextNode := range subG.Neighbors(thisNode) {
+						if _, ok := B[nextNode]; !ok {
+							B[nextNode] = make(map[uint64]struct{})
+						}
+						B[nextNode][thisNode] = struct{}{}
+					}
+				}
+				path = path[:len(path)-1]
+			}
+		}
+		subG.RemoveNode(startNode)
+		H := subG.Subgraph(g.Nodes())
+		newSCCs := StronglyConnectedComponents(H)
+		sccs = append(sccs, newSCCs...)
+	}
+	return cycles
+}
+
+// FindCycles returns edges from all cycles in the graph.
+func FindCycles(g *DiGraph) [][][2]uint64 {
+	simpleCycles := SimpleCycles(g)
+	var cycles [][][2]uint64
+
+	for _, cycle := range simpleCycles {
+		edges := make([][2]uint64, len(cycle)-1)
+		for i := 0; i < len(cycle)-1; i++ {
+			edges[i] = [2]uint64{cycle[i], cycle[i+1]}
+		}
+		cycles = append(cycles, edges)
+	}
+	return cycles
+}
+
+// min returns the minimum of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/gadgets/deadlock/go/digraph/digraph.go
+++ b/gadgets/deadlock/go/digraph/digraph.go
@@ -1,0 +1,108 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package digraph provides a directed graph implementation and methods for cycle detection.
+package digraph
+
+// DiGraph represents a directed graph.
+type DiGraph struct {
+	adjacencyMap  map[uint64]map[uint64]struct{}
+	attributesMap map[[2]uint64]map[string]interface{}
+}
+
+// NewDiGraph creates a new directed graph.
+func NewDiGraph() *DiGraph {
+	return &DiGraph{
+		adjacencyMap:  make(map[uint64]map[uint64]struct{}),
+		attributesMap: make(map[[2]uint64]map[string]interface{}),
+	}
+}
+
+// Neighbors returns the neighbors of a node.
+func (g *DiGraph) Neighbors(node uint64) []uint64 {
+	neighbors := []uint64{}
+	if adj, exists := g.adjacencyMap[node]; exists {
+		for neighbor := range adj {
+			neighbors = append(neighbors, neighbor)
+		}
+	}
+	return neighbors
+}
+
+// Edges returns all edges in the graph.
+func (g *DiGraph) Edges() [][2]uint64 {
+	edges := [][2]uint64{}
+	for node, neighbors := range g.adjacencyMap {
+		for neighbor := range neighbors {
+			edges = append(edges, [2]uint64{node, neighbor})
+		}
+	}
+	return edges
+}
+
+// Nodes returns all nodes in the graph.
+func (g *DiGraph) Nodes() []uint64 {
+	nodes := []uint64{}
+	for node := range g.adjacencyMap {
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+// Attributes returns the attributes of an edge.
+func (g *DiGraph) Attributes(node1, node2 uint64) map[string]interface{} {
+	return g.attributesMap[[2]uint64{node1, node2}]
+}
+
+// AddEdge adds an edge to the graph with optional attributes.
+func (g *DiGraph) AddEdge(node1, node2 uint64, attributes map[string]interface{}) {
+	if _, exists := g.adjacencyMap[node1]; !exists {
+		g.adjacencyMap[node1] = make(map[uint64]struct{})
+	}
+	if _, exists := g.adjacencyMap[node2]; !exists {
+		g.adjacencyMap[node2] = make(map[uint64]struct{})
+	}
+	g.adjacencyMap[node1][node2] = struct{}{}
+	g.attributesMap[[2]uint64{node1, node2}] = attributes
+}
+
+// RemoveNode removes a node and its edges from the graph.
+func (g *DiGraph) RemoveNode(node uint64) {
+	delete(g.adjacencyMap, node)
+	for _, neighbors := range g.adjacencyMap {
+		delete(neighbors, node)
+	}
+	for edge := range g.attributesMap {
+		if edge[0] == node || edge[1] == node {
+			delete(g.attributesMap, edge)
+		}
+	}
+}
+
+// Subgraph returns a subgraph containing only the specified nodes.
+func (g *DiGraph) Subgraph(nodes []uint64) *DiGraph {
+	subgraph := NewDiGraph()
+	nodeSet := make(map[uint64]struct{})
+	for _, node := range nodes {
+		nodeSet[node] = struct{}{}
+	}
+	for node := range nodeSet {
+		for _, neighbor := range g.Neighbors(node) {
+			if _, exists := nodeSet[neighbor]; exists {
+				subgraph.AddEdge(node, neighbor, g.Attributes(node, neighbor))
+			}
+		}
+	}
+	return subgraph
+}

--- a/gadgets/deadlock/go/go.mod
+++ b/gadgets/deadlock/go/go.mod
@@ -1,0 +1,9 @@
+module deadlock
+
+go 1.22.8
+
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// Only needed by in-tree gadgets
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/deadlock/go/program.go
+++ b/gadgets/deadlock/go/program.go
@@ -1,0 +1,270 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+
+	"deadlock/digraph"
+)
+
+// ProcInfo stores process information.
+type ProcInfo struct {
+	comm    string
+	mntnsId uint64
+}
+
+// The pidInfo map stores information about each process ID.
+var pidInfo map[uint32]ProcInfo
+
+// The graphs map stores a directed graph for each process ID.
+var graphs map[uint32]*digraph.DiGraph
+
+// The detectedCycles map stores the set of detected cycles for each PID.
+var detectedCycles map[uint32]map[string]struct{}
+
+//export gadgetInit
+func gadgetInit() int {
+	pidInfo = make(map[uint32]ProcInfo)
+	graphs = make(map[uint32]*digraph.DiGraph)
+	detectedCycles = make(map[uint32]map[string]struct{})
+
+	// Get the mutex datasource and its fields
+	dsMutex, err := api.GetDataSource("mutex")
+	if err != nil {
+		api.Warnf("failed to get datasource: %s", err)
+		return 1
+	}
+	mutex1F, err := dsMutex.GetField("mutex1")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	mutex2F, err := dsMutex.GetField("mutex2")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	tidF, err := dsMutex.GetField("tid")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	pidF, err := dsMutex.GetField("pid")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	mutex1StackF, err := dsMutex.GetField("mutex1_stack_id")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	mutex2StackF, err := dsMutex.GetField("mutex2_stack_id")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	commF, err := dsMutex.GetField("comm")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	mntnsIdF, err := dsMutex.GetField("mntns_id")
+	if err != nil {
+		api.Warnf("failed to get field: %s", err)
+		return 1
+	}
+	err = dsMutex.Unreference()
+	if err != nil {
+		api.Warnf("failed to unreference datasource: %s", err)
+		return 1
+	}
+
+	// Create the deadlock datasource and its fields
+	dsDeadlock, err := api.NewDataSource("deadlock", api.DataSourceTypeSingle)
+	if err != nil {
+		api.Warnf("failed to create datasource: %s", err)
+		return 1
+	}
+	deadlockPidF, err := dsDeadlock.AddField("pid", api.Kind_Uint32)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+	deadlockNodesF, err := dsDeadlock.AddField("nodes", api.Kind_Uint64)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+	deadlockStackIdsF, err := dsDeadlock.AddField("stack_ids", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+	deadlockCommF, err := dsDeadlock.AddField("comm", api.Kind_String)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+	deadlockMntnsIdF, err := dsDeadlock.AddField("mntns_id", api.Kind_Uint64)
+	if err != nil {
+		api.Warnf("failed to add field: %s", err)
+		return 1
+	}
+	err = deadlockMntnsIdF.AddTag("type:gadget_mntns_id") // enrich mntns id
+	if err != nil {
+		api.Warnf("failed to add tag to field: %s", err)
+		return 1
+	}
+
+	// Build the graph for deadlock detection using edges from the mutex datasource
+	dsMutex.SubscribeArray(func(source api.DataSource, data api.DataArray) error {
+		affectedPIDs := make(map[uint32]struct{})
+		for i := 0; i < data.Len(); i++ {
+			datum := data.Get(i)
+			mutex1, err := mutex1F.Uint64(datum)
+			if err != nil {
+				api.Warnf("failed to get mutex1: %s", err)
+				continue
+			}
+			mutex2, err := mutex2F.Uint64(datum)
+			if err != nil {
+				api.Warnf("failed to get mutex2: %s", err)
+				continue
+			}
+			tid, err := tidF.Uint32(datum)
+			if err != nil {
+				api.Warnf("failed to get tid: %s", err)
+				continue
+			}
+			pid, err := pidF.Uint32(datum)
+			if err != nil {
+				api.Warnf("failed to get pid: %s", err)
+				continue
+			}
+			mutex1Stack, err := mutex1StackF.Uint64(datum)
+			if err != nil {
+				api.Warnf("failed to get mutex1_stack_id: %s", err)
+				continue
+			}
+			mutex2Stack, err := mutex2StackF.Uint64(datum)
+			if err != nil {
+				api.Warnf("failed to get mutex2_stack_id: %s", err)
+				continue
+			}
+
+			// Record process information for the PID
+			if _, exists := pidInfo[pid]; !exists {
+				comm, err := commF.String(datum)
+				if err != nil {
+					api.Warnf("failed to get comm: %s", err)
+					continue
+				}
+				mntnsId, err := mntnsIdF.Uint64(datum)
+				if err != nil {
+					api.Warnf("failed to get mntns_id: %s", err)
+					continue
+				}
+				pidInfo[pid] = ProcInfo{
+					comm:    comm,
+					mntnsId: mntnsId,
+				}
+			}
+			// Update the graph for the PID
+			g, exists := graphs[pid]
+			if !exists {
+				g = digraph.NewDiGraph()
+				graphs[pid] = g
+			}
+			g.AddEdge(mutex1, mutex2, map[string]interface{}{
+				"tid":           tid,
+				"mutex1StackId": mutex1Stack,
+				"mutex2StackId": mutex2Stack,
+			})
+			affectedPIDs[pid] = struct{}{}
+		}
+
+		// Check for cycles only in the affected PIDs
+		for pid := range affectedPIDs {
+			g := graphs[pid]
+			cycles := digraph.FindCycles(g)
+			if _, exists := detectedCycles[pid]; !exists {
+				// Create entry for the PID
+				detectedCycles[pid] = make(map[string]struct{})
+			}
+			if len(cycles) == 0 || len(cycles) == len(detectedCycles[pid]) {
+				continue // no new cycles detected
+			}
+			for _, cycle := range cycles {
+				cycleKey := cycleToKeyString(cycle)
+				if _, exists := detectedCycles[pid][cycleKey]; !exists {
+					// New cycle detected
+					detectedCycles[pid][cycleKey] = struct{}{}
+
+					// Build the stack IDs string
+					var stackIds []string
+					for _, edge := range cycle {
+						attrs := g.Attributes(edge[0], edge[1])
+						stackId1 := attrs["mutex1StackId"].(uint64)
+						stackId2 := attrs["mutex2StackId"].(uint64)
+						stackIds = append(stackIds, fmt.Sprintf("[%d, %d]", stackId1, stackId2))
+					}
+					stackIdsStr := strings.Join(stackIds, ", ")
+
+					// Emit the deadlock packet for the new cycle
+					packet, err := dsDeadlock.NewPacketSingle()
+					if err != nil {
+						api.Warnf("failed to create new packet: %s", err)
+						continue
+					}
+					deadlockPidF.SetUint32(api.Data(packet), pid)
+					deadlockNodesF.SetUint64(api.Data(packet), uint64(len(cycle)))
+					deadlockStackIdsF.SetString(api.Data(packet), stackIdsStr)
+					deadlockCommF.SetString(api.Data(packet), pidInfo[pid].comm)
+					deadlockMntnsIdF.SetUint64(api.Data(packet), pidInfo[pid].mntnsId)
+
+					dsDeadlock.EmitAndRelease(api.Packet(packet))
+				}
+			}
+		}
+		return nil
+	}, 0)
+	return 0
+}
+
+// cycleToKeyString converts a cycle to a unique string representation.
+func cycleToKeyString(cycle [][2]uint64) string {
+	// Sort the cycle to ensure a consistent representation
+	sort.Slice(cycle, func(i, j int) bool {
+		if cycle[i][0] != cycle[j][0] {
+			return cycle[i][0] < cycle[j][0]
+		}
+		return cycle[i][1] < cycle[j][1]
+	})
+	// Convert the cycle to a string of format: "1->2,2->3,3->1"
+	var parts []string
+	for _, edge := range cycle {
+		parts = append(parts, fmt.Sprintf("%d->%d", edge[0], edge[1]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// The main function is not used, but it's still required by the compiler
+func main() {}

--- a/gadgets/deadlock/program.bpf.c
+++ b/gadgets/deadlock/program.bpf.c
@@ -8,40 +8,191 @@
 #include <gadget/buffer.h>
 #include <gadget/common.h>
 #include <gadget/macros.h>
+#include <gadget/maps.bpf.h>
 #include <gadget/mntns_filter.h>
 
-enum operation { lock, unlock };
+#define MAX_HELD_MUTEXES 16
+#define MAX_ENTRIES 65536
+#define MAX_STACK_DEPTH 50
 
-struct event {
-	gadget_timestamp timestamp_raw;
-	struct gadget_process proc;
+/* Stack map */
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__type(key, u32);
+	__uint(max_entries, 256);
+	__uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
+} stackmap SEC(".maps");
 
-	__u64 mutex_addr;
-	enum operation operation_raw;
+// Represents a mutex held by a thread.
+struct held_mutex {
+	u64 mutex;
+	u64 stack_id;
 };
 
-GADGET_TRACER_MAP(events, 1024 * 256);
-GADGET_TRACER(deadlock, events, event);
+// Represents an empty list of held mutexes.
+static const struct held_mutex EMPTY_HELD_MUTEXES[MAX_HELD_MUTEXES] = {};
 
-static __always_inline int
-gen_mutex_event(struct pt_regs *ctx, enum operation operation, u64 mutex_addr)
+/* Map of thread ID to an array of held_mutex structs */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, gadget_tid);
+	__type(value,
+	       struct held_mutex[MAX_HELD_MUTEXES]); // array of held mutexes
+} thread_to_held_mutexes SEC(".maps");
+
+// Key type for edges. Represents an edge from mutex1 to mutex2.
+struct edges_key {
+	__u64 mutex1;
+	__u64 mutex2;
+	gadget_pid pid;
+};
+
+// Value type for edges. Holds information about the edge.
+struct edges_value {
+	gadget_mntns_id mntns_id;
+
+	gadget_tid tid;
+
+	__u64 mutex1_stack_id;
+	__u64 mutex2_stack_id;
+
+	gadget_comm comm[TASK_COMM_LEN];
+};
+
+/* Map containing all edges in the mutex wait graph */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct edges_key);
+	__type(value, struct edges_value);
+} edges SEC(".maps");
+
+GADGET_MAPITER(mutex, edges);
+
+/*
+ * Creates edges in the mutex wait graph from each mutex
+ * held by the current thread to the newly acquired mutex.
+ */
+static __always_inline int trace_mutex_acquire(struct pt_regs *ctx, u64 mutex)
 {
-	struct event *event;
+	u64 mtns_id = gadget_get_mntns_id();
+	if (gadget_should_discard_mntns_id(mtns_id))
+		return 0;
 
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	u32 tid = (u32)pid_tgid;
+	u32 pid = pid_tgid >> 32;
+
+	struct held_mutex *held_mutexes = bpf_map_lookup_or_try_init(
+		&thread_to_held_mutexes, &tid, &EMPTY_HELD_MUTEXES);
+	if (!held_mutexes) {
+		bpf_printk(
+			"could not add thread_to_held_mutexes key. thread: %d, mutex: %p\n",
+			tid, mutex);
+		return 1; // out of memory
+	}
+
+// Check for recursive mutexes
+#pragma unroll
+	for (int i = 0; i < MAX_HELD_MUTEXES; ++i) {
+		if (held_mutexes[i].mutex == mutex) {
+			return 1; // disallow self edges
+		}
+	}
+	u64 stack_id = bpf_get_stackid(ctx, &stackmap, BPF_F_USER_STACK);
+
+	// Add mutex to `held_mutexes` and update the graph
+	int added_mutex =
+		0; // flag indicating whether the mutex was added to `held_mutexes`
+#pragma unroll
+	for (int i = 0; i < MAX_HELD_MUTEXES; ++i) {
+		if (!held_mutexes[i].mutex) {
+			// Free slot found, add mutex if not already added
+			if (!added_mutex) {
+				held_mutexes[i].mutex = mutex;
+				held_mutexes[i].stack_id = stack_id;
+				added_mutex = 1; // update flag
+			}
+			continue;
+		}
+		// Add edges from held mutex to current mutex
+		struct edges_key edge_key = {};
+		edge_key.mutex1 = held_mutexes[i].mutex;
+		edge_key.mutex2 = mutex;
+		edge_key.pid = pid;
+
+		struct edges_value edge_value = {};
+		edge_value.tid = tid;
+		edge_value.mntns_id = mtns_id;
+		edge_value.mutex1_stack_id = held_mutexes[i].stack_id;
+		edge_value.mutex2_stack_id = stack_id;
+		bpf_get_current_comm(&edge_value.comm, sizeof(edge_value.comm));
+
+		int result = bpf_map_update_elem(&edges, &edge_key, &edge_value,
+						 BPF_ANY); // update graph
+		if (result) {
+			bpf_printk(
+				"could not add edge key with mutexes %p and %p. error: %d\n",
+				edge_key.mutex1, edge_key.mutex2, result);
+			continue; // out of memory
+		}
+	}
+	if (!added_mutex) {
+		bpf_printk("could not add mutex %p\n", mutex);
+		return 1; // no more free space on `held_mutexes`
+	}
+	return 0;
+}
+
+/*
+ * Removes mutex from the list of held mutexes for the current thread.
+ *
+ * We don't remove the edges associated with the mutex from the mutex wait graph
+ * as we are detecting "potential" deadlocks (even if they might never happen).
+ *
+ * If we remove the edges, we only detect deadlocks that actually happen during the trace.
+ * But a deadlock that didn't happen during the trace could happen in the future
+ * as it depends on factors such as thread scheduling and order of mutex acquisitions/releases.
+ */
+static __always_inline int trace_mutex_release(struct pt_regs *ctx, u64 mutex)
+{
 	if (gadget_should_discard_mntns_id(gadget_get_mntns_id()))
 		return 0;
 
-	event = gadget_reserve_buf(&events, sizeof(*event));
-	if (!event)
-		return 0;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
 
-	gadget_process_populate(&event->proc);
-	event->mutex_addr = mutex_addr;
-	event->operation_raw = operation;
-	event->timestamp_raw = bpf_ktime_get_ns();
+	// Fetch the held mutexes for the current thread
+	struct held_mutex *held_mutexes =
+		bpf_map_lookup_elem(&thread_to_held_mutexes, &tid);
+	if (!held_mutexes) {
+		/*
+         * If `held_mutexes` doesn't exist for the tid, then it means we either missed
+         * the acquire event, or were out of memory when adding it.
+         */
+		bpf_printk(
+			"could not find the thread's held mutexes. thread: %d, mutex: %p\n",
+			tid, mutex);
+		return 1;
+	}
 
-	gadget_submit_buf(ctx, &events, event, sizeof(*event));
-
+	int is_cleared =
+		1; // flag indicating whether all held mutexes by the current thread are cleared
+	for (int i = 0; i < MAX_HELD_MUTEXES; ++i) {
+		// Find the current mutex and clear it
+		if (held_mutexes[i].mutex == mutex) {
+			held_mutexes[i].mutex = 0;
+			held_mutexes[i].stack_id = 0;
+		}
+		if (held_mutexes[i].mutex != 0 && held_mutexes[i].mutex != 0) {
+			// Thread still holds a mutex
+			is_cleared = 0;
+		}
+	}
+	if (is_cleared) {
+		// Remove the entry from the map if no mutex is held by the thread
+		bpf_map_delete_elem(&thread_to_held_mutexes, &tid);
+	}
 	return 0;
 }
 
@@ -49,14 +200,14 @@ gen_mutex_event(struct pt_regs *ctx, enum operation operation, u64 mutex_addr)
 SEC("uprobe/libc:pthread_mutex_lock")
 int BPF_UPROBE(trace_uprobe_mutex_lock, void *mutex_addr)
 {
-	return gen_mutex_event(ctx, lock, (u64)mutex_addr);
+	return trace_mutex_acquire(ctx, (u64)mutex_addr);
 }
 
 /* mutex release */
 SEC("uprobe/libc:pthread_mutex_unlock")
 int BPF_UPROBE(trace_uprobe_mutex_unlock, void *mutex_addr)
 {
-	return gen_mutex_event(ctx, unlock, (u64)mutex_addr);
+	return trace_mutex_release(ctx, (u64)mutex_addr);
 }
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
# adds deadlock detection using cycles in mutex wait graph

1. Builds edges of the graph in BPF code by tracing mutex locks/unlocks.
2. Sends events to user-space using `MAPITER`.
3. Added WASM modules that make a directed graph from the edges map and detects cycles in the `gadgetStop` callback (ie. when exiting the gadget).

## Challenges

1. Needs a way to run cycle detection every second (go routines?). A hack worth trying is to run a timer, and with each event check if it's time to run cycle detection.
2. Output formatting.. currently the output is just a trace of all edges in the graph as they are added.

## How to use

1. Run the gadget using `ig`.
2. Run the following [script](https://github.com/iovisor/bcc/blob/master/tools/deadlock_example.txt#L187) (simulates mutex lock inversions) in a separate container.
3. Stop the gadget once you see the traces of the above script.

## Testing done

Ran the above steps:

![image](https://github.com/user-attachments/assets/8f0205c4-0fc5-4c31-be31-944d27e4c93d)

