### PR TITLE
tests: Disable TestTraceNetwork on containerd

### DIFF
--- a/integration/k8s/trace_network_test.go
+++ b/integration/k8s/trace_network_test.go
@@ -29,6 +29,9 @@ func TestTraceNetwork(t *testing.T) {
 	if containerRuntime == ContainerRuntimeCRIO {
 		t.Skipf("Skip running trace network test for %q runtime. See issue #2358", containerRuntime)
 	}
+	if containerRuntime == ContainerRuntimeContainerd {
+		t.Skipf("Skip running trace network test for %q runtime. See issue #3643", containerRuntime)
+	}
 
 	t.Parallel()
 	ns := GenerateTestNamespaceName("test-trace-network")


### PR DESCRIPTION
This test is currently failing a lot of times and hinders us from merging and releasing without multiple attempts of re-runs