### PR TITLE
operators/ebpf: Fix race condition with wasm operator

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -188,6 +188,9 @@ type ebpfInstance struct {
 	stackIdMap *ebpf.Map
 
 	gadgetCtx operators.GadgetContext
+
+	// used to be sure all tracers are done before returning from Stop()
+	wg sync.WaitGroup
 }
 
 func (i *ebpfInstance) loadSpec() error {
@@ -643,12 +646,11 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 
 	for _, tracer := range i.tracers {
 		i.logger.Debugf("starting tracer %q", tracer.mapName)
-		go func(tracer *Tracer) {
-			err := i.runTracer(gadgetCtx, tracer)
-			if err != nil {
-				i.logger.Errorf("starting tracer: %w", err)
-			}
-		}(tracer)
+		err := i.runTracer(gadgetCtx, tracer)
+		if err != nil {
+			i.Close()
+			return fmt.Errorf("running tracer %q: %w", tracer.mapName, err)
+		}
 	}
 
 	// Attach programs
@@ -707,10 +709,15 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 
 func (i *ebpfInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	i.Close()
+	i.wg.Wait()
 	return nil
 }
 
 func (i *ebpfInstance) Close() {
+	for _, t := range i.tracers {
+		t.close()
+	}
+
 	if i.collection != nil {
 		i.collection.Close()
 		i.collection = nil

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -201,7 +201,9 @@ func (i *ebpfInstance) runMapIterators() error {
 			}
 			iter.ds.EmitAndRelease(p)
 		}
+		i.wg.Add(1)
 		go func() {
+			defer i.wg.Done()
 			if iter.interval == 0 {
 				// Only a single time; is this really useful?
 				fetch()


### PR DESCRIPTION
The ebpf operator runs the logic that reads and emmits the events on a separated goroutine. This wasn't synchronized at all with the Stop() operation, what means the goroutine continued emitting events even after the operator was stopped. This caused an issue on the wasm operator as it was processing a data source callback **after** being stopped.

The timeline of this issue was:

```
      goroutine 1        |       goroutine 2
-------------------------|-------------------------
                         | - ebpf op runTracer()
                         |   - ds.EmitData()
- Stop ebpf operator()   |
- Stop wasm operator()   |
  - i.handles = nil      |
                         | - wasm op addHandle
                         |  - crash because i.handles is nil
```

crash log:

```
panic: assignment to entry in nil map

goroutine 3387 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).addHandle(0xc0039f7e40, {0x2b9ec60, 0xc0081313b0})
	/gadget/pkg/operators/wasm/wasm.go:163 +0x153
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).dataSourceSubscribe.func1({0x1e59825?, 0xc002f17e98?}, {0x36582e0?, 0xc0081313b0?})
	/gadget/pkg/operators/wasm/datasource.go:285 +0x6f
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).Subscribe.func1({0x7f5b423cc5b8?, 0x50?}, {0x3658308?, 0xc0081313b0?})
	/gadget/pkg/datasource/data.go:585 +0x42
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).EmitAndRelease(0xc003c392c0, {0x3658308, 0xc0081313b0})
	/gadget/pkg/datasource/data.go:654 +0xef
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*Tracer).receiveEventsFromRingReader(0xc004d15ce0, {0x36b0af0, 0xc0058e1860})
	/gadget/pkg/operators/ebpf/tracer.go:142 +0x3fe
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*Tracer).receiveEvents(0x71fac5?, {0x36b0af0?, 0xc0058e1860?})
	/gadget/pkg/operators/ebpf/tracer.go:101 +0x2f
created by github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*ebpfInstance).runTracer in goroutine 3406
	/gadget/pkg/operators/ebpf/tracer.go:230 +0x345
```


One solution is to guarantee the ebpf operator doesn't emit any events after it's stopped. This is done by using a waiting group in it.

This happened on the CI: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/11183864584/job/31095062256


## Testing 

I was able to reproduce it after introducing some manual sleeps around:

```diff
diff --git a/cmd/ig/main.go b/cmd/ig/main.go
index 0416e65bc..64e8392a3 100644
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -17,6 +17,7 @@ package main
 import (
        "fmt"
        "os"
+       "time"

        log "github.com/sirupsen/logrus"
        "github.com/spf13/cobra"
@@ -109,4 +110,7 @@ func main() {
        if err := rootCmd.Execute(); err != nil {
                os.Exit(1)
        }
+
+       fmt.Printf("little sleeping on main.go\n")
+       time.Sleep(5 * time.Second)
 }
diff --git a/pkg/operators/wasm/datasource.go b/pkg/operators/wasm/datasource.go
index d2eb89b9a..fa8e3dc94 100644
--- a/pkg/operators/wasm/datasource.go
+++ b/pkg/operators/wasm/datasource.go
@@ -17,6 +17,7 @@ package wasm
 import (
        "context"
        "fmt"
+       "time"

        "github.com/tetratelabs/wazero"
        wapi "github.com/tetratelabs/wazero/api"
@@ -282,6 +283,10 @@ func (i *wasmOperatorInstance) dataSourceSubscribe(ctx context.Context, m wapi.M
        switch subscriptionType(typ) {
        case subscriptionTypeData:
                err = ds.Subscribe(func(source datasource.DataSource, data datasource.Data) error {
+
+                       time.Sleep(100 * time.Millisecond)
+                       fmt.Printf("addHandle\n")
+
                        tmpData := i.addHandle(data)
                        _, err := i.dataSourceCallback.Call(ctx, cbID, stack[0], wapi.EncodeU32(tmpData))
                        i.delHandle(tmpData)
diff --git a/pkg/operators/wasm/wasm.go b/pkg/operators/wasm/wasm.go
index 310093bac..29d135aa9 100644
--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -298,6 +298,7 @@ func (i *wasmOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
 func (i *wasmOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
        defer func() {
                i.handleLock.Lock()
+               fmt.Printf("Closing %d handles\n", len(i.handleMap))
                i.handleMap = nil
                i.handleLock.Unlock()
        }()
```

```bash 
# generate a lot of events (in a container if --host it not used below)
$  while true; do cat /dev/null; done

# run a trace and see it how explodes when hitting ctrl +c 
$ sudo ig run trace_open:latest
WARN[0000] Ignoring runtime "cri-o" with non-existent socketPath "/run/crio/crio.sock"
WARN[0000] Ignoring runtime "podman" with non-existent socketPath "/run/podman/podman.sock"
RUNTIME.CONTAINERNAME     COMM                 PID        TID        UID        GID  FD FNAME                    MODE          ERROR
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/tls/x86_64/libm.so… ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/tls/x86_64/libm.so… ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/tls/libm.so.6       ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/x86_64/x86_64/libm… ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/x86_64/libm.so.6    ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   0 /lib/x86_64/libm.so.6    ----------    ENOENT
addHandle
mycontainer               cat              1471669    1471669          0          0   3 /lib/libm.so.6           ----------
^CClosing 5 handles
little sleeping on main.go
addHandle
panic: assignment to entry in nil map

goroutine 1830 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).addHandle(0xc002d7b600, {0x41b1700, 0xc0077feaf0})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/wasm.go:163 +0x153
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm.(*wasmOperatorInstance).dataSourceSubscribe.func1({0x1f99785?, 0xc000714e98?}, {0x4ca2a20, 0xc0077feaf0})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/datasource.go:290 +0xb5
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).Subscribe.func1({0x7b6b74ecfa68?, 0x18ab75a?}, {0x4ca2a48?, 0xc0077feaf0?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/datasource/data.go:585 +0x42
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).EmitAndRelease(0xc002d3c840, {0x4ca2a48, 0xc0077feaf0})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/datasource/data.go:654 +0xef
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*Tracer).receiveEventsFromRingReader(0xc002a5dbc0, {0x4cfba10, 0xc004ed0820})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/ebpf/tracer.go:142 +0x3fe
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*Tracer).receiveEvents(0xc0055e77d0?, {0x4cfba10?, 0xc004ed0820?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/ebpf/tracer.go:101 +0x2f
created by github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*ebpfInstance).runTracer in goroutine 1804
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/ebpf/tracer.go:230 +0x345
```