### PR TITLE
Eventgen k8s implementation

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -37,6 +37,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/eventgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
@@ -172,7 +173,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			}
 			ops = append(ops, op)
 		}
-		ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator)
+		ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator, eventgen.EventGen)
 		initializedOperators = true
 
 		imageName := actualArgs[0]
@@ -291,8 +292,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			}
 			ops = append(ops, op)
 		}
-		ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator)
-
+		ops = append(ops, clioperator.CLIOperator, combiner.CombinerOperator, eventgen.EventGen)
 		timeoutDuration := time.Duration(timeoutSeconds) * time.Second
 
 		var image string

--- a/pkg/eventgenerator/dns/generator.go
+++ b/pkg/eventgenerator/dns/generator.go
@@ -1,0 +1,94 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+type Generator struct {
+	clientset *kubernetes.Clientset
+	config    *rest.Config
+	logger    logger.Logger
+	namespace string
+	podName   string
+}
+
+func NewGenerator(config *rest.Config, log logger.Logger) (*Generator, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+	return &Generator{
+		clientset: clientset,
+		config:    config,
+		logger:    log,
+		namespace: "default",
+		podName:   fmt.Sprintf("dns-eventgen-pod-%d", time.Now().Unix()),
+	}, nil
+}
+
+func (d *Generator) Generate(params map[string]string, count int, interval time.Duration) error {
+	pods, err := d.clientset.CoreV1().Pods(d.namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing pods: %w", err)
+	}
+
+	// Check for any pod with the dns-eventgen-pod prefix
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, "dns-eventgen-pod-") {
+			return fmt.Errorf("DNS event generator is already running with pod %s, please stop it first", pod.Name)
+		}
+	}
+
+	domain, ok := params["domain"]
+	if !ok {
+		return fmt.Errorf("domain parameter is required for DNS event generation")
+	}
+
+	sleepCount := fmt.Sprintf("%.0fs", interval.Seconds())
+	command := fmt.Sprintf("i=1; while [ $i -le %d ] || [ %d -eq -1 ]; do nslookup %s; i=$((i+1)); sleep %s; done", count, count, domain, sleepCount)
+
+	container := corev1.Container{
+		Name:    "dns-eventgen-container",
+		Image:   "busybox",
+		Command: []string{"sh", "-c", command},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: d.podName},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers:    []corev1.Container{container},
+		},
+	}
+
+	_, err = d.clientset.CoreV1().Pods(d.namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating pod: %w", err)
+	}
+
+	d.logger.Debugf("Created DNS event generation pod: %s", d.podName)
+	return nil
+}
+
+func (d *Generator) Cleanup() (string, error) {
+	if d.podName == "" {
+		return "", fmt.Errorf("pod %s is not found in %s namespace", d.podName, d.namespace)
+	}
+	err := d.clientset.CoreV1().Pods(d.namespace).Delete(context.Background(), d.podName, metav1.DeleteOptions{})
+	if err != nil {
+		return "", fmt.Errorf("deleting pod %s: %w", d.podName, err)
+	}
+	d.logger.Debugf("Successfully terminated DNS event generation pod: %s", d.podName)
+	d.podName = "" // Reset the podName after cleanup
+	return "", nil
+}

--- a/pkg/eventgenerator/http/generator.go
+++ b/pkg/eventgenerator/http/generator.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+type Generator struct {
+	clientset *kubernetes.Clientset
+	config    *rest.Config
+	logger    logger.Logger
+	namespace string
+	podName   string
+}
+
+func NewGenerator(config *rest.Config, log logger.Logger) (*Generator, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+	return &Generator{
+		clientset: clientset,
+		config:    config,
+		logger:    log,
+		namespace: "default",
+		podName:   fmt.Sprintf("http-eventgen-pod-%d", time.Now().Unix()),
+	}, nil
+}
+
+func (h *Generator) Generate(params map[string]string, count int, interval time.Duration) error {
+	pods, err := h.clientset.CoreV1().Pods(h.namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing pods: %w", err)
+	}
+
+	// Check for any pod with the dns-eventgen-pod prefix
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, "http-eventgen-pod-") {
+			return fmt.Errorf("HTTP event generator is already running with pod %s, please stop it first", pod.Name)
+		}
+	}
+
+	url, ok := params["url"]
+	if !ok {
+		return fmt.Errorf("url parameter is required for HTTP event generator")
+	}
+	sleepCount := fmt.Sprintf("%.0fs", interval.Seconds())
+	command := fmt.Sprintf("i=1; while [ $i -le %d ] || [ %d -eq -1 ]; do curl -s -o /dev/null -w '%%{http_code}\\n' -L %s; i=$((i+1)); sleep %v; done", count, count, url, sleepCount)
+
+	container := corev1.Container{
+		Name:    "http-eventgen-container",
+		Image:   "alpine/curl",
+		Command: []string{"sh", "-c", command},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: h.podName},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers:    []corev1.Container{container},
+		},
+	}
+
+	_, err = h.clientset.CoreV1().Pods(h.namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating pod: %w", err)
+	}
+
+	h.logger.Debugf("Created HTTP event generation pod: %s", h.podName)
+	return nil
+}
+
+func (h *Generator) Cleanup() (string, error) {
+	if h.podName == "" {
+		return "", fmt.Errorf("pod %s is not found in %s namespace", h.podName, h.namespace)
+	}
+	err := h.clientset.CoreV1().Pods(h.namespace).Delete(context.Background(), h.podName, metav1.DeleteOptions{})
+	if err != nil {
+		return "", fmt.Errorf("deleting pod %s: %w", h.podName, err)
+	}
+	h.logger.Debugf("Deleted HTTP event generation pod: %s", h.podName)
+	h.podName = "" // Reset the podName after cleanup
+	return "", nil
+}

