### PR TITLE
docs/gadget-devel/gadget-intro: Specify support of Map Iterators

### DIFF
--- a/docs/gadget-devel/gadget-intro.md
+++ b/docs/gadget-devel/gadget-intro.md
@@ -103,7 +103,3 @@ is an example of a gadget using this data source.
 ### Snapshotters
 
 TODO
-
-### Profilers
-
-TODO

--- a/docs/gadget-devel/gadget-intro.md
+++ b/docs/gadget-devel/gadget-intro.md
@@ -66,15 +66,15 @@ Map Iterators are used to report statistics like number of files being opened,
 bytes going through a network connection, etc. The information is saved by the
 Gadget on hash maps where it's then read by Inspektor Gadget.
 
-Gadgets need to define the types for the key and value and a hash map used to store the information:
+Gadgets need to define the fields for the key and value and a hash map used to store the information:
 
 ```c
 struct key {
-	// types in key
+	// fields in key
 };
 
 struct value {
-	// type sin value
+	// fields in value
 };
 
 struct {
@@ -93,6 +93,9 @@ GADGET_MAPITER(name, mapname)
 
 - name: Name of the data source
 - mapname: Name of the hash map used to store the data
+
+Currently, Map Iterator data sources only support iterating over maps of type
+`BPF_MAP_TYPE_HASH` with keys and values of type `struct`.
 
 [top_file](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets/top_file)
 is an example of a gadget using this data source.

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -248,6 +248,10 @@ func (i *ebpfInstance) populateMapIter(t btf.Type, varName string) error {
 		return fmt.Errorf("map %q not found in eBPF object", mapName)
 	}
 
+	if iterMap.Type != ebpf.Hash {
+		return fmt.Errorf("map %q is not a hash map", mapName)
+	}
+
 	keyStruct, ok := iterMap.Key.(*btf.Struct)
 	if !ok {
 		return fmt.Errorf("map %q key is not a struct", mapName)


### PR DESCRIPTION
# Specify support of Map Iterators

Add types we currently support on Map Iterator data sources.

Ref discussion on Slack: https://kubernetes.slack.com/archives/CSYL75LF6/p1729093452941369?thread_ts=1729093112.369419&cid=CSYL75LF6
