### PR TITLE
operators/ebpf: Fix map iterators waiting logic

### DIFF
--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -213,7 +213,7 @@ func (i *ebpfInstance) runMapIterators() error {
 			ticker := time.NewTicker(iter.interval)
 			for {
 				select {
-				case <-i.gadgetCtx.Context().Done():
+				case <-i.done:
 					return
 				case <-ticker.C:
 					fetch()


### PR DESCRIPTION
The previous logic was relying on the gadget context, but it was never being closed. This caused the map iterator to keep reading the map forever, producing the following error after a timeout:

```bash
 sudo ig run mygadget:latest --verify-image=false -o json --timeout 2WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
[]
[]
WARN[0004] error from map iterator: bad file descriptor
[]
WARN[0005] error from map iterator: bad file descriptor
[]
```
This logic switches to only rely on the Stop() operation and an internal channel.

This bug only appeared after 85b756c881d3 ("operators/ebpf: Fix race condition with wasm operator") as it introduced a waiting group, but the bug was present before.

Fixes: f6aedf67c485 ("pkg/operators/ebpf: introduce map iterators")


