### PR TITLE
ig-k8s: Fix fix server version message

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -120,8 +120,6 @@ func init() {
 }
 
 func main() {
-	log.Infof("Inspektor Gadget version: %s", version.Version().String())
-
 	flag.Parse()
 
 	if flag.NArg() > 0 {
@@ -284,6 +282,8 @@ func main() {
 	}
 
 	if serve {
+		log.Infof("Inspektor Gadget version: %s", version.Version().String())
+
 		if experimental.Enabled() {
 			log.Info("Experimental features enabled")
 		}


### PR DESCRIPTION
Print the version only when running with -serve, otherwise it messes up some json output used by the advise network-policy gadget.

It turns out adding a new info log on the gadget tracer manager breaks something. I was too confident a simple message won't break anything and merged #3743 without waiting for the CI to finish.

Fixes: a46f5c2efc55 ("ig-k8s: Fix server version message")

--- 

![Untitled](https://github.com/user-attachments/assets/26b9152b-bc68-425c-950d-f3273116b5b4)
