### PR TITLE
dependabot: Use directories key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
       prefix: "ci:"
   # Update root go dependencies
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: "daily"
       time: "05:00"
@@ -35,56 +36,6 @@ updates:
       containers:
         patterns:
           - "github.com/containers/*"
-  # Update other go depedendencies
-  - package-ecosystem: "gomod"
-    directory: "/examples/"
-    schedule:
-      interval: "daily"
-      time: "05:00"
-      timezone: "Europe/Paris"
-    commit-message:
-      prefix: "go:"
-    groups:
-      golang-x:
-        patterns:
-          - "golang.org/x/*"
-      k8s:
-        patterns:
-          - "k8s.io/*"
-      docker:
-        patterns:
-          - "github.com/docker/docker/*"
-          - "github.com/moby/moby/*"
-      otel:
-        patterns:
-          - "go.opentelemetry.io/*"
-      containers:
-        patterns:
-          - "github.com/containers/*"
-  - package-ecosystem: "gomod"
-    directory: "/tools/eks-cleanup/"
-    schedule:
-      interval: "daily"
-      time: "05:00"
-      timezone: "Europe/Paris"
-    commit-message:
-      prefix: "go:"
-  - package-ecosystem: "gomod"
-    directory: "/tools/testjson2md/"
-    schedule:
-      interval: "daily"
-      time: "05:00"
-      timezone: "Europe/Paris"
-    commit-message:
-      prefix: "go:"
-  - package-ecosystem: "gomod"
-    directory: "/tools/dnstester/"
-    schedule:
-      interval: "daily"
-      time: "05:00"
-      timezone: "Europe/Paris"
-    commit-message:
-      prefix: "go:"
   - package-ecosystem: "docker"
     directory: "/Dockerfiles"
     schedule:


### PR DESCRIPTION
Use this new key to update all directories containing a go.mod file. This fixes the issue that different gomodules weren't updated in a single PR.

See more information on: https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/

--- 

Hopefully it'll fix the issue described in [slack](https://kubernetes.slack.com/archives/CSYL75LF6/p1717097084440599?thread_ts=1716994391.199619&cid=CSYL75LF6) now that https://github.com/dependabot/dependabot-core/issues/1595#issuecomment-2189252273 is fixed. 

> I think I now understand what's going on:
> examples/go.mod uses inspektor-gadget through a [replace directive](https://github.com/inspektor-gadget/inspektor-gadget/blob/4662ce24870851d0231044eff7445e222f7d3195/examples/go.mod#L201). This causes that any update on the root go.mod should be propagated to examples/go.mod, hence PRs updating the root go.mod are failing because the examples/go.mod is not updated. AFAIU dependabot doesn't support updating all go.mod files at once: [Create 1 PR for the same update across update configs](https://github.com/dependabot/dependabot-core/issues/1595#top)
> The solution proposed in [dependabot doesn't work well for multi modules repository](https://github.com/dependabot/dependabot-core/issues/6678#top) is to use dependency-type: all , it allows the bot to update the indirect dependencies too. This kind of fixes the problem, as the bot will create two PRs: One for updating the dependency on the root go.mod and another for updating it on examples/go.mod, if they're merged on the right order (examples' one first), then all of this works. But has two issues (1) the second PR will need to be rebased (2) there is a lot of noise since the bot is trying to update a lot of dependencies.
> I really don't know how to fix it without [Create 1 PR for the same update across update configs](https://github.com/dependabot/dependabot-core/issues/1595#top). Some ideas:
> Completely remove examples/go.mod: this will cause examples dependencies being propagated to the main go.mod
> Manually run go mod tidy on PRs created by dependabot
> Implement logic to automatically run go mod tidy (described in https://github.com/dependabot/dependabot-core/issues/6678#issuecomment-1449543089)

