### PR TITLE
expose SocketPath in k8s.go

### DIFF
--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -41,10 +41,11 @@ import (
 )
 
 type K8sClient struct {
-	clientset     *kubernetes.Clientset
-	nodeName      string
-	fieldSelector string
-	runtimeClient runtimeclient.ContainerRuntimeClient
+	clientset         *kubernetes.Clientset
+	nodeName          string
+	fieldSelector     string
+	runtimeClient     runtimeclient.ContainerRuntimeClient
+	RuntimeSocketPath string
 }
 
 func NewK8sClient(nodeName string) (*K8sClient, error) {
@@ -94,10 +95,11 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 	}
 
 	return &K8sClient{
-		clientset:     clientset,
-		nodeName:      nodeName,
-		fieldSelector: fieldSelector,
-		runtimeClient: runtimeClient,
+		clientset:         clientset,
+		nodeName:          nodeName,
+		fieldSelector:     fieldSelector,
+		runtimeClient:     runtimeClient,
+		RuntimeSocketPath: socketPath,
 	}, nil
 }
 


### PR DESCRIPTION
# expose SocketPath in k8s.go

In our node-agent I need to create and use a runtime.NewImageServiceClient for which it's very handy to make sure I have the same socket path as IG.

## How to use

N/A

## Testing done

Works in my PR https://github.com/kubescape/node-agent/pull/384/
