### PR TITLE
Remove support for torcx

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -38,7 +38,6 @@ var RuntimePaths = []string{
 	"/usr/local/bin/runc",
 	"/usr/local/sbin/runc",
 	"/usr/lib/cri-o-runc/sbin/runc",
-	"/run/torcx/unpack/docker/bin/runc", // Used in Flatcar Container Linux
 	"/usr/bin/crun",
 	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
 	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2


### PR DESCRIPTION
Flatcar does not use torcx anymore.

December 2023:
  "Therefore, we recently removed Torcx and recommend using
   systemd-sysext for deploying custom Docker/containerd versions"
https://www.flatcar.org/blog/2023/12/extending-flatcar-say-goodbye-to-torcx-and-hello-to-systemd-sysext/

April 2024:
  "Therefore, we recently removed Torcx and recommend using systemd-sysext
   for deploying custom Docker/containerd versions"
https://www.flatcar.org/blog/2024/04/os-innovation-with-systemd-sysext/

Torcx is no longer in active development. See:
- https://github.com/coreos/torcx
- https://github.com/flatcar/torcx
