### PR TITLE
wasm/testdata: Use in-tree ig to build the images

### DIFF
--- a/pkg/operators/ebpf/testdata/Makefile
+++ b/pkg/operators/ebpf/testdata/Makefile
@@ -1,4 +1,5 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+IG ?= ig
 
 TEST_ARTIFACTS = \
 	empty \
@@ -9,10 +10,10 @@ all: $(TEST_ARTIFACTS)
 .PHONY: $(TEST_ARTIFACTS)
 $(TEST_ARTIFACTS):
 	@echo "Building $@"
-	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) ig image build -t $@:latest $@
-	@sudo ig image export $@:latest $@.tar
+	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) $(IG) image build -t $@:latest $@
+	@sudo $(IG) image export $@:latest $@.tar
 	# TODO: This fails with "Error: removing gadget image: unable to reload index:"
-	#@sudo ig image remove $@:latest
+	#@sudo $(IG) image remove $@:latest
 
 .PHONY:
 clean:

--- a/pkg/operators/wasm/testdata/Makefile
+++ b/pkg/operators/wasm/testdata/Makefile
@@ -1,4 +1,5 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+IG ?= ig
 
 TEST_ARTIFACTS = \
 	fields \
@@ -15,10 +16,10 @@ all: $(TEST_ARTIFACTS)
 .PHONY: $(TEST_ARTIFACTS)
 $(TEST_ARTIFACTS):
 	@echo "Building $@"
-	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) ig image build -t $@:latest $@
-	@sudo ig image export $@:latest $@.tar
+	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) $(IG) image build -t $@:latest $@ 
+	@sudo $(IG) image export $@:latest $@.tar
 	# TODO: This fails with "Error: removing gadget image: unable to reload index:"
-	#@sudo ig image remove $@:latest
+	#@sudo $(IG) image remove $@:latest
 
 .PHONY:
 clean:


### PR DESCRIPTION
This ensures the most up to date is used for building and exporting the images
