### PR TITLE
[Backport] kubeinventorycache: Include missing HostNetwork information

### DIFF
--- a/pkg/operators/common/kubeinventorycache.go
+++ b/pkg/operators/common/kubeinventorycache.go
@@ -170,6 +170,9 @@ func transformObject(obj any) (any, error) {
 				HostIP: t.Status.HostIP,
 				PodIP:  t.Status.PodIP,
 			},
+			Spec: v1.PodSpec{
+				HostNetwork: t.Spec.HostNetwork,
+			},
 		}
 		return p, nil
 	case *v1.Service:


### PR DESCRIPTION
Fixes: 761dbd2b62fe6c24b169041d1bff32e66bef196d

In 761dbd2b62fe6c24b169041d1bff32e66bef196d we started using SlimPod but while transforming we missed setting value for Spec.HostNetwork. This resulted in events for a pod with HostNetwork=true to have metadata information about one of the pod with HostNetwork=true.

```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: host-net1
spec:
  hostNetwork: true
  containers:
  - name: nginx
    image: nginx:alpine
EOF

cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: host-net2
spec:
  hostNetwork: true
  containers:
  - name: nginx
    image: nginx:alpine
EOF
```

```
$ kubectl gadget trace tcp
# open another terminal
$ kubectl exec -it host-net1 -- wget https://inspektor-gadget.io
# go back to terminal with trace tcp
K8S.NODE                                                 K8S.NAMESPACE                                            K8S.PODNAME                                              K8S.CONTAINERNAME                                        T PID        COMM             IP SRC                                                  DST                                                 
minikube-docker                                          default                                                  host-net1                                                nginx                                                    C 491776     wget             4  p/default/host-net2:42820                            r/172.67.166.105:443
```

### with PR

```
K8S.NODE                                                 K8S.NAMESPACE                                            K8S.PODNAME                                              K8S.CONTAINERNAME                                        T PID        COMM             IP SRC                                                  DST                                                 
minikube-docker                                          default                                                  host-net1                                                nginx                                                    C 496431     wget             4  r/192.168.49.2:43762                                 r/172.67.166.105:443
```
