### PR TITLE
ci: test image gadgets on different kernel versions

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1440,6 +1440,81 @@ jobs:
           test-step-conclusion: ${{ steps.gadgets-tests.conclusion }}
           test-summary-suffix: "gadgets-unittest"
 
+  gadgets-kernel-unittest:
+    name: Gadgets unit tests on kernel
+    needs:
+      - build-ig
+      - build-and-push-gadgets
+      - build-helper-images
+      - check-secrets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kernel:
+          - "6.8"
+          - "6.7"
+          - "6.6"
+          - "6.1"
+          - "5.15"
+          - "5.10"
+            # - "5.4"
+            # - "4.19"
+
+    steps:
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - name: Setup go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+      id: go
+    - name: Set container repository and determine image tag
+      id: set-repo-determine-image-tag
+      uses: ./.github/actions/set-container-repo-and-determine-image-tag
+      with:
+        registry: ${{ env.REGISTRY }}
+        container-image: ${{ env.CONTAINER_REPO }}
+    - name: Get ig-linux-amd64.tar.gz from artifact.
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        name: ig-linux-amd64-tar-gz
+        path: /home/runner/work/inspektor-gadget/
+    - name: Unpack ig-linux-amd64.tar.gz
+      run: |
+        tar zxvf /home/runner/work/inspektor-gadget/ig-linux-amd64.tar.gz
+        sudo mv ig /usr/bin/ig
+    - name: Set up QEMU
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-system-x86
+        sudo chmod 666 /dev/kvm
+    - name: Install vimto
+      run: |
+        CGO_ENABLED=0 GOBIN=$(go env GOPATH)/bin go install lmb.io/vimto@latest
+        ls $(go env GOPATH)/bin | grep vimto
+    - name: Run gadget unit tests for kernel ${{ matrix.kernel }}
+      id: gadgets-kernel-tests
+      shell: bash
+      env:
+        GADGET_REPOSITORY: '${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}'
+        GADGET_TAG: '${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}'
+        IG_VERIFY_IMAGE: 'false'
+        KERNEL_VERSION: '${{ matrix.kernel }}'
+      run: |
+        set -o pipefail
+        export VIMTO=$(go env GOPATH)/bin/vimto
+        make -C gadgets/ pull
+        make -C gadgets/ test-unit -o build |& tee gadgets-kernel-tests.log & wait $! 
+    - name: Prepare and publish test reports
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/prepare-and-publish-test-reports
+      with:
+        test-log-file: gadgets-kernel-tests.log
+        test-step-conclusion: ${{ steps.gadgets-kernel-tests.conclusion }}
+        test-summary-suffix: "gadgets-unittest-kernel-${{ matrix.kernel }}"
+
   test-gadgets-local:
     name: Test gadgets locally
     #level 3

--- a/Makefile
+++ b/Makefile
@@ -380,9 +380,13 @@ build-gadgets: install/ig
 push-gadgets: install/ig
 	$(MAKE) -C gadgets/ push
 
-.PHONY: test-gadgets
-test-gadgets: install/ig
-	$(MAKE) -C gadgets/ test
+.PHONY: unit-test-gadgets
+unit-test-gadgets: 
+	$(MAKE) -C gadgets/ test-unit
+
+.PHONY: integration-test-gadgets
+integration-test-gadgets: install/ig
+	$(MAKE) -C gadgets/ test-integration
 
 .PHONY: testdata
 testdata:
@@ -420,7 +424,8 @@ help:
 	@echo  '  controller-tests		- Run controllers unit tests'
 	@echo  '  ig-tests			- Run ig manager unit tests'
 	@echo  '  integration-tests		- Run integration tests (deploy IG before running the tests)'
-	@echo  '  test-gadgets			- Run gadgets test'
+	@echo  '  integration-test-gadgets	- Run gadgets integration test'
+	@echo  '  unit-test-gadgets		- Run gadgets unit test'
 	@echo  ''
 	@echo  'Installing targets:'
 	@echo  '  install/kubectl-gadget	- Build kubectl plugin and install it in ~/.local/bin'

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -5,11 +5,15 @@ ROOT_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
+# currently use mauriciovasquezbernal/ci-kernels as default
+KERNEL_REPOSITORY ?= ghcr.io/mauriciovasquezbernal/ci-kernels
 IG ?= ig
 KUBECTL_GADGET ?= kubectl-gadget
 IG_RUNTIME ?= docker
 IG_FLAGS ?=
 COSIGN ?= cosign
+VIMTO ?= vimto
+VIMTO_VM_MEMORY ?= 4096M
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -103,19 +107,42 @@ clean:
 	done
 
 .PHONY:
