### PR TITLE
Use `ContainerPid` method in example

### DIFF
--- a/examples/container-collection/container-collection.go
+++ b/examples/container-collection/container-collection.go
@@ -33,10 +33,10 @@ func main() {
 		switch event.Type {
 		case containercollection.EventTypeAddContainer:
 			fmt.Printf("Container added: %q pid %d\n",
-				event.Container.Runtime.ContainerName, event.Container.Pid)
+				event.Container.Runtime.ContainerName, event.Container.ContainerPid())
 		case containercollection.EventTypeRemoveContainer:
 			fmt.Printf("Container removed: %q pid %d\n",
-				event.Container.Runtime.ContainerName, event.Container.Pid)
+				event.Container.Runtime.ContainerName, event.Container.ContainerPid())
 		}
 	}
 


### PR DESCRIPTION
# Use `ContainerPid` in example

There was a change done to access container PID and the field is no longer directly accessible from `Container` field. We need to access it through the new method `ContainerPid()`

## How to use

This change is done as a part of examples in logging so review would be straightforward

## Testing done
