### PR TITLE
docs: audit-seccomp: update runc requirement

### DIFF
--- a/docs/gadgets/builtin/audit/seccomp.md
+++ b/docs/gadgets/builtin/audit/seccomp.md
@@ -9,9 +9,10 @@ The audit seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
 one of these two conditions:
 
-* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (currently
-  [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and
-  returns any action other than `SECCOMP_RET_ALLOW`.
+* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (supported from
+  [runc v1.2.0](https://github.com/opencontainers/runc/releases/tag/v1.2.0),
+  see [runc#3390](https://github.com/opencontainers/runc/pull/3390)) and returns
+  any action other than `SECCOMP_RET_ALLOW`.
 * The Seccomp profile does not have the flag `SECCOMP_FILTER_FLAG_LOG` but
   returns `SCMP_ACT_LOG` or `SCMP_ACT_KILL*`.
 

--- a/docs/legacy/crds/gadgets/audit-seccomp.md
+++ b/docs/legacy/crds/gadgets/audit-seccomp.md
@@ -7,9 +7,10 @@ The Audit Seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
 one of those two conditions:
 
-* The Seccomp profile has the flag SECCOMP_FILTER_FLAG_LOG (currently
-  [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and
-  returns any action other than SECCOMP_RET_ALLOW.
+* The Seccomp profile has the flag SECCOMP_FILTER_FLAG_LOG (supported from
+  [runc v1.2.0](https://github.com/opencontainers/runc/releases/tag/v1.2.0),
+  see [runc#3390](https://github.com/opencontainers/runc/pull/3390)) and returns
+  any action other than SECCOMP_RET_ALLOW.
 * The Seccomp profile does not have the flag SECCOMP_FILTER_FLAG_LOG but
   returns SCMP_ACT_LOG or SCMP_ACT_KILL*.
 

--- a/gadgets/audit_seccomp/README.md
+++ b/gadgets/audit_seccomp/README.md
@@ -4,9 +4,10 @@ The audit seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
 one of these two conditions:
 
-* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (currently
-  [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and
-  returns any action other than `SECCOMP_RET_ALLOW`.
+* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (supported from
+  [runc v1.2.0](https://github.com/opencontainers/runc/releases/tag/v1.2.0),
+  see [runc#3390](https://github.com/opencontainers/runc/pull/3390)) and returns
+  any action other than `SECCOMP_RET_ALLOW`.
 * The Seccomp profile does not have the flag `SECCOMP_FILTER_FLAG_LOG` but
   returns `SCMP_ACT_LOG` or `SCMP_ACT_KILL*`.
 

--- a/gadgets/audit_seccomp/README.mdx
+++ b/gadgets/audit_seccomp/README.mdx
@@ -10,9 +10,10 @@ The audit seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
 one of these two conditions:
 
-* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (currently
-  [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and
-  returns any action other than `SECCOMP_RET_ALLOW`.
+* The Seccomp profile has the flag `SECCOMP_FILTER_FLAG_LOG` (supported from
+  [runc v1.2.0](https://github.com/opencontainers/runc/releases/tag/v1.2.0),
+  see [runc#3390](https://github.com/opencontainers/runc/pull/3390)) and returns
+  any action other than `SECCOMP_RET_ALLOW`.
 * The Seccomp profile does not have the flag `SECCOMP_FILTER_FLAG_LOG` but
   returns `SCMP_ACT_LOG` or `SCMP_ACT_KILL*`.
 

--- a/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
+++ b/pkg/gadget-collection/gadgets/audit/seccomp/gadget.go
@@ -46,9 +46,10 @@ func (f *TraceFactory) Description() string {
 their seccomp filters generating an audit log. An audit log can be generated in
 one of those two conditions:
 
-* The Seccomp profile has the flag SECCOMP_FILTER_FLAG_LOG (currently
-  [unsupported by runc](https://github.com/opencontainers/runc/pull/3390)) and
-  returns any action other than SECCOMP_RET_ALLOW.
+* The Seccomp profile has the flag SECCOMP_FILTER_FLAG_LOG (supported from
+  [runc v1.2.0](https://github.com/opencontainers/runc/releases/tag/v1.2.0),
+  see [runc#3390](https://github.com/opencontainers/runc/pull/3390)) and returns
+  any action other than SECCOMP_RET_ALLOW.
 * The Seccomp profile does not have the flag SECCOMP_FILTER_FLAG_LOG but
   returns SCMP_ACT_LOG or SCMP_ACT_KILL*.
 `


### PR DESCRIPTION
runc v1.2.0 was released last week. It includes support for seccomp flag SECCOMP_FILTER_FLAG_LOG. The documentation of the audit-seccomp gadget can be updated accordingly.

See:
* https://github.com/opencontainers/runc/releases/tag/v1.2.0
* https://github.com/opencontainers/runc/pull/3390
