### PR TITLE
post-release[artifacthub]: update gadgets to 0.33.0

### DIFF
--- a/gadgets/audit_seccomp/artifacthub-pkg.yml
+++ b/gadgets/audit_seccomp/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "audit seccomp"
 category: monitoring-logging
 displayName: "audit seccomp"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Audit syscalls according to the seccomp profile"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/deadlock/artifacthub-pkg.yml
+++ b/gadgets/deadlock/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.32.0
+version: 0.33.0
 name: "deadlock"
 category: monitoring-logging
 displayName: "deadlock"
-createdAt: "2024-09-21T19:37:40Z"
-digest: 2024-09-21T19:37:40Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "use uprobe to trace pthread_mutex_lock and pthread_mutex_unlock in libc.so and detect potential deadlocks"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/fsnotify/artifacthub-pkg.yml
+++ b/gadgets/fsnotify/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: 0.31.0
+version: 0.33.0
 name: "fsnotify"
 category: monitoring-logging
 displayName: "fsnotify"
-createdAt: "2024-08-12T14:51:00Z"
-digest: "2024-08-12T14:51:00Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "enrich inotify or fanotify events"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/profile_blockio/artifacthub-pkg.yml
+++ b/gadgets/profile_blockio/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "profile blockio"
 category: monitoring-logging
 displayName: "profile blockio"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Profile block I/O operations"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/profile_tcprtt/artifacthub-pkg.yml
+++ b/gadgets/profile_tcprtt/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "profile tcprtt"
 category: monitoring-logging
 displayName: "profile tcprtt"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Profile TCP connections' Round-Trip Time (RTT)"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/snapshot_process/artifacthub-pkg.yml
+++ b/gadgets/snapshot_process/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "snapshot process"
 category: monitoring-logging
 displayName: "snapshot process"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Show running processes"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/snapshot_socket/artifacthub-pkg.yml
+++ b/gadgets/snapshot_socket/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "snapshot socket"
 category: monitoring-logging
 displayName: "snapshot socket"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Show TCP and UDP sockets"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/top_blockio/artifacthub-pkg.yml
+++ b/gadgets/top_blockio/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.32.0
+version: 0.33.0
 name: "top blockio"
 category: monitoring-logging
 displayName: "top blockio"
-createdAt: "2024-08-01T09:22:04Z"
-digest: "2024-08-01T13:58:59Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Periodically report input/output block device activity. This gadget requires Linux Kernel Version 6.5+"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/top_file/artifacthub-pkg.yml
+++ b/gadgets/top_file/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "top file"
 category: monitoring-logging
 displayName: "top file"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Periodically report read/write activity by file"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/top_tcp/artifacthub-pkg.yml
+++ b/gadgets/top_tcp/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "top tcp"
 category: monitoring-logging
 displayName: "top tcp"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: Periodically report tcp send receive activity by connection
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_bind/artifacthub-pkg.yml
+++ b/gadgets/trace_bind/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace bind"
 category: monitoring-logging
 displayName: "trace bind"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace stream socket binding syscalls"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_capabilities/artifacthub-pkg.yml
+++ b/gadgets/trace_capabilities/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace capabilities"
 category: monitoring-logging
 displayName: "trace capabilities"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace security capabilitiy checks"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_dns/artifacthub-pkg.yml
+++ b/gadgets/trace_dns/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace dns"
 category: monitoring-logging
 displayName: "trace dns"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace dns requests and responses"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_exec/artifacthub-pkg.yml
+++ b/gadgets/trace_exec/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace exec"
 category: monitoring-logging
 displayName: "trace exec"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace process executions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_fsslower/artifacthub-pkg.yml
+++ b/gadgets/trace_fsslower/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace fsslower"
 category: monitoring-logging
 displayName: "trace fsslower"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "Trace open, read, write and fsync operations slower than a threshold"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_lsm/artifacthub-pkg.yml
+++ b/gadgets/trace_lsm/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace lsm"
 category: monitoring-logging
 displayName: "trace lsm"
-createdAt: "2024-08-12T14:04:40Z"
-digest: 2024-08-14T13:05:50Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "a strace for LSM tracepoints"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_malloc/artifacthub-pkg.yml
+++ b/gadgets/trace_malloc/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace malloc"
 category: monitoring-logging
 displayName: "trace malloc"
-createdAt: "2024-08-12T14:04:40Z"
-digest: 2024-08-14T13:05:50Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "use uprobe to trace malloc and free in libc.so"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_mount/artifacthub-pkg.yml
+++ b/gadgets/trace_mount/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace mount"
 category: monitoring-logging
 displayName: "trace mount"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace mount syscalls"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_oomkill/artifacthub-pkg.yml
+++ b/gadgets/trace_oomkill/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace oomkill"
 category: monitoring-logging
 displayName: "trace oomkill"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace OOM killer"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_open/artifacthub-pkg.yml
+++ b/gadgets/trace_open/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace open"
 category: monitoring-logging
 displayName: "trace open"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace open files"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_signal/artifacthub-pkg.yml
+++ b/gadgets/trace_signal/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace signal"
 category: monitoring-logging
 displayName: "trace signal"
-createdAt: "2024-08-12T14:04:40Z"
-digest: 2024-08-14T13:05:50Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace signal"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_sni/artifacthub-pkg.yml
+++ b/gadgets/trace_sni/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace sni"
 category: monitoring-logging
 displayName: "trace sni"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace sni"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_ssl/artifacthub-pkg.yml
+++ b/gadgets/trace_ssl/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace ssl"
 category: monitoring-logging
 displayName: "trace ssl"
-createdAt: "2024-08-12T14:04:40Z"
-digest: 2024-08-14T13:05:50Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "use uprobe to capture data on read/recv or write/send functions of OpenSSL, GnuTLS, NSS and Libcrypto"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcp/artifacthub-pkg.yml
+++ b/gadgets/trace_tcp/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace tcp"
 category: monitoring-logging
 displayName: "trace tcp"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "monitor connect, accept and close events of TCP connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpconnect/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpconnect/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace tcpconnect"
 category: monitoring-logging
 displayName: "trace tcpconnect"
-createdAt: "2024-08-12T14:04:40Z"
-digest: 2024-08-14T13:05:50Z
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace tcp connections"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpdrop/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpdrop/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace tcpdrop"
 category: monitoring-logging
 displayName: "trace tcpdrop"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace TCP packets dropped by the kernel"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""

--- a/gadgets/trace_tcpretrans/artifacthub-pkg.yml
+++ b/gadgets/trace_tcpretrans/artifacthub-pkg.yml
@@ -1,10 +1,10 @@
 # Artifact Hub package metadata file
-version: v0.31.0
+version: 0.33.0
 name: "trace tcpretrans"
 category: monitoring-logging
 displayName: "trace tcpretrans"
-createdAt: "2024-08-12T14:04:40Z"
-digest: "2024-08-12T14:04:40Z"
+createdAt: "2024-10-08T09:57:54Z"
+digest: "2024-10-08T09:57:54Z"
 description: "trace TCP retransmissions"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""


### PR DESCRIPTION
Update the gadgets versions manually since the automated workflow is failing see: https://github.com/inspektor-gadget/inspektor-gadget/pull/3558.

I used the steps at https://github.com/inspektor-gadget/inspektor-gadget/blob/main/.github/workflows/release.yml#L24 to make the changes.
