### PR TITLE
operators: kubeipresolver for image-based gadgets

### DIFF
--- a/docs/spec/operators/kubeipresolver.md
+++ b/docs/spec/operators/kubeipresolver.md
@@ -2,24 +2,55 @@
 title: KubeIPResolver
 ---
 
-The KubeIPResolver operator enriches IP addresses with pod and service
-information. For instance, in this example the `10.96.0.10` IP is enriched with
-namespace, podname, kind, and pod labels.
+The KubeIPResolver operator enriches layer 4 endpoints ([gadget_l4endpoint_t](../../gadget-devel/gadget-ebpf-api.md#struct-gadget_l4endpoint_t))
+with pod and service information by adding following fields to the events:
+
+- `k8s`:
+  - `kind`: The Kubernetes object kind, which can be either `pod` or `svc`.
+  - `labels`: The labels of the Kubernetes object.
+  - `name`: The name of the Kubernetes object.
+  - `namespace`: The namespace of the Kubernetes object.
+
+For instance, the example below shows a request from `mypod` pod to `kube-dns` service:
 
 ```json
+{
+  ...
   "dst": {
     "addr": "10.96.0.10",
-    "version": 4,
-    "namespace": "kube-system",
-    "podname": "kube-dns",
-    "kind": "svc",
-    "podlabels": {
-      "k8s-app": "kube-dns",
-      "kubernetes.io/cluster-service": "true",
-      "kubernetes.io/name": "CoreDNS"
-    }
-  }
+    "k8s": {
+      "kind": "svc",
+      "labels": "k8s-app=kube-dns,kubernetes.io/cluster-service=true,kubernetes.io/name=CoreDNS",
+      "name": "kube-dns",
+      "namespace": "kube-system"
+    },
+    "port": 53,
+    "proto": "UDP",
+    "proto_raw": 17,
+    "version": 4
+  },
+  ...
+  "src": {
+    "addr": "10.244.0.12",
+    "k8s": {
+      "kind": "pod",
+      "labels": "run=mypod",
+      "name": "mypod",
+      "namespace": "demo"
+    },
+    "port": 57066,
+    "proto": "UDP",
+    "proto_raw": 17,
+    "version": 4
+  },
+  ...
+}
 ```
+
+
+## Priority
+
+10
 
 ## Parameters
 

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -53,6 +53,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubeipresolver"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"

--- a/pkg/operators/common/datasource.go
+++ b/pkg/operators/common/datasource.go
@@ -1,0 +1,49 @@
+// Copyright 2023-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+)
+
+func GetIPForVersion(data datasource.Data, version, ipAddr datasource.FieldAccessor) (string, error) {
+	ip := ipAddr.Get(data)
+	if ip == nil {
+		return "", fmt.Errorf("IP field not found")
+	}
+
+	v, err := version.Uint8(data)
+	if err != nil {
+		return "", fmt.Errorf("getting version: %w", err)
+	}
+
+	var ipStr string
+	switch v {
+	case 4:
+		ipStr, err = net.IP(ip[:4]).String(), nil
+	case 6:
+		ipStr, err = net.IP(ip).String(), nil
+	default:
+		err = fmt.Errorf("unknown IP version: %d", v)
+	}
+	if err != nil {
+		return "", fmt.Errorf("getting IP: %w", err)
+	}
+
+	return ipStr, nil
+}

--- a/pkg/operators/common/kubeinventorycache.go
+++ b/pkg/operators/common/kubeinventorycache.go
@@ -170,6 +170,9 @@ func transformObject(obj any) (any, error) {
 				HostIP: t.Status.HostIP,
 				PodIP:  t.Status.PodIP,
 			},
+			Spec: v1.PodSpec{
+				HostNetwork: t.Spec.HostNetwork,
+			},
 		}
 		return p, nil
 	case *v1.Service:

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -16,7 +16,6 @@ package formatters
 
 import (
 	"fmt"
-	"net"
 	"strings"
 	"syscall"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/protocols"
@@ -181,20 +181,9 @@ func handleL3Endpoint(in datasource.FieldAccessor) (func(entry datasource.Data) 
 	in.SetHidden(false, false)
 
 	return func(entry datasource.Data) (string, error) {
-		ip := ips[0].Get(entry)
-		v, err := versions[0].Uint8(entry)
+		addrStr, err := common.GetIPForVersion(entry, versions[0], ips[0])
 		if err != nil {
-			return "", err
-		}
-
-		var addrStr string
-		switch v {
-		case 4:
-			addrStr = net.IP(ip[:4]).String()
-		case 6:
-			addrStr = net.IP(ip).String()
-		default:
-			return "", fmt.Errorf("invalid IP version %d for l4endpoint", v)
+			return "", fmt.Errorf("getting IP address: %w", err)
 		}
 
 		addrF.PutString(entry, addrStr)

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -17,8 +17,12 @@
 package kubeipresolver
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
@@ -28,6 +32,12 @@ import (
 
 const (
 	OperatorName = "KubeIPResolver"
+	Priority     = 10
+)
+
+const (
+	endpointL4Type = "gadget_l4endpoint_t"
+	ipAddrType     = "gadget_ip_addr_t"
 )
 
 type KubeIPResolverInterface interface {
@@ -83,9 +93,10 @@ func (k *KubeIPResolver) Instantiate(gadgetCtx operators.GadgetContext, gadgetIn
 }
 
 type KubeIPResolverInstance struct {
-	gadgetCtx      operators.GadgetContext
-	k8sInventory   common.K8sInventoryCache
-	gadgetInstance any
+	gadgetCtx          operators.GadgetContext
+	k8sInventory       common.K8sInventoryCache
+	gadgetInstance     any
+	endpointsAccessors map[datasource.DataSource][]endpointAccessors
 }
 
 func (m *KubeIPResolverInstance) Name() string {
@@ -134,6 +145,184 @@ func (m *KubeIPResolverInstance) EnrichEvent(ev any) error {
 	return nil
 }
 
+func (k *KubeIPResolver) GlobalParams() api.Params {
+	return nil
+}
+
+func (k *KubeIPResolver) InstanceParams() api.Params {
+	return nil
+}
+
+type endpointAccessors struct {
+	root            datasource.FieldAccessor
+	subK8sKind      datasource.FieldAccessor
+	subK8sName      datasource.FieldAccessor
+	subK8sNamespace datasource.FieldAccessor
+	subK8sLabels    datasource.FieldAccessor
+}
+
+func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	logger := gadgetCtx.Logger()
+	epAccessors := make(map[datasource.DataSource][]endpointAccessors)
+	for _, ds := range gadgetCtx.GetDataSources() {
+		logger.Debugf("KubeIPResolverOperator inspecting datasource %q", ds.Name())
+
+		endpoints := ds.GetFieldsWithTag("type:" + endpointL4Type)
+		if len(endpoints) == 0 {
+			logger.Debugf("> no endpoint fields found")
+			continue
+		}
+
+		logger.Debugf("> found %d endpoint fields", len(endpoints))
+		for _, ep := range endpoints {
+			// validate the endpoint fields
+			ips := ep.GetSubFieldsWithTag("type:" + ipAddrType)
+			if len(ips) != 1 {
+				return nil, fmt.Errorf("%s: expected %d %q field, got %d", ep.Name(), 1, ipAddrType, len(ips))
+			}
+
+			if ips[0].Size() != 16 {
+				return nil, fmt.Errorf("%s: expected %q field to have size %d, got %d", ep.Name(), ipAddrType, 16, ips[0].Size())
+			}
+
+			version := ep.GetSubFieldsWithTag("name:version")
+			if len(version) != 1 {
+				return nil, fmt.Errorf("%s: expected %d %q field, got %d", ep.Name(), 1, "version", len(version))
+			}
+
+			// Add subfields for k8s metadata to the endpoint
+			k8sSubAcc, err := ep.AddSubField("k8s", api.Kind_Invalid, datasource.WithFlags(datasource.FieldFlagEmpty))
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "k8s", err)
+			}
+			k8sKindAcc, err := k8sSubAcc.AddSubField("kind", api.Kind_String,
+				datasource.WithAnnotations(map[string]string{
+					datasource.ColumnsMaxWidthAnnotation: "12",
+				}),
+				datasource.WithFlags(datasource.FieldFlagHidden),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "kind", err)
+			}
+			k8sNameAcc, err := k8sSubAcc.AddSubField("name",
+				api.Kind_String,
+				datasource.WithAnnotations(map[string]string{
+					datasource.TemplateAnnotation: "pod",
+				}),
+				datasource.WithFlags(datasource.FieldFlagHidden),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "name", err)
+			}
+			k8sNamespaceAcc, err := k8sSubAcc.AddSubField("namespace",
+				api.Kind_String,
+				datasource.WithAnnotations(map[string]string{
+					datasource.TemplateAnnotation: "namespace",
+				}),
+				datasource.WithFlags(datasource.FieldFlagHidden),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "namespace", err)
+			}
+			k8sLabelsAcc, err := k8sSubAcc.AddSubField("labels", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "labels", err)
+			}
+			ea := endpointAccessors{
+				root:            ep,
+				subK8sKind:      k8sKindAcc,
+				subK8sName:      k8sNameAcc,
+				subK8sNamespace: k8sNamespaceAcc,
+				subK8sLabels:    k8sLabelsAcc,
+			}
+			epAccessors[ds] = append(epAccessors[ds], ea)
+		}
+	}
+
+	// No endpoints found, nothing to do
+	if len(epAccessors) == 0 {
+		return nil, nil
+	}
+
+	k8sInventory, err := common.GetK8sInventoryCache()
+	if err != nil {
+		return nil, fmt.Errorf("creating k8s inventory cache: %w", err)
+	}
+
+	return &KubeIPResolverInstance{
+		k8sInventory:       k8sInventory,
+		endpointsAccessors: epAccessors,
+	}, nil
+}
+
+func (k *KubeIPResolver) Priority() int {
+	return Priority
+}
+
+func (m *KubeIPResolverInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	m.k8sInventory.Start()
+	return nil
+}
+
+func (m *KubeIPResolverInstance) Start(gadgetCtx operators.GadgetContext) error {
+	for ds, acc := range m.endpointsAccessors {
+		ds.Subscribe(func(source datasource.DataSource, data datasource.Data) error {
+			var errs error
+			for _, a := range acc {
+				ip := a.root.GetSubFieldsWithTag("type:" + ipAddrType)[0]
+				version := a.root.GetSubFieldsWithTag("name:version")[0]
+				addrStr, err := common.GetIPForVersion(data, version, ip)
+				if err != nil {
+					errors.Join(errs, fmt.Errorf("%s: getting IP: %w", a.root.Name(), err))
+					continue
+				}
+
+				pod := m.k8sInventory.GetPodByIp(addrStr)
+				if pod != nil {
+					if pod.Spec.HostNetwork {
+						continue
+					}
+					a.subK8sName.Set(data, []byte(pod.Name))
+					a.subK8sKind.Set(data, []byte("pod"))
+					a.subK8sNamespace.Set(data, []byte(pod.Namespace))
+					// TODO: labels should be a map/slice
+					var labels []string
+					for key, val := range pod.Labels {
+						labels = append(labels, fmt.Sprintf("%s=%s", key, val))
+					}
+					a.subK8sLabels.Set(data, []byte(strings.Join(labels, ",")))
+					continue
+				}
+
+				svc := m.k8sInventory.GetSvcByIp(addrStr)
+				if svc != nil {
+					a.subK8sKind.Set(data, []byte("svc"))
+					a.subK8sName.Set(data, []byte(svc.Name))
+					a.subK8sNamespace.Set(data, []byte(svc.Namespace))
+					// TODO: labels should be a map/slice
+					var labels []string
+					for key, val := range svc.Labels {
+						labels = append(labels, fmt.Sprintf("%s=%s", key, val))
+					}
+					a.subK8sLabels.Set(data, []byte(strings.Join(labels, ",")))
+				}
+			}
+			return errs
+		}, 0)
+	}
+	return nil
+}
+
+func (m *KubeIPResolverInstance) PostStop(gadgetCtx operators.GadgetContext) error {
+	m.k8sInventory.Stop()
+	return nil
+}
+
+func (m *KubeIPResolverInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.Register(&KubeIPResolver{})
+	operators.RegisterDataOperator(&KubeIPResolver{})
 }

