### PR TITLE
ci: Bump trivy-action to 0.29.0.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -714,7 +714,7 @@ jobs:
           name: gadget-container-image-${{ matrix.os }}-${{ matrix.platform }}.tar
           path: ${{ github.workspace }}
       - name: Scan gadget ${{ matrix.os }} ${{ matrix.platform }} container image
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
         with:
           input: gadget-container-image-${{ matrix.os }}-${{ matrix.platform }}.tar
           format: 'table'


### PR DESCRIPTION
Pulling the trivy DB of CVE leaded to several of failures due to ghcr limitations [1].
trivy was modified to use other repositories as mirrors for the DB, this change landed in 0.57.1 [2].
The trivy-action was updated recently to 0.57.1, thus pulling from the mirrors [3].

Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1]: https://github.com/aquasecurity/trivy-action/issues/389
[2]: https://github.com/aquasecurity/trivy/discussions/7951
[3]: https://github.com/aquasecurity/trivy-action/commit/18f2510ee396