### PR TITLE
pkg/operators/otel-metrics: Add test for print and export features

### DIFF
--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -17,6 +17,7 @@ package otelmetrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -78,6 +79,7 @@ var renderedDsCliAnnotations = map[string]string{
 
 type otelMetricsOperator struct {
 	// exporter is the global exporter instance
+	server        *http.Server
 	exporter      *otelprometheus.Exporter
 	meterProvider metric.MeterProvider
 
@@ -95,6 +97,8 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 		return nil
 	}
 
+	// TODO: Validate the listen address to immediately return an error
+
 	// create a global prometheus collector/exporter; this will be exposed using an HTTP endpoint, if activated
 	exporter, err := otelprometheus.New()
 	if err != nil {
@@ -108,14 +112,35 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 		go func() {
 			mux := http.NewServeMux()
 			mux.Handle("/metrics", promhttp.Handler())
-			err := http.ListenAndServe(globalParams.Get(ParamOtelMetricsListenAddress).AsString(), mux)
-			if err != nil {
+
+			m.server = &http.Server{
+				Addr:    globalParams.Get(ParamOtelMetricsListenAddress).AsString(),
+				Handler: mux,
+			}
+
+			// ErrServerClosed on graceful close
+			err := m.server.ListenAndServe()
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				log.Errorf("serving otel metrics on: %s", err)
+				m.server = nil
 				return
 			}
 		}()
 	}
 	return nil
+}
+
+func (m *otelMetricsOperator) Close() {
+	if m.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := m.server.Shutdown(ctx); err != nil {
+			log.Errorf("shutting down otel metrics server: %s", err)
+		}
+	}
+	if m.exporter != nil {
+		m.exporter.Shutdown(context.Background())
+	}
 }
 
 func (m *otelMetricsOperator) GlobalParams() api.Params {


### PR DESCRIPTION
# Add test for print and export features of Otel Metrics operator

```
TestMetricsParamsAndAnnotations tests the following features:
  - Print: This feature is requested by setting the AnnotationMetricsPrint
    annotation to true. When requested, the tests verify the operator
    creates and disable data sources as expected, and emits (or not) some data.
  - Export: This feature is requested by setting the AnnotationMetricsPrint
    annotation to true and the ParamOtelMetricsListen global parameter to
    true. When requested, the tests verify the operator exports some data.

The tests consider the following parameters/annotations/conditions:
  - AnnotationMetricsPrint ds annotation (Print/NoPrint)
  - AnnotationMetricsCollect ds annotation (Collect/NoCollect)
  - ParamOtelMetricsListen global param (Export/NoExport)
  - Where the operator is running gadgetcontext.WithAsRemoteCall(ClientSide/ServerSide)

And, a few special cases:
  - AnnotationMetricsType=MetricsTypeGauge field annotation (WithoutMetricsTypeHistogram)
  - ParamOtelMetricsName instance param (WithoutMetricsName)

Note these tests don't focus on the correctness of the data emitted or
exported, but on the operator's behaviour. For the correctness of the data
emitted or exported, see the other tests TestMetricsCounterAndGauge and
TestMetricsHistogram.
```

## Test design

![image](https://github.com/user-attachments/assets/1d514a99-9352-4d80-8219-58856644bdfa)

## How to use

```bash
go test -run TestMetricsParamsAndAnnotations github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics
```