--- a/pkg/eventgenerator/types.go
+++ b/pkg/eventgenerator/types.go
@@ -1,0 +1,52 @@
+package eventgenerator
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/eventgenerator/dns"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/eventgenerator/http"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+// Generator defines the interface for event generators
+type Generator interface {
+	Generate(params map[string]string, count int, interval time.Duration) error
+	Cleanup() (string, error)
+}
+
+const (
+	InfiniteCount = -1
+)
+
+// NewGenerator creates a new event generator based on the type
+func NewGenerator(eventType string, log logger.Logger) (Generator, error) {
+	config, err := getKubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("getting Kubernetes config: %w", err)
+	}
+
+	switch eventType {
+	case "dns":
+		return dns.NewGenerator(config, log)
+	case "http":
+		return http.NewGenerator(config, log)
+	default:
+		return nil, fmt.Errorf("unknown generator type: %s", eventType)
+	}
+}
+
+// k8sutils can't be used here because utils.KubernetesConfigFlags is only available when using kubectl-gadget.
+// To make ig talk to API server we also need to expose Kubernetes flags.
+func getKubeConfig() (*rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, nil
+	}
+
+	kubeconfig := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}

--- a/pkg/operators/eventgen/operator.go
+++ b/pkg/operators/eventgen/operator.go
@@ -1,0 +1,131 @@
+package eventgen
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/eventgenerator"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+type eventGenOperator struct{}
+
+func (e eventGenOperator) Name() string {
+	return name
+}
+
+func (e eventGenOperator) Init(params *params.Params) error {
+	return nil
+}
+
+func (e eventGenOperator) GlobalParams() api.Params {
+	return getGlobalParams()
+}
+
+func (e eventGenOperator) InstanceParams() api.Params {
+	return getInstanceParams()
+}
+
+func (e eventGenOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	enable, exists := instanceParamValues[ParamEventGenEnable]
+	eventType, _ := instanceParamValues[ParamEventGenType]
+	paramsStr, _ := instanceParamValues[ParamEventGenParams]
+	countVal, _ := instanceParamValues[ParamEventGenCount]
+	intervalVal, _ := instanceParamValues[ParamEventGenInterval]
+
+	// If enable parameter doesn't exist, return disabled instance without logging
+	if !exists || enable != "true" {
+		return &eventGenOperatorInstance{enable: false}, nil
+	}
+
+	if eventType == "" {
+		return nil, fmt.Errorf("eventgen-type not specified")
+	}
+
+	// Parse count
+	count := eventgenerator.InfiniteCount
+	if countVal != "" {
+		parsedCount, err := strconv.Atoi(countVal)
+		if err != nil {
+			count = eventgenerator.InfiniteCount
+		} else {
+			count = parsedCount
+		}
+	}
+
+	// Parse interval
+	interval := time.Second
+	if intervalVal != "" {
+		parsedInterval, err := time.ParseDuration(intervalVal)
+		if err != nil {
+			return nil, fmt.Errorf("invalid interval format: %w", err)
+		}
+		interval = parsedInterval
+	}
+
+	return &eventGenOperatorInstance{
+		enable:    true,
+		eventType: eventType,
+		params:    ParseParams(paramsStr),
+		count:     count,
+		interval:  interval,
+	}, nil
+}
+
+func (e eventGenOperator) Priority() int {
+	return 0
+}
+
+type eventGenOperatorInstance struct {
+	enable    bool
+	eventType string
+	params    map[string]string
+	count     int
+	interval  time.Duration
+	generator eventgenerator.Generator
+}
+
+func (e *eventGenOperatorInstance) Name() string {
+	return name
+}
+
+func (e *eventGenOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	if !e.enable {
+		if e.eventType != "" {
+			gadgetCtx.Logger().Info("Eventgen not enabled, skipping")
+		}
+		return nil
+	}
+
+	gadgetCtx.Logger().Debugf("Starting EventGen with type: %s, params: %v", e.eventType, e.params)
+
+	var err error
+	e.generator, err = eventgenerator.NewGenerator(e.eventType, gadgetCtx.Logger())
+	if err != nil {
+		return fmt.Errorf("creating generator: %w", err)
+	}
+
+	err = e.generator.Generate(e.params, e.count, e.interval)
+	if err != nil {
+		return fmt.Errorf("generating event: %w", err)
+	}
+
+	gadgetCtx.Logger().Debugf("Generated %s event successfully", e.eventType)
+	return nil
+}
+
+func (e *eventGenOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	if e.generator != nil {
+		_, err := e.generator.Cleanup()
+		if err != nil {
+			return fmt.Errorf("cleaning up event pod: %w", err)
+		}
+	}
+	return nil
+}
+
+// EventGen is used to expose the eventgen operator
+var EventGen = &eventGenOperator{}

