### PR TITLE
tests: added unit test to fsnotify gadget

### DIFF
--- a/gadgets/fsnotify/test/unit/fsnotify_test.go
+++ b/gadgets/fsnotify/test/unit/fsnotify_test.go
@@ -1,0 +1,227 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type Process struct {
+	PPid  uint32 `json:"ppid"`
+	Pid   uint32 `json:"pid"`
+	Tid   uint32 `json:"tid"`
+	Comm  string `json:"comm"`
+	PComm string `json:"pcomm"`
+}
+
+type EventDetails struct {
+	FileName string
+	Ino      uint32
+	InoDir   uint32
+}
+
+type ExpectedFsnotifyEvent struct {
+	Timestamp string `json:"timestamp"`
+
+	Type string `json:"type"`
+
+	TraceeProc Process `json:"tracee_proc"`
+	TracerProc Process `json:"tracer_proc"`
+
+	TraceeMntnsId uint64 `json:"tracee_mntns_id"`
+	TracerMntnsId uint64 `json:"tracer_mntns_id"`
+
+	TraceeUId uint32 `json:"tracee_uid"`
+	TraceeGId uint32 `json:"tracee_gid"`
+	TracerUId uint32 `json:"tracer_uid"`
+	TracerGId uint32 `json:"tracer_gid"`
+
+	Prio uint32 `json:"prio"`
+
+	FaMask string `json:"fa_mask"`
+	IMask  string `json:"i_mask"`
+
+	FaType     string `json:"fa_type"`
+	FaPId      uint32 `json:"fa_pid"`
+	FaFlags    uint32 `json:"fa_flags"`
+	FaFFlags   uint32 `json:"fa_f_flags"`
+	FaResponse string `json:"fa_response"`
+
+	IWd     int32  `json:"i_wd"`
+	ICookie uint32 `json:"i_cookie"`
+	IIno    uint32 `json:"i_ino"`
+	IInoDir uint32 `json:"i_ino_dir"`
+
+	Name string `json:"name"`
+}
+
+type testDef struct {
+	runnerConfig  *utilstest.RunnerConfig
+	generateEvent func() (EventDetails, error)
+	validateEvent func(t *testing.T, info *utilstest.RunnerInfo, eventDetails EventDetails, events []ExpectedFsnotifyEvent)
+}
+
+func TestFsnotifyGadget(t *testing.T) {
+	gadgettesting.MinimumKernelVersion(t, "5.10")
+	gadgettesting.InitUnitTest(t)
+	runnerConfig := &utilstest.RunnerConfig{}
+
+	testCases := map[string]testDef{
+		"captures_inotify_event": {
+			runnerConfig:  runnerConfig,
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utilstest.RunnerInfo, eventDetails EventDetails, events []ExpectedFsnotifyEvent) {
+				utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, pid int) *ExpectedFsnotifyEvent {
+					return &ExpectedFsnotifyEvent{
+						Timestamp: utils.NormalizedStr,
+
+						Type:  "inotify",
+						IMask: "IN_MODIFY",
+
+						TraceeMntnsId: info.MountNsID,
+						TracerMntnsId: utils.NormalizedInt,
+
+						FaType:     utils.NormalizedStr,
+						FaResponse: utils.NormalizedStr,
+
+						IWd:     utils.NormalizedInt,
+						IIno:    eventDetails.Ino,
+						IInoDir: eventDetails.InoDir,
+
+						Name: eventDetails.FileName,
+					}
+				})(t, info, 0, events)
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var eventDetails EventDetails
+			runner := utilstest.NewRunnerWithTest(t, testCase.runnerConfig)
+
+			normalizeEvent := func(event *ExpectedFsnotifyEvent) {
+				utils.NormalizeString(&event.Timestamp)
+				utils.NormalizeInt(&event.TracerMntnsId)
+
+				utils.NormalizeString(&event.FaType)
+				utils.NormalizeString(&event.FaResponse)
+			}
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, func() error {
+					var err error
+					eventDetails, err = testCase.generateEvent()
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+				return nil
+			}
+			opts := gadgetrunner.GadgetRunnerOpts[ExpectedFsnotifyEvent]{
+				Image:          "fsnotify",
+				Timeout:        5 * time.Second,
+				OnGadgetRun:    onGadgetRun,
+				NormalizeEvent: normalizeEvent,
+			}
+
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+			gadgetRunner.RunGadget()
+
+			testCase.validateEvent(t, runner.Info, eventDetails, gadgetRunner.CapturedEvents)
+		})
+	}
+}
+
+func generateEvent() (EventDetails, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return EventDetails{}, err
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(os.TempDir())
+	if err != nil {
+		return EventDetails{}, err
+	}
+
+	// event 1
+	newFile, err := os.CreateTemp(os.TempDir(), "test-*.txt")
+	if err != nil {
+		return EventDetails{}, err
+	}
+	defer newFile.Close()
+
+	// event 2
+	_, err = newFile.WriteString("Hello, fsnotify!")
+	if err != nil {
+		return EventDetails{}, err
+	}
+
+	// Receiving events.
+forLoop:
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return EventDetails{}, errors.New("channel closed")
+			}
+			if event.Has(fsnotify.Write) {
+				if event.Name != newFile.Name() {
+					return EventDetails{}, fmt.Errorf("watcher: unexpected event: %q, expected %q", event.Name, newFile.Name())
+				}
+				break forLoop
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return EventDetails{}, errors.New("channel closed")
+			}
+			return EventDetails{}, fmt.Errorf("watcher: %w", err)
+		}
+	}
+
+	// Get inode values of test file and its parent directory
+	fileInode, err := utils.GetInode(newFile.Name())
+	if err != nil {
+		return EventDetails{}, err
+	}
+	dirInode, err := utils.GetInode(path.Dir(newFile.Name()))
+	if err != nil {
+		return EventDetails{}, err
+	}
+
+	fileName := path.Base(newFile.Name())
+	eventDetails := EventDetails{
+		FileName: fileName,
+		Ino:      uint32(fileInode),
+		InoDir:   uint32(dirInode),
+	}
+	return eventDetails, nil
+}

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -213,6 +215,21 @@ func GetContainerRuntime(t *testing.T) string {
 	parts := strings.Split(ret, ":")
 	require.GreaterOrEqual(t, len(parts), 1, "unexpected container runtime version")
 	return parts[0]
+}
+
+// GetInode extracts the inode of a given path
+func GetInode(path string) (uint64, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("attempting to stat path %s: %w", path, err)
+	}
+
+	// Extract the inode value from the system information
+	sysInfo := fileInfo.Sys()
+	if stat, ok := sysInfo.(*syscall.Stat_t); ok {
+		return uint64(stat.Ino), nil
+	}
+	return 0, fmt.Errorf("encountering issues when asserting system info as *syscall.Stat_t for path: %s", path)
 }
 
 // GenerateTestNamespaceName returns a string which can be used as unique


### PR DESCRIPTION
Unit test to validate `inotify` event capture through `fsnotify` gadget.

Related to #3627

### About test

The test simulates event generation based on the example in the gadget’s [documentation](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/fsnotify/README.mdx). 
It uses the [fsnotify](https://github.com/fsnotify/fsnotify) Go package to watch the `/tmp` path and capture events.

Dependencies: [fsnotify package](https://github.com/fsnotify/fsnotify)

### Testing done

Tested with `gadgets-unittest` step of inspektor-gadget.yml workflow. [[successful run](https://github.com/4rivappa/inspektor-gadget/actions/runs/12074081422)]

[21st Dec 2024] Updated PR test [successful run](https://github.com/4rivappa/inspektor-gadget/actions/runs/12443836290/job/34743485124)