### PR TITLE
oci-handler: fix annotate param merge with prior config

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -302,15 +302,40 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		switch len(subject) {
 		case 1:
 			// data source
-			current := viper.GetStringMapString("datasources." + annInfo[0] + ".annotations")
-			current[annotation[0]] = annotation[1]
-			viper.Set("datasources."+subject[0]+".annotations", current)
+			tmpConfig := map[string]any{
+				"datasources": map[string]any{
+					annInfo[0]: map[string]any{
+						"annotations": map[string]any{
+							annotation[0]: annotation[1],
+						},
+					},
+				},
+			}
+			viper.Set("a", "b")
+			err = viper.MergeConfigMap(tmpConfig)
+			if err != nil {
+				return fmt.Errorf("adding annotation %q: %w", ann, err)
+			}
 			log.Debugf("ds annotation %q added", ann)
 		case 2:
 			// field
-			current := viper.GetStringMapString("datasources." + subject[0] + ".fields." + subject[1] + ".annotations")
-			current[annotation[0]] = annotation[1]
-			viper.Set("datasources."+subject[0]+".fields."+subject[1]+".annotations", current)
+			tmpConfig := map[string]any{
+				"datasources": map[string]any{
+					subject[0]: map[string]any{
+						"fields": map[string]any{
+							subject[1]: map[string]any{
+								"annotations": map[string]any{
+									annotation[0]: annotation[1],
+								},
+							},
+						},
+					},
+				},
+			}
+			err = viper.MergeConfigMap(tmpConfig)
+			if err != nil {
+				return fmt.Errorf("adding annotation %q: %w", ann, err)
+			}
 			log.Debugf("field annotation %q added", ann)
 		}
 	}


### PR DESCRIPTION
This fixes an issue that could occur when merging `--annotate` flags into an existing `gadget.yaml` viper config. With the previous method it could happen that viper would place the key in an ambiguous way so that the older values got lost.