### PR TITLE
operators/formatters: Hide endpoint subfield proto

### DIFF
--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -403,7 +403,7 @@ var replacers = []replacer{
 					return nil, fmt.Errorf("proto size expected to be 2 bytes")
 				}
 				protoFieldName = strings.TrimSuffix(protos[0].Name(), "_raw")
-				protoField, err = in.AddSubField(protoFieldName, api.Kind_String)
+				protoField, err = in.AddSubField(protoFieldName, api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Fixes: d5e0f1198bd74c9ef66dea1c53a84ea94b40cecc

### before

```
→ ./kubectl-gadget run trace_dns -n demo 
K8S.NODE           K8S.NAMESPACE      K8S.PODNAME        K8S.CONTAINERNAME  SRC                    DST                    COMM            PID QR QTYPE     NAME              RCODE    ADDRESSES SRC.PROTO DST.PROTO
minikube-docker    demo               mypod              mypod              10.244.0.12:47222      10.96.0.10:53          isc-net-…    630277 Q  A         google.com.                          UDP       UDP      
minikube-docker    demo               mypod              mypod              10.96.0.10:53          10.244.0.12:47222      isc-net-…    630277 R  A         google.com.       Success  142.250.… UDP       UDP  
```

### after

```
→ ./kubectl-gadget run trace_dns -n demo 
K8S.NODE             K8S.NAMESPACE        K8S.PODNAME          K8S.CONTAINERNAME    SRC                       DST                       COMM              PID QR QTYPE      NAME                RCODE    ADDRESSES 
minikube-docker      demo                 mypod                mypod                10.244.0.12:33520         10.96.0.10:53             isc-net-0…     670506 Q  A          google.com.                            
minikube-docker      demo                 mypod                mypod                10.96.0.10:53             10.244.0.12:33520         isc-net-0…     670506 R  A          google.com.         Success  172.217.1…

```
