### PR TITLE
Makefile: Introduce target to run go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,10 @@ test-gadgets: install/ig
 testdata:
 	$(MAKE) -C testdata/
 
+.PHONY: go-mod-tidy
+go-mod-tidy:
+	find ./ -type f -name go.mod -execdir go mod tidy \;
+
 .PHONY: help
 help:
 	@echo  'Building targets:'
@@ -397,6 +401,7 @@ help:
 	@echo  '* build		  		- Build all targets marked with [o]'
 	@echo  'o manifests			- Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects'
 	@echo  'o generate			- Generate client API code and DeepCopy related code'
+	@echo  '  go-mod-tidy			- Run go mod tidy for all go modules in the repo'
 	@echo  'o kubectl-gadget		- Build the kubectl plugin'
 	@echo  '  kubectl-gadget-all		- Build the kubectl plugin for all architectures'
 	@echo  '  kubectl-gadget-container	- Build container for kubectl-gadget'


### PR DESCRIPTION
We have different golang modules in the repository, un fortunately there is a not an easy way to update all of them. This commit introduces a new target to the Makefile that runs `go mod tidy` in all the modules. This is useful to update all modules when the main one is updated by dependabot.

Useful to handle PRs like #3647