### PR TITLE
build: fix dockerignore file

### DIFF
--- a/Dockerfiles/ig.Dockerfile.dockerignore
+++ b/Dockerfiles/ig.Dockerfile.dockerignore
@@ -3,6 +3,7 @@
 !go.sum
 !cmd
 !gadget-container
+!internal
 !pkg
 !tools
 !Makefile*


### PR DESCRIPTION
The dockerignore file must be named after the Dockerfile with the ".dockerignore" suffix. It was ignored by docker-build because it didn't have the correct name.

The content was wrong. Add missing directory.

Fixes: d8e9d0f2774c ("ig/local-gadget: Rename local-gadget in docker images and containers")

cc @burak-ok 