### PR TITLE
go.mod: update cilium/ebpf with more memory optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,8 +218,10 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-// cilium/ebpf with https://github.com/cilium/ebpf/pull/1588
-replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.16.1-0.20241017091859-59f2044b26b5
+// cilium/ebpf with:
+// - https://github.com/cilium/ebpf/pull/1588
+// - https://github.com/cilium/ebpf/pull/1590
+replace github.com/cilium/ebpf => github.com/cilium/ebpf v0.16.1-0.20241023154409-d3c63ab2edcb
 
 replace k8s.io/component-base => k8s.io/component-base v0.0.0-20240417101527-62c04b35eff6
 

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/ebpf v0.16.1-0.20241017091859-59f2044b26b5 h1:09rId+70PyTuXqz7E6k5bLxFj7yqYKHfxRAye+i5VAU=
-github.com/cilium/ebpf v0.16.1-0.20241017091859-59f2044b26b5/go.mod h1:g+Zxp5bVKYJy9/njLFYE+mNTcw1P8TnE59/2Qq2Pr3I=
+github.com/cilium/ebpf v0.16.1-0.20241023154409-d3c63ab2edcb h1:+iehd0qMFPh2flZVusGXGSPTCMcHBRl4FkPjeTXqGAg=
+github.com/cilium/ebpf v0.16.1-0.20241023154409-d3c63ab2edcb/go.mod h1:g+Zxp5bVKYJy9/njLFYE+mNTcw1P8TnE59/2Qq2Pr3I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=


### PR DESCRIPTION
This uses an unreleased version of cilium/ebpf.

The specific patches from cilium/ebpf are listed in a comment in go.mod.

This includes https://github.com/cilium/ebpf/pull/1590.

https://github.com/cilium/ebpf/pull/1588 was already picked up via [#3595](https://github.com/inspektor-gadget/inspektor-gadget/pull/3595).

cc @burak-ok