### PR TITLE
port advise_seccomp to image-based gadget

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -19,6 +19,7 @@ UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
 
 GADGETS = \
+	advise_seccomp \
 	audit_seccomp \
 	deadlock \
 	fsnotify \

--- a/gadgets/advise_seccomp/build.yaml
+++ b/gadgets/advise_seccomp/build.yaml
@@ -1,0 +1,1 @@
+wasm: go/program.go

--- a/gadgets/advise_seccomp/gadget.yaml
+++ b/gadgets/advise_seccomp/gadget.yaml
@@ -1,0 +1,14 @@
+name: advise_seccomp
+datasources:
+  syscallconv:
+    annotations:
+      cli.output-mode: none
+  syscalls:
+    annotations:
+      cli.output-mode: none
+      ebpf.map.flush-on-stop: true
+      ebpf.map.init.0.key: "0000000000000000"
+  advise:
+    annotations:
+      cli.supported-output-modes: advise
+      cli.default-output-mode: advise

--- a/gadgets/advise_seccomp/go/go.mod
+++ b/gadgets/advise_seccomp/go/go.mod
@@ -1,0 +1,11 @@
+module main
+
+go 1.22.8
+
+toolchain go1.22.6
+
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// Only needed by in-tree gadgets
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/advise_seccomp/go/program.go
+++ b/gadgets/advise_seccomp/go/program.go
@@ -1,0 +1,179 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+var (
+	sc             api.DataSource
+	syscallds      api.DataSource
+	textds         api.DataSource
+	textField      api.Field
+	syscallMapping map[uint64]string
+)
+
+//export gadgetPreStart
+func gadgetPreStart() int {
+	syscallMapping = make(map[uint64]string)
+
+	scStringField, err := sc.GetField("syscall")
+	if err != nil {
+		api.Warnf("getting syscall text field (enricher inactive?)")
+		return 1
+	}
+
+	scIntField, err := sc.GetField("syscall_raw")
+	if err != nil {
+		api.Warnf("getting syscall int field")
+		return 1
+	}
+
+	sc.Unreference() // probably too late
+
+	sc.Subscribe(func(ds api.DataSource, data api.Data) {
+		intVal, _ := scIntField.Uint64(data)
+		stringVal, _ := scStringField.String(data)
+		syscallMapping[intVal] = strings.ToLower(strings.TrimPrefix(stringVal, "SYS_"))
+	}, 10000)
+
+	parr, _ := sc.NewPacketArray()
+	arr := api.DataArray(parr)
+	for i := 0; i <= 500; i++ {
+		data := arr.New()
+		scIntField.SetUint64(data, uint64(i))
+		arr.Append(data)
+	}
+	sc.EmitAndRelease(api.Packet(parr))
+
+	syscalls, err := syscallds.GetField("syscalls")
+	if err != nil {
+		api.Warnf("getting field: %s", err)
+		return 1
+	}
+
+	mntnsidField, err := syscallds.GetField("mntns_id_raw")
+	if err != nil {
+		api.Warnf("getting field: %s", err)
+		return 1
+	}
+
+	container, err := syscallds.GetField("runtime.containerName")
+	if err != nil {
+		api.Warnf("getting field: %s", err)
+		return 1
+	}
+
+	err = syscallds.SubscribeArray(func(source api.DataSource, dataArr api.DataArray) error {
+		// Get all fields sent by ebpf
+		for j := 0; j < dataArr.Len(); j++ {
+			data := dataArr.Get(j)
+
+			mntnsid, _ := mntnsidField.Uint64(data)
+			if mntnsid == 0 {
+				// this is the zero mntnsid template, we don't need that
+				continue
+			}
+
+			scs, _ := syscalls.Bytes(data)
+			containerName, _ := container.String(data)
+
+			syscallStrings := make([]string, 0)
+			for i := 0; i < len(scs); i++ {
+				if scs[i] > 0 {
+					syscallName, ok := syscallMapping[uint64(i)]
+					if !ok {
+						syscallName = fmt.Sprintf("unknown_syscall_%d", i)
+					}
+					syscallStrings = append(syscallStrings, syscallName)
+				}
+			}
+
+			slices.Sort(syscallStrings)
+
+			if containerName == "" {
+				switch mntnsid {
+				case 1:
+					containerName = "host"
+				default:
+					containerName = fmt.Sprintf("mntnsid %d", mntnsid)
+				}
+			}
+
+			var out strings.Builder
+			out.WriteString(fmt.Sprintf("// %s\n", containerName))
+			jsonText, _ := json.MarshalIndent(map[string]any{
+				"defaultAction": "SCMP_ACT_ERRNO",
+				"architectures": []string{
+					"SCMP_ARCH_X86_64",
+					"SCMP_ARCH_X86",
+					"SCMP_ARCH_X32",
+				},
+				"syscalls": syscallStrings,
+			}, "", "  ")
+			out.Write(jsonText)
+			out.WriteRune('\n')
+
+			nd, _ := textds.NewPacketSingle()
+			textField.SetString(api.Data(nd), out.String())
+			textds.EmitAndRelease(api.Packet(nd))
+		}
+		return nil
+	}, 9999)
+	if err != nil {
+		api.Warnf("subscribing to syscalls: %s", err)
+		return 1
+	}
+	return 0
+}
+
+//export gadgetInit
+func gadgetInit() int {
+	var err error
+	// We need syscall id to name mapping; this is an ugly way to get it:
+	sc, err = api.NewDataSource("syscallconv", api.DataSourceTypeArray)
+	if err != nil {
+		api.Warnf("creating syscalls data source %v", err)
+		return 1
+	}
+
+	scField, err := sc.AddField("syscall_raw", api.Kind_Uint64)
+	if err != nil {
+		api.Warnf("creating syscall_raw field %v", err)
+		return 1
+	}
+	scField.AddTag("type:gadget_syscall")
+
+	// We'll read the input from the eBPF source, emit
+	syscallds, err = api.GetDataSource("syscalls")
+	if err != nil {
+		api.Warnf("getting datasource: %s", err)
+		return 1
+	}
+	// ds.Unreference()
+
+	textds, _ = api.NewDataSource("advise", api.DataSourceTypeSingle)
+	textField, _ = textds.AddField("text", api.Kind_String)
+
+	return 0
+}
+
+func main() {}

