### PR TITLE
datasource: refactor `SetRequested` to `Unreference` & add to WASM API

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -205,6 +205,26 @@ Parameters:
 Return value:
 - None
 
+#### `dataSourceUnreference(u32 ds)`
+
+Unreference a data source from further operators.
+
+Parameters:
+- `ds` (u32): Datasource handle (as returned by `getDataSource` or `newDataSource`)
+
+Return value:
+- None
+
+#### `dataSourceIsReferenced(u32 ds)`
+
+Check if the data source is referenced.
+
+Parameters:
+- `ds` (u32): Datasource handle (as returned by `getDataSource` or `newDataSource`)
+
+Return value:
+- (u32): Boolean value on success (0 or 1), 2 on error
+
 #### `dataArrayNew(d uint32) uint32`
 
 Allocate and return a new element on the array. If the whole DataArray is not

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -172,7 +172,7 @@ type dataSource struct {
 
 	subscriptions []*subscription
 
-	requested bool
+	referenced bool
 
 	byteOrder binary.ByteOrder
 	lock      sync.RWMutex
@@ -191,7 +191,7 @@ func newDataSource(t Type, name string, options ...DataSourceOption) (*dataSourc
 		name:            name,
 		dType:           t,
 		requestedFields: make(map[string]bool),
-		requested:       true,
+		referenced:      true,
 		fieldMap:        make(map[string]*field),
 		byteOrder:       binary.NativeEndian,
 		tags:            make([]string, 0),
@@ -768,16 +768,16 @@ func (ds *dataSource) Accessors(rootOnly bool) []FieldAccessor {
 	return res
 }
 
-func (ds *dataSource) SetRequested(v bool) {
+func (ds *dataSource) Unreference() {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
-	ds.requested = v
+	ds.referenced = false
 }
 
-func (ds *dataSource) IsRequested() bool {
+func (ds *dataSource) IsReferenced() bool {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()
-	return ds.requested
+	return ds.referenced
 }
 
 func (ds *dataSource) AddAnnotation(key, value string) {

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -172,8 +172,8 @@ type DataSource interface {
 
 	Accessors(rootOnly bool) []FieldAccessor
 
-	SetRequested(bool)
-	IsRequested() bool
+	Unreference()
+	IsReferenced() bool
 
 	// ByteOrder returns a binary accessor using the byte order of the creator of the DataSource
 	ByteOrder() binary.ByteOrder

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -239,8 +239,8 @@ func (c *GadgetContext) getDataSources(all bool) map[string]datasource.DataSourc
 
 	ret := maps.Clone(c.dataSources)
 	for name, ds := range ret {
-		// Don't forward unrequested data sources if all is false
-		if !all && !ds.IsRequested() {
+		// Don't forward unreferenced data sources if all is false
+		if !all && !ds.IsReferenced() {
 			delete(ret, name)
 		}
 	}

--- a/pkg/operators/combiner/combiner.go
+++ b/pkg/operators/combiner/combiner.go
@@ -248,7 +248,7 @@ func (o *combinerOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 
 	for ds, config := range o.configs {
 		// Disable original data source to avoid other operators subscribing to it
-		ds.SetRequested(false)
+		ds.Unreference()
 
 		// Register a new data source that will emit the combined data
 		combinedDs, err := gadgetCtx.RegisterDataSource(

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -647,7 +647,7 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 			gadgetCtx.Logger().Debugf("enabling print for %s", ds.Name())
 
 			// Disable original data source to avoid other operators subscribing to it
-			ds.SetRequested(false)
+			ds.Unreference()
 
 			// Create a new data source for the output with a single field
 			odsName := fmt.Sprintf("%s-%s", ds.Name(), PrintDataSourceSuffix)

--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -47,6 +47,12 @@ func dataSourceEmitAndRelease(ds uint32, packet uint32) uint32
 //go:wasmimport env dataSourceRelease
 func dataSourceRelease(ds uint32, packet uint32) uint32
 
+//go:wasmimport env dataSourceUnreference
+func dataSourceUnreference(ds uint32) uint32
+
+//go:wasmimport env dataSourceIsReferenced
+func dataSourceIsReferenced(ds uint32) uint32
+
 //go:wasmimport env dataArrayNew
 func dataArrayNew(d uint32) uint32
 
@@ -203,6 +209,18 @@ func (ds DataSource) Release(packet Packet) error {
 		return fmt.Errorf("releasing data")
 	}
 	return nil
+}
+
+func (ds DataSource) Unreference() error {
+	ret := dataSourceUnreference(uint32(ds))
+	if ret != 0 {
+		return fmt.Errorf("unreferencing data source")
+	}
+	return nil
+}
+
+func (ds DataSource) IsReferenced() bool {
+	return dataSourceIsReferenced(uint32(ds)) == 1
 }
 
 func (ds DataSource) GetField(name string) (Field, error) {


### PR DESCRIPTION
# Refactors `requested` to `referenced`

- Updates naming from requested to referenced.
- Updates `SetRequested(bool)` to `Unreference()` and `IsRequested` to `IsReferenced` on dataSource
- Adds `Unreference` and `IsReferenced` methods on the datasource to the WASM api.

## How to use

You can unreference a datasource from the WASM module now using `ds.Unreference`.

## Testing done

Ran it on a gadget and observed the output
