### PR TITLE
ci: Fix permission for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      # This is needed by below action used to open PR:
+      # https://github.com/peter-evans/create-pull-request#token
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
     - name: Update new version in krew-index


### PR DESCRIPTION
It seems the release workflow has been failing for past few release because of missing permissions:

- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/11211512604/job/31160543248#step:6:1720
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/10664736937/job/29556607272#step:6:190
- https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/10254676159/job/28369971796#step:6:188

This change fixes the permission issues that was introduced by https://github.com/inspektor-gadget/inspektor-gadget/pull/3197

cc: @burak-ok @alban 