### PR TITLE
pkg/operators/wasm/testdata: Update go version

### DIFF
--- a/pkg/operators/wasm/testdata/dataarray/go.mod
+++ b/pkg/operators/wasm/testdata/dataarray/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.22.0
+go 1.22.8
 
 require github.com/inspektor-gadget/inspektor-gadget v0.27.0
 

--- a/pkg/operators/wasm/testdata/fields/go.mod
+++ b/pkg/operators/wasm/testdata/fields/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.22.0
+go 1.22.8
 
 require github.com/inspektor-gadget/inspektor-gadget v0.27.0
 


### PR DESCRIPTION
Missing bumping golang version to 1.22.8 on tests for wasm operators, which makes compilation fail:

```bash
$ make -C pkg/operators/wasm/testdata/ dataarray
make: Entering directory '/home/jose/go/src/inspektor-gadget/pkg/operators/wasm/testdata'
Building dataarray
Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
latest: Pulling from inspektor-gadget/ebpf-builder
Digest: sha256:a79067988b121c64a6f14e22b19ad995bcc5c5c3425b1b1f550883999142a685
Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
Builder container logs start:
clang -target bpf -Wall -g -O2 -I /work/include/ -D __TARGET_ARCH_x86 \
        -c /work/pkg/operators/wasm/testdata/dataarray/program.bpf.c -I /usr/include/gadget/amd64/ -o /out/amd64.bpf.o
clang -target bpf -Wall -g -O2 -I /work/include/ -D __TARGET_ARCH_arm64 \
        -c /work/pkg/operators/wasm/testdata/dataarray/program.bpf.c -I /usr/include/gadget/arm64/ -o /out/arm64.bpf.o
cd /work/pkg/operators/wasm/testdata/dataarray/ && \
tinygo build -o /out/program.wasm -target=wasi --no-debug program.go
llvm-strip -g /out/arm64.bpf.o
llvm-strip -g /out/amd64.bpf.o
go: updates to go.mod needed; to update it:
        go mod tidy
make: *** [/out/Makefile.build:28: wasm] Error 1
Builder container logs end
Error: builder container exited with status 2
make: *** [Makefile:17: dataarray] Error 1
make: Leaving directory '/home/jose/go/src/inspektor-gadget/pkg/operators/wasm/testdata'
```

Fixes https://github.com/inspektor-gadget/inspektor-gadget/pull/3589
