### PR TITLE
Revert "ci: Use -j$(nproc) with gadgets Makefile."

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1407,13 +1407,13 @@ jobs:
           export GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
           export BUILDER_IMAGE=${{ needs.build-helper-images.outputs.ebpf_builder_image }}
 
-          make build-gadgets -o install/ig -j$(nproc)
+          make build-gadgets -o install/ig
 
           # Check that metadata files are updated
           git diff --exit-code HEAD --
 
           # Avoid building the gadgets again
-          make -C gadgets/ push-existing -j$(nproc)
+          make -C gadgets/ push -o build
       - name: Sign the gadgets
         if: needs.check-secrets.outputs.cosign == 'true'
         env:
@@ -1423,7 +1423,7 @@ jobs:
           export GADGET_REPOSITORY=${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
           export GADGET_TAG=${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
 
-          make -C gadgets/ sign-existing -j$(nproc)
+          make -C gadgets/ sign -o push
 
   test-gadgets-local:
     name: Test gadgets locally

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -81,39 +81,25 @@ $(GADGETS_README):
 		ln -sf ../../gadgets/$@ $(ROOT_DIR)../docs/gadgets/$(shell dirname $@).mdx ; \
 	fi
 
-%-push: %-build
-	@echo "Pushing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+.PHONY:
+push: build
+	@echo "Pushing all gadgets"
+	for GADGET in $(GADGETS); do \
+		sudo -E $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
+	done
+
+sign: push
+	@echo "Signing all gadgets"
+	for GADGET in $(GADGETS); do \
+		digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+		cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$$GADGET@$$digest || exit 1 ; \
+	done
 
 .PHONY:
-push: $(addsuffix -push,$(GADGETS))
-
-%-push-existing: %
-	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
-
-.PHONY:
-push-existing: $(addsuffix -push-existing,$(GADGETS))
-
-%-sign: %-push
-	@echo "Signing $*"
-	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
-
-sign: $(addsuffix -sign,$(GADGETS))
-
-%-sign-existing:
-	@echo "Signing existing $*"
-	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
-
-sign-existing: $(addsuffix -sign-existing,$(GADGETS))
-
-%-clean:
-	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
-
-.PHONY:
-clean: $(addsuffix -clean,$(GADGETS))
+clean:
+	for GADGET in $(GADGETS); do \
+		sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+	done
 
 .PHONY:
 test: build


### PR DESCRIPTION
This reverts commit 9f4cc8109141ef2d54734c0c8a4147034561321f.

"ig image build" doesn't work well on parallel, see issue #3554.

