### PR TITLE
  operators/bpf: Fix perf ring buffer fallback logic

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1458,7 +1458,7 @@ jobs:
           - "6.1"
           - "5.15"
           - "5.10"
-            # - "5.4"
+          - "5.4"
             # - "4.19"
 
     steps:
@@ -1505,7 +1505,7 @@ jobs:
         set -o pipefail
         export VIMTO=$(go env GOPATH)/bin/vimto
         make -C gadgets/ pull
-        make -C gadgets/ test-unit -o build |& tee gadgets-kernel-tests.log & wait $! 
+        make -C gadgets/ test-unit -o build |& tee gadgets-kernel-tests.log & wait $!
     - name: Prepare and publish test reports
       if: always()
       continue-on-error: true

--- a/gadgets/snapshot_process/test/unit/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/unit/snapshot_process_test.go
@@ -40,6 +40,8 @@ type testDef struct {
 }
 
 func TestSnapshotProcessGadget(t *testing.T) {
+	// task iterator was introduced in 5.8
+	gadgettesting.MinimumKernelVersion(t, "5.8")
 	gadgettesting.InitUnitTest(t)
 	runnerConfig := &utilstest.RunnerConfig{}
 	testCases := map[string]testDef{

--- a/gadgets/top_file/test/unit/top_file_test.go
+++ b/gadgets/top_file/test/unit/top_file_test.go
@@ -49,6 +49,10 @@ type testDef struct {
 }
 
 func TestTopFileGadget(t *testing.T) {
+	// BPF_MAP_LOOKUP_AND_DELETE_BATCH used by the ebpf operator was introduced
+	// in
+	// https://github.com/torvalds/linux/commit/057996380a42bb64ccc04383cfa9c0ace4ea11f0
+	gadgettesting.MinimumKernelVersion(t, "5.6")
 	gadgettesting.InitUnitTest(t)
 	runnerConfig := &utilstest.RunnerConfig{}
 

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -229,11 +229,11 @@ func (i *ebpfInstance) analyze() error {
 			validator:    i.validateGlobalConstVoidPtrVar,
 			populateFunc: i.populateParam,
 		},
-		// {
-		// 	prefixFunc:   hasPrefix(tracerMapPrefix),
-		// 	validator:    i.validateGlobalConstVoidPtrVar,
-		// 	populateFunc: i.populateMap,
-		// },
+		{
+			prefixFunc:   hasPrefix(tracerMapPrefix),
+			validator:    i.validateGlobalConstVoidPtrVar,
+			populateFunc: i.fixTracerMap,
+		},
 		{
 			prefixFunc:   hasPrefix(mapIterPrefix),
 			validator:    i.validateGlobalConstVoidPtrVar,

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -51,6 +51,22 @@ func validateTracerMap(traceMap *ebpf.MapSpec) error {
 	return nil
 }
 
+// fixTracerMap updates the tracer map type in case ringbuf is not available.
+func (i *ebpfInstance) fixTracerMap(t btf.Type, varName string) error {
+	bufMap, ok := i.collectionSpec.Maps[varName]
+	if !ok {
+		return fmt.Errorf("map %q not found in eBPF object", varName)
+	}
+
+	if !isRingbufAvailable() {
+		bufMap.Type = ebpf.PerfEventArray
+		bufMap.KeySize = 4
+		bufMap.ValueSize = 4
+	}
+
+	return nil
+}
+
 func (i *ebpfInstance) populateTracer(t btf.Type, varName string) error {
 	i.logger.Debugf("populating tracer %q", varName)
 


### PR DESCRIPTION
Logic to fallback to a perf ring buffer when ring buffer is not supported
was introduced in ba2bfca2aa77 ("run: Add functions to use perf or ring
buffer."), however it wasn't ported in d28c76d0ef85
("pkg/operators/ebpf: ebpf layer operator").

## Testing 


```bash
$ make -C gadgets/ IG_VERIFY_IMAGE=false KERNEL_VERSION=5.4 test-unit
```