### PR TITLE
ci/check-artifacthub-tags: Add permissions

### DIFF
--- a/.github/workflows/check-artifacthub-tags.yml
+++ b/.github/workflows/check-artifacthub-tags.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+permissions: read-all
+
 env:
   NO_COLOR: '\033[0m'
   RED: '\033[0;31m'


### PR DESCRIPTION
We seem to be getting warning about missing permission for check-artifacthub: https://scorecard.dev/viewer/?uri=github.com/inspektor-gadget/inspektor-gadget. This change adds a top level permission similar to other workflows.