### PR TITLE
Flush memory allocations when no longer needed

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -15,6 +15,12 @@
 package main
 
 import (
+	"net/http"
+	_ "net/http/pprof"
+	"runtime"
+	"runtime/debug"
+	"time"
+
 	"fmt"
 	"os"
 
@@ -54,6 +60,18 @@ import (
 )
 
 func main() {
+	go func() {
+		for {
+			runtime.GC()
+			debug.FreeOSMemory()
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	go func() {
+		http.ListenAndServe("localhost:6060", nil)
+	}()
+
 	if experimental.Enabled() {
 		log.Info("Experimental features enabled")
 	}

--- a/pkg/container-hook/tracer.go
+++ b/pkg/container-hook/tracer.go
@@ -46,6 +46,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/s3rj1k/go-fanotify/fanotify"
@@ -259,8 +260,10 @@ func (n *ContainerNotifier) installEbpf(fanotifyFd int) error {
 	}
 
 	if err := spec.LoadAndAssign(&n.objs, &opts); err != nil {
+		btf.FlushKernelSpec()
 		return fmt.Errorf("loading maps and programs: %w", err)
 	}
+	btf.FlushKernelSpec()
 
 	// Attach ebpf programs
 	l, err := link.Kprobe("fsnotify_remove_first_event", n.objs.IgFaPickE, nil)

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -363,6 +363,16 @@ func parseExtraInfo(extraInfo map[string]string,
 	return nil
 }
 
+// ParseExtraInfoTest exports parseExtraInfo for the tests only (cri_test.go)
+// This allows the tests to be in a separate package (package cri_test) so we
+// can remove memory expensive dependencies from ig
+// (github.com/google/go-cmp/cmp)
+func ParseExtraInfoTest(extraInfo map[string]string,
+	containerDetailsData *runtimeclient.ContainerDetailsData,
+) error {
+	return parseExtraInfo(extraInfo, containerDetailsData)
+}
+
 // Convert the state from container status to state of runtime client.
 func containerStatusStateToRuntimeClientState(containerStatusState runtime.ContainerState) (runtimeClientState string) {
 	switch containerStatusState {

--- a/pkg/container-utils/cri/cri_test.go
+++ b/pkg/container-utils/cri/cri_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cri
+package cri_test
 
 import (
 	"reflect"
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cri"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
@@ -181,7 +182,7 @@ func TestParseExtraInfo(t *testing.T) {
 	for _, entry := range table {
 		// Parse the extra info.
 		containerDetailsData := &runtimeclient.ContainerDetailsData{}
-		err := parseExtraInfo(entry.info, containerDetailsData)
+		err := cri.ParseExtraInfoTest(entry.info, containerDetailsData)
 		// Expected error.
 		if err != nil {
 			if entry.expected != nil {

--- a/pkg/gadgets/helpers.go
+++ b/pkg/gadgets/helpers.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/link"
 	"golang.org/x/sys/unix"
@@ -239,8 +240,10 @@ func LoadeBPFSpec(
 	}
 
 	if err := spec.LoadAndAssign(objs, &opts); err != nil {
+		btf.FlushKernelSpec()
 		return fmt.Errorf("loading maps and programs: %w", err)
 	}
+	btf.FlushKernelSpec()
 
 	return nil
 }

--- a/pkg/kfilefields/tracer.go
+++ b/pkg/kfilefields/tracer.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	"golang.org/x/sys/unix"
 
@@ -126,8 +127,10 @@ func (t *Tracer) install() error {
 		},
 	}
 	if err := spec.LoadAndAssign(&t.objs, &opts); err != nil {
+		btf.FlushKernelSpec()
 		return fmt.Errorf("loading maps and programs: %w", err)
 	}
+	btf.FlushKernelSpec()
 
 	// Attach ebpf programs
 	l, err := link.Kprobe("__scm_send", t.objs.IgScmSndE, nil)

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -631,6 +631,7 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		opts.Programs.KernelTypes = btfSpec
 	}
 	collection, err := ebpf.NewCollectionWithOptions(i.collectionSpec, opts)
+	btf.FlushKernelSpec()
 	if err != nil {
 		var verifierErr *ebpf.VerifierError
 		if errors.As(err, &verifierErr) {

--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -68,6 +68,8 @@ func byteSliceAsUint64(in []byte, signed bool, ds datasource.DataSource) uint64 
 
 func (i *ebpfInstance) initEnumFormatter(gadgetCtx operators.GadgetContext) error {
 	btfSpec, err := btf.LoadKernelSpec()
+	btf.FlushKernelSpec()
+
 	if err != nil {
 		i.logger.Warnf("Kernel BTF information not available. Enums won't be resolved to strings")
 	}

--- a/pkg/socketenricher/tracer.go
+++ b/pkg/socketenricher/tracer.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	log "github.com/sirupsen/logrus"
 
@@ -107,8 +108,10 @@ func (se *SocketEnricher) start() error {
 	}
 
 	if err := spec.LoadAndAssign(&se.objs, &opts); err != nil {
+		btf.FlushKernelSpec()
 		return fmt.Errorf("loading ebpf program: %w", err)
 	}
+	btf.FlushKernelSpec()
 
 	var l link.Link
 


### PR DESCRIPTION
Flush btf kernel data from cache when no longer needed.

Also remove unnecessary regexp from the cri test.

```
sudo -E ./ig trace exec
go tool pprof -http=:8081 http://localhost:6060/debug/pprof/heap
```

Before: 45 MB

![pprof-ig-1](https://github.com/user-attachments/assets/8a50fd37-51db-4b71-9796-0f724ccbd402)

After: 3 MB

![pprof-ig-4](https://github.com/user-attachments/assets/674a7fd8-59c8-4b67-b9ea-2adee76528e2)

## How to use

No changes

## Testing done

- I have not checked how slower it becomes.
- I have not checked with pmap or smem, only pprof.
- The numbers above are with the builtin trace-exec gadget. With the image-based trace_exec gadget, there are still some btf allocations that are not flushed, so pprof shows 38MB in initEnumFormatters:

cc @burak-ok 

Fixes: #3541