+pull:
+	GADGET_TAG=$(GADGET_TAG) \
+	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
+	for GADGET in $(GADGETS); do \
+		sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+	done
+
+.PHONY:
+%/pull:
+	GADGET_TAG=$(GADGET_TAG) \
+	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
+	sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+
+.PHONY:
 test-unit: build
 	IG_VERIFY_IMAGE=$(IG_VERIFY_IMAGE) \
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	go test -v -exec 'sudo -E' ./.../$(UNIT_TEST_DIR)/...
-
+	VIMTO=$(VIMTO) \
+	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
+	$(if $(KERNEL_VERSION), \
+		sudo -E $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		-memory $(VIMTO_VM_MEMORY) -- go test -v ./.../$(UNIT_TEST_DIR)/..., \
+		go test -v -exec 'sudo -E' ./.../$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-unit: %
 	IG_VERIFY_IMAGE=$(IG_VERIFY_IMAGE) \
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	go test -v -exec 'sudo -E' ./$*/$(UNIT_TEST_DIR)/...
+	VIMTO=$(VIMTO) \
+	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
+	$(if $(KERNEL_VERSION), \
+		sudo -E $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		-memory $(VIMTO_VM_MEMORY) -- go test -v ./$*/$(UNIT_TEST_DIR)/..., \
+		go test -v -exec 'sudo -E' ./$*/$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-integration: %

--- a/gadgets/ci/inner_fields/test/unit/inner_fields_test.go
+++ b/gadgets/ci/inner_fields/test/unit/inner_fields_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
@@ -58,8 +59,7 @@ type ExpectedInnerEvent struct {
 }
 
 func TestInnerFields(t *testing.T) {
-	utilstest.RequireRoot(t)
-
+	gadgettesting.InitUnitTest(t)
 	t.Parallel()
 
 	runnerConfig := &utilstest.RunnerConfig{}

--- a/gadgets/snapshot_process/test/unit/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/unit/snapshot_process_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
 
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
@@ -39,7 +40,7 @@ type testDef struct {
 }
 
 func TestSnapshotProcessGadget(t *testing.T) {
-	utilstest.RequireRoot(t)
+	gadgettesting.InitUnitTest(t)
 	runnerConfig := &utilstest.RunnerConfig{}
 	testCases := map[string]testDef{
 		"captures_events_with_no_filter": {

--- a/gadgets/top_file/test/unit/top_file_test.go
+++ b/gadgets/top_file/test/unit/top_file_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
@@ -48,7 +49,7 @@ type testDef struct {
 }
 
 func TestTopFileGadget(t *testing.T) {
-	utilstest.RequireRoot(t)
+	gadgettesting.InitUnitTest(t)
 	runnerConfig := &utilstest.RunnerConfig{}
 
 	testCases := map[string]testDef{

--- a/gadgets/trace_open/test/unit/trace_open_test.go
+++ b/gadgets/trace_open/test/unit/trace_open_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
@@ -48,7 +49,7 @@ type testDef struct {
 }
 
 func TestTraceOpenGadget(t *testing.T) {
-	utilstest.RequireRoot(t)
+	gadgettesting.InitUnitTest(t)
 	testCases := map[string]testDef{
 		"captures_all_events_with_no_filters_configured": {
 			runnerConfig:  &utilstest.RunnerConfig{},

--- a/gadgets/trace_tcp/test/unit/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/unit/trace_tcp_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
@@ -47,7 +48,7 @@ type testDef struct {
 }
 
 func TestTraceTcpGadget(t *testing.T) {
-	utilstest.RequireRoot(t)
+	gadgettesting.InitUnitTest(t)
 	testCases := map[string]testDef{
 		"captures_all_events": {
 			addr:          "127.0.0.1",


### PR DESCRIPTION
fixes: #1343
cc @mauriciovasquezbernal @alban 
### Introduced testing of image based gadgets on different kernel versions for which support was added in https://github.com/inspektor-gadget/inspektor-gadget/pull/3502

This PR provides a GitHub workflow job and a Makefile target to run unit tests for image-based gadgets. The workflow uses the Makefile target to run tests with different kernel versions passed as parameters. The Makefile first pulls gadget images from the repository where they were pushed during the build-and-push process. Then, it uses Vimto to pull the kernel image from the respective kernel image repository, as Vimto does not allow networking between the host and the VM.

TODO:
- [ ] Figure out why given test are not being runned in parallel even though t.Parallel() is used, example: parallel test take around 7-8 second to run for Trace_open so In total it take nearly 7-8 sec to run all of Trace_open subtest to run, running in vimto they are taking around 44-45 sec same goes for snapshot_process which take 22 sec.
- [ ] Investigate why when --parallel is used in command it works, It is a little weird since --parallel shouldn't affect subtest that are marked as t.Parallel(), since --parallel should run test from different test packages parallely and for our unittest they are all in `package tests`, It might be due to file structure.?
- [ ] We either want to get the changes required in ci-kernel to upstream or may be fork the ci-kernel under inspektor-gadget repo.

### Testing done
Testing is done both on fork and locally, summary for the test ran on fork can be found here: https://github.com/mastersans/inspektor-gadget/actions/runs/11517810558?pr=11 
the tests seems to pass on <= 5.10 tag kernel version. and fails on 5.4 and 4.19

