### PR TITLE
gadgets: Automatically add annotations based on the field types

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -313,6 +313,20 @@ struct event {
 
 - `uidgidresolver.target`: Name of the new field. If the annotation is not set and the source field name has a `_raw` suffix, the target name will be set to the source name without that suffix.
 
+### Automatic Annotations
+
+In addition to the enrichment described above, using `gadget_` types will
+automatically add annotations to those fields using the templates described in
+[metadata](metadata.md#field)
+
+This is also available for the following types:
+
+- `gadget_pid`: Process PID
+- `gadget_tid`: Process Thread ID
+- `gadget_ppid`: Parent process PID
+- `gadget_comm`: Process name
+- `gadget_pcomm`: Parent process name
+
 ### Enumerations
 
 Inspektor Gadget supports enums already defined on the kernel or enums defined

--- a/gadgets/audit_seccomp/gadget.yaml
+++ b/gadgets/audit_seccomp/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   seccomp:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       syscall_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/audit_seccomp/program.bpf.c
+++ b/gadgets/audit_seccomp/program.bpf.c
@@ -29,12 +29,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	gadget_syscall syscall_raw;
 	enum code code_raw;

--- a/gadgets/deadlock/gadget.yaml
+++ b/gadgets/deadlock/gadget.yaml
@@ -7,14 +7,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   deadlock:
     fields:
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       mutex_addr:
         annotations:
           columns.hex: "true"
@@ -24,19 +16,5 @@ datasources:
         annotations:
           description: mutex operation type
       operation_raw:
-        annotations:
-          columns.hidden: "true"
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      timestamp:
-        annotations:
-          template: timestamp
-      timestamp_raw:
         annotations:
           columns.hidden: "true"

--- a/gadgets/deadlock/program.bpf.c
+++ b/gadgets/deadlock/program.bpf.c
@@ -15,9 +15,9 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
-	__u32 pid;
-	__u32 tid;
+	gadget_comm comm[TASK_COMM_LEN];
+	gadget_pid pid;
+	gadget_tid tid;
 
 	__u64 mutex_addr;
 

--- a/gadgets/fsnotify/gadget.yaml
+++ b/gadgets/fsnotify/gadget.yaml
@@ -70,43 +70,31 @@ datasources:
           description: 'fsnotify group priorities. Events are send in order from highest
             priority to lowest priority. 0: default, normal notifiers, no permissions.
             1: fanotify content based access control. 2: fanotify pre-content access.'
-      timestamp:
-        annotations:
-          template: timestamp
-      timestamp_raw:
-        annotations:
-          columns.hidden: "true"
       tracee:
         annotations:
           columns.hidden: "true"
       tracee.comm:
         annotations:
           description: Tracee process name
-          template: comm
       tracee.pcomm:
         annotations:
           columns.hidden: "true"
           description: Tracee parent process name
-          template: pcomm
       tracee.pid:
         annotations:
           description: Tracee process ID
-          template: pid
       tracee.ppid:
         annotations:
           columns.hidden: "true"
           description: Tracee parent process ID
-          template: pid
       tracee.tid:
         annotations:
           columns.hidden: "true"
           description: Tracee thread ID
-          template: pid
       tracee_gid_raw:
         annotations:
           columns.hidden: "true"
           description: Tracee group ID
-          template: uid
           uidgidresolver.target: tracee_group
       tracee_group:
         annotations:
@@ -116,12 +104,10 @@ datasources:
         annotations:
           columns.hidden: "true"
           description: Tracee mount namespace inode id
-          template: ns
       tracee_uid_raw:
         annotations:
           columns.hidden: "true"
           description: Tracee user ID
-          template: uid
           uidgidresolver.target: tracee_user
       tracee_user:
         annotations:
@@ -133,31 +119,25 @@ datasources:
       tracer.comm:
         annotations:
           description: Tracer process name
-          template: comm
       tracer.pcomm:
         annotations:
           columns.hidden: "true"
           description: Tracer parent process name
-          template: pcomm
       tracer.pid:
         annotations:
           description: Tracer process ID
-          template: pid
       tracer.ppid:
         annotations:
           columns.hidden: "true"
           description: Tracer parent process ID
-          template: pid
       tracer.tid:
         annotations:
           columns.hidden: "true"
           description: Tracer thread ID
-          template: pid
       tracer_gid_raw:
         annotations:
           columns.hidden: "true"
           description: Tracer group ID
-          template: uid
           uidgidresolver.target: tracer_group
       tracer_group:
         annotations:
@@ -167,12 +147,10 @@ datasources:
         annotations:
           columns.hidden: "true"
           description: Tracer mount namespace inode id
-          template: ns
       tracer_uid_raw:
         annotations:
           columns.hidden: "true"
           description: Tracer user ID
-          template: uid
           uidgidresolver.target: tracer_user
       tracer_user:
         annotations:

--- a/gadgets/snapshot_process/gadget.yaml
+++ b/gadgets/snapshot_process/gadget.yaml
@@ -6,34 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   processes:
     fields:
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      ppid:
-        annotations:
-          description: Parent process ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
 params:
   ebpf:
     show_threads:

--- a/gadgets/snapshot_process/program.bpf.c
+++ b/gadgets/snapshot_process/program.bpf.c
@@ -22,14 +22,14 @@ GADGET_PARAM(show_threads);
 struct process_entry {
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
-	__u32 ppid;
+	gadget_ppid ppid;
 };
 
 GADGET_SNAPSHOTTER(processes, process_entry, ig_snap_proc);

--- a/gadgets/top_blockio/gadget.yaml
+++ b/gadgets/top_blockio/gadget.yaml
@@ -20,23 +20,6 @@ datasources:
       minor:
         annotations:
           description: Minor device number
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Command name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-          columns.hidden: true
       rw_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/top_blockio/program.bpf.c
+++ b/gadgets/top_blockio/program.bpf.c
@@ -15,8 +15,6 @@
 #define REQ_OP_BITS 8
 #define REQ_OP_MASK ((1 << REQ_OP_BITS) - 1)
 
-#define TASK_COMM_LEN 16
-
 enum rw_type : u8 {
 	read,
 	write,
@@ -31,9 +29,9 @@ struct start_req_t {
 // for saving process info by request
 struct who_t {
 	gadget_mntns_id mntns_id;
-	__u32 pid;
-	__u32 tid;
-	char comm[TASK_COMM_LEN];
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_comm comm[TASK_COMM_LEN];
 };
 
 struct {
@@ -53,12 +51,12 @@ struct {
 // the key for the output summary
 struct info_t {
 	gadget_mntns_id mntns_id;
-	__u32 pid;
-	__u32 tid;
+	gadget_pid pid;
+	gadget_tid tid;
 	enum rw_type rw_raw;
 	int major;
 	int minor;
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 };
 
 // the value of the output summary

--- a/gadgets/top_file/gadget.yaml
+++ b/gadgets/top_file/gadget.yaml
@@ -8,29 +8,6 @@ datasources:
     annotations:
       cli.clear-screen-before: "true"
     fields:
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-          columns.hidden: true
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
-      comm:
-        annotations:
-          description: Command name
-          template: comm
       reads:
         annotations:
           description: Reads by file
@@ -79,10 +56,6 @@ datasources:
           columns.hidden: true
           columns.width: 12
           columns.alignment: right
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
 params:
   ebpf:
     all_files:

--- a/gadgets/top_file/program.bpf.c
+++ b/gadgets/top_file/program.bpf.c
@@ -15,7 +15,6 @@
 #include "stat.h"
 
 #define PATH_MAX 4096
-#define TASK_COMM_LEN 16
 
 enum op {
 	READ,
@@ -31,20 +30,20 @@ enum type {
 struct file_id {
 	__u64 inode;
 	__u32 dev;
-	__u32 pid;
-	__u32 tid;
+	gadget_pid pid;
+	gadget_tid tid;
 };
 
 struct file_stat {
 	gadget_mntns_id mntns_id;
-	__u32 uid;
-	__u32 gid;
+	gadget_uid uid;
+	gadget_gid gid;
 	__u64 reads;
 	__u64 rbytes;
 	__u64 writes;
 	__u64 wbytes;
 	char file[PATH_MAX];
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	enum type t_raw;
 };
 

--- a/gadgets/top_tcp/gadget.yaml
+++ b/gadgets/top_tcp/gadget.yaml
@@ -8,23 +8,6 @@ datasources:
     annotations:
       cli.clear-screen-before: "true"
     fields:
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-          columns.hidden: true
       received:
         annotations:
           description: Received bytes

--- a/gadgets/top_tcp/program.bpf.c
+++ b/gadgets/top_tcp/program.bpf.c
@@ -19,16 +19,14 @@ GADGET_PARAM(target_pid);
 const volatile int target_family = -1;
 GADGET_PARAM(target_family);
 
-#define TASK_COMM_LEN 16
-
 struct ip_key_t {
 	gadget_mntns_id mntns_id;
-	__u32 pid;
-	__u32 tid;
+	gadget_pid pid;
+	gadget_tid tid;
 
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 };
 
 struct traffic_t {

--- a/gadgets/trace_bind/gadget.yaml
+++ b/gadgets/trace_bind/gadget.yaml
@@ -6,40 +6,10 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   bind:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       addr:
         annotations:
           description: Address the socket is bound to
           columns.width: 32
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       error_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_bind/program.bpf.c
+++ b/gadgets/trace_bind/program.bpf.c
@@ -37,12 +37,12 @@ struct event {
 	gadget_mntns_id mntns_id;
 	struct gadget_l4endpoint_t addr;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	gadget_errno error_raw;
 	enum bind_options_set opts_raw;

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   capabilities:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       current_userns:
         annotations:
           template: ns

--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -20,8 +20,6 @@
 #define CAP_OPT_NOAUDIT (1UL << 1)
 #define CAP_OPT_INSETID (1UL << 2)
 
-#define TASK_COMM_LEN 16
-
 #define FOR_EACH_CAPABILITY(F)  \
 	F(CAP_CHOWN)            \
 	F(CAP_DAC_OVERRIDE)     \
@@ -79,12 +77,12 @@ struct cap_event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u64 current_userns;
 	__u64 target_userns;

--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -9,10 +9,6 @@ datasources:
       anaddr:
         annotations:
           columns.width: "16"
-      comm:
-        annotations:
-          description: Process name
-          template: comm
       data:
         annotations:
           columns.hidden: "true"
@@ -29,11 +25,6 @@ datasources:
         annotations:
           description: Destination endpoint
           template: l4endpoint
-      gid:
-        annotations:
-          columns.hidden: "true"
-          description: Group ID
-          template: uid
       id:
         annotations:
           columns.hidden: "true"
@@ -42,29 +33,13 @@ datasources:
           columns.hidden: "true"
           columns.width: "8"
           description: DNS request latency
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       name:
         annotations:
           columns.width: "30"
-      netns_id:
-        annotations:
-          description: Network namespace inode id
-          template: ns
       num_answers:
         annotations:
           columns.hidden: "true"
           description: Number of answers
-      pcomm:
-        annotations:
-          columns.hidden: "true"
-          template: pcomm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
       pkt_type:
         annotations:
           columns.hidden: "true"
@@ -72,11 +47,6 @@ datasources:
       pkt_type_raw:
         annotations:
           columns.hidden: "true"
-      ppid:
-        annotations:
-          columns.hidden: "true"
-          description: Parent process ID
-          template: pid
       qr:
         annotations:
           columns.minwidth: "2"
@@ -101,19 +71,3 @@ datasources:
         annotations:
           description: Source endpoint
           template: l4endpoint
-      tid:
-        annotations:
-          columns.hidden: "true"
-          description: Thread ID
-          template: pid
-      timestamp:
-        annotations:
-          template: timestamp
-      timestamp_raw:
-        annotations:
-          columns.hidden: "true"
-      uid:
-        annotations:
-          columns.hidden: "true"
-          description: User ID
-          template: uid

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -70,8 +70,6 @@ enum pkt_type_t : __u8 {
 // Or can we remove this altogether?
 #define MAX_PACKET (1024 * 9) // 9KB
 
-#define TASK_COMM_LEN 16
-
 struct event_t {
 	gadget_timestamp timestamp_raw;
 
@@ -81,14 +79,14 @@ struct event_t {
 	gadget_mntns_id mntns_id;
 	gadget_netns_id netns_id;
 
-	char comm[TASK_COMM_LEN];
-	char pcomm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
+	gadget_pcomm pcomm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 ppid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_ppid ppid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum pkt_type_t pkt_type_raw;
 	__u64 latency_ns; // Set only if the packet is a response and pkt_type is 0 (Host).
@@ -114,14 +112,14 @@ struct event_header_t {
 	gadget_mntns_id mntns_id;
 	gadget_netns_id netns_id;
 
-	char comm[TASK_COMM_LEN];
-	char pcomm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
+	gadget_pcomm pcomm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 ppid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_ppid ppid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum pkt_type_t pkt_type_raw;
 	__u64 latency_ns; // Set only if the packet is a response and pkt_type is 0 (Host).

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -6,52 +6,12 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   exec:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
       cwd:
         annotations:
           description: The current working directory of the process (require --paths flag)
           columns.width: 64
           columns.hidden: "true"
           columns.alignment: left
-      pcomm:
-        annotations:
-          template: pcomm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-          uidgidresolver.target: user
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
-          uidgidresolver.target: group
-      ppid:
-        annotations:
-          template: pid
       loginuid:
         annotations:
           template: uid

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -27,15 +27,15 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
+	gadget_pid pid;
+	gadget_tid tid;
 	gadget_uid uid;
 	gadget_gid gid;
 
-	char pcomm[TASK_COMM_LEN];
-	__u32 ppid;
+	gadget_pcomm pcomm[TASK_COMM_LEN];
+	gadget_ppid ppid;
 	gadget_uid loginuid;
 	__u32 sessionid;
 	gadget_errno error_raw;

--- a/gadgets/trace_fsslower/gadget.yaml
+++ b/gadgets/trace_fsslower/gadget.yaml
@@ -6,38 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   malloc:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
       delta_us:
         annotations:
           description: Time spent by the operation in microseconds

--- a/gadgets/trace_fsslower/program.bpf.c
+++ b/gadgets/trace_fsslower/program.bpf.c
@@ -12,7 +12,6 @@
 #include <gadget/mntns_filter.h>
 
 #define FILE_NAME_LEN 32
-#define TASK_COMM_LEN 16
 
 enum fs_file_op {
 	F_READ,
@@ -27,12 +26,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u64 delta_us; // TODO: use result of https://github.com/inspektor-gadget/inspektor-gadget/issues/3393
 	__s64 offset;
@@ -53,7 +52,7 @@ GADGET_TRACER_MAP(events, 1024 * 256);
 GADGET_TRACER(malloc, events, event);
 
 struct data_key {
-	__u32 tid;
+	gadget_tid tid;
 	/*
 	 * We need to take into account the operation to avoid losing some of
 	 * them.

--- a/gadgets/trace_lsm/gadget.yaml
+++ b/gadgets/trace_lsm/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   lsm:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       tracepoint_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_lsm/program.bpf.c
+++ b/gadgets/trace_lsm/program.bpf.c
@@ -170,12 +170,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum lsm_tracepoint tracepoint_raw;
 };

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   malloc:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       operation_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -30,12 +30,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum memop operation_raw;
 	__u64 addr;

--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -6,38 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   mount:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
       delta:
         annotations:
           columns.width: 8

--- a/gadgets/trace_mount/program.bpf.c
+++ b/gadgets/trace_mount/program.bpf.c
@@ -9,7 +9,6 @@
 #include <gadget/types.h>
 
 #define MAX_ENTRIES 10240
-#define TASK_COMM_LEN 16
 #define FS_NAME_LEN 8
 #define DATA_LEN 512
 #define PATH_MAX 4096
@@ -68,12 +67,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u64 delta;
 	enum flags_set flags_raw;

--- a/gadgets/trace_oomkill/gadget.yaml
+++ b/gadgets/trace_oomkill/gadget.yaml
@@ -6,12 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   events:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
       fpid:
         annotations:
           template: pid
@@ -28,10 +22,6 @@ datasources:
         annotations:
           columns.width: 8
           columns.alignment: right
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
       fcomm:
         annotations:
           template: comm

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   open:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       flags_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -25,12 +25,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	gadget_errno error_raw;
 	__u32 fd;

--- a/gadgets/trace_signal/gadget.yaml
+++ b/gadgets/trace_signal/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   signal:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       tpid:
         annotations:
           description: Target process ID

--- a/gadgets/trace_signal/program.bpf.c
+++ b/gadgets/trace_signal/program.bpf.c
@@ -18,12 +18,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u32 tpid;
 
@@ -170,7 +170,7 @@ int ig_sig_generate(struct trace_event_raw_signal_generate *ctx)
 	int ret = ctx->errno;
 	int sig = ctx->sig;
 	__u64 pid_tgid;
-	__u32 pid;
+	gadget_pid pid;
 	u64 mntns_id;
 	__u64 uid_gid = bpf_get_current_uid_gid();
 

--- a/gadgets/trace_sni/gadget.yaml
+++ b/gadgets/trace_sni/gadget.yaml
@@ -6,40 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   sni:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      netns_id:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       name:
         annotations:
           columns.width: 30

--- a/gadgets/trace_sni/program.bpf.c
+++ b/gadgets/trace_sni/program.bpf.c
@@ -53,19 +53,17 @@
 // The offset of the session ID length field from the start of the TLS payload.
 #define TLS_SESSION_ID_LENGTH_OFF 43
 
-#define TASK_COMM_LEN 16
-
 struct event_t {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 	gadget_netns_id netns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	char name[TLS_MAX_SERVER_NAME_LEN];
 };

--- a/gadgets/trace_ssl/gadget.yaml
+++ b/gadgets/trace_ssl/gadget.yaml
@@ -7,39 +7,9 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   ssl:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
       latency_ns:
         annotations:
           columns.width: 10
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       len:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_ssl/program.bpf.c
+++ b/gadgets/trace_ssl/program.bpf.c
@@ -49,12 +49,12 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	gadget_mntns_id mntns_id;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum operation operation_raw;
 	u64 latency_ns;

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -6,40 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   tracetcp:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      netns_id:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       src:
         annotations:
           template: l4endpoint

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -17,8 +17,6 @@
 /* The maximum number of items in maps */
 #define MAX_ENTRIES 8192
 
-#define TASK_COMM_LEN 16
-
 enum event_type : u8 {
 	connect,
 	accept,
@@ -33,12 +31,12 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum event_type type_raw;
 };
@@ -69,7 +67,7 @@ struct tuple_key_t {
 
 struct pid_comm_t {
 	u64 pid_tgid;
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	u64 mntns_id;
 	u64 uid_gid;
 };

--- a/gadgets/trace_tcpconnect/gadget.yaml
+++ b/gadgets/trace_tcpconnect/gadget.yaml
@@ -6,36 +6,6 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   tcpconnect:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
       src:
         annotations:
           template: l4endpoint

--- a/gadgets/trace_tcpconnect/program.bpf.c
+++ b/gadgets/trace_tcpconnect/program.bpf.c
@@ -40,12 +40,12 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u64 latency;
 	gadget_errno error_raw;
@@ -74,7 +74,7 @@ struct {
 } sockets_per_process SEC(".maps");
 
 struct piddata {
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	u64 ts;
 	u32 pid;
 	u32 tid;

--- a/gadgets/trace_tcpdrop/gadget.yaml
+++ b/gadgets/trace_tcpdrop/gadget.yaml
@@ -6,51 +6,12 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   tcpdrop:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
       src:
         annotations:
           template: l4endpoint
       dst:
         annotations:
           template: l4endpoint
-      netns_id:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
-      task:
-        annotations:
-          template: comm
       tcpflags_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_tcpdrop/program.bpf.c
+++ b/gadgets/trace_tcpdrop/program.bpf.c
@@ -23,8 +23,6 @@
 #define GADGET_TYPE_TRACING
 #include <gadget/sockets-map.h>
 
-#define TASK_COMM_LEN 16
-
 // This enum is the same as the one in vmlinux.h, but redefined so that it can provide a name
 // to be used for `state` in struct event. This way we get a readable value for column `state`.
 enum tcp_state {
@@ -66,12 +64,12 @@ struct event {
 	// socket context for now. Once sub-structures in the `event` are supported, convert the
 	// next fields to a struct.
 	gadget_mntns_id mount_ns_id;
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	enum tcp_state state_raw;
 	enum tcp_flags_set tcpflags_raw;

--- a/gadgets/trace_tcpretrans/gadget.yaml
+++ b/gadgets/trace_tcpretrans/gadget.yaml
@@ -6,51 +6,12 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   tcpretrans:
     fields:
-      timestamp_raw:
-        annotations:
-          columns.hidden: true
-      timestamp:
-        annotations:
-          template: timestamp
       src:
         annotations:
           template: l4endpoint
       dst:
         annotations:
           template: l4endpoint
-      netns_id:
-        annotations:
-          description: Network namespace inode id
-          template: ns
-      mntns_id:
-        annotations:
-          description: Mount namespace inode id
-          template: ns
-      comm:
-        annotations:
-          description: Process name
-          template: comm
-      pid:
-        annotations:
-          description: Process ID
-          template: pid
-      tid:
-        annotations:
-          description: Thread ID
-          template: pid
-      uid:
-        annotations:
-          description: User ID
-          template: uid
-          columns.hidden: true
-      gid:
-        annotations:
-          description: Group ID
-          template: uid
-          columns.hidden: true
-      task:
-        annotations:
-          template: comm
       tcpflags_raw:
         annotations:
           columns.hidden: true

--- a/gadgets/trace_tcpretrans/program.bpf.c
+++ b/gadgets/trace_tcpretrans/program.bpf.c
@@ -24,8 +24,6 @@
 #define GADGET_TYPE_TRACING
 #include <gadget/sockets-map.h>
 
-#define TASK_COMM_LEN 16
-
 enum type {
 	RETRANS,
 	LOSS,
@@ -50,12 +48,12 @@ struct event {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
 
-	char comm[TASK_COMM_LEN];
+	gadget_comm comm[TASK_COMM_LEN];
 	// user-space terminology for pid and tid
-	__u32 pid;
-	__u32 tid;
-	__u32 uid;
-	__u32 gid;
+	gadget_pid pid;
+	gadget_tid tid;
+	gadget_uid uid;
+	gadget_gid gid;
 
 	__u8 state;
 	enum tcp_flags_set tcpflags_raw;

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -59,6 +59,16 @@ typedef __u64 gadget_syscall;
 
 typedef __u32 gadget_kernel_stack;
 
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+typedef __u32 gadget_pid;
+typedef __u32 gadget_ppid;
+typedef __u32 gadget_tid;
+typedef char gadget_comm;
+typedef char gadget_pcomm;
+
 // typedefs used for metrics
 typedef __u32 gadget_counter__u32;
 typedef __u64 gadget_counter__u64;
@@ -66,5 +76,6 @@ typedef __u32 gadget_gauge__u32;
 typedef __u64 gadget_gauge__u64;
 typedef __u32 gadget_histogram_slot__u32;
 typedef __u64 gadget_histogram_slot__u64;
+
 
 #endif /* __TYPES_H */

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -3,7 +3,7 @@
 #ifndef __TYPES_H
 #define __TYPES_H
 
-// Keep these types aligned with definitions in pkg/gadgets/run/tracer/tracer.go.
+// Keep these types aligned with definitions in pkg/operators/ebpf/types/types.go.
 
 // union defining either an IPv4 or IPv6 address
 union gadget_ip_addr_t {

--- a/pkg/datasource/columns.go
+++ b/pkg/datasource/columns.go
@@ -31,18 +31,6 @@ const (
 	// ColumnsReplaceAnnotation is used to indicate that this field should be
 	// replaced by the one indicated in the annotation when printing it.
 	ColumnsReplaceAnnotation = "columns.replace"
-
-	ColumnsWidthAnnotation     = "columns.width"
-	ColumnsMaxWidthAnnotation  = "columns.maxwidth"
-	ColumnsMinWidthAnnotation  = "columns.minwidth"
-	ColumnsAlignmentAnnotation = "columns.alignment"
-	ColumnsEllipsisAnnotation  = "columns.ellipsis"
-	ColumnsHiddenAnnotation    = "columns.hidden"
-	ColumnsFixedAnnotation     = "columns.fixed"
-	ColumnsHexAnnotation       = "columns.hex"
-
-	DescriptionAnnotation = "description"
-	TemplateAnnotation    = "template"
 )
 
 type DataTuple struct {
@@ -114,7 +102,7 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 		// extract attributes from annotations
 		for k, v := range f.Annotations {
 			switch k {
-			case ColumnsAlignmentAnnotation:
+			case metadatav1.ColumnsAlignmentAnnotation:
 				switch metadatav1.Alignment(v) {
 				case metadatav1.AlignmentLeft:
 					attributes.Alignment = columns.AlignLeft
@@ -123,7 +111,7 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				default:
 					return nil, fmt.Errorf("invalid alignment type for column %q: %s", f.Name, v)
 				}
-			case ColumnsEllipsisAnnotation:
+			case metadatav1.ColumnsEllipsisAnnotation:
 				switch metadatav1.EllipsisType(v) {
 				case metadatav1.EllipsisNone:
 					attributes.EllipsisType = ellipsis.None
@@ -136,29 +124,29 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 				default:
 					return nil, fmt.Errorf("invalid ellipsis type for column %q: %s", f.Name, v)
 				}
-			case ColumnsWidthAnnotation:
+			case metadatav1.ColumnsWidthAnnotation:
 				var err error
 				attributes.Width, err = getWidth(f.ReflectType(), v)
 				if err != nil {
 					return nil, fmt.Errorf("reading width for column %q: %w", f.Name, err)
 				}
-			case ColumnsMinWidthAnnotation:
+			case metadatav1.ColumnsMinWidthAnnotation:
 				var err error
 				attributes.MinWidth, err = getWidth(f.ReflectType(), v)
 				if err != nil {
 					return nil, fmt.Errorf("reading minWidth for column %q: %w", f.Name, err)
 				}
-			case ColumnsMaxWidthAnnotation:
+			case metadatav1.ColumnsMaxWidthAnnotation:
 				var err error
 				attributes.MaxWidth, err = getWidth(f.ReflectType(), v)
 				if err != nil {
 					return nil, fmt.Errorf("reading maxWidth for column %q: %w", f.Name, err)
 				}
-			case ColumnsFixedAnnotation:
+			case metadatav1.ColumnsFixedAnnotation:
 				if v == "true" {
 					attributes.FixedWidth = true
 				}
-			case ColumnsHexAnnotation:
+			case metadatav1.ColumnsHexAnnotation:
 				if v == "true" {
 					attributes.Hex = true
 				}
@@ -242,78 +230,7 @@ func (ds *dataSource) Columns() (*columns.Columns[DataTuple], error) {
 }
 
 var defaultFieldAnnotations = map[string]string{
-	ColumnsWidthAnnotation:     "16",
-	ColumnsEllipsisAnnotation:  string(metadatav1.EllipsisEnd),
-	ColumnsAlignmentAnnotation: string(metadatav1.AlignmentLeft),
-}
-
-var annotationsTemplates = map[string]map[string]string{
-	"timestamp": {
-		ColumnsWidthAnnotation:    "35",
-		ColumnsMaxWidthAnnotation: "35",
-		ColumnsEllipsisAnnotation: "end",
-		ColumnsHiddenAnnotation:   "true",
-		DescriptionAnnotation:     "Human-readable timestamp",
-	},
-	"node": {
-		ColumnsWidthAnnotation:    "30",
-		ColumnsEllipsisAnnotation: string(metadatav1.EllipsisMiddle),
-	},
-	"pod": {
-		ColumnsWidthAnnotation:    "30",
-		ColumnsEllipsisAnnotation: string(metadatav1.EllipsisMiddle),
-	},
-	"container": {
-		ColumnsWidthAnnotation: "30",
-	},
-	"namespace": {
-		ColumnsWidthAnnotation: "30",
-	},
-	"containerImageName": {
-		ColumnsWidthAnnotation: "30",
-	},
-	"containerImageDigest": {
-		ColumnsWidthAnnotation: "30",
-	},
-	"containerStartedAt": {
-		ColumnsHiddenAnnotation: "true",
-		ColumnsWidthAnnotation:  "35",
-	},
-	"comm": {
-		DescriptionAnnotation:     "Process name",
-		ColumnsMaxWidthAnnotation: "16",
-	},
-	"pcomm": {
-		DescriptionAnnotation:     "The process name of the parent process",
-		ColumnsMaxWidthAnnotation: "16",
-	},
-	"pid": {
-		ColumnsMinWidthAnnotation:  "7",
-		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
-	},
-	"uid": {
-		ColumnsMinWidthAnnotation:  "8",
-		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
-	},
-	"gid": {
-		ColumnsMinWidthAnnotation:  "8",
-		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
-	},
-	"ns": {
-		ColumnsHiddenAnnotation:    "true",
-		ColumnsWidthAnnotation:     "12",
-		ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
-	},
-	"l4endpoint": {
-		ColumnsMinWidthAnnotation: "22",
-		ColumnsWidthAnnotation:    "40",
-		ColumnsMaxWidthAnnotation: "52",
-	},
-	"syscall": {
-		ColumnsWidthAnnotation:    "18",
-		ColumnsMaxWidthAnnotation: "28",
-	},
-	"errorString": {
-		ColumnsWidthAnnotation: "12",
-	},
+	metadatav1.ColumnsWidthAnnotation:     "16",
+	metadatav1.ColumnsEllipsisAnnotation:  string(metadatav1.EllipsisEnd),
+	metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentLeft),
 }

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -20,10 +20,15 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
+
+func init() {
+	datasource.RegisterAnnotationTemplateCallback(metadatav1.ApplyAnnotationsTemplate)
+}
 
 const (
 	MntNsIdType = "type:" + ebpftypes.MntNsTypeName
@@ -140,7 +145,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			datasource.TemplateAnnotation: "node",
+			metadatav1.TemplateAnnotation: "node",
 		}),
 		datasource.WithOrder(-31),
 	)
@@ -152,7 +157,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			datasource.TemplateAnnotation: "namespace",
+			metadatav1.TemplateAnnotation: "namespace",
 		}),
 		datasource.WithOrder(-30),
 	)
@@ -164,7 +169,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			datasource.TemplateAnnotation: "pod",
+			metadatav1.TemplateAnnotation: "pod",
 		}),
 		datasource.WithOrder(-29),
 	)
@@ -176,7 +181,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		api.Kind_String,
 		datasource.WithTags("kubernetes"),
 		datasource.WithAnnotations(map[string]string{
-			datasource.TemplateAnnotation: "container",
+			metadatav1.TemplateAnnotation: "container",
 		}),
 		datasource.WithOrder(-28),
 	)
@@ -231,7 +236,7 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"containerName",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			datasource.TemplateAnnotation: "container",
+			metadatav1.TemplateAnnotation: "container",
 		}),
 		datasource.WithOrder(-26),
 	)
@@ -242,8 +247,8 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"runtimeName",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			datasource.ColumnsWidthAnnotation: "19",
-			datasource.ColumnsFixedAnnotation: "true",
+			metadatav1.ColumnsWidthAnnotation: "19",
+			metadatav1.ColumnsFixedAnnotation: "true",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
 		datasource.WithOrder(-25),
@@ -255,8 +260,8 @@ func WrapAccessors(source datasource.DataSource, mntnsidAccessor datasource.Fiel
 		"containerId",
 		api.Kind_String,
 		datasource.WithAnnotations(map[string]string{
-			datasource.ColumnsWidthAnnotation:    "13",
-			datasource.ColumnsMaxWidthAnnotation: "64",
+			metadatav1.ColumnsWidthAnnotation:    "13",
+			metadatav1.ColumnsMaxWidthAnnotation: "64",
 		}),
 		datasource.WithFlags(datasource.FieldFlagHidden),
 		datasource.WithOrder(-24),

--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -21,13 +21,13 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/environment"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
-// Keep this aligned with include/gadget/types.h
 const (
-	MntNsIdType = "type:gadget_mntns_id"
-	NetNsIdType = "type:gadget_netns_id"
+	MntNsIdType = "type:" + ebpftypes.MntNsTypeName
+	NetNsIdType = "type:" + ebpftypes.NetNsTypeName
 )
 
 type EventWrapperBase struct {

--- a/pkg/datasource/templates.go
+++ b/pkg/datasource/templates.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import "sync"
+
+var (
+	annotationMutex             sync.Mutex
+	annotationTemplateCallbacks []func(string, map[string]string) bool
+)
+
+func init() {
+	annotationTemplateCallbacks = make([]func(string, map[string]string) bool, 0)
+}
+
+func RegisterAnnotationTemplateCallback(cb func(string, map[string]string) bool) {
+	annotationMutex.Lock()
+	defer annotationMutex.Unlock()
+	annotationTemplateCallbacks = append(annotationTemplateCallbacks, cb)
+}
+
+func ApplyAnnotationTemplates(name string, annotations map[string]string) bool {
+	annotationMutex.Lock()
+	defer annotationMutex.Unlock()
+
+	handled := false
+	for _, cb := range annotationTemplateCallbacks {
+		if ok := cb(name, annotations); ok {
+			handled = true
+		}
+	}
+	return handled
+}

--- a/pkg/metadata/v1/annotations.go
+++ b/pkg/metadata/v1/annotations.go
@@ -1,0 +1,128 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadatav1
+
+const (
+	ColumnsWidthAnnotation     = "columns.width"
+	ColumnsMaxWidthAnnotation  = "columns.maxwidth"
+	ColumnsMinWidthAnnotation  = "columns.minwidth"
+	ColumnsAlignmentAnnotation = "columns.alignment"
+	ColumnsEllipsisAnnotation  = "columns.ellipsis"
+	ColumnsHiddenAnnotation    = "columns.hidden"
+	ColumnsFixedAnnotation     = "columns.fixed"
+	ColumnsHexAnnotation       = "columns.hex"
+
+	DescriptionAnnotation = "description"
+	TemplateAnnotation    = "template"
+)
+
+var AnnotationsTemplates = map[string]map[string]string{
+	"node": {
+		ColumnsWidthAnnotation:    "30",
+		ColumnsEllipsisAnnotation: string(EllipsisMiddle),
+	},
+	"pod": {
+		ColumnsWidthAnnotation:    "30",
+		ColumnsEllipsisAnnotation: string(EllipsisMiddle),
+	},
+	"container": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"namespace": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerImageName": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerImageDigest": {
+		ColumnsWidthAnnotation: "30",
+	},
+	"containerStartedAt": {
+		ColumnsHiddenAnnotation: "true",
+		ColumnsWidthAnnotation:  "35",
+	},
+	"comm": {
+		DescriptionAnnotation:     "Process name",
+		ColumnsMaxWidthAnnotation: "16",
+	},
+	"pcomm": {
+		DescriptionAnnotation:     "Parent process name",
+		ColumnsMaxWidthAnnotation: "16",
+		ColumnsHiddenAnnotation:   "true",
+	},
+	"pid": {
+		DescriptionAnnotation:      "Process ID",
+		ColumnsMinWidthAnnotation:  "7",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"ppid": {
+		DescriptionAnnotation:      "Parent Process ID",
+		ColumnsMinWidthAnnotation:  "7",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+		ColumnsHiddenAnnotation:    "true",
+	},
+	"tid": {
+		DescriptionAnnotation:      "Thread ID",
+		ColumnsMinWidthAnnotation:  "7",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"uid": {
+		DescriptionAnnotation:      "User ID",
+		ColumnsMinWidthAnnotation:  "8",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"gid": {
+		DescriptionAnnotation:      "Group ID",
+		ColumnsMinWidthAnnotation:  "8",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"ns": {
+		ColumnsHiddenAnnotation:    "true",
+		ColumnsWidthAnnotation:     "12",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"mntns_id": {
+		DescriptionAnnotation:      "Mount namespace ID",
+		ColumnsHiddenAnnotation:    "true",
+		ColumnsWidthAnnotation:     "12",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"netns_id": {
+		DescriptionAnnotation:      "Network namespace ID",
+		ColumnsHiddenAnnotation:    "true",
+		ColumnsWidthAnnotation:     "12",
+		ColumnsAlignmentAnnotation: string(AlignmentRight),
+	},
+	"l4endpoint": {
+		ColumnsMinWidthAnnotation: "22",
+		ColumnsWidthAnnotation:    "40",
+		ColumnsMaxWidthAnnotation: "52",
+	},
+	"syscall": {
+		ColumnsWidthAnnotation:    "18",
+		ColumnsMaxWidthAnnotation: "28",
+	},
+	"errorString": {
+		ColumnsWidthAnnotation: "12",
+	},
+}
+
+func ApplyAnnotationsTemplate(templateAnn string, dst map[string]string) bool {
+	template, ok := AnnotationsTemplates[templateAnn]
+	for k, v := range template {
+		dst[k] = v
+	}
+	return ok
+}

--- a/pkg/metadata/v1/annotations.go
+++ b/pkg/metadata/v1/annotations.go
@@ -29,6 +29,13 @@ const (
 )
 
 var AnnotationsTemplates = map[string]map[string]string{
+	"timestamp": {
+		ColumnsWidthAnnotation:    "35",
+		ColumnsMaxWidthAnnotation: "35",
+		ColumnsEllipsisAnnotation: "end",
+		ColumnsHiddenAnnotation:   "true",
+		DescriptionAnnotation:     "Microseconds since Unix epoch",
+	},
 	"node": {
 		ColumnsWidthAnnotation:    "30",
 		ColumnsEllipsisAnnotation: string(EllipsisMiddle),
@@ -68,7 +75,7 @@ var AnnotationsTemplates = map[string]map[string]string{
 		ColumnsAlignmentAnnotation: string(AlignmentRight),
 	},
 	"ppid": {
-		DescriptionAnnotation:      "Parent Process ID",
+		DescriptionAnnotation:      "Parent process ID",
 		ColumnsMinWidthAnnotation:  "7",
 		ColumnsAlignmentAnnotation: string(AlignmentRight),
 		ColumnsHiddenAnnotation:    "true",

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/formatters/json"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
@@ -174,7 +175,7 @@ func (o *cliOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api
 		fmt.Fprintf(&sb, "  %q (data source):\n", ds.Name())
 		for _, f := range availableFields {
 			fmt.Fprintf(&sb, "    %s\n", f.FullName)
-			if desc, ok := f.Annotations[datasource.DescriptionAnnotation]; ok {
+			if desc, ok := f.Annotations[metadatav1.DescriptionAnnotation]; ok {
 				fmt.Fprintf(&sb, "      %s\n", desc)
 			}
 		}

--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -25,6 +25,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/kallsyms"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
 )
 
@@ -32,10 +33,6 @@ const (
 	kernelStackTargetNameAnnotation = "ebpf.formatter.kstack"
 	enumTargetNameAnnotation        = "ebpf.formatter.enum"
 	enumBitfieldSeparatorAnnotation = "ebpf.formatter.bitfield.separator"
-)
-
-const (
-	StackIdKernelType = "type:gadget_kernel_stack"
 )
 
 func byteSliceAsUint64(in []byte, signed bool, ds datasource.DataSource) uint64 {
@@ -155,7 +152,7 @@ func (i *ebpfInstance) initEnumFormatter(gadgetCtx operators.GadgetContext) erro
 func (i *ebpfInstance) initStackConverter(gadgetCtx operators.GadgetContext) error {
 	var kernelSymbolResolver *kallsyms.KAllSyms = nil
 	for _, ds := range gadgetCtx.GetDataSources() {
-		for _, in := range ds.GetFieldsWithTag(StackIdKernelType) {
+		for _, in := range ds.GetFieldsWithTag("type:" + ebpftypes.KernelStackTypeName) {
 			if in == nil {
 				continue
 			}

--- a/pkg/operators/ebpf/types/types.go
+++ b/pkg/operators/ebpf/types/types.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// Keep this aligned with include/gadget/types.h
+const (
+	IPAddrTypeName      = "gadget_ip_addr_t"
+	L3EndpointTypeName  = "gadget_l3endpoint_t"
+	L4EndpointTypeName  = "gadget_l4endpoint_t"
+	MntNsTypeName       = "gadget_mntns_id"
+	NetNsTypeName       = "gadget_netns_id"
+	TimestampTypeName   = "gadget_timestamp"
+	SignalTypeName      = "gadget_signal"
+	ErrnoTypeName       = "gadget_errno"
+	UidTypeName         = "gadget_uid"
+	GidTypeName         = "gadget_gid"
+	KernelStackTypeName = "gadget_kernel_stack"
+	SyscallTypeName     = "gadget_syscall"
+
+	// Metrics
+	CounterU32TypeName       = "gadget_counter__u32"
+	CounterU64TypeName       = "gadget_counter__u64"
+	GaugeU32TypeName         = "gadget_gauge__u32"
+	GaugeU64TypeName         = "gadget_gauge__u64"
+	HistogramSlotU32TypeName = "gadget_histogram_slot__u32"
+	HistogramSlotU64TypeName = "gadget_histogram_slot__u64"
+)

--- a/pkg/operators/ebpf/types/types.go
+++ b/pkg/operators/ebpf/types/types.go
@@ -27,6 +27,11 @@ const (
 	UidTypeName         = "gadget_uid"
 	GidTypeName         = "gadget_gid"
 	KernelStackTypeName = "gadget_kernel_stack"
+	PidTypeName         = "gadget_pid"
+	PpidTypeName        = "gadget_ppid"
+	TidTypeName         = "gadget_tid"
+	CommTypeName        = "gadget_comm"
+	PcommTypeName       = "gadget_pcomm"
 	SyscallTypeName     = "gadget_syscall"
 
 	// Metrics

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -28,6 +28,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
@@ -212,7 +213,7 @@ var replacers = []replacer{
 
 			opts := []datasource.FieldOption{
 				datasource.WithAnnotations(map[string]string{
-					datasource.TemplateAnnotation: "errorString",
+					metadatav1.TemplateAnnotation: "errorString",
 				}),
 				datasource.WithSameParentAs(in),
 			}
@@ -291,7 +292,7 @@ var replacers = []replacer{
 
 			opts := []datasource.FieldOption{
 				datasource.WithAnnotations(map[string]string{
-					datasource.TemplateAnnotation: "timestamp",
+					metadatav1.TemplateAnnotation: "timestamp",
 				}),
 				datasource.WithSameParentAs(in),
 			}

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
@@ -197,7 +198,7 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			}
 			k8sKindAcc, err := k8sSubAcc.AddSubField("kind", api.Kind_String,
 				datasource.WithAnnotations(map[string]string{
-					datasource.ColumnsMaxWidthAnnotation: "12",
+					metadatav1.ColumnsMaxWidthAnnotation: "12",
 				}),
 				datasource.WithFlags(datasource.FieldFlagHidden),
 			)
@@ -207,7 +208,7 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			k8sNameAcc, err := k8sSubAcc.AddSubField("name",
 				api.Kind_String,
 				datasource.WithAnnotations(map[string]string{
-					datasource.TemplateAnnotation: "pod",
+					metadatav1.TemplateAnnotation: "pod",
 				}),
 				datasource.WithFlags(datasource.FieldFlagHidden),
 			)
@@ -217,7 +218,7 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			k8sNamespaceAcc, err := k8sSubAcc.AddSubField("namespace",
 				api.Kind_String,
 				datasource.WithAnnotations(map[string]string{
-					datasource.TemplateAnnotation: "namespace",
+					metadatav1.TemplateAnnotation: "namespace",
 				}),
 				datasource.WithFlags(datasource.FieldFlagHidden),
 			)

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -38,6 +38,7 @@ import (
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
 
@@ -620,11 +621,11 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 			// Try to auto-apply metricsType from tags
 			if metricsType == "" {
 				// tbd: should we rather handle this mapping in the eBPF operator to keep the types there?
-				if f.HasAnyTagsOf("type:gadget_histogram_slot__u32", "type:gadget_histogram_slot__u64") {
+				if f.HasAnyTagsOf("type:"+ebpftypes.HistogramSlotU32TypeName, "type:"+ebpftypes.HistogramSlotU64TypeName) {
 					metricsType = MetricTypeHistogram
-				} else if f.HasAnyTagsOf("type:gadget_counter__u32", "type:gadget_counter__u64") {
+				} else if f.HasAnyTagsOf("type:"+ebpftypes.CounterU32TypeName, "type:"+ebpftypes.CounterU64TypeName) {
 					metricsType = MetricTypeCounter
-				} else if f.HasAnyTagsOf("type:gadget_gauge__u32", "type:gadget_gauge__u64") {
+				} else if f.HasAnyTagsOf("type:"+ebpftypes.GaugeU32TypeName, "type:"+ebpftypes.GaugeU64TypeName) {
 					metricsType = MetricTypeGauge
 				}
 			}

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -31,7 +31,9 @@ import (
 )
 
 const (
-	OperatorName = "UidGidResolver"
+	OperatorName          = "UidGidResolver"
+	DefaultUserFieldName  = "user"
+	DefaultGroupFieldName = "group"
 )
 
 type UidResolverInterface interface {
@@ -124,13 +126,14 @@ func (k *UidGidResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			for _, uid := range uids {
 				outName, err := annotations.GetTargetNameFromAnnotation(logger, "uidgidresolver.uid", uid, "uidgidresolver.target")
 				if err != nil {
-					logger.Warnf("failed to get target name for uid: %s", err)
-					continue
+					logger.Debugf("no target name found for uid, falling back to %s", DefaultUserFieldName)
+					outName = DefaultUserFieldName
 				}
 				uidStrField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(uid))
 				if err != nil {
 					return nil, err
 				}
+				uidStrField.SetHidden(true, false)
 
 				uid.SetHidden(true, false)
 				fieldsUid[ds] = append(fieldsUid[ds], fieldAccPair{srcFieldAcc: uid, dstFieldAcc: uidStrField})
@@ -143,13 +146,14 @@ func (k *UidGidResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			for _, gid := range gids {
 				outName, err := annotations.GetTargetNameFromAnnotation(logger, "uidgidresolver.gid", gid, "uidgidresolver.target")
 				if err != nil {
-					logger.Warnf("failed to get target name for gid: %s", err)
-					continue
+					logger.Debugf("no target name found for gid, falling back to %s", DefaultGroupFieldName)
+					outName = DefaultGroupFieldName
 				}
 				gidStrField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(gid))
 				if err != nil {
 					return nil, err
 				}
+				gidStrField.SetHidden(true, false)
 
 				gid.SetHidden(true, false)
 				fieldsGid[ds] = append(fieldsGid[ds], fieldAccPair{srcFieldAcc: gid, dstFieldAcc: gidStrField})

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
 )
@@ -114,8 +115,8 @@ func (k *UidGidResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 	for _, ds := range gadgetCtx.GetDataSources() {
 		logger.Debugf("UidGidResolver inspecting datasource %q", ds.Name())
 
-		uids := ds.GetFieldsWithTag("type:gadget_uid")
-		gids := ds.GetFieldsWithTag("type:gadget_gid")
+		uids := ds.GetFieldsWithTag("type:" + ebpftypes.UidTypeName)
+		gids := ds.GetFieldsWithTag("type:" + ebpftypes.GidTypeName)
 
 		if len(uids) > 0 {
 			logger.Debugf("> found %d uid fields", len(uids))


### PR DESCRIPTION
Gadgets use a lot of well-known fields like pid, tid, uid. etc. This commit adds logic in Inspektor Gadget to automatically add annotations for those types to avoid having to repeat the same thing in the metadata file for all gadgets. It is still possible for gadget developers to override the defaults.

Part of #1567


### TODO
- [ ]  Update hello-world guide (will be done in (#3506)