### PR TITLE
tests: Increase timeout for snapshotter tests

### DIFF
--- a/gadgets/snapshot_process/test/integration/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/integration/snapshot_process_test.go
@@ -68,12 +68,14 @@ func TestSnapshotProcess(t *testing.T) {
 	var testingOpts []igtesting.Option
 	commonDataOpts := []utils.CommonDataOption{utils.WithContainerImageName(containerImage), utils.WithContainerID(testContainer.ID())}
 
-	// TODO: timeout shouldn't be required
+	// TODO: timeout shouldn't be required. We need to use something big like 5
+	// seconds to avoid the message being lost.
+	const timeoutParam = "--timeout=5"
 	switch utils.CurrentTestComponent {
 	case utils.IgLocalTestComponent:
-		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), "--timeout=1"))
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), timeoutParam))
 	case utils.KubectlGadgetTestComponent:
-		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns), "--timeout=1"))
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns), timeoutParam))
 		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
 		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
 	}

--- a/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
@@ -73,12 +73,14 @@ func TestSnapshotSocket(t *testing.T) {
 	var testingOpts []igtesting.Option
 	commonDataOpts := []utils.CommonDataOption{utils.WithContainerImageName(containerImage), utils.WithContainerID(testContainer.ID())}
 
-	// TODO: timeout shouldn't be required
+	// TODO: timeout shouldn't be required. We need to use something big like 5
+	// seconds to avoid the message to be lost.
+	const timeoutParam = "--timeout=5"
 	switch utils.CurrentTestComponent {
 	case utils.IgLocalTestComponent:
-		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), "--timeout=1"))
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), timeoutParam))
 	case utils.KubectlGadgetTestComponent:
-		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns), "--timeout=1"))
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", ns), timeoutParam))
 		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
 		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
 	}


### PR DESCRIPTION
Snapshotter tests are failing a lot (see issue #3361). It seems to be that 1 second is too low for the message pump to send the information to the client, hence it's being dropped.

This commit increases the timeout to 5 seconds, however the final solution should be to fix #3033.

Fixes #3361