### PR TITLE
cmd: fix OCI params issue when using a gadget instance manifest

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -317,9 +316,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			isDetach := detachedParam != nil && detachedParam.AsBool()
 
 			if isDetach {
-				// Copy special oci params
-				ociParams.CopyToMap(paramValueMap, "operator.oci.")
-				return runInstanceSpecsDetached(ctx, runtime, specs, runtimeParams, paramValueMap,
+				return runInstanceSpecsDetached(ctx, runtime, specs, runtimeParams,
 					gadgetcontext.WithDataOperators(ops...),
 					gadgetcontext.WithTimeout(timeoutDuration),
 					gadgetcontext.WithUseInstance(false),
@@ -342,9 +339,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			runtimeParams.Set("tags", strings.Join(spec.Tags, ","))
 			runtimeParams.Set("node", strings.Join(spec.Nodes, ","))
 
-			tempParams := spec.ParamValues
-			maps.Copy(tempParams, paramValueMap)
-			paramValueMap = tempParams
+			paramValueMap = spec.ParamValues
 		}
 
 		if commandMode == CommandModeAttach {
@@ -426,7 +421,6 @@ func runInstanceSpecsDetached(
 	runtime runtime.Runtime,
 	specs []*gadgetmanifest.InstanceSpec,
 	runtimeParams *params.Params,
-	paramValueMap map[string]string,
 	runOptions ...gadgetcontext.Option,
 ) error {
 	var merr error
@@ -438,8 +432,6 @@ func runInstanceSpecsDetached(
 		runtimeParams.Set("name", spec.Name)
 		runtimeParams.Set("tags", strings.Join(spec.Tags, ","))
 		runtimeParams.Set("node", strings.Join(spec.Nodes, ","))
-
-		maps.Copy(spec.ParamValues, paramValueMap)
 
 		gadgetCtx := gadgetcontext.New(ctx, image, runOptions...)
 


### PR DESCRIPTION
This will ignore any additional instance flags when specifying a gadget instance manifest. Previously, paramValues could be overwritten by those flags, and especially the `operator.oci.*` settings would get set to empty.

Fixes #3676