### PR TITLE
Add runc path of kubeadm cluster running on Debian12 with upstream cri-o

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -42,6 +42,7 @@ var RuntimePaths = []string{
 	"/usr/bin/crun",
 	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
 	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2
+	"/usr/libexec/crio/runc",                     // Used in kubeadm on Debian, upstream crio
 }
 
 // Notify marks the runtime path given as argument if it exists.


### PR DESCRIPTION
# Add path to runc for kubeadm

Running a kubeadm cluster on Debian with upstream cri-o introduces this path to the runc binary. 

## How to use
Install kubeadm cluster on Debian12 with crio from ```https://pkgs.k8s.io/addons:/cri-o:/stable:/v1.30/deb/```

## Testing done
Precondition is a working kubeadm cluster with cri-o from above.

I installed kubescape via helm
```
helm upgrade --install kubescape kubescape/kubescape-operator -n kubescape --create-namespace --set clusterName=`kubectl config current-context`
```

Immediately after installation the node-agent pods goes into CrashLoopBackOff
```
k -n kubescape get po | grep Crash
node-agent-25djz                  0/1     CrashLoopBackOff   2 (11s ago)   68s
node-agent-2p6fh                  0/1     CrashLoopBackOff   2 (7s ago)    68s
node-agent-f68pd                  0/1     CrashLoopBackOff   2 (8s ago)    68s
node-agent-hzwsb                  0/1     CrashLoopBackOff   2 (8s ago)    68s
node-agent-pkhxp                  0/1     CrashLoopBackOff   2 (11s ago)   68s
```

Edit the daemonset and add RUNETIME_PATH
```
jonas@u3dev1:~$ k -n kubescape get daemonsets.apps node-agent -o yaml | k neat > /var/tmp/node-agent.1
jonas@u3dev1:~$ k -n kubescape edit daemonsets.apps node-agent 
Warning: spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/node-agent]: deprecated since v1.30; use the "appArmorProfile" field instead
daemonset.apps/node-agent edited
jonas@u3dev1:~$ k -n kubescape get daemonsets.apps node-agent -o yaml | k neat > /var/tmp/node-agent.2
jonas@u3dev1:~$ diff -by --suppress-common-lines /var/tmp/node-agent.*
    deprecated.daemonset.template.generation: "1"             |     deprecated.daemonset.template.generation: "2"
                                                              >         - name: RUNTIME_PATH
                                                              >           value: /usr/libexec/crio/runc

```
And the node-agents become healthy

```
jonas@u3dev1:~$ k -n kubescape get po | grep node-a
node-agent-4j5m9                  1/1     Running   0          83s
node-agent-5mhwb                  1/1     Running   0          83s
node-agent-7qrs6                  1/1     Running   0          83s
node-agent-csxmp                  1/1     Running   0          83s
node-agent-ffph8                  1/1     Running   0          83s

```
