### PR TITLE
uprobe,container-hook: add coherence check on file sizes

### DIFF
--- a/pkg/uprobetracer/ldcache_parser.go
+++ b/pkg/uprobetracer/ldcache_parser.go
@@ -59,6 +59,10 @@ const (
 	ldCache1Size      = uint32(unsafe.Sizeof(ldCache1{}))
 	ldCache2EntrySize = uint32(unsafe.Sizeof(ldCache2Entry{}))
 	ldCache2Size      = uint32(unsafe.Sizeof(ldCache2{}))
+
+	// ld.so.cache is typically less than 200 KiB.
+	// 16 MiB should be enough.
+	ldCacheMaxSize = int64(16 * 1024 * 1024)
 )
 
 type ldEntry struct {
@@ -136,7 +140,7 @@ func readCacheFormat2(data []byte) []ldEntry {
 // see https://github.com/bminor/glibc/blob/master/elf/cache.c#L292, the `print_cache` func
 // see https://github.com/iovisor/bcc/blob/master/src/cc/bcc_proc.c#L508, the `bcc_procutils_which_so` func
 func parseLdCache(containerPid uint32, ldCachePath string, libraryName string) ([]string, error) {
-	ldCacheFile, err := secureopen.ReadFileInContainer(containerPid, ldCachePath)
+	ldCacheFile, err := secureopen.ReadFileInContainer(containerPid, ldCachePath, ldCacheMaxSize)
 	if err != nil {
 		return nil, fmt.Errorf("reading file %q in container pid %d: %w", ldCachePath, containerPid, err)
 	}

--- a/pkg/utils/secureopen/secureopen.go
+++ b/pkg/utils/secureopen/secureopen.go
@@ -80,11 +80,15 @@ func OpenInContainer(containerPid uint32, unsafePath string) (*os.File, error) {
 //
 // This is similar to os.ReadFile() except the file is opened with
 // OpenInContainer().
-func ReadFileInContainer(containerPid uint32, unsafePath string) ([]byte, error) {
+func ReadFileInContainer(containerPid uint32, unsafePath string, limitBytes int64) ([]byte, error) {
 	fh, err := OpenInContainer(containerPid, unsafePath)
 	if err != nil {
 		return nil, fmt.Errorf("secureopen: %w", err)
 	}
 	defer fh.Close()
+
+	if limitBytes > 0 {
+		return io.ReadAll(io.LimitReader(fh, limitBytes))
+	}
 	return io.ReadAll(fh)
 }


### PR DESCRIPTION
uprobetracer reads ld.so.cache, which is typically less than 200KiB. A 16MiB limit seems like a reasonable limit.

The pid file created by the container runtime should be a small regular file. Don't waste time reading it if it is not the case.