### PR TITLE
Move authfile and pull-secret to GlobalParams and update documentation

### DIFF
--- a/docs/spec/operators/oci.md
+++ b/docs/spec/operators/oci.md
@@ -13,6 +13,20 @@ and invokes the different layer operators according to the
 
 ## Global Parameters
 
+### `authfile`
+
+Path of the authentication file. This overrides the `REGISTRY_AUTH_FILE`
+environment variable. If the default file doesn't exist,
+`$HOME/.docker/config.json` is used as a fallback.
+
+Default: `/var/lib/ig/config.json`
+
+### `pull-secret`
+
+Secret to use when pulling the gadget image
+
+Fully qualified name: `operator.oci.pull-secret`
+
 ### `verify-image`
 
 Verify image using the provided public key. Check [Verify image-based
@@ -48,18 +62,6 @@ Default: `false`
 
 ## Instance Parameters
 
-### `authfile`
-
-TODO: is this really a instance param?
-
-Path of the authentication file. This overrides the `REGISTRY_AUTH_FILE`
-environment variable. If the default file doesn't exist,
-`$HOME/.docker/config.json` is used as a fallback.
-
-Fully qualified name: `operator.oci.authfile`
-
-Default: `/var/lib/ig/config.json`
-
 ### `validate-metadata`
 
 Validate the gadget metadata before running the gadget
@@ -80,12 +82,6 @@ Possible Values:
 Fully qualified name: `operator.oci.pull`
 
 Default: `missing`
-
-### `pull-secret`
-
-Secret to use when pulling the gadget image
-
-Fully qualified name: `operator.oci.pull-secret`
 
 ### `annotate`
 

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -94,12 +94,6 @@ func (o *ociHandler) GlobalParams() api.Params {
 			Description: "Disallow pulling gadgets from registries",
 			TypeHint:    api.TypeBool,
 		},
-	}
-}
-
-func (o *ociHandler) InstanceParams() api.Params {
-	return api.Params{
-		// Hardcoded for now
 		{
 			Key:          authfileParam,
 			Title:        "Auth file",
@@ -107,6 +101,18 @@ func (o *ociHandler) InstanceParams() api.Params {
 			DefaultValue: oci.DefaultAuthFile,
 			TypeHint:     api.TypeString,
 		},
+		{
+			Key:         pullSecret,
+			Title:       "Pull secret",
+			Description: "Secret to use when pulling the gadget image",
+			TypeHint:    api.TypeString,
+		},
+	}
+}
+
+func (o *ociHandler) InstanceParams() api.Params {
+	return api.Params{
+		// Hardcoded for now
 		{
 			Key:          validateMetadataParam,
 			Title:        "Validate metadata",
@@ -125,12 +131,6 @@ func (o *ociHandler) InstanceParams() api.Params {
 				oci.PullImageNever,
 			},
 			TypeHint: api.TypeString,
-		},
-		{
-			Key:         pullSecret,
-			Title:       "Pull secret",
-			Description: "Secret to use when pulling the gadget image",
-			TypeHint:    api.TypeString,
 		},
 		{
 			Key:   annotate,


### PR DESCRIPTION
# moving the `authfile` and `pull-secret` parameters from InstanceParams to GlobalParams.

- Moved `authfile` and `pull-secret` to GlobalParams in `pkg/operators/oci-handler/oci.go`.
- Updated the corresponding documentation to reflect this change.

Closes [#3444](https://github.com/inspektor-gadget/inspektor-gadget/issues/3444).