### PR TITLE
pkg/operators/otel-metrics: Hide render datasource from gadget users

### DIFF
--- a/docs/gadget-devel/output.md
+++ b/docs/gadget-devel/output.md
@@ -1,0 +1,33 @@
+---
+title: 'Displaying Output'
+sidebar_position: 620
+---
+
+By default, Inspektor Gadget allows you to display the output of each data
+source in all the output modes supported by the [CLI
+operator](../spec/operators/cli.md#output). Unless you have specific
+requirements, we recommend using the CLI operator's default configuration.
+However, for [Map Iterators](./gadget-intro.md#map-iterators) with a map value
+type of `gadget_histogram_slot__u32` or `gadget_histogram_slot__u64` (TODO: Add
+links), the output should be displayed as a chart, which the CLI operator
+doesn't support. In such cases, you can use the [Otel
+Metrics](../spec/operators/otel-metrics.md) operator to render the output as a
+histogram by annotating the data source with [metrics.print:
+"true"](../spec/operators/otel-metrics.md#metricsprint). The
+[profile_blockio](../gadgets/profile_blockio.mdx) gadget is an example of this.
+
+## Fields
+
+The fields to be displayed in the output when using the `columns`, `json`,
+`jsonpretty` or `yaml` output modes depend on the data source type:
+
+- Tracers: The fields are all the elements of the event `struct` specified when
+  defining the data source.
+- Map Iterators: The fields are all the elements of the key and value `struct`s
+  used to define the eBPF map to be iterated. As mentioned above, there is a
+  special case for the map iterators with a map value type of
+  `gadget_histogram_slot__u32` or `gadget_histogram_slot__u64`. In such cases,
+  the data source created by the Otel Metrics operator will contain just one
+  field called `text` which will carry the rendered histogram as a plain text.
+- Snapshotters: The fields are all the elements of the snapshot entry `struct`
+  specified when defining the data source.

--- a/docs/spec/operators/cli.md
+++ b/docs/spec/operators/cli.md
@@ -10,9 +10,11 @@ different output formats, depending on the gadget and the use case.
 
 10000
 
-## Instance Parameters
+## Parameters
 
-### `fields`
+### Instance Parameters
+
+#### `fields`
 
 Set the fields to be printed. Multiple data sources and fields can be specified
 using the format
@@ -20,16 +22,64 @@ using the format
 
 Fully qualified name: `operator.cli.fields`
 
-### `mode`
+#### `output`
 
-Determines the output format:
-- `json`: Outputs in JSON format.
-- `jsonpretty`: Outputs in pretty-printed JSON format.
-- `columns`: Outputs in a columnar format.
-- `yaml`: Outputs in YAML format.
-- `none`: No output.
-- `raw`: Outputs raw data.
+Determines the output format of the data source. It can be either a single output
+mode for all data sources or an output mode for each data source individually in
+the format `datasource:mode,datasource2:mode`.
 
-Fully qualified name: `operator.cli.mode`
+The following modes are supported:
+
+- `columns`: This is the default output mode. It displays the output in a
+  tabular format with a column for each field in the data source, unless the
+  field is annotated with `columns.hidden: true`. In addition to hiding columns,
+  you can also customize the columns format by using several annotations like
+  `columns.width`, `columns.alignment`, etc., as explained in TODO.
+- `json`: This mode displays the output in JSON format. Note that the output
+  contains all the fields of the data source, even if they annotated with
+  `columns.hidden: true` as this annotation applies only to the `columns` mode.
+  Depending on the data source type, it may be an array of objects or multiple
+  objects separated by newlines.
+- `jsonpretty`: As the `json` mode, but the output is formatted in a more
+  human-readable way.
+- `yaml`: This mode displays the output in YAML format. Like the `json` mode, it
+  contains all the fields of the data source. YAML entries will be separated by
+  `---` to make it easier to read.
+
+By default, the CLI operator allows setting the output of each data source in
+all the supported modes. However, this can be customized by annotating the data
+source with the [supported-output-modes](#clisupported-output-modes) annotation.
+
+Also, you can change the default output mode for each data source by setting the
+[default-output-mode](#clidefault-output-mode) annotation.
+
+Fully qualified name: `operator.cli.output`
 
 Default: `columns`
+
+## Annotations
+
+### Data Source Annotations
+
+#### `cli.supported-output-modes`
+
+Comma-separated list of output modes supported for the data source. This is
+useful when you want to customize the output modes supported by the data source.
+
+Note that if you include any output mode different from the ones supported by
+the CLI operator, it will treat as a custom output mode and will be printed as a
+string.
+
+#### `cli.default-output-mode`
+
+Set the default output mode for the data source. This is useful when you want to
+set a different default output mode for a data source.
+
+#### `cli.clear-screen-before`
+
+Clear the screen before printing the output of the data source. This is useful
+for data sources that emit periodically the batch of data and you want to clear
+the screen before printing the new data.
+
+This annotation is only applicable to the `columns` and custom output modes
+added by annotating the data source with `cli.supported-output-modes`.

--- a/docs/spec/operators/otel-metrics.md
+++ b/docs/spec/operators/otel-metrics.md
@@ -11,31 +11,99 @@ The otel-metrics operator handles collecting and exporting metrics using the
 
 9995
 
-## Global Parameters
+## Parameters
 
-### `otel-metrics-listen`
+### Global Parameters
+
+#### `otel-metrics-listen`
 
 Enables the Prometheus exporter on the address given by `otel-metrics-listen-address` if set to `true`.
 
 Default: `false`
 
-## Instance Parameters
+#### `otel-metrics-listen-address`
 
 The listen address that should be serving Prometheus requests.
 
 Default: `0.0.0.0:2224`
 
-## Instance Parameters
+### Instance Parameters
 
-### `otel-metrics-name`
+#### `otel-metrics-name`
 
 Overrides the name of a datasource and explicitly sets it as name for the export. This is mandatory if you
 want to export the metrics. Use a name that is unique to the gadget+params combination to avoid collision of metrics.
 
-### `otel-metrics-print-interval`
+Fully qualified name: `operator.otel-metrics.otel-metrics-name`
+
+#### `otel-metrics-print-interval`
 
 Interval in which metrics should be emitted as human-readable text. This only has effect for data sources that are
 annotated using `metrics.print=true`. This is also limited to print histograms for now. This functionality might be
 removed in the future.
+The minimum interval is 25ms.
+
+Fully qualified name: `operator.otel-metrics.otel-metrics-print-interval`
 
 Default: `1000ms`
+
+## Annotations
+
+### Data Source Annotations
+
+#### `metrics.collect`
+
+Together with the `otel-metrics-listen=true` and `otel-metrics-name=<name>`
+flags, this annotation is used to enable the Otel Metrics operator to export the
+data source's output as Prometheus metrics.
+
+#### `metrics.print`
+
+If set to `"true"`, the Otel Metrics operator will render the data source's
+output in more human-friendly formats.
+
+Currently, this feature only supports rendering as histograms the output of [Map
+Iterators](../../gadget-devel/gadget-intro.md#map-iterators) with the map’s
+value type of `gadget_histogram_slot__u32` or `gadget_histogram_slot__u64`
+(TODO: Add link). To achieve this, the Otel Metrics operator disables the
+original data source and creates a new one, suffixed with `-rendered`, which
+will emit the original data source's output as a rendered histogram.
+Additionally, the Otel Metrics operator will configure the CLI operator for this
+new data source as follows:
+
+- Set both the [cli.supported-output-modes](./cli.md#clisupported-output-modes)
+  and [cli.default-output-mode](./cli.md#clidefault-output-mode) annotations to
+  `histogram`. This will create a custom output mode that will make the CLI
+  operator print the output as it is received (i.e., a rendered histogram), and
+  use this mode as the default.
+- Set the [cli.clear-screen-before](./cli.md#cliclear-screen-before) annotation
+  to `true` to make the CLI operator clear the screen before printing each
+  histogram.
+
+### Field Annotations
+
+#### `metrics.type`
+
+Defines the type of the field. If not set, the operator will try to infer it
+from the field type.
+
+Possible values: `counter`, `gauge`, `histogram`, `key`.
+
+#### `metrics.unit`
+
+This annotation is used to set the [OpenTelemetry instrument
+unit](https://pkg.go.dev/go.opentelemetry.io/otel/metric@v1.30.0#WithUnit). It
+should be defined using the appropriate [UCUM](https://ucum.org) case-sensitive
+code.
+
+#### `metrics.description`
+
+This annotation is used to set the [OpenTelemetry instrument
+description](https://pkg.go.dev/go.opentelemetry.io/otel/metric@v1.30.0#WithDescription).
+
+#### `metrics.boundaries`
+
+For fields of type `histogram`, this annotation allows to specify the
+[OpenTelemetry instrument explicit bucket
+boundaries](https://pkg.go.dev/go.opentelemetry.io/otel/metric@v1.30.0#WithExplicitBucketBoundaries).
+It should be a comma-separated list of numbers.

--- a/gadgets/profile_blockio/gadget.yaml
+++ b/gadgets/profile_blockio/gadget.yaml
@@ -6,12 +6,8 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 dataSources:
   blockio:
     annotations:
-      cli.output: "none"
       metrics.print: "true"
     fields:
       latency:
         annotations:
           metrics.unit: µs
-  renderedmetrics:
-    annotations:
-      cli.clear-screen-before: "true"

--- a/gadgets/profile_tcprtt/gadget.yaml
+++ b/gadgets/profile_tcprtt/gadget.yaml
@@ -6,15 +6,11 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 dataSources:
   tcprtt:
     annotations:
-      cli.output: "none"
       metrics.print: "true"
     fields:
       latency:
         annotations:
           metrics.unit: µs
-  renderedmetrics:
-    annotations:
-      cli.clear-screen-before: "true"
 params:
   ebpf:
     targ_sport:

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -44,7 +44,6 @@ const (
 	ModeJSONPretty = "jsonpretty"
 	ModeColumns    = "columns"
 	ModeYAML       = "yaml"
-	ModeRaw        = "raw"
 
 	DefaultOutputMode = ModeColumns
 
@@ -322,7 +321,7 @@ func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 		}
 
 		switch mode {
-		case ModeRaw:
+		default:
 			before := func() {}
 			if ds.Annotations()[AnnotationClearScreenBefore] == "true" && term.IsTerminal(int(os.Stdout.Fd())) {
 				before = clearScreen

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -44,7 +44,6 @@ const (
 	ModeJSONPretty = "jsonpretty"
 	ModeColumns    = "columns"
 	ModeYAML       = "yaml"
-	ModeNone       = "none"
 	ModeRaw        = "raw"
 
 	DefaultOutputMode = ModeColumns
@@ -61,7 +60,7 @@ const (
 	AnnotationDefaultOutputMode = "cli.default-output-mode"
 )
 
-var DefaultSupportedOutputModes = []string{ModeColumns, ModeJSON, ModeJSONPretty, ModeNone, ModeYAML}
+var DefaultSupportedOutputModes = []string{ModeColumns, ModeJSON, ModeJSONPretty, ModeYAML}
 
 type cliOperator struct{}
 

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -65,8 +65,16 @@ const (
 	PrintDataSourceSuffix = "rendered"
 	PrintFieldName        = "text"
 
+	HistogramOutputMode = "histogram"
+
 	MinPrintInterval = time.Millisecond * 25
 )
+
+var renderedDsCliAnnotations = map[string]string{
+	"cli.supported-output-modes": HistogramOutputMode,
+	"cli.default-output-mode":    HistogramOutputMode,
+	"cli.clear-screen-before":    "true",
+}
 
 type otelMetricsOperator struct {
 	// exporter is the global exporter instance
@@ -538,9 +546,9 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 			}
 
 			// Set default annotations
-			ods.AddAnnotation("cli.supported-output-modes", "raw")
-			ods.AddAnnotation("cli.default-output-mode", "raw")
-			ods.AddAnnotation("cli.clear-screen-before", "true")
+			for k, v := range renderedDsCliAnnotations {
+				ods.AddAnnotation(k, v)
+			}
 
 			// Use annotations from the original data source
 			for k, v := range ds.Annotations() {


### PR DESCRIPTION
# Hide render datasource from gadget users

Making the render datasource (used by the otel-metrics to print histograms on CLI side) visible to users provides some issues and unnecessary complexity:

- Gadget developer needs to apply some annotations to the datasource they created and some others to a datasource named `renderedmetrics` (which they didn't created). For instance, for the `trace_tcprtt` gadget:

    ```yaml
    dataSources:
      tcprtt:
        annotations:
          cli.output: "none"
          metrics.print: "true"
        fields:
          latency:
            annotations:
              metrics.unit: µs
      renderedmetrics:
        annotations:
          cli.clear-screen-before: "true"
    ```

- Available fields on help message is confusing:

    ```bash
      --fields string                          Available data sources / fields
                                                 "tcprtt" (data source):
                                                   latency
                                                   unused

                                                 "renderedmetrics" (data source):
                                                   text
                                                (default "tcprtt:unused,latency;renderedmetrics:text")
    ```

- [#3454](https://github.com/inspektor-gadget/inspektor-gadget/issues/3454) Additionally, any output mode different than raw is ignored and it always print the raw output (histogram)

   ```bash
   $ go run --exec "sudo" ./cmd/ig/... run profile_tcprtt -o json
   latency
           µs               : count    distribution
            0 -> 1          : 0        |                                        |
   [...]
   ```
This PR proposes to hide the `renderedmetrics` datasource from users by disabling the original data source and applying its annotations on the one for render the output. Doing so, we simplify the yaml by setting all the annotations to one datasource and preventing users from setting `cli.output: "none"` (which was quite strange because it's not even an annotation):

```yaml
dataSources:
  tcprtt:
    annotations:
      metrics.print: "true"
    fields:
      latency:
        annotations:
          metrics.unit: µs
```

The available flags now look cleaner:

```bash
  --fields string                          Available data sources / fields
                                             "tcprtt-rendered" (data source):
                                               text
                                            (default "text")
```

Yeah, I know there's still some magic with this `-rendered` suffixed data source, but I tried to document it in a new gadget-devel documentation: [Displaying Output](https://github.com/inspektor-gadget/inspektor-gadget/blob/jose/render-datasource/docs/gadget-devel/output.md).

In addition, any output different than `raw` fails, mitigating [#3454](https://github.com/inspektor-gadget/inspektor-gadget/issues/3454):

```bash
$ go run --exec "sudo" ./cmd/ig/... run $LOCAL_REPO/profile_tcprtt:outputmode --insecure-registries=$LOCAL_REPO --verify-image=false --help
  -o, --output string                          Specifies output mode for all ("mode1") or per data source ("datasource:mode1,datasource2:mode2")
                                                 Supported data sources / output modes:
                                                   "tcprtt-rendered" (data source):
                                                     histogram
                                                (default "histogram")

$ go run --exec "sudo" ./cmd/ig/... run $LOCAL_REPO/profile_tcprtt:outputmode --insecure-registries=$LOCAL_REPO --verify-image=false -o json
[...]
WARN[0000] output mode "json" for data source "tcprtt-rendered" is not supported; skipping data source
```

### TODOs to be managed on other PRs (I'll create issues for them)

- [ ] Uniform flag format of fields supporting values per datasource. Some of them use "," (e.g., `map-fetch-interval` and `map-fetch-count`) and some other ";" (e.g., `fields`) as separator.
- [ ] Support more human readable manifest format for fields supporting values per datasouce. [Here](https://github.com/inspektor-gadget/inspektor-gadget/pull/3566#discussion_r1802630951) an option.