### PR TITLE
feat: enhance version command output to json format

### DIFF
--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -24,7 +25,21 @@ import (
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
 )
 
+// VersionInfo represents the structure for version information output
+type VersionInfo struct {
+	ClientVersion *Version `json:"clientVersion,omitempty"`
+	ServerVersion *Version `json:"serverVersion,omitempty"`
+}
+
+// Version contains detailed version information
+type Version struct {
+	Version string `json:"version"`
+}
+
+var outputFormat string
+
 func init() {
+	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format. One of: json|''")
 	rootCmd.AddCommand(versionCmd)
 }
 
@@ -33,31 +48,51 @@ var versionCmd = &cobra.Command{
 	Short:        "Show version",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("Client version: v%s\n", version.Version())
+		// Initialize version info structure
+		versionInfo := &VersionInfo{
+			ClientVersion: &Version{
+				Version: version.Version().String(),
+			},
+		}
 
+		// Get server version information
 		gadgetNamespaces, err := utils.GetRunningGadgetNamespaces()
 		if err != nil {
-			return fmt.Errorf("searching for running Inspektor Gadget instances: %w", err)
+			return fmt.Errorf("getting running Inspektor Gadget instances: %w", err)
 		}
 
-		switch len(gadgetNamespaces) {
-		case 0:
-			fmt.Println("Server version:", "not installed")
-			return nil
-		case 1:
+		if len(gadgetNamespaces) == 1 {
 			// Exactly one running gadget instance found, use it
 			runtimeGlobalParams.Set(grpcruntime.ParamGadgetNamespace, gadgetNamespaces[0])
+			info, err := grpcRuntime.InitDeployInfo()
+			if err != nil {
+				return fmt.Errorf("loading deploy info: %w", err)
+			}
+			versionInfo.ServerVersion = &Version{
+				Version: info.ServerVersion,
+			}
+		} else if len(gadgetNamespaces) > 1 {
+			return fmt.Errorf("multiple Inspektor Gadget instances found in namespaces: %v", gadgetNamespaces)
+		}
+
+		// Output based on format
+		switch outputFormat {
+		case "json":
+			output, err := json.MarshalIndent(versionInfo, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshaling version info: %w", err)
+			}
+			fmt.Println(string(output))
+		case "":
+			fmt.Printf("Client version: v%s\n", versionInfo.ClientVersion.Version)
+			if versionInfo.ServerVersion != nil && versionInfo.ServerVersion.Version != "" {
+				fmt.Printf("Server version: v%s\n", versionInfo.ServerVersion.Version)
+			} else {
+				fmt.Println("Server version: not available")
+			}
 		default:
-			// Multiple running gadget instances found, error out
-			return fmt.Errorf("multiple running Inspektor Gadget instances found in following namespaces: %v", gadgetNamespaces)
+			return fmt.Errorf("invalid output format: %s", outputFormat)
 		}
-
-		info, err := grpcRuntime.InitDeployInfo()
-		if err != nil {
-			return fmt.Errorf("loading deploy info: %w", err)
-		}
-
-		fmt.Printf("Server version: v%s\n", info.ServerVersion)
 
 		return nil
 	},


### PR DESCRIPTION
# enhance version command output to give json format

![git_pr](https://github.com/user-attachments/assets/2a71d4e8-c1db-4c52-922b-5db2d33584e7)


## How to use

 kubectl-gadget version -o json