### PR TITLE
operators/kubeipresolver: Improve how endpoint is displayed

### DIFF
--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -404,6 +404,7 @@ var replacers = []replacer{
 				datasource.WithAnnotations(map[string]string{
 					json.SkipFieldAnnotation: "true",
 				}),
+				datasource.WithTags("endpoint"),
 				datasource.WithFlags(datasource.FieldFlagHidden),
 			)
 			if err != nil {

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -159,6 +159,9 @@ type endpointAccessors struct {
 	subK8sName      datasource.FieldAccessor
 	subK8sNamespace datasource.FieldAccessor
 	subK8sLabels    datasource.FieldAccessor
+
+	column datasource.FieldAccessor
+	port   datasource.FieldAccessor
 }
 
 func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
@@ -228,12 +231,25 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			if err != nil {
 				return nil, fmt.Errorf("adding field %q: %w", "labels", err)
 			}
+
+			// control how the field is displayed
+			var endpointColAcc datasource.FieldAccessor
+			if ec := ep.GetSubFieldsWithTag("endpoint"); len(ec) == 1 {
+				endpointColAcc = ec[0]
+			}
+			var portAcc datasource.FieldAccessor
+			if p := ep.GetSubFieldsWithTag("name:port"); len(p) == 1 && p[0].Size() == 2 {
+				portAcc = p[0]
+			}
+
 			ea := endpointAccessors{
 				root:            ep,
 				subK8sKind:      k8sKindAcc,
 				subK8sName:      k8sNameAcc,
 				subK8sNamespace: k8sNamespaceAcc,
 				subK8sLabels:    k8sLabelsAcc,
+				column:          endpointColAcc,
+				port:            portAcc,
 			}
 			epAccessors[ds] = append(epAccessors[ds], ea)
 		}
@@ -291,6 +307,11 @@ func (m *KubeIPResolverInstance) Start(gadgetCtx operators.GadgetContext) error 
 						labels = append(labels, fmt.Sprintf("%s=%s", key, val))
 					}
 					a.subK8sLabels.Set(data, []byte(strings.Join(labels, ",")))
+					if a.column != nil && a.port != nil {
+						p, _ := a.port.Uint16(data)
+						v := fmt.Sprintf("p/%s/%s:%d", pod.Namespace, pod.Name, p)
+						a.column.Set(data, []byte(v))
+					}
 					continue
 				}
 
@@ -305,10 +326,16 @@ func (m *KubeIPResolverInstance) Start(gadgetCtx operators.GadgetContext) error 
 						labels = append(labels, fmt.Sprintf("%s=%s", key, val))
 					}
 					a.subK8sLabels.Set(data, []byte(strings.Join(labels, ",")))
+
+					if a.column != nil && a.port != nil {
+						p, _ := a.port.Uint16(data)
+						v := fmt.Sprintf("s/%s/%s:%d", svc.Namespace, svc.Name, p)
+						a.column.Set(data, []byte(v))
+					}
 				}
 			}
 			return errs
-		}, 0)
+		}, Priority)
 	}
 	return nil
 }


### PR DESCRIPTION
This change allows improving format of endpoint field by including Kubernetes metadata:

```
→ ./kubectl-gadget run trace_dns -A
K8S.NODE               K8S.NAMESPACE          K8S.PODNAME           K8S.CONTAINERNAME     SRC                          DST                          COMM               PID QR QTYPE       NAME                  RCODE    ADDRESSES  
minikube-docker        demo                   mypod                 mypod                 p/demo/mypod:53574           s/kube-system/kube-dns:53    isc-net-00…     594477 Q  A           google.com.                               
minikube-docker                                                                           p/demo/mypod:53574           s/kube-system/kube-dns:53                         0 Q  A           google.com.                               
minikube-docker                                                                           p/demo/mypod:53574           p/kube-system/coredns-7db6d…                      0 Q  A           google.com.                               
minikube-docker        kube-system            coredns-7d…ff4d-kslx2 coredns               p/demo/mypod:53574           p/kube-system/coredns-7db6d… coredns         276581 Q  A           google.com.                               
minikube-docker        kube-system            coredns-7d…ff4d-kslx2 coredns               p/kube-system/coredns-7db6d… p/demo/mypod:53574           coredns         276581 R  A           google.com.           Success  142.250.18…
minikube-docker                                                                           p/kube-system/coredns-7db6d… p/demo/mypod:53574                                0 R  A           google.com.           Success  142.250.18…
minikube-docker                                                                           s/kube-system/kube-dns:53    p/demo/mypod:53574                                0 R  A           google.com.           Success  142.250.18…
minikube-docker        demo                   mypod                 mypod                 s/kube-system/kube-dns:53    p/demo/mypod:53574           isc-net-00…     594477 R  A           google.com.           Success  142.250.18…
```


cc @burak-ok 