### PR TITLE
increase capabilities perf buffer size

### DIFF
--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -166,7 +166,7 @@ struct {
 	       1048576); // There can be many threads sleeping in some futex/poll syscalls
 } current_syscall SEC(".maps");
 
-GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER_MAP(events, 1024 * 1024 * 1024 * 256);
 GADGET_TRACER(capabilities, events, cap_event);
 
 const volatile bool print_stack = true;


### PR DESCRIPTION
Increase perf buffer in `ig trace capabilities` to reduce events loss.

