### PR TITLE
feat: Accepting IPv4 and IPv6 parameters as command line input arguments

### DIFF
--- a/pkg/operators/ebpf/params.go
+++ b/pkg/operators/ebpf/params.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/btfhelpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
 
@@ -70,6 +71,11 @@ func getTypeHint(typ btf.Type) params.TypeHint {
 		return getTypeHint(typ)
 	case *btf.Volatile:
 		return getTypeHint(typedMember.Type)
+	case *btf.Struct:
+		switch typedMember.Name {
+		case ebpftypes.L3EndpointTypeName:
+			return params.TypeIP
+		}
 	}
 
 	return params.TypeUnknown

--- a/pkg/operators/ebpf/params_defaults.go
+++ b/pkg/operators/ebpf/params_defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/ebpf/btf"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/btfhelpers"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 )
 
 var errMapNoBTFValue = errors.New("map spec does not contain a BTF Value")
@@ -111,6 +112,11 @@ func (i *ebpfInstance) fillParamDefaults() error {
 					} else {
 						defaultValue = "true"
 					}
+				}
+			case *btf.Struct:
+				switch t.Name {
+				case ebpftypes.L3EndpointTypeName:
+					defaultValue = "0.0.0.0"
 				}
 			}
 

--- a/pkg/operators/ebpf/types/types.go
+++ b/pkg/operators/ebpf/types/types.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package types contains the names and Golang representation of the types used
+// by the eBPF programs. Keep this aligned with include/gadget/types.h
 package types
 
-// Keep this aligned with include/gadget/types.h
 const (
 	IPAddrTypeName      = "gadget_ip_addr_t"
 	L3EndpointTypeName  = "gadget_l3endpoint_t"
@@ -42,3 +43,10 @@ const (
 	HistogramSlotU32TypeName = "gadget_histogram_slot__u32"
 	HistogramSlotU64TypeName = "gadget_histogram_slot__u64"
 )
+
+// L3Endpoint is the Golang representation of struct gadget_l3endpoint_t
+type L3Endpoint struct {
+	V6      [16]byte
+	Version uint8
+	_       [3]byte
+}


### PR DESCRIPTION
- Made changes to params.go to label all parameters with prefix `ipaddr` as type TypeString
- Made changes to ebpf.go operator to convert all parameters with prefix `ipaddr_v4` from string to uint32 and
 all parameters with prefix `ipaddr_v6` from string to struct uint128
- Defined uint128 as a struct with 2 members of uint64 and wrote a helper function `IPStringToUint128()` in helpers.go

# Accepting IPv4 and IPv6 arguments as a input parameter

This commit allows us to now specify IPv4 addresses as an input parameter in the cli. 

For example:
Let's assume we wanted to have a parameter of ipv4 and ipv6 address. We declare it as a u32 int and u128 in the kernel space as shown below:
```C
volatile const __u32 ipaddr_v4 = 3232235777;
volatile const u128 ipaddr_v6 =  {0x123456789ABCDEF0, 0x0FEDCBA987654321}; 

GADGET_PARAM(ipaddr_v4);
GADGET_PARAM(ipaddr_v6);
```
Then after building the gadget we run it using the following

```bash
sudo ig run bit_flip:exp --verify-image=false --ipaddr_v4="127.0.0.1"  --ipaddr_v6="2001:db8::1" -v
```

Here the ipaddr_v4 is be converted into a 32 bit integer using the pre-defined helper function `gadgets.IPStringToUint32()`
And the ipaddr_v6 is converted into uint128 using a custom defined helper function `gadgets.IPStringToU128()`

There values are logged when we use `-v` flag:
```bash
DEBU[0007] setting param value "ipaddr_v4" = 16777343   
DEBU[0007] setting param value "ipaddr_v6" = {2306139568115548160 1} 
```

## How to use

The parameters to be accepted as IPv4 must begin with `prefix ipaddr_v4`
So it can be `ipaddr_v4_1` or `ipaddr_v4_anything` but should have prefix ipaddr_v4

Similar for IPv6 parameters, they need to have prefix `ipaddr_v6`

## Testing done

Locally tested it. 
