### PR TITLE
Export filter operator

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 )
 
 require (
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/pkg/operators/filter/filter.go
+++ b/pkg/operators/filter/filter.go
@@ -426,3 +426,5 @@ func getFilterFunc(f datasource.FieldAccessor, op comparisonType, negate bool, s
 func init() {
 	operators.RegisterDataOperator(&filterOperator{})
 }
+
+var FilterOperator = &filterOperator{}

--- a/pkg/testing/match/match_test.go
+++ b/pkg/testing/match/match_test.go
@@ -21,11 +21,32 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 type testEvent struct {
 	Foo int    `json:"foo"`
 	Bar string `json:"bar"`
+}
+
+func TestPodLabelsUnmarshal(t *testing.T) {
+	input := `{"node": "node1", "namespace": "default", "podName": "test", "podLabels": "app=nginx,foo=bar"}`
+	expected := &types.K8sMetadata{
+		Node: "node1",
+		BasicK8sMetadata: types.BasicK8sMetadata{
+			Namespace: "default",
+			PodName:   "test",
+			PodLabels: map[string]string{
+				"app": "nginx",
+				"foo": "bar",
+			},
+		},
+	}
+	actual := decodeJSONOutput(t, JSONSingleObjectMode, input, func(*types.K8sMetadata) {})
+
+	require.Len(t, actual, 1)
+	assert.Equal(t, expected, actual[0])
 }
 
 func TestSingleObject(t *testing.T) {

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -113,6 +113,8 @@ func NormalizeCommonData(e *eventtypes.CommonData) {
 
 	e.Runtime.ContainerPID = 0
 
+	e.Runtime.ContainerStartedAt = 0
+
 	if CurrentTestComponent == KubectlGadgetTestComponent {
 		e.K8s.Node = ""
 		// TODO: Verify container runtime and container name

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestK8sMetadataUnmarshal(t *testing.T) {
+	input := `{"podLabels": "app=nginx,valid=yes"}`
+	expected := &K8sMetadata{
+		BasicK8sMetadata: BasicK8sMetadata{
+			PodLabels: map[string]string{
+				"app":   "nginx",
+				"valid": "yes",
+			},
+		},
+	}
+
+	var actual K8sMetadata
+	err := json.Unmarshal([]byte(input), &actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected.PodLabels, actual.PodLabels)
+}
+
+func TestK8sMetadataUnmarshalBadFormat(t *testing.T) {
+	input := `{"podLabels": "app=nginx,foo:bar,valid=yes,invalid"}`
+	err := json.Unmarshal([]byte(input), &K8sMetadata{})
+	assert.Error(t, err)
+}
+
+func TestK8sMetadataUnmarshalBadFormat2(t *testing.T) {
+	input := `{"podlabels":{"k8s-app":"kube-dns","kubernetes.io/cluster-service":"true","kubernetes.io/name":"CoreDNS"}}`
+	expected := &K8sMetadata{
+		BasicK8sMetadata: BasicK8sMetadata{
+			PodLabels: map[string]string{
+				"k8s-app":                       "kube-dns",
+				"kubernetes.io/cluster-service": "true",
+				"kubernetes.io/name":            "CoreDNS",
+			},
+		},
+	}
+
+	var actual K8sMetadata
+	err := json.Unmarshal([]byte(input), &actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected.PodLabels, actual.PodLabels)
+}


### PR DESCRIPTION
In order to use the Filter operator in Golang library, the user should be able to pass the operator to the [WithDataOperators](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/gadget-context/options.go#L43) option. Therefore, the filter should be exported.