--- a/pkg/testing/utils/types.go
+++ b/pkg/testing/utils/types.go
@@ -16,11 +16,19 @@ package utils
 
 // Define some types that are only used for testing purposes
 
+type K8s struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Labels    string `json:"labels"`
+}
+
 type L4Endpoint struct {
 	Addr    string `json:"addr"`
 	Version uint8  `json:"version"`
 	Port    uint16 `json:"port"`
 	Proto   string `json:"proto"`
+	K8s     K8s    `json:"k8s"`
 }
 
 type L3Endpoint struct {

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -90,6 +90,18 @@ func BuildCommonData(containerName string, options ...CommonDataOption) eventtyp
 	return e
 }
 
+func BuildEndpointK8sData(kind, name, namespace, labels string) K8s {
+	if CurrentTestComponent != KubectlGadgetTestComponent {
+		return K8s{}
+	}
+	return K8s{
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		Labels:    labels,
+	}
+}
+
 func NormalizeCommonData(e *eventtypes.CommonData) {
 	// The container image digest is not currently enriched for Docker containers:
 	// https://github.com/inspektor-gadget/inspektor-gadget/issues/2365


### PR DESCRIPTION
Allow using kubeipresolver for image-based gadgets:

```
→ ./kubectl-gadget run trace_dns -n demo  --fields=+src.k8s.kind,+src.k8s.name,+dst.k8s.kind,+dst.k8s.name
# kubectl -n demo run mypod -it --image=wbitt/network-multitool -- /bin/sh
# nslookup example.com.
SRC                    DST                    COMM            PID QR QTYPE     NAME             RCODE    ADDRESSES K8S.NODE        K8S.NAMESPACE   K8S.PODNAME     K8S.CONTAINERN… SRC.K8S… SRC.K8S.NAME    DST.K8S… DST.K8S.NAME   
10.244.0.5:41390       10.96.0.10:53          isc-net-…    989183 Q  A         example.com.                        minikube-docker demo            mypod           mypod           pod      mypod           svc      kube-dns       
10.96.0.10:53          10.244.0.5:41390       isc-net-…    989183 R  A         example.com.     Success  93.184.2… minikube-docker demo            mypod           mypod           svc      kube-dns        pod      mypod          
10.96.0.10:53          10.244.0.5:33274       isc-net-…    989183 R  AAAA      example.com.     Success  2606:280… minikube-docker demo            mypod           mypod           svc      kube-dns        pod      mypod          
10.244.0.5:33274       10.96.0.10:53          isc-net-…    989183 Q  AAAA      example.com.                        minikube-docker demo            mypod           mypod           pod      mypod           svc      kube-dns 
```

or

```
$ ./kubectl-gadget run trace_dns -n demo -o jsonpretty -F qr=Q
{
  "addresses": "",
  "comm": "isc-net-0000",
  "dst": {
    "addr": "10.96.0.10",
    "k8s": {
      "kind": "svc",
      "labels": "k8s-app=kube-dns,kubernetes.io/cluster-service=true,kubernetes.io/name=CoreDNS",
      "name": "kube-dns",
      "namespace": "kube-system"
    },
    "port": 53,
    "proto": "UDP",
    "proto_raw": 17,
    "version": 4
  },
  "gid": 0,
  "id": "47df",
  "k8s": {
    "containerName": "mypod",
    "hostnetwork": false,
    "namespace": "demo",
    "node": "minikube-docker",
    "owner": {
      "kind": "",
      "name": ""
    },
    "podName": "mypod"
  },
  "latency_ns": 0,
  "mntns_id": 4026533342,
  "name": "google.com.",
  "netns_id": 4026533069,
  "num_answers": 0,
  "pcomm": "sh",
  "pid": 205498,
  "pkt_type": "OUTGOING",
  "pkt_type_raw": 4,
  "ppid": 41727,
  "qr": "Q",
  "qr_raw": false,
  "qtype": "A",
  "qtype_raw": 1,
  "rcode": "",
  "rcode_raw": 0,
  "runtime": {
    "containerId": "65c4d9ac52c20ac956d1ce2c93988f2ef1fbd8b5131f6239b92143df3aea3ef2",
    "containerImageDigest": "sha256:d1137e87af76ee15cd0b3d4c7e2fcd111ffbd510ccd0af076fc98dddfc50a735",
    "containerImageName": "wbitt/network-multitool:latest",
    "containerName": "mypod",
    "runtimeName": "docker"
  },
  "src": {
    "addr": "10.244.0.12",
    "k8s": {
      "kind": "pod",
      "labels": "run=mypod",
      "name": "mypod",
      "namespace": "demo"
    },
    "port": 45485,
    "proto": "UDP",
    "proto_raw": 17,
    "version": 4
  },
  "tid": 205499,
  "timestamp": "2024-10-17T15:11:53.222225812Z",
  "timestamp_raw": 1729177913222225812,
  "uid": 0
}
...
```

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/3483

## Testing Done:

`trace_dns` tests has been updated to validate the src/dst endpoints other tests aren't relying on any k8s resources (e.g use `127.0.0.1` and hence src/dst endpoints validation can be skipped)