--- a/pkg/operators/eventgen/params.go
+++ b/pkg/operators/eventgen/params.go
@@ -1,0 +1,78 @@
+package eventgen
+
+import (
+	"strings"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+const (
+	name                  = "eventgen"
+	ParamEventGenEnable   = "eventgen-enable"
+	ParamEventGenType     = "eventgen-type"
+	ParamEventGenParams   = "eventgen-params"
+	ParamEventGenCount    = "eventgen-count"
+	ParamEventGenInterval = "eventgen-interval"
+)
+
+const (
+	EventTypeDNS  = "dns"
+	EventTypeHTTP = "http"
+)
+
+// ParseParams converts a comma-separated key-value string into a map
+func ParseParams(paramStr string) map[string]string {
+	params := make(map[string]string)
+	if paramStr == "" {
+		return params
+	}
+
+	pairs := strings.Split(paramStr, ",")
+	for _, pair := range pairs {
+		kv := strings.Split(pair, ":")
+		if len(kv) == 2 {
+			params[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}
+	}
+	return params
+}
+
+// getGlobalParams returns the operator's global parameters
+func getGlobalParams() api.Params {
+	return api.Params{}
+}
+
+// getInstanceParams returns the operator's instance parameters
+func getInstanceParams() api.Params {
+	return api.Params{
+		// TODO:: put --eventgen-enable parameter in global parameters section
+		&api.Param{
+			Key:         ParamEventGenEnable,
+			Description: "Enable event generation",
+			TypeHint:    "bool",
+		},
+		&api.Param{
+			Key:            ParamEventGenType,
+			Description:    "Type of event to generate",
+			TypeHint:       api.TypeString,
+			PossibleValues: []string{EventTypeDNS, EventTypeHTTP},
+		},
+		&api.Param{
+			Key:         ParamEventGenParams,
+			Description: "Comma-separated list of param:value pairs to pass to the event generator, e.g. eventgen-params=domain:example.com,port:80",
+			TypeHint:    api.TypeString,
+		},
+		&api.Param{
+			Key:          ParamEventGenCount,
+			Description:  "Number of events to generate (use -1 for unlimited)",
+			TypeHint:     api.TypeInt,
+			DefaultValue: "-1",
+		},
+		&api.Param{
+			Key:          ParamEventGenInterval,
+			Description:  "Interval between events in seconds",
+			TypeHint:     api.TypeString,
+			DefaultValue: "1s",
+		},
+	}
+}


### PR DESCRIPTION
# Eventgen k8s implementation
dns and http event generator. Creates pod and container using kubernetes and generate events from that pod when running gadget and delete pod after done. 
`sudo ./ig run trace_dns --filter name==example.com. --eventgen-enable=true --eventgen-params=type:dns,target:example.com,count:5,interval:2s`
## How to use
`$ make ig`
`$ sudo ./ig run trace_dns --filter name==example.com. --eventgen-enable=true --eventgen-params=type:dns,target:example.com,count:5,interval:2s`