--- a/gadgets/advise_seccomp/program.bpf.c
+++ b/gadgets/advise_seccomp/program.bpf.c
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2021 The Inspektor Gadget authors */
+
+/* This BPF program uses the GPL-restricted function bpf_probe_read*().
+ */
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/types.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+
+#define SYSCALLS_COUNT 500
+#define SYSCALLS_MAP_VALUE_FOOTER_SIZE 1
+#define SYSCALLS_MAP_VALUE_SIZE \
+	(SYSCALLS_COUNT + SYSCALLS_MAP_VALUE_FOOTER_SIZE)
+
+#define TASK_COMM_LEN 16
+#define TS_COMPAT 0x0002
+
+// prctl syscall number from
+// https://github.com/seccomp/libseccomp/blob/abad8a8f41fc13efbb95fc1ccaa3e181342bade7/src/syscalls.csv#L265
+#ifndef __NR_prctl
+#if defined(bpf_target_x86)
+#define __NR_prctl 157
+#elif defined(bpf_target_arm64)
+#define __NR_prctl 167
+#else
+#error "Unsupported architecture"
+#endif
+#endif
+
+// prclt syscall parameters from
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L10
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L175
+#ifndef PR_GET_PDEATHSIG
+#define PR_GET_PDEATHSIG 2
+#endif
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+
+// Seccomp syscall number from
+// https://github.com/torvalds/linux/blob/v5.12/tools/testing/selftests/seccomp/seccomp_bpf.c#L115
+// Only x86_64 is supported for now.
+#ifndef __NR_seccomp
+#if defined(bpf_target_x86)
+#define __NR_seccomp 317
+#elif defined(bpf_target_arm64)
+#define __NR_seccomp 277
+#else
+#error "Unsupported architecture"
+#endif
+#endif
+
+struct key_t {
+	gadget_mntns_id mntns_id_raw;
+};
+
+struct val_t {
+	unsigned char syscalls[SYSCALLS_MAP_VALUE_SIZE];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct key_t);
+	__type(value, struct val_t);
+	__uint(max_entries, 1024);
+} syscalls_per_mntns SEC(".maps");
+
+GADGET_MAPITER(syscalls, syscalls_per_mntns);
+
+#ifdef __TARGET_ARCH_x86
+static __always_inline int is_x86_compat(struct task_struct *task)
+{
+	return !!(BPF_CORE_READ(task, thread_info.status) & TS_COMPAT);
+}
+#endif
+
+SEC("raw_tracepoint/sys_enter")
+int ig_seccomp_e(struct bpf_raw_tracepoint_args *ctx)
+{
+	struct pt_regs regs = {};
+	unsigned int id;
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+
+	bpf_probe_read(&regs, sizeof(struct pt_regs), (void *)ctx->args[0]);
+	id = ctx->args[1];
+
+#ifdef __TARGET_ARCH_x86
+	if (is_x86_compat(task)) {
+		return 0;
+	}
+#endif
+
+	if (id < 0 || id >= SYSCALLS_COUNT)
+		return 0;
+
+	char comm[TASK_COMM_LEN];
+	bpf_get_current_comm(comm, sizeof(comm));
+	int is_runc = comm[0] == 'r' && comm[1] == 'u' && comm[2] == 'n' &&
+			comm[3] == 'c';
+
+	__u64 mntns = BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+	if (mntns == 0) {
+		return 0;
+	}
+
+	if (gadget_should_discard_mntns_id(mntns))
+		return 0;
+
+	struct key_t key = { .mntns_id_raw = mntns };
+
+	struct val_t *syscall_bitmap =
+		bpf_map_lookup_elem(&syscalls_per_mntns, &mntns);
+	if (syscall_bitmap == 0) {
+		struct key_t zero = { .mntns_id_raw = 0 };
+		struct val_t *blank_bitmap =
+			bpf_map_lookup_elem(&syscalls_per_mntns, &zero);
+		if (blank_bitmap == 0) {
+			bpf_printk("blank bitmap not found");
+			return 0;
+		}
+		bpf_map_update_elem(&syscalls_per_mntns, &key, blank_bitmap,
+							BPF_NOEXIST);
+
+		syscall_bitmap = bpf_map_lookup_elem(&syscalls_per_mntns, &key);
+		if (syscall_bitmap == 0)
+			return 0;
+	}
+
+	// If it is runc, we want to record only the syscalls executed after the
+	// seccomp profile is actually installed. However, if we are running the
+	// seccomp-advisor gadget, it is very probably that the pod does not have
+	// a seccomp profile yet, so seccomp() will not be called. Therefore, we
+	// decide to start recording from the prctl(PR_GET_PDEATHSIG) call on. It
+	// is a safe place right before all the seccomp() calls that will be always
+	// executed during the runc initialisation:
+	// https://github.com/opencontainers/runc/blob/8b4a8f093d0dbdf45100597f710d16777845ee83/libcontainer/standard_init_linux.go#L148
+	if (is_runc) {
+		if (syscall_bitmap->syscalls[SYSCALLS_COUNT] == 0) {
+			if (id == __NR_prctl &&
+				PT_REGS_PARM1(&regs) == PR_GET_PDEATHSIG) {
+				// Start recording the runc syscalls from now on.
+				syscall_bitmap->syscalls[SYSCALLS_COUNT] = 1;
+			}
+			return 0;
+		}
+
+		// Record all the runc syscalls after prctl(PR_GET_PDEATHSIG) except
+		// for seccomp() and prctl(PR_SET_NO_NEW_PRIVS) because we know they
+		// are executed before the seccomp profile is installed.
+		if ((id == __NR_prctl &&
+			PT_REGS_PARM1(&regs) == PR_SET_NO_NEW_PRIVS) ||
+			(id == __NR_seccomp)) {
+			return 0;
+		}
+	}
+
+	// Record the syscall
+	syscall_bitmap->syscalls[id] = 0x01;
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -119,13 +119,24 @@ func (c *GadgetContext) stop(dataOperatorInstances []operators.DataOperatorInsta
 	// Stop/DeInit in reverse order
 	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
 		opInst := dataOperatorInstances[i]
+		preStop, ok := opInst.(operators.PreStop)
+		if !ok {
+			continue
+		}
+		c.Logger().Debugf("pre-stopping op %q", opInst.Name())
+		err := preStop.PreStop(c)
+		if err != nil {
+			c.Logger().Errorf("pre-stopping operator %q: %v", opInst.Name(), err)
+		}
+	}
+	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
+		opInst := dataOperatorInstances[i]
 		c.Logger().Debugf("stopping op %q", opInst.Name())
 		err := opInst.Stop(c)
 		if err != nil {
 			c.Logger().Errorf("stopping operator %q: %v", opInst.Name(), err)
 		}
 	}
