### PR TITLE
operators/otel-metrics: add support for implicit counter

### DIFF
--- a/docs/gadget-devel/metrics.md
+++ b/docs/gadget-devel/metrics.md
@@ -74,6 +74,23 @@ values.
 
 > Note: adding multiple metric.key annotations will increase cardinality a lot and take up more space and storage.
 
+#### Adding an implicit counter
+
+If you just want to count the number of events happening for a given set of keys, you can add another annotation to your
+datasource that will increase a counter whenever a new event has been emitted.
+
+```yaml
+datasources:
+  events:
+    annotations:
+      metrics.implicit-counter.name: eventctr
+      matrics.implicit-counter.description: number of events
+...
+```
+
+This is especially useful if you just want to quickly convert an existing event-based gadget to a metrics collector, as
+you can easily set annotations when running a gadget using the `--annotate` flag.
+
 ### Using well-known types in the eBPF code
 
 You can also edit your eBPF source code and use well-known types (TODO links to well known types) instead of annotating

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -62,6 +62,9 @@ const (
 	AnnotationMetricsUnit        = "metrics.unit"
 	AnnotationMetricsBoundaries  = "metrics.boundaries"
 
+	AnnotationImplicitCounterName        = "metrics.implicit-counter.name"
+	AnnotationImplicitCounterDescription = "metrics.implicit-counter.description"
+
 	PrintDataSourceSuffix = "rendered"
 	PrintFieldName        = "text"
 
@@ -611,6 +614,22 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 		}
 
 		hasValueFields := false
+
+		// Support an implicit counter
+		if implicitCounter := ds.Annotations()[AnnotationImplicitCounterName]; implicitCounter != "" {
+			tOptions := make([]metric.Int64CounterOption, 0)
+			if implicitCounterDescription := ds.Annotations()[AnnotationImplicitCounterDescription]; implicitCounterDescription != "" {
+				tOptions = append(tOptions, metric.WithDescription(implicitCounterDescription))
+			}
+			ctr, err := collector.meter.Int64Counter(implicitCounter, tOptions...)
+			if err != nil {
+				return fmt.Errorf("adding implicit counter %q: %w", implicitCounter, err)
+			}
+			collector.values = append(collector.values, func(ctx context.Context, data datasource.Data, set attribute.Set) {
+				ctr.Add(ctx, 1, metric.WithAttributeSet(set))
+			})
+			hasValueFields = true
+		}
 
 		fields := ds.Accessors(false)
 		for _, f := range fields {


### PR DESCRIPTION
This adds support for an implicit counter that can be activated if the annotation `metrics.implicit-counter.name` contains a value. A description can optionally be added using `metrics.implicit-counter.description`. The added Int64Counter is increased whenever the targeted datasource emits an event.

Example of how to quickly convert an existing trace gadget into a metrics collector using this (Note though that events are collected in userspace, so this might not be viable for gadgets with high throughput. In those cases using a map iterator is preferable):

```sh
./ig run trace_open:latest --host --verify-image=false --otel-metrics-name open:open --annotate open:metrics.collect=true,open:metrics.implicit-counter.name=ctr,open.runtime.containername:metrics.type=key
```