### PR TITLE
Alias ebpftypes.Process as Process in utils package

### DIFF
--- a/gadgets/audit_seccomp/test/integration/audit_seccomp_test.go
+++ b/gadgets/audit_seccomp/test/integration/audit_seccomp_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type auditSeccompEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Syscall string `json:"syscall"`
 	Code    string `json:"code"`

--- a/gadgets/fdpass/test/unit/fdpass_test.go
+++ b/gadgets/fdpass/test/unit/fdpass_test.go
@@ -24,12 +24,12 @@ import (
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
 type ExpectedFdpassEvent struct {
-	Proc ebpftypes.Process `json:"proc"`
+	Proc utils.Process `json:"proc"`
 
 	SocketIno uint64 `json:"socket_ino"`
 	Sockfd    uint32 `json:"sockfd"`

--- a/gadgets/snapshot_process/test/integration/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/integration/snapshot_process_test.go
@@ -22,18 +22,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type snapshotProcessEntry struct {
-	eventtypes.CommonData
-	ebpftypes.Process
+	utils.CommonData
+	utils.Process
 }
 
 func TestSnapshotProcess(t *testing.T) {

--- a/gadgets/snapshot_process/test/unit/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/unit/snapshot_process_test.go
@@ -26,11 +26,11 @@ import (
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
-type ExpectedSnapshotProcessEvent ebpftypes.Process
+type ExpectedSnapshotProcessEvent utils.Process
 
 type testDef struct {
 	runnerConfig   *utilstest.RunnerConfig
@@ -54,7 +54,7 @@ func TestSnapshotProcessGadget(t *testing.T) {
 						Comm: "sleep",
 						Pid:  uint32(sleepPid),
 						Tid:  uint32(sleepPid),
-						Parent: ebpftypes.Parent{
+						Parent: utils.Parent{
 							Pid:  uint32(info.Tid),
 							Comm: info.Comm,
 						},
@@ -85,7 +85,7 @@ func TestSnapshotProcessGadget(t *testing.T) {
 						Comm: "sleep",
 						Pid:  uint32(sleepPid),
 						Tid:  uint32(sleepPid),
-						Parent: ebpftypes.Parent{
+						Parent: utils.Parent{
 							Pid:  uint32(info.Tid),
 							Comm: info.Comm,
 						},

--- a/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
@@ -27,11 +27,10 @@ import (
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type snapshotSocketEntry struct {
-	eventtypes.CommonData
+	utils.CommonData
 
 	NetNsID     uint64 `json:"netns_id"`
 	InodeNumber uint64 `json:"ino"`

--- a/gadgets/top_blockio/test/integration/top_blockio_test.go
+++ b/gadgets/top_blockio/test/integration/top_blockio_test.go
@@ -22,19 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type topBlockioEntry struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Proc ebpftypes.Process `json:"proc"`
+	Proc utils.Process `json:"proc"`
 
 	Bytes uint64 `json:"bytes"`
 	Io    uint32 `json:"io"`

--- a/gadgets/top_file/test/integration/top_file_test.go
+++ b/gadgets/top_file/test/integration/top_file_test.go
@@ -21,19 +21,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type topFileEntry struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Proc ebpftypes.Process `json:"proc"`
+	Proc utils.Process `json:"proc"`
 
 	Reads      uint64 `json:"reads"`
 	Writes     uint64 `json:"writes"`

--- a/gadgets/top_file/test/unit/top_file_test.go
+++ b/gadgets/top_file/test/unit/top_file_test.go
@@ -25,20 +25,19 @@ import (
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
 type ExpectedTopFileEvent struct {
-	Proc   ebpftypes.Process `json:"proc"`
-	Dev    uint32            `json:"dev"`
-	File   string            `json:"file"`
-	RBytes uint64            `json:"rbytes"`
-	Reads  uint64            `json:"reads"`
-	WBytes uint64            `json:"wbytes"`
-	Writes uint64            `json:"writes"`
-	T      string            `json:"t"`
+	Proc   utils.Process `json:"proc"`
+	Dev    uint32        `json:"dev"`
+	File   string        `json:"file"`
+	RBytes uint64        `json:"rbytes"`
+	Reads  uint64        `json:"reads"`
+	WBytes uint64        `json:"wbytes"`
+	Writes uint64        `json:"writes"`
+	T      string        `json:"t"`
 }
 
 type testDef struct {

--- a/gadgets/top_tcp/test/integration/top_tcp_test.go
+++ b/gadgets/top_tcp/test/integration/top_tcp_test.go
@@ -26,11 +26,10 @@ import (
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type topTcpEntry struct {
-	eventtypes.CommonData
+	utils.CommonData
 
 	MntNsID uint64 `json:"mntns_id"`
 

--- a/gadgets/trace_bind/test/integration/trace_bind_test.go
+++ b/gadgets/trace_bind/test/integration/trace_bind_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceBindEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Addr       utils.L4Endpoint `json:"addr"`
 	Error      string           `json:"error"`

--- a/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
@@ -22,20 +22,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceCapabilitiesEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	CurrentUserNs uint64 `json:"current_user_ns"`
 	TargetUserNs  uint64 `json:"target_user_ns"`

--- a/gadgets/trace_dns/test/integration/trace_dns_test.go
+++ b/gadgets/trace_dns/test/integration/trace_dns_test.go
@@ -22,21 +22,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceDNSEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	NetNsID   uint64            `json:"netns_id"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	NetNsID   uint64        `json:"netns_id"`
+	Proc      utils.Process `json:"proc"`
 
 	Src utils.L4Endpoint `json:"src"`
 	Dst utils.L4Endpoint `json:"dst"`

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -23,20 +23,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceExecEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Loginuid    uint32 `json:"loginuid"`
 	Sessionid   uint32 `json:"sessionid"`

--- a/gadgets/trace_fsslower/test/integration/trace_fsslower_test.go
+++ b/gadgets/trace_fsslower/test/integration/trace_fsslower_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceFSSlowerEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Delta  uint64 `json:"delta_us"`
 	Offset uint64 `json:"offset"`

--- a/gadgets/trace_mount/test/integration/trace_mount_test.go
+++ b/gadgets/trace_mount/test/integration/trace_mount_test.go
@@ -22,20 +22,18 @@ import (
 	"golang.org/x/sys/unix"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceMountEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Delta uint64 `json:"delta"`
 	Flags string `json:"flags"`

--- a/gadgets/trace_oomkill/test/integration/trace_oomkill_test.go
+++ b/gadgets/trace_oomkill/test/integration/trace_oomkill_test.go
@@ -25,11 +25,10 @@ import (
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceOomKillEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
 	Fpid      uint32 `json:"fpid"`
 	Fuid      uint32 `json:"fuid"`

--- a/gadgets/trace_open/test/integration/trace_open_test.go
+++ b/gadgets/trace_open/test/integration/trace_open_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceOpenEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Fd    uint32 `json:"fd"`
 	Error string `json:"error"`

--- a/gadgets/trace_open/test/unit/trace_open_test.go
+++ b/gadgets/trace_open/test/unit/trace_open_test.go
@@ -27,12 +27,12 @@ import (
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
 type ExpectedTraceOpenEvent struct {
-	Proc ebpftypes.Process `json:"proc"`
+	Proc utils.Process `json:"proc"`
 
 	Fd       uint32 `json:"fd"`
 	FName    string `json:"fname"`

--- a/gadgets/trace_signal/test/integration/trace_signal_test.go
+++ b/gadgets/trace_signal/test/integration/trace_signal_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceSignalEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Signal    string `json:"sig"`
 	SignalRaw int    `json:"sig_raw"`

--- a/gadgets/trace_sni/test/integration/trace_sni_test.go
+++ b/gadgets/trace_sni/test/integration/trace_sni_test.go
@@ -21,21 +21,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceSNIEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	NetNs     uint64            `json:"netns_id"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	NetNs     uint64        `json:"netns_id"`
+	Proc      utils.Process `json:"proc"`
 
 	Name string `json:"name"`
 }

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -21,21 +21,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceTCPEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
-	NetNsID   uint64            `json:"netns_id"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
+	NetNsID   uint64        `json:"netns_id"`
 
 	Src  utils.L4Endpoint `json:"src"`
 	Dst  utils.L4Endpoint `json:"dst"`

--- a/gadgets/trace_tcp/test/unit/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/unit/trace_tcp_test.go
@@ -24,14 +24,13 @@ import (
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
 type ExpectedTraceTcpEvent struct {
-	Proc ebpftypes.Process `json:"proc"`
+	Proc utils.Process `json:"proc"`
 
 	Type    string           `json:"type"`
 	NetNsId int              `json:"netns_id"`

--- a/gadgets/trace_tcpconnect/test/integration/trace_tcpconnect_test.go
+++ b/gadgets/trace_tcpconnect/test/integration/trace_tcpconnect_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceTcpconnectEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
 
 	Latency     uint64           `json:"latency,omitempty"`
 	SrcEndpoint utils.L4Endpoint `json:"src"`

--- a/gadgets/trace_tcpretrans/test/integration/trace_tcpretrans_test.go
+++ b/gadgets/trace_tcpretrans/test/integration/trace_tcpretrans_test.go
@@ -21,21 +21,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type traceTCPretransEvent struct {
-	eventtypes.CommonData
+	utils.CommonData
 
-	Timestamp string            `json:"timestamp"`
-	NetNs     uint64            `json:"netns_id"`
-	Proc      ebpftypes.Process `json:"proc"`
+	Timestamp string        `json:"timestamp"`
+	NetNs     uint64        `json:"netns_id"`
+	Proc      utils.Process `json:"proc"`
 
 	Type string           `json:"type"`
 	Src  utils.L4Endpoint `json:"src"`

--- a/pkg/testing/utils/types.go
+++ b/pkg/testing/utils/types.go
@@ -14,6 +14,11 @@
 
 package utils
 
+import (
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
 // Define some types that are only used for testing purposes
 
 type K8s struct {
@@ -35,3 +40,11 @@ type L3Endpoint struct {
 	Addr    string `json:"addr"`
 	Version uint8  `json:"version"`
 }
+
+type (
+	Creds   = ebpftypes.Creds
+	Parent  = ebpftypes.Parent
+	Process = ebpftypes.Process
+)
+
+type CommonData = eventtypes.CommonData

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/constraints"
 
-	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
@@ -121,17 +120,17 @@ func NormalizeCommonData(e *eventtypes.CommonData) {
 	}
 }
 
-func BuildProc(comm string, uid, tid uint32) ebpftypes.Process {
-	return ebpftypes.Process{
+func BuildProc(comm string, uid, tid uint32) Process {
+	return Process{
 		Comm:    comm,
 		Pid:     NormalizedInt,
 		Tid:     NormalizedInt,
 		MntNsID: NormalizedInt,
-		Creds: ebpftypes.Creds{
+		Creds: Creds{
 			Uid: uid,
 			Gid: tid,
 		},
-		Parent: ebpftypes.Parent{
+		Parent: Parent{
 			Comm: NormalizedStr,
 			Pid:  NormalizedInt,
 		},
@@ -140,7 +139,7 @@ func BuildProc(comm string, uid, tid uint32) ebpftypes.Process {
 
 // NormalizeProc normalizes the pid, tid, parent pid and parent comm fields on
 // p.
-func NormalizeProc(p *ebpftypes.Process) {
+func NormalizeProc(p *Process) {
 	NormalizeInt(&p.Pid)
 	NormalizeInt(&p.Tid)
 	NormalizeInt(&p.MntNsID)


### PR DESCRIPTION
# Alias ebpftypes.Process as Process in utils package

- Updated utils package to alias ebpftypes.Process as Process.
- Refactored test files to use utils.Process instead of ebpftypes.Process.
- Modified utils.go functions to reflect the alias change.


