### PR TITLE
cri: move tests to separate package

### DIFF
--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -363,6 +363,16 @@ func parseExtraInfo(extraInfo map[string]string,
 	return nil
 }
 
+// ParseExtraInfoTest exports parseExtraInfo for the tests only (cri_test.go)
+// This allows the tests to be in a separate package (package cri_test) so we
+// can remove memory expensive dependencies from ig
+// (github.com/google/go-cmp/cmp)
+func ParseExtraInfoTest(extraInfo map[string]string,
+	containerDetailsData *runtimeclient.ContainerDetailsData,
+) error {
+	return parseExtraInfo(extraInfo, containerDetailsData)
+}
+
 // Convert the state from container status to state of runtime client.
 func containerStatusStateToRuntimeClientState(containerStatusState runtime.ContainerState) (runtimeClientState string) {
 	switch containerStatusState {

--- a/pkg/container-utils/cri/cri_test.go
+++ b/pkg/container-utils/cri/cri_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cri
+package cri_test
 
 import (
 	"reflect"
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cri"
 	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
 )
 
@@ -181,7 +182,7 @@ func TestParseExtraInfo(t *testing.T) {
 	for _, entry := range table {
 		// Parse the extra info.
 		containerDetailsData := &runtimeclient.ContainerDetailsData{}
-		err := parseExtraInfo(entry.info, containerDetailsData)
+		err := cri.ParseExtraInfoTest(entry.info, containerDetailsData)
 		// Expected error.
 		if err != nil {
 			if entry.expected != nil {


### PR DESCRIPTION
The tests depends on github.com/google/go-cmp/cmp which is not necessary to include in ig. The dependency compiles regexp which cause 0.5MB to be permanently used by the ig process. This is visible in the pprof flamegraph as 'regexp.MustCompile'.

This patch was originally part of #3571 but that PR might not be merged, so I am submitting the patch separately.

cc @burak-ok 