-	// Stop/DeInit in reverse order
 	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
 		opInst := dataOperatorInstances[i]
 		postStop, ok := opInst.(operators.PostStop)

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -474,8 +474,8 @@ func getGadgetImages(ctx context.Context, store *oci.Store) ([]*GadgetImageDesc,
 			image, err := getGadgetImageDescriptor(ctx, store, fullTag)
 			if err != nil {
 				log.Debugf("getting gadget image descriptor for %s: %v", fullTag, err)
+				continue
 			}
-
 			images = append(images, image)
 		}
 		return nil

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -137,6 +137,10 @@ func (o *cliOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api
   Supported data sources / output modes:`)
 	outputDefaultValues := make([]string, 0, len(dataSources))
 	for _, ds := range dataSources {
+		if ds.Annotations()["cli.output-mode"] == "none" {
+			continue
+		}
+
 		// Fields
 		fields := ds.Fields()
 		availableFields := make([]*api.Field, 0, len(fields))
@@ -297,7 +301,10 @@ func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 	}
 
 	for _, ds := range gadgetCtx.GetDataSources() {
-		gadgetCtx.Logger().Debugf("subscribing to %s", ds.Name())
+		// this needs to be discussed
+		if ds.Annotations()["cli.output-mode"] == "none" {
+			continue
+		}
 
 		fields, hasFields := fieldLookup[ds.Name()]
 		if !hasFields {

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -48,6 +48,8 @@ type mapIter struct {
 
 	interval time.Duration
 	count    int
+
+	flushOnStop bool
 }
 
 func (i *ebpfInstance) populateMap(t btf.Type, varName string) error {
@@ -204,18 +206,26 @@ func (i *ebpfInstance) runMapIterators() error {
 		i.wg.Add(1)
 		go func() {
 			defer i.wg.Done()
-			if iter.interval == 0 {
-				// Only a single time; is this really useful?
+			if iter.interval == 0 && iter.count == 1 {
+				// Only a single time if interval is zero and count is 1
 				fetch()
 				return
 			}
 			ctr := 0
-			ticker := time.NewTicker(iter.interval)
+
+			tickerChan := make(<-chan time.Time)
+			if iter.interval > 0 {
+				tickerChan = time.NewTicker(iter.interval).C
+			}
 			for {
 				select {
 				case <-i.done:
+					if iter.flushOnStop {
+						i.logger.Debugf("flushing map")
+						fetch()
+					}
 					return
-				case <-ticker.C:
+				case <-tickerChan:
 					fetch()
 					ctr++
 					if iter.count > 0 && ctr >= iter.count {

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -410,6 +410,20 @@ func (o *OciHandlerInstance) Start(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (o *OciHandlerInstance) PreStop(gadgetCtx operators.GadgetContext) error {
+	for _, opInst := range o.imageOperatorInstances {
+		preStop, ok := opInst.(operators.PreStop)
+		if !ok {
+			continue
+		}
+		err := preStop.PreStop(gadgetCtx)
+		if err != nil {
+			o.gadgetCtx.Logger().Errorf("pre-stopping operator %q: %v", opInst.Name(), err)
+		}
+	}
+	return nil
+}
+
 func (o *OciHandlerInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Stop(o.gadgetCtx)

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -149,6 +149,10 @@ type PreStart interface {
 	PreStart(gadgetCtx GadgetContext) error
 }
 
+type PreStop interface {
+	PreStop(gadgetCtx GadgetContext) error
+}
+
 type PostStop interface {
 	PostStop(gadgetCtx GadgetContext) error
 }

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -97,6 +97,8 @@ func (w *wasmOperator) InstantiateImageOperator(
 }
 
 type wasmOperatorInstance struct {
+	ctx       context.Context
+	cancel    func()
 	rt        wazero.Runtime
 	gadgetCtx operators.GadgetContext
 	mod       wapi.Module
@@ -289,14 +291,19 @@ func (i *wasmOperatorInstance) callGuestFunction(ctx context.Context, name strin
 }
 
 func (i *wasmOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
-	return i.callGuestFunction(gadgetCtx.Context(), "gadgetPreStart")
+	// We're creating a new context here that gets cancelled when Stop() is called; it is important to know
+	// that gadgetInit uses the gadgetContext instead, which will be cancelled whenever the gadgetCtx is cancelled
+	// (and so are any callbacks registered in gadgetInit)
+	i.ctx, i.cancel = context.WithCancel(context.Background())
+	return i.callGuestFunction(i.ctx, "gadgetPreStart")
 }
 
 func (i *wasmOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
-	return i.callGuestFunction(gadgetCtx.Context(), "gadgetStart")
+	return i.callGuestFunction(i.ctx, "gadgetStart")
 }
 
 func (i *wasmOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	i.cancel()
 	defer func() {
 		i.handleLock.Lock()
 		i.handleMap = nil


### PR DESCRIPTION
Currently WIP

This implements a couple of things:
* adds a PreStop() lifecycle hook to do things "last minute"
* fixes lifecycle of WASM instances
* adds "flush-on-stop" annotation for map fetching in PreStop()
* adds an option to create initial map values for datasources (this is used as scratch map because the syscall bitmap is too large to fit on the stack)

How it currently works is:
* WASM module creates and self-subscribes to a new DataSource which is just used to emit every possible syscall IDs; this will be enriched by the formatter operator to contain the actual syscall names, with which the WASM module will create a lookup map (this is somewhat hacky but works well)
* WASM creates a new text DataSource for the actual advise output
* Once the gadget is stopped, it will flush the map contents (due to the annotation) of the eBPF part and convert it to a proper output

Currently needs to be run with some map flags:
```
ig run advise_seccomp --verify-image=false --map-fetch-count=0 --map-fetch-interval=0
```

Output looks like this:

```
// otel2-grafana-1
{
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "defaultAction": "SCMP_ACT_ERRNO",
  "syscalls": [
    "epoll_pwait",
    "futex",
    "nanosleep",
    "read",
    "sched_yield",
    "write"
  ]
}
// otel2-backend-1
{
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "defaultAction": "SCMP_ACT_ERRNO",
  "syscalls": [
    "accept4",
    "close",
    "connect",
    "epoll_ctl",
    "epoll_pwait",
    "futex",
    "getpeername",
    "getsockname",
    "getsockopt",
    "nanosleep",
    "read",
    "sched_yield",
    "setsockopt",
    "socket",
    "write"
  ]
}
// otel2-tempo-1
{
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "defaultAction": "SCMP_ACT_ERRNO",
  "syscalls": [
    "epoll_pwait",
    "futex",
    "nanosleep",
    "read",
    "write"
  ]
}
```

This will only work in interactive mode, as we don't have a "stopped" state in detached mode for now.

Part of #3003 