### PR TITLE
pkg/operators/otel-metrics: Add mechanism for graceful close server

### DIFF
--- a/pkg/operators/otel-metrics/otel-metrics_test.go
+++ b/pkg/operators/otel-metrics/otel-metrics_test.go
@@ -16,6 +16,8 @@ package otelmetrics
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -30,6 +32,112 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
 )
+
+func TestMetricsInit(t *testing.T) {
+	type test struct {
+		name                      string
+		metricsListenValue        string
+		metricsListenAddressValue string
+		expectedError             bool
+	}
+
+	tests := []test{
+		{
+			name:          "default params values",
+			expectedError: false,
+		},
+		{
+			name:               "enable listener with default address",
+			metricsListenValue: "true",
+			expectedError:      false,
+		},
+		{
+			name:                      "enable listener at custom address",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "127.0.0.1:8080",
+			expectedError:             false,
+		},
+		{
+			name:                      "enable listener at all interfaces",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "0.0.0.0:8080",
+			expectedError:             false,
+		},
+		{
+			name:                      "enable listener at reserved port",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "0.0.0.0:22",
+			expectedError:             true,
+		},
+		{
+			name:                      "enable listener at invalid address without port",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "invalid",
+			expectedError:             true,
+		},
+		{
+			name:                      "enable listener at invalid address with port",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "invalid:8080",
+			expectedError:             true,
+		},
+		{
+			name:                      "enable listener at invalid port",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "0.0.0.0:invalid",
+			expectedError:             true,
+		},
+		{
+			name:                      "invalid format for listen address (missing addr)",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: ":8080",
+			expectedError:             true,
+		},
+		{
+			name:                      "invalid format for listen address (missing port)",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: "0.0.0.0:",
+			expectedError:             true,
+		},
+		{
+			name:                      "invalid format for listen address (missing addr and port)",
+			metricsListenValue:        "true",
+			metricsListenAddressValue: ":",
+			expectedError:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &otelMetricsOperator{}
+			globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+
+			if tt.metricsListenValue != "" {
+				globalParams.Set(ParamOtelMetricsListen, tt.metricsListenValue)
+			}
+			if tt.metricsListenAddressValue != "" {
+				globalParams.Set(ParamOtelMetricsListenAddress, tt.metricsListenAddressValue)
+			}
+
+			err := o.Init(globalParams)
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			defer o.Close()
+
+			if tt.metricsListenValue == "true" {
+				// Wait for HTTP listener to start
+				time.Sleep(500 * time.Millisecond)
+
+				// Check if the listener is running at the expected address
+				_, err := http.Get(fmt.Sprintf("http://%s/metrics", globalParams.Get(ParamOtelMetricsListenAddress)))
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestMetricsCounterAndGauge(t *testing.T) {
 	o := &otelMetricsOperator{skipListen: true}


### PR DESCRIPTION
# Add mechanism for graceful close otel-metrics server

While writing some tests, I found the otel-metrics server doesn't have a mechanism to gracefully close the server for exporting data. This PR adds that support.

## How to use

No changes from users perspectives.

## Testing done

This PR adds some unit tests for it.