### PR TITLE
introduce support for otel-logs

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -39,6 +39,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-logs"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/sort"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -318,9 +317,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			isDetach := detachedParam != nil && detachedParam.AsBool()
 
 			if isDetach {
-				// Copy special oci params
-				ociParams.CopyToMap(paramValueMap, "operator.oci.")
-				return runInstanceSpecsDetached(ctx, runtime, specs, runtimeParams, paramValueMap,
+				return runInstanceSpecsDetached(ctx, runtime, specs, runtimeParams,
 					gadgetcontext.WithDataOperators(ops...),
 					gadgetcontext.WithTimeout(timeoutDuration),
 					gadgetcontext.WithUseInstance(false),
@@ -343,9 +340,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			runtimeParams.Set("tags", strings.Join(spec.Tags, ","))
 			runtimeParams.Set("node", strings.Join(spec.Nodes, ","))
 
-			tempParams := spec.ParamValues
-			maps.Copy(tempParams, paramValueMap)
-			paramValueMap = tempParams
+			paramValueMap = spec.ParamValues
 		}
 
 		if commandMode == CommandModeAttach {
@@ -427,7 +422,6 @@ func runInstanceSpecsDetached(
 	runtime runtime.Runtime,
 	specs []*gadgetmanifest.InstanceSpec,
 	runtimeParams *params.Params,
-	paramValueMap map[string]string,
 	runOptions ...gadgetcontext.Option,
 ) error {
 	var merr error
@@ -439,8 +433,6 @@ func runInstanceSpecsDetached(
 		runtimeParams.Set("name", spec.Name)
 		runtimeParams.Set("tags", strings.Join(spec.Tags, ","))
 		runtimeParams.Set("node", strings.Join(spec.Nodes, ","))
-
-		maps.Copy(spec.ParamValues, paramValueMap)
 
 		gadgetCtx := gadgetcontext.New(ctx, image, runOptions...)
 

--- a/docs/reference/export-logs.mdx
+++ b/docs/reference/export-logs.mdx
@@ -1,0 +1,68 @@
+---
+title: Exporting Logs (OpenTelemetry)
+sidebar_position: 1200
+description: Using OpenTelemetry to export gadget logs
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Inspektor Gadget supports [exporting logs to OpenTelemetry](https://opentelemetry.io/docs/specs/otel/logs/) using the
+otlp-grpc exporter. You can log the events of any datasource by configuring exporters in the `operator.otel-logs`
+section of the config file like so:
+
+```yaml
+operator:
+  otel-logs:
+    exporters:
+      my-log-exporter:
+        exporter: otlp-grpc
+        compression: gzip
+        endpoint: "127.0.0.1:4317"
+        insecure: true
+```
+
+This will configure an exporter named `my-log-exporter` with the given endpoint, gzip compression enabled and TLS
+disabled.
+
+You can then run a gadget and activate the exporter for it by setting the `--otel-logs-exporter=my-log-exporter` flag.
+
+### Exporter settings
+
+#### exporter
+
+Currently we only support `otlp-grpc`.
+
+#### compression
+
+Compression can be set to either "none" (no compression) or "gzip" (gzip compression).
+
+#### endpoint
+
+IP address and port of the gRPC receiver.
+
+#### insecure
+
+If set to true, the gRPC connection will not use TLS encryption. False by default.
+
+## Annotations
+
+Annotations can be used to define how logs should be generated from a datasource. Let's look at an example:
+
+```yaml
+datasources:
+  open:
+    annotations:
+      logs.name: my-gadget
+      logs.severity: 13 # equals WARN severity and will be set for every event
+      logs.body: "file " + fname + " was opened by " + comm + " (PID " + string(pid) + ")"
+    fields:
+      timestamp:
+        logs.name: timestamp # this expects the field to contain the time in unix microseconds
+      ## Alternatively, you could set the severity from a field of any int type like so:
+      # severity:
+      #   logs.name: severity
+      ## You can also set any string typed field as body for the log entry
+      # comm:
+      #   logs.name: body
+```

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -59,6 +59,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubeipresolver"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-logs"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/sort"

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,10 @@ require (
 	github.com/sigstore/sigstore v1.8.10
 	github.com/spf13/pflag v1.0.5
 	github.com/tetratelabs/wazero v1.8.1
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.7.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.31.0
+	go.opentelemetry.io/otel/log v0.7.0
+	go.opentelemetry.io/otel/sdk/log v0.7.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 
 require (
 	github.com/containerd/errdefs v1.0.0
+	github.com/expr-lang/expr v1.16.9
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gopacket/gopacket v1.3.1
 	github.com/sigstore/sigstore v1.8.10

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIX
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0/go.mod h1:jjdQuTGVsXV4vSs+CJ2qYDeDPf9yIJV23qlIzBm73Vg=
 go.opentelemetry.io/otel v1.31.0 h1:NsJcKPIW0D0H3NgzPDHmo0WW6SptzPdqg/L1zsIm2hY=
 go.opentelemetry.io/otel v1.31.0/go.mod h1:O0C14Yl9FgkjqcCZAsE053C13OaddMYr/hz6clDkEJE=
+go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.7.0 h1:iNba3cIZTDPB2+IAbVY/3TUN+pCCLrNYo2GaGtsKBak=
+go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.7.0/go.mod h1:l5BDPiZ9FbeejzWTAX6BowMzQOM/GeaUQ6lr3sOcSkc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.31.0 h1:FZ6ei8GFW7kyPYdxJaV2rgI6M+4tvZzhYsQ2wgyVC08=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.31.0/go.mod h1:MdEu/mC6j3D+tTEfvI15b5Ci2Fn7NneJ71YMoiS3tpI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=
@@ -477,10 +479,14 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 h1:digkE
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0/go.mod h1:/OpE/y70qVkndM0TrxT4KBoN3RsFZP0QaofcfYrj76I=
 go.opentelemetry.io/otel/exporters/prometheus v0.53.0 h1:QXobPHrwiGLM4ufrY3EOmDPJpo2P90UuFau4CDPJA/I=
 go.opentelemetry.io/otel/exporters/prometheus v0.53.0/go.mod h1:WOAXGr3D00CfzmFxtTV1eR0GpoHuPEu+HJT8UWW2SIU=
+go.opentelemetry.io/otel/log v0.7.0 h1:d1abJc0b1QQZADKvfe9JqqrfmPYQCz2tUSO+0XZmuV4=
+go.opentelemetry.io/otel/log v0.7.0/go.mod h1:2jf2z7uVfnzDNknKTO9G+ahcOAyWcp1fJmk/wJjULRo=
 go.opentelemetry.io/otel/metric v1.31.0 h1:FSErL0ATQAmYHUIzSezZibnyVlft1ybhy4ozRPcF2fE=
 go.opentelemetry.io/otel/metric v1.31.0/go.mod h1:C3dEloVbLuYoX41KpmAhOqNriGbA+qqH6PQ5E5mUfnY=
 go.opentelemetry.io/otel/sdk v1.31.0 h1:xLY3abVHYZ5HSfOg3l2E5LUj2Cwva5Y7yGxnSW9H5Gk=
 go.opentelemetry.io/otel/sdk v1.31.0/go.mod h1:TfRbMdhvxIIr/B2N2LQW2S5v9m3gOQ/08KsbbO5BPT0=
+go.opentelemetry.io/otel/sdk/log v0.7.0 h1:dXkeI2S0MLc5g0/AwxTZv6EUEjctiH8aG14Am56NTmQ=
+go.opentelemetry.io/otel/sdk/log v0.7.0/go.mod h1:oIRXpW+WD6M8BuGj5rtS0aRu/86cbDV/dAfNaZBIjYM=
 go.opentelemetry.io/otel/sdk/metric v1.31.0 h1:i9hxxLJF/9kkvfHppyLL55aW7iIJz4JjxTeYusH7zMc=
 go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/trace v1.31.0 h1:ffjsj1aRouKewfr85U2aGagJ46+MvodynlQ1HYdmJys=

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ
 github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
+github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/florianl/go-tc v0.4.4 h1:q6lhEWEfyhGffRzdl3eIcNqX/yVIw0IJwXqa9Rdcctw=

--- a/pkg/datasource/expr/expr.go
+++ b/pkg/datasource/expr/expr.go
@@ -1,0 +1,209 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/vm"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+type wrap struct {
+	d datasource.Data
+}
+
+func (w wrap) GetString(f datasource.FieldAccessor) string {
+	d, _ := f.String(w.d)
+	return d
+}
+
+func (w wrap) GetUint8(f datasource.FieldAccessor) uint8 {
+	d, _ := f.Uint8(w.d)
+	return d
+}
+
+func (w wrap) GetUint16(f datasource.FieldAccessor) uint16 {
+	d, _ := f.Uint16(w.d)
+	return d
+}
+
+func (w wrap) GetUint32(f datasource.FieldAccessor) uint32 {
+	d, _ := f.Uint32(w.d)
+	return d
+}
+
+func (w wrap) GetUint64(f datasource.FieldAccessor) uint64 {
+	d, _ := f.Uint64(w.d)
+	return d
+}
+
+func (w wrap) GetInt8(f datasource.FieldAccessor) int8 {
+	d, _ := f.Int8(w.d)
+	return d
+}
+
+func (w wrap) GetInt16(f datasource.FieldAccessor) int16 {
+	d, _ := f.Int16(w.d)
+	return d
+}
+
+func (w wrap) GetInt32(f datasource.FieldAccessor) int32 {
+	d, _ := f.Int32(w.d)
+	return d
+}
+
+func (w wrap) GetInt64(f datasource.FieldAccessor) int64 {
+	d, _ := f.Int64(w.d)
+	return d
+}
+
+func (w wrap) GetFloat32(f datasource.FieldAccessor) float32 {
+	d, _ := f.Float32(w.d)
+	return d
+}
+
+func (w wrap) GetFloat64(f datasource.FieldAccessor) float64 {
+	d, _ := f.Float64(w.d)
+	return d
+}
+
+func (w wrap) GetBool(f datasource.FieldAccessor) bool {
+	d, _ := f.Bool(w.d)
+	return d
+}
+
+type dsPatcher struct {
+	ds datasource.DataSource
+}
+
+func (dsp dsPatcher) Visit(node *ast.Node) {
+	switch nx := (*node).(type) {
+	case *ast.MemberNode:
+		cn, ok := nx.Node.(*ast.ConstantNode)
+		if !ok {
+			return
+		}
+		pn, ok := nx.Property.(*ast.StringNode)
+		if !ok {
+			return
+		}
+
+		rf, ok := cn.Value.(datasource.FieldAccessor)
+		if !ok {
+			return
+		}
+		var f datasource.FieldAccessor
+		for _, sf := range rf.SubFields() {
+			if sf.Name() == pn.Value {
+				f = sf
+				break
+			}
+		}
+		replaceNode(node, f)
+	case *ast.IdentifierNode:
+		f := dsp.ds.GetField(nx.Value)
+		replaceNode(node, f)
+	}
+}
+
+func replaceNode(node *ast.Node, f datasource.FieldAccessor) {
+	if f == nil {
+		return
+	}
+
+	// if target contains subfields, return the fieldAccessor itself
+	if len(f.SubFields()) > 0 {
+		constNode := &ast.ConstantNode{Value: f}
+		ast.Patch(node, constNode)
+		(*node).SetType(reflect.TypeOf(f))
+		return
+	}
+
+	// otherwise return value
+	fn, ft := getFnAndReflectType(f)
+	if fn == "" {
+		return
+	}
+
+	callNode := &ast.CallNode{
+		Callee:    &ast.IdentifierNode{Value: fn},
+		Arguments: []ast.Node{&ast.ConstantNode{Value: f}},
+	}
+	ast.Patch(node, callNode)
+	(*node).SetType(ft)
+}
+
+func getFnAndReflectType(f datasource.FieldAccessor) (string, reflect.Type) {
+	switch f.Type() {
+	default:
+		fallthrough // anything can be read as string
+	case api.Kind_CString, api.Kind_String:
+		return "GetString", reflect.TypeOf("")
+	case api.Kind_Uint8:
+		return "GetUint8", reflect.TypeOf(uint8(0))
+	case api.Kind_Uint16:
+		return "GetUint16", reflect.TypeOf(uint16(0))
+	case api.Kind_Uint32:
+		return "GetUint32", reflect.TypeOf(uint32(0))
+	case api.Kind_Uint64:
+		return "GetUint64", reflect.TypeOf(uint64(0))
+	case api.Kind_Int8:
+		return "GetInt8", reflect.TypeOf(int8(0))
+	case api.Kind_Int16:
+		return "GetInt16", reflect.TypeOf(int16(0))
+	case api.Kind_Int32:
+		return "GetInt32", reflect.TypeOf(int32(0))
+	case api.Kind_Int64:
+		return "GetInt64", reflect.TypeOf(int64(0))
+	case api.Kind_Float32:
+		return "GetFloat32", reflect.TypeOf(float32(0))
+	case api.Kind_Float64:
+		return "GetFloat64", reflect.TypeOf(float64(0))
+	case api.Kind_Bool:
+		return "GetBool", reflect.TypeOf(false)
+	}
+}
+
+func CompileStringProgram(ds datasource.DataSource, expression string) (*vm.Program, error) {
+	dsp := dsPatcher{
+		ds: ds,
+	}
+	prog, err := expr.Compile(expression, expr.AsKind(reflect.String), expr.Patch(dsp), expr.Env(&wrap{}))
+	if err != nil {
+		return nil, fmt.Errorf("compiling string expression: %w", err)
+	}
+	return prog, nil
+}
+
+func CompileFilterProgram(ds datasource.DataSource, expression string) (*vm.Program, error) {
+	dsp := dsPatcher{
+		ds: ds,
+	}
+	prog, err := expr.Compile(expression, expr.AsBool(), expr.Patch(dsp), expr.Env(&wrap{}))
+	if err != nil {
+		return nil, fmt.Errorf("compiling filter expression: %w", err)
+	}
+	return prog, nil
+}
+
+func Run(program *vm.Program, data datasource.Data) (any, error) {
+	return expr.Run(program, wrap{data})
+}

--- a/pkg/datasource/expr/expr_test.go
+++ b/pkg/datasource/expr/expr_test.go
@@ -1,0 +1,389 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+type testCaseString struct {
+	name         string
+	filterString string
+	result       string
+	error        bool
+}
+
+type testCaseFilter struct {
+	name         string
+	filterString string
+	match        bool
+	error        bool
+}
+
+type testCaseData struct {
+	stringValue  string
+	int64Value   int64
+	float64Value float64
+	boolValue    bool
+}
+
+func TestExpressionString(t *testing.T) {
+	testCaseData := testCaseData{
+		stringValue:  "abc",
+		int64Value:   123,
+		float64Value: 456.0,
+		boolValue:    true,
+	}
+
+	testCases := []testCaseString{
+		{
+			name:         "concat string",
+			filterString: "\"hello \"+stringValue",
+			error:        false,
+			result:       "hello abc",
+		},
+		{
+			name:         "all of them",
+			filterString: "\"hello \"+stringValue+\", the int64 is \"+string(int64Value)+\", the float is \"+string(float64Value)+\", and the bool is \"+string(boolValue)",
+			error:        false,
+			result:       "hello abc, the int64 is 123, the float is 456, and the bool is true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stringField datasource.FieldAccessor
+			var int64Field datasource.FieldAccessor
+			var float64Field datasource.FieldAccessor
+			var boolField datasource.FieldAccessor
+
+			ds, err := datasource.New(datasource.TypeSingle, "filter")
+			require.NoError(t, err)
+			stringField, err = ds.AddField("stringValue", api.Kind_String)
+			require.NoError(t, err)
+			int64Field, err = ds.AddField("int64Value", api.Kind_Int64)
+			require.NoError(t, err)
+			float64Field, err = ds.AddField("float64Value", api.Kind_Float64)
+			require.NoError(t, err)
+			boolField, err = ds.AddField("boolValue", api.Kind_Bool)
+			require.NoError(t, err)
+
+			data, err := ds.NewPacketSingle()
+			require.NoError(t, err)
+			err = stringField.PutString(data, testCaseData.stringValue)
+			require.NoError(t, err)
+			err = int64Field.PutInt64(data, testCaseData.int64Value)
+			require.NoError(t, err)
+			err = float64Field.PutFloat64(data, testCaseData.float64Value)
+			require.NoError(t, err)
+			err = boolField.PutBool(data, testCaseData.boolValue)
+			require.NoError(t, err)
+
+			filter, err := CompileStringProgram(ds, tc.filterString)
+			if tc.error {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			res, err := expr.Run(filter, wrap{d: data})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.result, res.(string), tc.name)
+		})
+	}
+}
+
+func TestExpressionFilter(t *testing.T) {
+	testCaseData := testCaseData{
+		stringValue:  "abc",
+		int64Value:   123,
+		float64Value: 456.0,
+		boolValue:    true,
+	}
+	testCases := []testCaseFilter{
+		{
+			name:         "incomplete filter",
+			filterString: "abc",
+			error:        true,
+		},
+		{
+			name:         "string match positive",
+			filterString: "stringValue=='abc'",
+			match:        true,
+		},
+		{
+			name:         "string match negative",
+			filterString: "stringValue=='def'",
+			match:        false,
+		},
+		{
+			name:         "string not match positive",
+			filterString: "stringValue!='def'",
+			match:        true,
+		},
+		{
+			name:         "string not match negative",
+			filterString: "stringValue!='abc'",
+			match:        false,
+		},
+		{
+			name:         "string lte positive",
+			filterString: "stringValue<='def'",
+			match:        true,
+		},
+		{
+			name:         "string gte negative",
+			filterString: "stringValue>='def'",
+			match:        false,
+		},
+		{
+			name:         "string regex match positive",
+			filterString: "stringValue matches 'a..'",
+			match:        true,
+		},
+		{
+			name:         "string regex match negative",
+			filterString: "stringValue matches 'b..'",
+			match:        false,
+		},
+		{
+			name:         "string regex not match positive",
+			filterString: "stringValue not matches 'b..'",
+			match:        true,
+		},
+		{
+			name:         "string regex not match negative",
+			filterString: "stringValue not matches 'a..'",
+			match:        false,
+		},
+		{
+			name:         "string regex invalid",
+			filterString: "stringValue matches '???a..'",
+			error:        true,
+		},
+
+		{
+			name:         "int match positive",
+			filterString: "int64Value==123",
+			match:        true,
+		},
+		{
+			name:         "int match negative",
+			filterString: "int64Value==345",
+			match:        false,
+		},
+		{
+			name:         "int gte positive",
+			filterString: "int64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "int gte positive",
+			filterString: "int64Value>=123",
+			match:        true,
+		},
+		{
+			name:         "int gte negative",
+			filterString: "int64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "int lte positive",
+			filterString: "int64Value<=1000",
+			match:        true,
+		},
+		{
+			name:         "int lte positive",
+			filterString: "int64Value<=123",
+			match:        true,
+		},
+		{
+			name:         "int lte negative",
+			filterString: "int64Value<=1",
+			match:        false,
+		},
+		{
+			name:         "int gt positive",
+			filterString: "int64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "int gt negative",
+			filterString: "int64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "int lt positive",
+			filterString: "int64Value>1",
+			match:        true,
+		},
+		{
+			name:         "int lt negative",
+			filterString: "int64Value>1000",
+			match:        false,
+		},
+		{
+			name:         "int no int",
+			filterString: "int64Value>'abc'",
+			error:        true,
+		},
+
+		{
+			name:         "float match positive",
+			filterString: "float64Value==456",
+			match:        true,
+		},
+		{
+			name:         "float match positive",
+			filterString: "float64Value==456.0",
+			match:        true,
+		},
+		{
+			name:         "float match negative",
+			filterString: "float64Value==345",
+			match:        false,
+		},
+		{
+			name:         "float match negative",
+			filterString: "float64Value==456.8",
+			match:        false,
+		},
+		{
+			name:         "float gte positive",
+			filterString: "float64Value>=1",
+			match:        true,
+		},
+		{
+			name:         "float gte positive",
+			filterString: "float64Value>=456",
+			match:        true,
+		},
+		{
+			name:         "float gte negative",
+			filterString: "float64Value>=1000",
+			match:        false,
+		},
+		{
+			name:         "float lte positive",
+			filterString: "float64Value<=1000",
+			match:        true,
+		},
+		{
+			name:         "float lte positive",
+			filterString: "float64Value<=456",
+			match:        true,
+		},
+		{
+			name:         "float lte negative",
+			filterString: "float64Value<=1",
+			match:        false,
+		},
+		{
+			name:         "float gt positive",
+			filterString: "float64Value>=1.0",
+			match:        true,
+		},
+		{
+			name:         "float gt negative",
+			filterString: "float64Value>=1000.0",
+			match:        false,
+		},
+		{
+			name:         "float lt positive",
+			filterString: "float64Value>1.0",
+			match:        true,
+		},
+		{
+			name:         "float lt negative",
+			filterString: "float64Value>1000.0",
+			match:        false,
+		},
+		{
+			name:         "float no float",
+			filterString: "float64Value>'abc'",
+			error:        true,
+		},
+
+		{
+			name:         "bool match positive",
+			filterString: "boolValue==true",
+			match:        true,
+		},
+		{
+			name:         "bool match negative",
+			filterString: "boolValue==false",
+			match:        false,
+		},
+		{
+			name:         "bool not match positive",
+			filterString: "boolValue!=false",
+			match:        true,
+		},
+		{
+			name:         "bool not match negative",
+			filterString: "boolValue!=true",
+			match:        false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stringField datasource.FieldAccessor
+			var int64Field datasource.FieldAccessor
+			var float64Field datasource.FieldAccessor
+			var boolField datasource.FieldAccessor
+
+			ds, err := datasource.New(datasource.TypeSingle, "filter")
+			require.NoError(t, err)
+			stringField, err = ds.AddField("stringValue", api.Kind_String)
+			require.NoError(t, err)
+			int64Field, err = ds.AddField("int64Value", api.Kind_Int64)
+			require.NoError(t, err)
+			float64Field, err = ds.AddField("float64Value", api.Kind_Float64)
+			require.NoError(t, err)
+			boolField, err = ds.AddField("boolValue", api.Kind_Bool)
+			require.NoError(t, err)
+
+			data, err := ds.NewPacketSingle()
+			require.NoError(t, err)
+			err = stringField.PutString(data, testCaseData.stringValue)
+			require.NoError(t, err)
+			err = int64Field.PutInt64(data, testCaseData.int64Value)
+			require.NoError(t, err)
+			err = float64Field.PutFloat64(data, testCaseData.float64Value)
+			require.NoError(t, err)
+			err = boolField.PutBool(data, testCaseData.boolValue)
+			require.NoError(t, err)
+
+			filter, err := CompileFilterProgram(ds, tc.filterString)
+			if tc.error {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			res, err := expr.Run(filter, wrap{d: data})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.match, res.(bool), tc.name)
+		})
+	}
+}

--- a/pkg/datasource/helpers.go
+++ b/pkg/datasource/helpers.go
@@ -1,0 +1,120 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/constraints"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+)
+
+func AsInt64Func[T constraints.Integer](extract func(Data) (T, error)) func(Data) int64 {
+	return func(data Data) int64 {
+		v, err := extract(data)
+		if err != nil {
+			return 0
+		}
+		return int64(v)
+	}
+}
+
+func AsInt64(f FieldAccessor) (func(Data) int64, error) {
+	switch f.Type() {
+	default:
+		return nil, fmt.Errorf("invalid field type for AsInt64: %s", f.Type())
+	case api.Kind_Int8:
+		return AsInt64Func(f.Int8), nil
+	case api.Kind_Int16:
+		return AsInt64Func(f.Int16), nil
+	case api.Kind_Int32:
+		return AsInt64Func(f.Int32), nil
+	case api.Kind_Int64:
+		return AsInt64Func(f.Int64), nil
+	case api.Kind_Uint8:
+		return AsInt64Func(f.Uint8), nil
+	case api.Kind_Uint16:
+		return AsInt64Func(f.Uint16), nil
+	case api.Kind_Uint32:
+		return AsInt64Func(f.Uint32), nil
+	case api.Kind_Uint64:
+		return AsInt64Func(f.Uint64), nil
+	}
+}
+
+func AsFloat64Func[T constraints.Float](extract func(Data) (T, error)) func(Data) float64 {
+	return func(data Data) float64 {
+		v, err := extract(data)
+		if err != nil {
+			return 0
+		}
+		return float64(v)
+	}
+}
+
+func AsFloat64(f FieldAccessor) (func(Data) float64, error) {
+	switch f.Type() {
+	default:
+		return nil, fmt.Errorf("invalid field type for AsFloat64: %s", f.Type())
+	case api.Kind_Float32:
+		return AsFloat64Func(f.Float32), nil
+	case api.Kind_Float64:
+		return AsFloat64Func(f.Float64), nil
+	}
+}
+
+// GetKeyValueFunc takes a FieldAccessor and returns a function that can convert Data to a key/value pair of types S/T
+// using the primitive converters given; this is especially useful for the otel libraries which deal with different
+// types for key/value pairs. Error checking is omitted here as it should a) have been done by type checking beforehand,
+// and b) it is too costly when done in here. Instead, on error, the default values will be returned.
+func GetKeyValueFunc[S ~string, T any](
+	f FieldAccessor,
+	int64Fn func(int64) T,
+	float64Fn func(float64) T,
+	stringFn func(string) T,
+) (func(Data) (S, T), error) {
+	emptyVal := *new(T)
+	name := f.Name()
+	switch f.Type() {
+	default:
+		return nil, fmt.Errorf("unsupported field type for key: %s", f.Type())
+	case api.Kind_String, api.Kind_CString:
+		return func(data Data) (S, T) {
+			val, err := f.String(data)
+			if err != nil {
+				return "", emptyVal
+			}
+			return S(name), stringFn(val)
+		}, nil
+	case api.Kind_Uint8,
+		api.Kind_Uint16,
+		api.Kind_Uint32,
+		api.Kind_Uint64,
+		api.Kind_Int8,
+		api.Kind_Int16,
+		api.Kind_Int32,
+		api.Kind_Int64:
+		asIntFn, _ := AsInt64(f) // error can't happen
+		return func(data Data) (S, T) {
+			return S(name), int64Fn(asIntFn(data))
+		}, nil
+	case api.Kind_Float32, api.Kind_Float64:
+		asFloatFn, _ := AsFloat64(f) // error can't happen
+		return func(data Data) (S, T) {
+			return S(name), float64Fn(asFloatFn(data))
+		}, nil
+	}
+}

--- a/pkg/operators/otel-logs/otel-logs.go
+++ b/pkg/operators/otel-logs/otel-logs.go
@@ -1,0 +1,320 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otellogs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/expr"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const (
+	ParamOtelLogsExporter = "otel-logs-exporter"
+
+	AnnotationLogsName = "logs.name"
+
+	AnnotationLogsBody     = "logs.body"
+	AnnotationLogsSeverity = "logs.severity"
+
+	FieldNameBody      = "body"
+	FieldNameTimestamp = "timestamp"
+	FieldNameSeverity  = "severity"
+
+	ExporterOTLPGRPC = "otlp-grpc"
+
+	CompressionNone = "none"
+	CompressionGZIP = "gzip"
+)
+
+var supportedExporters = []string{ExporterOTLPGRPC}
+
+type logConfig struct {
+	Exporter    string `json:"exporter" yaml:"exporter"`
+	Endpoint    string `json:"endpoint" yaml:"endpoint"`
+	Insecure    bool   `json:"insecure" yaml:"insecure"`
+	Compression string `json:"compression" yaml:"compression"`
+}
+
+type otelLogsOperator struct {
+	providers map[string]*sdklog.LoggerProvider
+}
+
+func (o *otelLogsOperator) Name() string {
+	return "otel-logs"
+}
+
+func (o *otelLogsOperator) Init(params *params.Params) error {
+	o.providers = make(map[string]*sdklog.LoggerProvider)
+
+	res, _ := resource.New(context.Background(), resource.WithAttributes(
+		semconv.ServiceNameKey.String("inspektor-gadget"),
+		semconv.ServiceVersionKey.String(version.Version().String()),
+	))
+
+	if config.Config == nil {
+		return nil
+	}
+
+	configs := make(map[string]*logConfig, 0)
+	log.Debugf("loading log exporters")
+	err := config.Config.UnmarshalKey("operator.otel-logs.exporters", &configs)
+	if err != nil {
+		log.Warnf("failed to load operator.otel-logs.exporters: %v", err)
+	}
+	for k, v := range configs {
+		if v.Exporter != ExporterOTLPGRPC {
+			return fmt.Errorf("unsupported log exporter %q; expected one of %s", v.Exporter,
+				strings.Join(supportedExporters, ", "))
+		}
+		var options []otlploggrpc.Option
+
+		options = append(options, otlploggrpc.WithEndpoint(v.Endpoint))
+		if v.Insecure {
+			options = append(options, otlploggrpc.WithInsecure())
+		}
+		switch v.Compression {
+		default:
+			return fmt.Errorf("unsupported log compression %q", v.Compression)
+		case "", CompressionNone:
+		case CompressionGZIP:
+			options = append(options, otlploggrpc.WithCompressor("gzip"))
+		}
+
+		exp, err := otlploggrpc.New(context.Background(), options...)
+		if err != nil {
+			return fmt.Errorf("creating otlp exporter: %w", err)
+		}
+		processor := sdklog.NewBatchProcessor(exp)
+		provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor), sdklog.WithResource(res))
+		o.providers[k] = provider
+		log.Debugf("> log exporter %q with endpoint %q loaded", k, v.Endpoint)
+	}
+
+	return nil
+}
+
+func (o *otelLogsOperator) GlobalParams() api.Params {
+	return api.Params{}
+}
+
+func (o *otelLogsOperator) InstanceParams() api.Params {
+	return api.Params{
+		&api.Param{
+			Key:          ParamOtelLogsExporter,
+			Description:  "Exporter to use for log exporting",
+			DefaultValue: "",
+		},
+	}
+}
+
+func (o *otelLogsOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	if len(o.providers) == 0 {
+		return nil, nil
+	}
+	mappings, err := apihelpers.GetStringValuesPerDataSource(instanceParamValues[ParamOtelLogsExporter])
+	if err != nil {
+		return nil, fmt.Errorf("parsing name mappings: %w", err)
+	}
+	inst := &otelLogsOperatorInstance{
+		o:        o,
+		mappings: mappings,
+		loggers:  make(map[datasource.DataSource]otellog.Logger),
+	}
+	err = inst.init(gadgetCtx)
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+func (o *otelLogsOperator) Priority() int {
+	return 9999
+}
+
+type otelLogsOperatorInstance struct {
+	o        *otelLogsOperator
+	mappings map[string]string
+	loggers  map[datasource.DataSource]otellog.Logger
+}
+
+func (o *otelLogsOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
+	for _, ds := range gadgetCtx.GetDataSources() {
+		annotations := ds.Annotations()
+
+		// Find mapping
+		exporterName, ok := o.mappings[ds.Name()]
+		if !ok {
+			exporterName, ok = o.mappings[""]
+			if !ok {
+				continue
+			}
+		}
+
+		exporter, ok := o.o.providers[exporterName]
+		if !ok {
+			return fmt.Errorf("exporter not found: %q", exporterName)
+		}
+
+		loggerName := annotations[AnnotationLogsName]
+		if loggerName == "" {
+			loggerName = gadgetCtx.ImageName()
+		}
+
+		gadgetCtx.Logger().Debugf("logging %q to exporter %q", ds.Name(), exporterName)
+		o.loggers[ds] = exporter.Logger(loggerName)
+	}
+	return nil
+}
+
+func (o *otelLogsOperatorInstance) Name() string {
+	return "otel-logs"
+}
+
+func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, logger := range o.loggers {
+		fields := ds.Accessors(false)
+		annotations := ds.Annotations()
+
+		prep := make([]func(data datasource.Data) otellog.KeyValue, 0)
+		kvCount := 0
+
+		fns := make([]func(datasource.Data, *otellog.Record), 0)
+
+		// fixed severity by annotation
+		if severity, ok := annotations[AnnotationLogsSeverity]; ok {
+			sv, err := strconv.ParseFloat(severity, 64)
+			if err != nil {
+				return fmt.Errorf("invalid log severity %q: %w", severity, err)
+			}
+			fns = append(fns, func(data datasource.Data, record *otellog.Record) {
+				record.SetSeverity(otellog.Severity(sv))
+			})
+		}
+
+		// body string by annotation
+		if bodyString, ok := annotations[AnnotationLogsBody]; ok {
+			prog, err := expr.CompileStringProgram(ds, bodyString)
+			if err != nil {
+				return fmt.Errorf("compiling expression %q: %w", bodyString, err)
+			}
+			fns = append(fns, func(data datasource.Data, record *otellog.Record) {
+				s, err := expr.Run(prog, data)
+				if err != nil {
+					return
+				}
+				record.SetBody(otellog.StringValue(s.(string)))
+			})
+		}
+
+		for _, f := range fields {
+			fieldAnnotations := f.Annotations()
+			name, ok := fieldAnnotations[AnnotationLogsName]
+			if !ok {
+				continue
+			}
+
+			switch name {
+			case FieldNameBody:
+				fns = append(fns, func(data datasource.Data, record *otellog.Record) {
+					str, _ := f.String(data)
+					record.SetBody(otellog.StringValue(str))
+				})
+			case FieldNameTimestamp:
+				ts, err := datasource.AsInt64(f)
+				if err != nil {
+					return fmt.Errorf("using field %q as %q: %w", f.Name(), name, err)
+				}
+				fns = append(fns, func(data datasource.Data, record *otellog.Record) {
+					record.SetObservedTimestamp(time.Unix(0, ts(data)*int64(time.Microsecond)))
+				})
+			case FieldNameSeverity:
+				severity, err := datasource.AsInt64(f)
+				if err != nil {
+					return fmt.Errorf("using field %q as %q: %w", f.Name(), name, err)
+				}
+				fns = append(fns, func(data datasource.Data, record *otellog.Record) {
+					record.SetSeverity(otellog.Severity(severity(data)))
+				})
+				continue
+			}
+
+			kvf, err := datasource.GetKeyValueFunc[string, otellog.Value](f, otellog.Int64Value, otellog.Float64Value, otellog.StringValue)
+			if err != nil {
+				return fmt.Errorf("getting key/val func for %s.%s: %w", ds.Name(), f.Name(), err)
+			}
+			prep = append(prep, func(data datasource.Data) otellog.KeyValue {
+				key, val := kvf(data)
+				return otellog.KeyValue{
+					Key:   key,
+					Value: val,
+				}
+			})
+			kvCount++
+		}
+
+		ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+			var rec otellog.Record
+
+			// Collect attributes
+			attribs := make([]otellog.KeyValue, 0, kvCount)
+			for _, p := range prep {
+				attribs = append(attribs, p(data))
+			}
+			rec.AddAttributes(attribs...)
+
+			// Set other values
+			for _, f := range fns {
+				f(data, &rec)
+			}
+			rec.SetTimestamp(time.Now())
+
+			logger.Emit(gadgetCtx.Context(), rec)
+			return nil
+		}, 10000)
+	}
+	return nil
+}
+
+func (o *otelLogsOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (o *otelLogsOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+var Operator = &otelLogsOperator{}
+
+func init() {
+	operators.RegisterDataOperator(Operator)
+}


### PR DESCRIPTION
This adds support for [OpenTelemetry Logs](https://opentelemetry.io/docs/specs/otel/logs/) using the [otlp protocol](https://opentelemetry.io/docs/specs/otlp/). Fields of datasources can be configured to be exported as KeyValue pairs alongside the log body. The severity can also be read from a field. The message body can be composed using [expr-lang](https://expr-lang.org) (see below) to include fields from the datasource.

This also introduces support for [expr-lang](https://expr-lang.org) to be able to use filters and string composition with datasources. In this PR, the string composition feature will be used to create the actual log body message. If for example you have a datasource with a `StringField` and an `IntField` that you want to include in the log body, you could simply define the body as `StringField + string(IntField)` to have those fields' contents concatenated. For other features of the expr-lang, read the [language definition](https://expr-lang.org/docs/language-definition).

### Todo

* [x] Docs / Examples
* [ ] Tests
* [ ] Add support for static key/values
* [x] Add support for static severities

### How to test

#### Setup otel-collector

```yaml
# otel-config.yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317

processors:
  batch:
  memory_limiter:
    # 75% of maximum memory up to 2G
    limit_mib: 1536
    # 25% of limit up to 2G
    spike_limit_mib: 512
    check_interval: 5s

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    logs:
      receivers: [otlp]
      processors: [batch]
      exporters: [debug]
    metrics:
      receivers: [otlp]
      processors: [memory_limiter, batch]
      exporters: [debug]
```

```yaml
# docker-compose.yaml
services:
  otel-collector:
    image: otel/opentelemetry-collector:latest
    ports:
      - "4317:4317" # gRPC endpoint for traces
    volumes:
      - ./otel-config.yaml:/otel-config.yaml
    command: ["--config", "/otel-config.yaml"]
```

Then run with `docker compose up`

#### Configure ig

```yaml
# config.yaml
operator:
  otel-logs:
    exporters:
      grpc:
        exporter: otlp-grpc
        compression: gzip
        endpoint: "127.0.0.1:4317"
        insecure: true
  otel-metrics:
    exporters:
      grpc:
        exporter: otlp-grpc
        endpoint: "127.0.0.1:4317"
        insecure: true
        temporality: delta
        interval: 30s
```

Then run `ig daemon --group 1000 -v --verify-image=false`, for example.

#### Run ig/gadgetctl

```bash
gadgetctl run trace_open --host -v --otel-logs-exporter=grpc --annotate "open:logs.name=trace_open,open.proc.pid:logs.name=pid,open:logs.body=\"file \" + fname + \" was opened by \" + proc.comm + \" (PID \" + string(proc.pid) + \")\",open:logs.severity=21"
```

#### Example output of otel-logs collector

```
otel-otel-collector-1  | 2024-11-13T00:41:06.118Z	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 2}
otel-otel-collector-1  | 2024-11-13T00:41:06.120Z	info	ResourceLog #0
otel-otel-collector-1  | Resource SchemaURL:
otel-otel-collector-1  | Resource attributes:
otel-otel-collector-1  |      -> service.name: Str(inspektor-gadget)
otel-otel-collector-1  |      -> service.version: Str(0.0.0)
otel-otel-collector-1  | ScopeLogs #0
otel-otel-collector-1  | ScopeLogs SchemaURL:
otel-otel-collector-1  | InstrumentationScope trace_open
otel-otel-collector-1  | LogRecord #0
otel-otel-collector-1  | ObservedTimestamp: 2024-11-13 00:41:05.041374423 +0000 UTC
otel-otel-collector-1  | Timestamp: 2024-11-13 00:41:05.041352089 +0000 UTC
otel-otel-collector-1  | SeverityText:
otel-otel-collector-1  | SeverityNumber: Fatal(21)
otel-otel-collector-1  | Body: Str(file /proc was opened by ig (PID 726))
otel-otel-collector-1  | Attributes:
otel-otel-collector-1  |      -> pid: Int(726)
otel-otel-collector-1  | Trace ID:
otel-otel-collector-1  | Span ID:
otel-otel-collector-1  | Flags: 0
otel-otel-collector-1  | LogRecord #1
otel-otel-collector-1  | ObservedTimestamp: 2024-11-13 00:41:05.282250048 +0000 UTC
otel-otel-collector-1  | Timestamp: 2024-11-13 00:41:05.282241381 +0000 UTC
otel-otel-collector-1  | SeverityText:
otel-otel-collector-1  | SeverityNumber: Fatal(21)
otel-otel-collector-1  | Body: Str(file /proc was opened by ig (PID 4529))
otel-otel-collector-1  | Attributes:
otel-otel-collector-1  |      -> pid: Int(4529)
otel-otel-collector-1  | Trace ID:
otel-otel-collector-1  | Span ID:
otel-otel-collector-1  | Flags: 0
otel-otel-collector-1  | 	{"kind": "exporter", "data_type": "logs", "name": "debug"}
```