### PR TITLE
fix: json decoder out of sync error for gadgetrunner

### DIFF
--- a/pkg/testing/gadgetrunner/gadgetrunner.go
+++ b/pkg/testing/gadgetrunner/gadgetrunner.go
@@ -116,6 +116,7 @@ func (g *GadgetRunner[T]) RunGadget() {
 	if g.DataFunc == nil {
 		// Use default data function if none is provided
 		g.DataFunc = func(source datasource.DataSource, data datasource.Data) error {
+			mu.Lock()
 			event := new(T)
 			jsonOutput := g.JsonFormatter.Marshal(data)
 			err := json.Unmarshal(jsonOutput, event)
@@ -125,7 +126,6 @@ func (g *GadgetRunner[T]) RunGadget() {
 				g.normalizeEvent(event)
 			}
 
-			mu.Lock()
 			g.CapturedEvents = append(g.CapturedEvents, *event)
 			mu.Unlock()
 			return nil


### PR DESCRIPTION
# Description

Newly added unittest might be a little flaky due to json decoder out of sync error in gadgetrunner package see this:
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/11277713751/job/31365192850

## Testing done
Manual testing is done locally.
