### PR TITLE
ig-k8s: Fix server version message

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -74,8 +74,6 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "{{ .Values.image.repository }}"
-            - name: INSPEKTOR_GADGET_VERSION
-              value: {{ include "gadget.image.tag" . | quote }}
             - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
               value: {{ .Values.config.hookMode | quote }}
             - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -60,7 +60,6 @@ import (
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
-	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config/gadgettracermanagerconfig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/resources"
@@ -672,8 +671,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				switch gadgetContainer.Env[i].Name {
 				case "GADGET_IMAGE":
 					gadgetContainer.Env[i].Value = image
-				case "INSPEKTOR_GADGET_VERSION":
-					gadgetContainer.Env[i].Value = version.Version().String()
 				case "INSPEKTOR_GADGET_OPTION_HOOK_MODE":
 					gadgetContainer.Env[i].Value = hookMode
 				case "INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER":

--- a/gadget-container/entrypoint/entrypoint.go
+++ b/gadget-container/entrypoint/entrypoint.go
@@ -261,8 +261,6 @@ func main() {
 		log.Infof("%s: %v", k, v)
 	}
 
-	log.Infof("Inspektor Gadget version: %s", os.Getenv("INSPEKTOR_GADGET_VERSION"))
-
 	if hasGadgetPullSecret() {
 		err = prepareGadgetPullSecret()
 		if err != nil {

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -37,6 +37,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	// Import this early to set the environment variable before any other package is imported
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/environment/k8s"
 	instancemanager "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/instance-manager"
@@ -119,6 +120,8 @@ func init() {
 }
 
 func main() {
+	log.Infof("Inspektor Gadget version: %s", version.Version().String())
+
 	flag.Parse()
 
 	if flag.NArg() > 0 {

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -189,8 +189,6 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "ghcr.io/inspektor-gadget/inspektor-gadget"
-            - name: INSPEKTOR_GADGET_VERSION
-              value: "latest"
             - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
               value: "auto"
             - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER


### PR DESCRIPTION
Use the version of the server instead of the client.

And easy PR to fix an old and annoying low handing fruit.

Fixes #1061