### PR TITLE
gadgets: add qdisc_latency tracer

### DIFF
--- a/docs/gadgets/profile_qdisc_latency.mdx
+++ b/docs/gadgets/profile_qdisc_latency.mdx
@@ -1,0 +1,1 @@
+../../gadgets/profile_qdisc_latency/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -24,6 +24,7 @@ GADGETS = \
 	fdpass \
 	fsnotify \
 	profile_blockio \
+	profile_qdisc_latency \
 	profile_tcprtt \
 	trace_bind \
 	trace_capabilities \

--- a/gadgets/profile_qdisc_latency/README.md
+++ b/gadgets/profile_qdisc_latency/README.md
@@ -1,0 +1,5 @@
+# profile_qdisc_latency
+
+The `profile_qdisc_latency` gadget that profiles the latency of the network scheduler on a node.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/profile_qdisc_latency

--- a/gadgets/profile_qdisc_latency/README.mdx
+++ b/gadgets/profile_qdisc_latency/README.mdx
@@ -1,0 +1,351 @@
+---
+title: profile_qdisc_latency
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# profile_qdisc_latency
+
+The `profile_qdisc_latency` gadget gathers information about the usage of the
+network interfaces, generating a histogram distribution of latency caused by
+the network scheduler when consuming packets off qdiscs, when the gadget is stopped.
+
+The histogram shows the number of packets enqueued to qdiscs (`count` column) that lie in the
+latency range `interval-start` -> `interval-end` (`µs` column). By default the latency is
+measured in microseconds. If the `--ms` flag is passed, it will be shown in milliseconds.
+
+This guide will use the [netem qdisc](https://man7.org/linux/man-pages/man8/tc-netem.8.html) to
+emulate delay in sending packets. To configure it, the [tc](https://man7.org/linux/man-pages/man8/tc.8.html)
+program of the `iproute2` is used.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Guide
+
+Run the gadget in a terminal:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run profile_qdisc_latency:%IG_TAG% --node minikube-docker
+        ```
+
+        It will start to display the qdisc latency distribution as follows:
+        ```bash
+        latency
+        µs               : count    distribution
+               0 -> 1          : 2        |****************************************|
+               1 -> 2          : 0        |                                        |
+               2 -> 4          : 0        |                                        |
+               4 -> 8          : 0        |                                        |
+               8 -> 16         : 0        |                                        |
+              16 -> 32         : 0        |                                        |
+              32 -> 64         : 0        |                                        |
+              64 -> 128        : 0        |                                        |
+             128 -> 256        : 0        |                                        |
+             256 -> 512        : 0        |                                        |
+             512 -> 1024       : 0        |                                        |
+            1024 -> 2048       : 0        |                                        |
+            2048 -> 4096       : 0        |                                        |
+            4096 -> 8192       : 0        |                                        |
+            8192 -> 16384      : 0        |                                        |
+           16384 -> 32768      : 0        |                                        |
+           32768 -> 65536      : 0        |                                        |
+           65536 -> 131072     : 0        |                                        |
+          131072 -> 262144     : 0        |                                        |
+          262144 -> 524288     : 0        |                                        |
+          524288 -> 1048576    : 0        |                                        |
+         1048576 -> 2097152    : 0        |                                        |
+         2097152 -> 4194304    : 0        |                                        |
+         4194304 -> 8388608    : 0        |                                        |
+         8388608 -> 16777216   : 0        |                                        |
+        16777216 -> 33554432   : 0        |                                        |
+        33554432 -> 67108864   : 0        |                                        |
+        ```
+
+        Now to introduce some more latency, let's add a `netem` qdisc with some latency and jitter.
+
+        ```bash
+        # Start by creating our testing namespace
+        $ kubectl create ns qdisc-latency-test
+
+        # Run a pod that we will emulate network latency in
+        $ kubectl run -n qdisc-latency-test --rm -it netem-test \
+            --image=alpine --restart=Never \
+            --privileged
+
+        # Inside the container run the following commands
+        $ apk update
+        $ apk add iproute2
+        # This will introduce a latency of 100ms with 100ms jitter
+        $ tc qdisc add dev eth0 root netem delay 100ms 100ms
+
+        # Now let's ping some remote host
+        $ ping google.com
+        ```
+
+        Using the profile qdisc-latency gadget, we can generate another histogram to analyse the
+        latency of scheduled network packets:
+
+        ```bash
+        # Run the gadget again
+        $ kubectl gadget run profile_qdisc_latency:%IG_TAG% --node minikube-docker
+        latency
+              µs               : count    distribution
+               0 -> 1          : 2        |****                                    |
+               1 -> 2          : 0        |                                        |
+               2 -> 4          : 0        |                                        |
+               4 -> 8          : 1        |**                                      |
+               8 -> 16         : 0        |                                        |
+              16 -> 32         : 5        |***********                             |
+              32 -> 64         : 14       |********************************        |
+              64 -> 128        : 17       |****************************************|
+             128 -> 256        : 0        |                                        |
+             256 -> 512        : 0        |                                        |
+             512 -> 1024       : 0        |                                        |
+            1024 -> 2048       : 0        |                                        |
+            2048 -> 4096       : 0        |                                        |
+            4096 -> 8192       : 0        |                                        |
+            8192 -> 16384      : 0        |                                        |
+           16384 -> 32768      : 0        |                                        |
+           32768 -> 65536      : 0        |                                        |
+           65536 -> 131072     : 0        |                                        |
+          131072 -> 262144     : 0        |                                        |
+          262144 -> 524288     : 0        |                                        |
+          524288 -> 1048576    : 0        |                                        |
+         1048576 -> 2097152    : 0        |                                        |
+         2097152 -> 4194304    : 0        |                                        |
+         4194304 -> 8388608    : 0        |                                        |
+         8388608 -> 16777216   : 0        |                                        |
+        16777216 -> 33554432   : 0        |                                        |
+        33554432 -> 67108864   : 0        |                                        |
+        ```
+
+        The new histogram shows how the latency numbers increased.
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run profile_qdisc_latency:%IG_TAG%
+        ```
+
+        It will start to display the qdisc latency distribution as follows:
+
+        ```bash
+        latency
+        µs               : count    distribution
+               0 -> 1          : 2        |****************************************|
+               1 -> 2          : 0        |                                        |
+               2 -> 4          : 0        |                                        |
+               4 -> 8          : 0        |                                        |
+               8 -> 16         : 0        |                                        |
+              16 -> 32         : 0        |                                        |
+              32 -> 64         : 0        |                                        |
+              64 -> 128        : 0        |                                        |
+             128 -> 256        : 0        |                                        |
+             256 -> 512        : 0        |                                        |
+             512 -> 1024       : 0        |                                        |
+            1024 -> 2048       : 0        |                                        |
+            2048 -> 4096       : 0        |                                        |
+            4096 -> 8192       : 0        |                                        |
+            8192 -> 16384      : 0        |                                        |
+           16384 -> 32768      : 0        |                                        |
+           32768 -> 65536      : 0        |                                        |
+           65536 -> 131072     : 0        |                                        |
+          131072 -> 262144     : 0        |                                        |
+          262144 -> 524288     : 0        |                                        |
+          524288 -> 1048576    : 0        |                                        |
+         1048576 -> 2097152    : 0        |                                        |
+         2097152 -> 4194304    : 0        |                                        |
+         4194304 -> 8388608    : 0        |                                        |
+         8388608 -> 16777216   : 0        |                                        |
+        16777216 -> 33554432   : 0        |                                        |
+        33554432 -> 67108864   : 0        |                                        |
+        ```
+
+        Now to introduce some more latency, let's add a `netem` qdisc with some latency and jitter.
+
+        ```bash
+        # We spawn a container where we will add network latency to
+        $ docker run --rm --privileged --name qdisc-latency-test -it alpine
+
+        # Inside the container run the following commands
+        apk update
+        apk add iproute2
+        # This will introduce a latency of 100ms with 100ms jitter
+        tc qdisc add dev eth0 root netem delay 100ms 100ms
+
+        # Now let's ping some remote host
+        ping google.com
+        ```
+
+        Using the profile qdisc-latency gadget, we can generate another histogram to analyse the
+        latency of scheduled network packets:
+
+        ```bash
+        $ sudo ig run profile_qdisc_latency:%IG_TAG%
+        latency
+              µs               : count    distribution
+               0 -> 1          : 2        |****                                    |
+               1 -> 2          : 0        |                                        |
+               2 -> 4          : 0        |                                        |
+               4 -> 8          : 1        |**                                      |
+               8 -> 16         : 0        |                                        |
+              16 -> 32         : 5        |***********                             |
+              32 -> 64         : 14       |********************************        |
+              64 -> 128        : 17       |****************************************|
+             128 -> 256        : 0        |                                        |
+             256 -> 512        : 0        |                                        |
+             512 -> 1024       : 0        |                                        |
+            1024 -> 2048       : 0        |                                        |
+            2048 -> 4096       : 0        |                                        |
+            4096 -> 8192       : 0        |                                        |
+            8192 -> 16384      : 0        |                                        |
+           16384 -> 32768      : 0        |                                        |
+           32768 -> 65536      : 0        |                                        |
+           65536 -> 131072     : 0        |                                        |
+          131072 -> 262144     : 0        |                                        |
+          262144 -> 524288     : 0        |                                        |
+          524288 -> 1048576    : 0        |                                        |
+         1048576 -> 2097152    : 0        |                                        |
+         2097152 -> 4194304    : 0        |                                        |
+         4194304 -> 8388608    : 0        |                                        |
+         8388608 -> 16777216   : 0        |                                        |
+        16777216 -> 33554432   : 0        |                                        |
+        33554432 -> 67108864   : 0        |                                        |
+        ```
+    </TabItem>
+</Tabs>
+
+You can clean up the resources created during this guide by running the following commands:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl delete ns qdisc-latency-test
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker rm -f qdisc-latency-test
+        ```
+    </TabItem>
+</Tabs>
+
+## Exporting metrics
+
+The `profile_qdisc_latency` gadget can expose the histograms it generates to a
+Prometheus endpoint. To do so, you need to activate both the metrics listener as
+well as the gadget collector. To enable the metrics listener, check the
+[Exporting Metrics](../reference/export-metrics.mdx) documentation. To enable
+the collector for the `profile_qdisc_latency` gadget with the metrics name
+`qdisc-latency-metrics`, run the following command:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        gadgetctl run ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:%IG_TAG% \
+                    --annotate=qdisc_latency:metrics.collect=true \
+                    --otel-metrics-name=qdisc:qdisc-latency-metrics \
+                    --detach
+        ```
+    </TabItem>
+</Tabs>
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        Unless you configured the metrics listener to do differently, the
+        metrics will be available at `http://localhost:2224/metrics` on the
+        server side. For the `profile_qdisc_latency` gadget we ran above, you
+        can find the metrics under the `qdisc-latency-metrics` scope:
+
+        ```bash
+        $ curl http://localhost:2224/metrics -s | grep qdisc-latency
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="1"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="2"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="4"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="8"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="16"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="32"} 0
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="64"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="128"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="256"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="512"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="1024"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="2048"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="4096"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="8192"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="16384"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="32768"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="65536"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="131072"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="262144"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="524288"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="1.048576e+06"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="2.097152e+06"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="4.194304e+06"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="8.388608e+06"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="1.6777216e+07"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="3.3554432e+07"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="6.7108864e+07"} 3
+        latency_bucket{otel_scope_name="qdisc-latency-metrics",otel_scope_version="",le="+Inf"} 3
+        latency_sum{otel_scope_name="qdisc-latency-metrics",otel_scope_version=""} 192
+        latency_count{otel_scope_name="qdisc-latency-metrics",otel_scope_version=""} 3
+        otel_scope_info{otel_scope_name="qdisc-latency-metrics",otel_scope_version=""} 1
+        ```
+    </TabItem>
+</Tabs>
+
+Finally, stop metrics collection:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ gadgetctl list
+        ID           NAME                                                      TAGS                                                      GADGET
+        3e68634c4c28 amazing_payne                                                                                                       ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:latest
+        ```
+
+        ```bash
+        $ gadgetctl delete 3e68634c4c28
+        3e68634c4c28a981a60fe96a29d24a99
+        ```
+    </TabItem>
+</Tabs>

--- a/gadgets/profile_qdisc_latency/artifacthub-pkg.yml
+++ b/gadgets/profile_qdisc_latency/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+# Artifact Hub package metadata file
+version: 0.37.0
+name: "profile qdisc latency"
+category: monitoring-logging
+displayName: "profile qdisc latency"
+createdAt: "2024-11-06T19:00:00Z"
+digest: "2024-11-06T19:00:00Z"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/profile_qdisc_latency/"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/profile_qdisc_latency"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/profile_qdisc_latency:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/profile_qdisc_latency/gadget.yaml
+++ b/gadgets/profile_qdisc_latency/gadget.yaml
@@ -1,0 +1,23 @@
+name: profile qdisc latency
+description: Profile network scheduler latency
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/profile_qdisc_latency
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/profile_qdisc_latency
+datasources:
+  qdisc:
+    annotations:
+      metrics.print: "true"
+    fields:
+      latency:
+        annotations:
+          metrics.unit: µs
+params:
+  ebpf:
+    ifindex:
+      key: ifindex
+      defaultValue: "-1"
+      description: 'Interface index to collect metrics for. To collect metric for all interfaces, set to -1.'
+    targ_ms:
+      key: ms
+      defaultValue: "false"
+      description: Convert latency to milliseconds, by default it uses nanoseconds.

--- a/gadgets/profile_qdisc_latency/program.bpf.c
+++ b/gadgets/profile_qdisc_latency/program.bpf.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include <gadget/bits.bpf.h>
+#include <gadget/core_fixes.bpf.h>
+#include <gadget/types.h>
+#include <gadget/macros.h>
+
+#ifndef PROFILER_MAX_SLOTS
+#define PROFILER_MAX_SLOTS 27
+#endif /* !PROFILER_MAX_SLOTS */
+
+#define MAX_ENTRIES 10240
+#define IFNAMSIZ 16
+
+const volatile int ifindex = -1;
+const volatile bool targ_ms = false;
+
+GADGET_PARAM(ifindex);
+GADGET_PARAM(targ_ms);
+
+struct hist_key {
+	u8 unused;
+};
+
+// hist_value is used as value for profiler hash map.
+struct hist_value {
+	gadget_histogram_slot__u32 latency[PROFILER_MAX_SLOTS];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct hist_key);
+	__type(value, struct hist_value);
+} hists SEC(".maps");
+
+GADGET_MAPITER(qdisc, hists);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct sk_buff *);
+	__type(value, u64);
+} start SEC(".maps");
+
+static struct hist_value initial_hist;
+
+static __always_inline void trace_stop(struct sk_buff *skb)
+{
+	u64 slot, *tsp, ts = bpf_ktime_get_ns();
+	struct hist_key hkey = { 0 };
+	struct hist_value *histp;
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&start, &skb);
+	if (!tsp)
+		return;
+	delta = (s64)(ts - *tsp);
+	if (delta < 0)
+		goto cleanup;
+
+	histp = bpf_map_lookup_elem(&hists, &hkey);
+	if (!histp) {
+		bpf_map_update_elem(&hists, &hkey, &initial_hist, 0);
+		histp = bpf_map_lookup_elem(&hists, &hkey);
+		if (!histp)
+			goto cleanup;
+	}
+
+	if (targ_ms)
+		delta /= 1000000U;
+	else
+		delta /= 1000U;
+	slot = log2l(delta);
+	if (slot >= PROFILER_MAX_SLOTS)
+		slot = PROFILER_MAX_SLOTS - 1;
+	__sync_fetch_and_add(&histp->latency[slot], 1);
+
+cleanup:
+	bpf_map_delete_elem(&start, &skb);
+}
+
+SEC("raw_tp/qdisc_enqueue")
+int BPF_PROG(qdisc_enqueue, struct Qdisc *qdisc, const struct netdev_queue *txq,
+	     struct sk_buff *skb)
+{
+	if (ifindex >= 0) {
+		int pkg_ifindex;
+		BPF_CORE_READ_INTO(&pkg_ifindex, txq, dev, ifindex);
+
+		if (pkg_ifindex != ifindex) {
+			return 0;
+		}
+	}
+
+	u64 ts = bpf_ktime_get_ns();
+
+	bpf_map_update_elem(&start, &skb, &ts, 0);
+	return 0;
+}
+
+SEC("raw_tp/qdisc_dequeue")
+int BPF_PROG(qdisc_dequeue, struct Qdisc *qdisc, const struct netdev_queue *txq,
+	     int packets, struct sk_buff *skb)
+{
+	trace_stop(skb);
+	return 0;
+}
+
+SEC("raw_tp/consume_skb")
+int BPF_PROG(consume_skb, struct sk_buff *skb, void *location)
+{
+	trace_stop(skb);
+	return 0;
+}
+
+SEC("raw_tp/kfree_skb")
+int BPF_PROG(kfree_skb, struct sk_buff *skb, void *location,
+	     enum skb_drop_reason reason)
+{
+	trace_stop(skb);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
# Introduce qdisc_latency profiler

In order to analyse network related issues, the qdisc_latency profiler tool has been added. It will visualise the amount a network packet spend in the network scheduler in an histogram. 

**Note:** The profiler requires at least kernel 5.14, as the tracepoints used were introduced in that kernel version. 

## How to use

Run the new profiler via `ig profile qdisc-latency`. 

## Testing done

I tried running the gadget while performing various network tasks. One strange thing I could not get figured out though was, that I never managed to get a packet queued in my qdisc. Maybe somebody has an idea here? 

Fix #3118

