### PR TITLE
operators/localmanager: Do not print warning if the runtime is not found

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,7 +18,6 @@ DEBU[0000] using target "gadget-b7jrc" ("minikube-docker")
 # Disable image verification (not recommended)
 $ export INSPEKTOR_GADGET_OPERATOR_OCI_VERIFY_IMAGE=false
 $ sudo ig run trace_open
-WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
 WARN[0000] image signature verification is disabled due to using corresponding option
 WARN[0000] image signature verification is disabled due to using corresponding option
 ...

--- a/gadgets/trace_bind/README.mdx
+++ b/gadgets/trace_bind/README.mdx
@@ -78,7 +78,6 @@ Then, let's run the gadget:
     <TabItem value="ig" label="ig">
         ```bash
         $ sudo ig run trace_bind:%IG_TAG% --containername test-trace-bind
-        WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME               ADDR                                  COMM                            PID                TID                UID                GID BOUND_DEV_… ERROR
         test-trace-bind                     :::4242                               nc                           647422             647422                  0                  0 0
         test-trace-bind                     :::4242                               nc                           647472             647472                  0                  0 0

--- a/gadgets/trace_capabilities/README.mdx
+++ b/gadgets/trace_capabilities/README.mdx
@@ -126,7 +126,6 @@ Default value: "false"
     <TabItem value="ig" label="ig">
         ```bash
         $ sudo ig run trace_capabilities:%IG_TAG% --containername test-trace-capabilities
-        WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         ...
         ```
 

--- a/gadgets/trace_exec/README.mdx
+++ b/gadgets/trace_exec/README.mdx
@@ -115,7 +115,6 @@ Then, let's run the gadget:
     <TabItem value="ig" label="ig">
         ```bash
         $ sudo ig run trace_exec:%IG_TAG% --containername test-trace-exec
-        WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME           COMM                            PID              TID PCOMM                        PPID ARGS             ERROR USER             LOGINUSER        GROUP
         test-trace-exec                 true                        2920998          2920998 sh                        2920573 /bin/true              root             uid:4294967295   root
         test-trace-exec                 whoami                      2920999          2920999 sh                        2920573 /bin/whoami            root             uid:4294967295   root

--- a/gadgets/trace_mount/README.mdx
+++ b/gadgets/trace_mount/README.mdx
@@ -83,7 +83,6 @@ Then, let's run the gadget:
     <TabItem value="ig" label="ig">
         ```bash
         $ sudo ig run trace_mount:%IG_TAG% --containername test-trace-mount
-        WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
         RUNTIME.CONTAINERNAME                    COMM                               PID                   TID       DELTA FLAGS                CALL                                      ERROR
         test-trace-mount                         mount                            51158                 51158        3460 MS_SILENT            mount("/bar", "/foo", "ext3", MS_SILENT,… ENOENT
         test-trace-mount                         mount                            51158                 51158        1250 MS_SILENT            mount("/bar", "/foo", "ext2", MS_SILENT,… ENOENT

--- a/gadgets/trace_open/README.mdx
+++ b/gadgets/trace_open/README.mdx
@@ -107,8 +107,6 @@ We can stop the gadget by hitting Ctrl-C.
   <TabItem value="ig" label="ig">
 ```bash
 $ sudo ig run trace_open:%IG_TAG% --containername test-trace-open
-WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
-WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
 RUNTIME.CONTAINERNA… COMM                PID         TID         UID        GID  FD FNAME                    MODE       ERROR   TIMESTAMP
 test-trace-open      true             515458      515458           0          0   0 /etc/ld.so.cache         ---------- ENOENT  2024-07-29T16:53:44.0…
 test-trace-open      true             515458      515458           0          0   0 /lib/x86_64-linux-gnu/g… ---------- ENOENT  2024-07-29T16:53:44.0…


### PR DESCRIPTION
In most of the cases users don't have all runtimes available, these warnings are very noisy. This commit updates the logic to avoid printing any warning if the runtime path is not set, if it's set then an error is returned.

## Testing 

### Before 

```bash 
# warnings printed 
$ sudo ig run trace_open:latest --pull always
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
RUNTIME.CONTAINERNAME     COMM                 PID        TID        UID        GID  FD FNAME                    MODE          ERROR

# even more warnings printed when explicitly setting the path 
$ sudo ig run trace_open:latest --pull always --docker-socketpath=nonexistingpath
WARN[0000] Ignoring runtime "docker" with non-existent socketPath "nonexistingpath"
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
RUNTIME.CONTAINERNAME     COMM                 PID        TID        UID        GID  FD FNAME                    MODE          ERROR
```

### After

```bash 
# not warning is printed 
$ sudo ig run trace_open:latest --pull always
RUNTIME.CONTAINERNAME     COMM                 PID        TID        UID        GID  FD FNAME                    MODE          ERROR

# error out if explicitly provided path doesn't exist
$ sudo ig run trace_open:latest --pull always --docker-socketpath=nonexistingpath
WARN[0000] error initializing operator LocalManager: runtime "docker" with non-existent socketPath "nonexistingpath"
Error: starting operators: pre-starting operator "LocalManager": container-collection isn't available
```

cc @blixtra 