### PR TITLE
 operators: Clean up and document lifecycle

### DIFF
--- a/docs/devel/operator/lifecycle.md
+++ b/docs/devel/operator/lifecycle.md
@@ -1,0 +1,67 @@
+---
+title: Lifecycle
+sidebar_position: 10
+description: >
+  Lilfecycle of an operator
+---
+
+This section describes the different hooks that can be implemented by an
+operator and what their use case is.
+
+## Priority
+
+Operators are initialized (PreStart and Start) according to their priority and
+they are closed (Stop, PreStop and Close) in the reverse order.
+
+## Lifecycle
+
+Under the hood, Inspektor Gadget uses two separate functions that control these
+lifecycles. One is to get information from a gadget ("GetGadgetInfo"), one is to
+actually run a gadget ("RunGadget").
+
+While the latter runs all lifecycle steps in the order documented below, the
+former will only call `Instantiate` and `Close`. That means that everything you
+do in `Instantiate` should use the least possible resources, but also that
+everything a gadget "offers" should be known after that step. That means: all
+DataSources should be known and finalized (fields added/modified, annotations
+added, etc.) after this step.
+
+Actual work should only be done on the forthcoming hooks (`PreStart`/`Start`).
+If the initialization step needs to actually create some kind of state that is
+necessary for later steps in the `RunGadget` case, the `Close` hook can be used
+to tear everything back down.
+
+### Instantiate
+
+Instances (`DataOperatorInstance` and `ImageOperatorInstance`) are created by
+`InstantiateDataOperator()` and `InstantiateImageOperator()` respectively. Those
+functions should return a new initalized instance of the operator. They can also
+return `nil` if the operator should be skipped. Data sources should be created
+in this step.
+
+### PreStart (optional)
+
+The PreStart() method is called before the gadget is started. The operator can
+subscribe to existing data sources here.
+
+### Start
+
+This method indicates the operator should start emitting data.
+
+### Stop
+
+The operator shouldn't emit any other data after stop has been called.
+
+### PostStop (optional)
+
+The PostStop() method is used to perform last minute operations after the
+operator has been stopped.
+
+### Close
+
+The Close() method is called to shutdown the operator. It must release all
+resources and stop all operations started by the methods above.
+
+### ExtraParams (optional)
+
+The ExtraParams() method is used to expose parameters to control the operator.

--- a/pkg/gadget-context/context_test.go
+++ b/pkg/gadget-context/context_test.go
@@ -21,10 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
 
 // newSimpleOperator takes a name, a priority and a pointer to a string that the operator writes its name
@@ -84,56 +82,6 @@ func TestOperatorOrder(t *testing.T) {
 			assert.Equal(t, tc.expectedOrder, out)
 		})
 	}
-}
-
-type fakeOperator struct {
-	name     string
-	priority int
-}
-
-func (s *fakeOperator) Name() string {
-	return s.name
-}
-
-func (s *fakeOperator) Init(*params.Params) error {
-	return nil
-}
-
-func (s *fakeOperator) GlobalParams() api.Params {
-	return nil
-}
-
-func (s *fakeOperator) InstanceParams() api.Params {
-	return api.Params{
-		{
-			Key:          "foo",
-			DefaultValue: "567",
-		},
-	}
-}
-
-func (s *fakeOperator) InstantiateDataOperator(operators.GadgetContext, api.ParamValues) (operators.DataOperatorInstance, error) {
-	return s, nil
-}
-
-func (s *fakeOperator) Priority() int {
-	return s.priority
-}
-
-func (s *fakeOperator) PreStart(operators.GadgetContext) error {
-	return nil
-}
-
-func (s *fakeOperator) Start(operators.GadgetContext) error {
-	return nil
-}
-
-func (s *fakeOperator) Stop(operators.GadgetContext) error {
-	return nil
-}
-
-func (s *fakeOperator) PostStop(operators.GadgetContext) error {
-	return nil
 }
 
 func TestParamsDefault(t *testing.T) {

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -320,15 +320,17 @@ func (c *GadgetContext) LoadGadgetInfo(info *api.GadgetInfo, paramValues api.Par
 
 	c.Logger().Debug("loaded gadget info")
 
-	var err error
-	// After loading gadget info, get local operators params as well
-	c.localOperators, err = c.initAndPrepareOperators(paramValues)
+	// After loading gadget info, start local operators as well
+	err := c.instantiateOperators(paramValues)
 	if err != nil {
 		return fmt.Errorf("initializing local operators: %w", err)
 	}
 
 	if run {
-		if err := c.start(c.localOperators); err != nil {
+		if err := c.preStart(); err != nil {
+			return fmt.Errorf("pre-starting operators: %w", err)
+		}
+		if err := c.start(); err != nil {
 			return fmt.Errorf("starting local operators: %w", err)
 		}
 		c.Logger().Debugf("running...")
@@ -355,7 +357,8 @@ func (c *GadgetContext) StopLocalOperators() {
 	if c.localOperators == nil {
 		return
 	}
-	c.stop(c.localOperators)
+	c.stop()
+	c.postStop()
 	c.localOperators = nil
 }
 

--- a/pkg/gadget-context/helpers_test.go
+++ b/pkg/gadget-context/helpers_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgetcontext
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+type fakeOperator struct {
+	name     string
+	priority int
+
+	// list of methods that will fail
+	fails []string
+
+	// list of methods called which didn't return an error
+	called *[]string
+}
+
+func (s *fakeOperator) Name() string {
+	return s.name
+}
+
+func (s *fakeOperator) Init(*params.Params) error {
+	return nil
+}
+
+func (s *fakeOperator) GlobalParams() api.Params {
+	return nil
+}
+
+func (s *fakeOperator) InstanceParams() api.Params {
+	return api.Params{
+		{
+			Key:          "foo",
+			DefaultValue: "567",
+		},
+	}
+}
+
+func (s *fakeOperator) InstantiateDataOperator(operators.GadgetContext, api.ParamValues) (operators.DataOperatorInstance, error) {
+	return s, nil
+}
+
+func (s *fakeOperator) Priority() int {
+	return s.priority
+}
+
+func (s *fakeOperator) runMethod(name string) error {
+	if slices.Contains(s.fails, name) {
+		return errors.New("needs to fail")
+	}
+
+	if s.called != nil {
+		*s.called = append(*s.called, s.name+"_"+name)
+	}
+
+	return nil
+}
+
+func (s *fakeOperator) PreStart(operators.GadgetContext) error {
+	return s.runMethod("prestart")
+}
+
+func (s *fakeOperator) Start(operators.GadgetContext) error {
+	return s.runMethod("start")
+}
+
+func (s *fakeOperator) Stop(operators.GadgetContext) error {
+	return s.runMethod("stop")
+}
+
+func (s *fakeOperator) PostStop(operators.GadgetContext) error {
+	return s.runMethod("poststop")
+}
+
+func (s *fakeOperator) Close(operators.GadgetContext) error {
+	return s.runMethod("close")
+}

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -16,6 +16,7 @@ package gadgetcontext
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -29,7 +30,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 )
 
-func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]operators.DataOperatorInstance, error) {
+func (c *GadgetContext) instantiateOperators(paramValues api.ParamValues) error {
 	log := c.Logger()
 
 	ops := c.DataOperators()
@@ -48,7 +49,7 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 
 	params := make([]*api.Param, 0)
 
-	dataOperatorInstances := make([]operators.DataOperatorInstance, 0, len(ops))
+	c.localOperators = make([]operators.DataOperatorInstance, 0, len(ops))
 	for _, op := range ops {
 		log.Debugf("initializing data op %q", op.Name())
 		opParamPrefix := fmt.Sprintf("operator.%s", op.Name())
@@ -60,36 +61,36 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		// Ensure all params are present
 		err := apihelpers.NormalizeWithDefaults(instanceParams, opParamValues)
 		if err != nil {
-			return nil, fmt.Errorf("normalizing instance params for operator %q: %w", op.Name(), err)
+			return fmt.Errorf("normalizing instance params for operator %q: %w", op.Name(), err)
 		}
 
 		err = apihelpers.Validate(instanceParams, opParamValues)
 		if err != nil {
-			return nil, fmt.Errorf("validating instance params for operator %q: %w", op.Name(), err)
+			return fmt.Errorf("validating instance params for operator %q: %w", op.Name(), err)
 		}
 
 		opInst, err := op.InstantiateDataOperator(c, opParamValues)
 		if err != nil {
-			return nil, fmt.Errorf("instantiating operator %q: %w", op.Name(), err)
+			return fmt.Errorf("instantiating operator %q: %w", op.Name(), err)
 		}
 		if opInst == nil {
 			log.Debugf("> skipped %s", op.Name())
 			continue
 		}
-		dataOperatorInstances = append(dataOperatorInstances, opInst)
+		c.localOperators = append(c.localOperators, opInst)
 
 		// Add instance params only if operator was actually instantiated (i.e., activated)
 		params = append(params, instanceParams...)
 	}
 
-	for _, opInst := range dataOperatorInstances {
+	for _, opInst := range c.localOperators {
 		log.Debugf("preparing op %q", opInst.Name())
 		opParamPrefix := fmt.Sprintf("operator.%s", opInst.Name())
 
 		// Second pass params; this time the operator had the chance to prepare itself based on DataSources, etc.
 		// this mainly is postponed to read default values that might differ from before; this second pass is
 		// what is handed over to the remote end
-		if extra, ok := opInst.(operators.DataOperatorExtraParams); ok {
+		if extra, ok := opInst.(operators.ExtraParams); ok {
 			pd := extra.ExtraParams(c)
 			params = append(params, pd.AddPrefix(opParamPrefix)...)
 		}
@@ -110,76 +111,114 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 
 	c.SetParams(params)
 
-	return dataOperatorInstances, nil
+	return nil
 }
 
-func (c *GadgetContext) start(dataOperatorInstances []operators.DataOperatorInstance) error {
-	for _, opInst := range dataOperatorInstances {
-		preStart, ok := opInst.(operators.PreStart)
-		if !ok {
-			continue
-		}
-		c.Logger().Debugf("pre-starting op %q", opInst.Name())
-		err := preStart.PreStart(c)
-		if err != nil {
-			c.cancel()
-			return fmt.Errorf("pre-starting operator %q: %w", opInst.Name(), err)
-		}
-	}
-	for _, opInst := range dataOperatorInstances {
-		c.Logger().Debugf("starting op %q", opInst.Name())
-		err := opInst.Start(c)
-		if err != nil {
-			c.cancel()
-			return fmt.Errorf("starting operator %q: %w", opInst.Name(), err)
+func (c *GadgetContext) preStart() error {
+	for _, opInst := range c.localOperators {
+		if preStart, ok := opInst.(operators.PreStart); ok {
+			c.Logger().Debugf("pre-starting op %q", opInst.Name())
+			err := preStart.PreStart(c)
+			if err != nil {
+				return fmt.Errorf("pre-starting operator %q: %w", opInst.Name(), err)
+			}
 		}
 	}
 	return nil
 }
 
-func (c *GadgetContext) stop(dataOperatorInstances []operators.DataOperatorInstance) {
-	// Stop/DeInit in reverse order
-	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
-		opInst := dataOperatorInstances[i]
-		preStop, ok := opInst.(operators.PreStop)
-		if !ok {
-			continue
-		}
-		c.Logger().Debugf("pre-stopping op %q", opInst.Name())
-		err := preStop.PreStop(c)
+func (c *GadgetContext) start() error {
+	started := []operators.DataOperatorInstance{}
+
+	for _, opInst := range c.localOperators {
+		c.Logger().Debugf("starting op %q", opInst.Name())
+		err := opInst.Start(c)
 		if err != nil {
-			c.Logger().Errorf("pre-stopping operator %q: %v", opInst.Name(), err)
+			// Stop all operators that were started to be sure they're able to
+			// release resources there
+			c.stopOperators(started)
+			c.postStopOperators(started)
+			return fmt.Errorf("starting operator %q: %w", opInst.Name(), err)
+		}
+		started = append(started, opInst)
+	}
+	return nil
+}
+
+func (c *GadgetContext) preStop() error {
+	var errs []error
+
+	// PreStop in reverse order
+	for i := len(c.localOperators) - 1; i >= 0; i-- {
+		opInst := c.localOperators[i]
+		if preStop, ok := opInst.(operators.PreStop); ok {
+			c.Logger().Debugf("pre-stopping op %q", opInst.Name())
+			err := preStop.PreStop(c)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pre-stopping operator %q: %w", opInst.Name(), err))
+			}
 		}
 	}
-	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
-		opInst := dataOperatorInstances[i]
+	return errors.Join(errs...)
+}
+
+func (c *GadgetContext) stopOperators(ops []operators.DataOperatorInstance) error {
+	var errs []error
+
+	// Stop in reverse order
+	for i := len(ops) - 1; i >= 0; i-- {
+		opInst := ops[i]
 		c.Logger().Debugf("stopping op %q", opInst.Name())
-		err := opInst.Stop(c)
-		if err != nil {
-			c.Logger().Errorf("stopping operator %q: %v", opInst.Name(), err)
+		errs = append(errs, opInst.Stop(c))
+	}
+	return errors.Join(errs...)
+}
+
+func (c *GadgetContext) stop() error {
+	return c.stopOperators(c.localOperators)
+}
+
+func (c *GadgetContext) postStopOperators(ops []operators.DataOperatorInstance) error {
+	var errs []error
+
+	// PostStop in reverse order
+	for i := len(ops) - 1; i >= 0; i-- {
+		opInst := ops[i]
+		if postStop, ok := opInst.(operators.PostStop); ok {
+			c.Logger().Debugf("post-stopping op %q", opInst.Name())
+			errs = append(errs, postStop.PostStop(c))
 		}
 	}
-	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
-		opInst := dataOperatorInstances[i]
-		postStop, ok := opInst.(operators.PostStop)
-		if !ok {
-			continue
-		}
-		c.Logger().Debugf("post-stopping op %q", opInst.Name())
-		err := postStop.PostStop(c)
-		if err != nil {
-			c.Logger().Errorf("post-stopping operator %q: %v", opInst.Name(), err)
+	return errors.Join(errs...)
+}
+
+func (c *GadgetContext) postStop() error {
+	return c.postStopOperators(c.localOperators)
+}
+
+func (c *GadgetContext) close() error {
+	var errs []error
+
+	// Close in reverse order
+	for i := len(c.localOperators) - 1; i >= 0; i-- {
+		opInst := c.localOperators[i]
+		c.Logger().Debugf("closing op %q", opInst.Name())
+		if err := opInst.Close(c); err != nil {
+			errs = append(errs, fmt.Errorf("closing operator %q: %w", opInst.Name(), err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 func (c *GadgetContext) PrepareGadgetInfo(paramValues api.ParamValues) error {
-	_, err := c.initAndPrepareOperators(paramValues)
+	err := c.instantiateOperators(paramValues)
+	c.close()
 	return err
 }
 
 func (c *GadgetContext) Run(paramValues api.ParamValues) error {
 	defer c.cancel()
+	defer c.close()
 
 	metricAttribs := attribute.NewSet(
 		attribute.KeyValue{Key: "gadget_image", Value: attribute.StringValue(c.imageName)},
@@ -188,21 +227,35 @@ func (c *GadgetContext) Run(paramValues api.ParamValues) error {
 	udCtrRunningGadgets.Add(context.Background(), 1, metric.WithAttributeSet(metricAttribs))
 	defer udCtrRunningGadgets.Add(context.Background(), -1, metric.WithAttributeSet(metricAttribs))
 
-	dataOperatorInstances, err := c.initAndPrepareOperators(paramValues)
+	err := c.instantiateOperators(paramValues)
 	if err != nil {
 		return fmt.Errorf("initializing and preparing operators: %w", err)
 	}
 
-	if err := c.start(dataOperatorInstances); err != nil {
+	if err := c.preStart(); err != nil {
+		return fmt.Errorf("pre-starting operators: %w", err)
+	}
+
+	if err := c.start(); err != nil {
 		return fmt.Errorf("starting operators: %w", err)
 	}
 
 	c.Logger().Debugf("running...")
-
 	WaitForTimeoutOrDone(c)
-	c.stop(dataOperatorInstances)
 
-	return nil
+	var errs []error
+
+	if err := c.preStop(); err != nil {
+		errs = append(errs, fmt.Errorf("pre-stopping operators: %w", err))
+	}
+	if err := c.stop(); err != nil {
+		errs = append(errs, fmt.Errorf("stopping operators: %w", err))
+	}
+	if err := c.postStop(); err != nil {
+		errs = append(errs, fmt.Errorf("post-stopping operators: %w", err))
+	}
+
+	return errors.Join(errs...)
 }
 
 var udCtrRunningGadgets, _ = metrics.Int64UpDownCounter("ig_gadgets_running",

--- a/pkg/gadget-context/run_test.go
+++ b/pkg/gadget-context/run_test.go
@@ -1,0 +1,314 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgetcontext
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+)
+
+func TestRun(t *testing.T) {
+	type testCase struct {
+		name          string
+		ops           []*fakeOperator
+		expectedCalls []string
+		expectedErr   bool
+	}
+
+	tests := []testCase{
+		// all operations should be called if there is not any error
+		{
+			name: "single_operator_all_work",
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op1_start",
+				"op1_stop",
+				"op1_poststop",
+				"op1_close",
+			},
+		},
+		// close should always be called if another operation fails
+		{
+			name:        "single_operator_prestart_fails",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"prestart"},
+				},
+			},
+			expectedCalls: []string{
+				"op1_close",
+			},
+		},
+		{
+			name:        "single_operator_start_fails",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"start"},
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op1_close",
+			},
+		},
+		{
+			name:        "single_operator_stop_fails",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"stop"},
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op1_start",
+				"op1_poststop", // TODO: Ideally poststop shouldn't be called if stop failed
+				"op1_close",
+			},
+		},
+		{
+			name:        "single_operator_poststop_fails",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"poststop"},
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op1_start",
+				"op1_stop",
+				"op1_close",
+			},
+		},
+		{
+			name: "multiple_operators_all_work",
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+				},
+				{
+					name:     "op2",
+					priority: 2,
+				},
+			},
+			expectedCalls: []string{
+				// prestart and start in order
+				"op1_prestart",
+				"op2_prestart",
+
+				"op1_start",
+				"op2_start",
+
+				// stop, prestop and close in inverse order
+				"op2_stop",
+				"op1_stop",
+
+				"op2_poststop",
+				"op1_poststop",
+
+				"op2_close",
+				"op1_close",
+			},
+		},
+		{
+			name:        "multiple_operators_with_prestart_failure",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"prestart"},
+				},
+				{
+					name:     "op2",
+					priority: 2,
+				},
+			},
+			expectedCalls: []string{
+				"op2_close",
+				"op1_close",
+			},
+		},
+		{
+			name:        "multiple_operators_with_start_failure",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"start"},
+				},
+				{
+					name:     "op2",
+					priority: 2,
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op2_prestart",
+
+				// close is always called
+				"op2_close",
+				"op1_close",
+			},
+		},
+		{
+			name:        "multiple_operators_with_start_failure_2",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+				},
+				{
+					name:     "op2",
+					priority: 2,
+					fails:    []string{"start"},
+				},
+			},
+			expectedCalls: []string{
+				"op1_prestart",
+				"op2_prestart",
+
+				"op1_start",
+
+				// stop and poststop should be called on op1 as it was succesfully started
+				"op1_stop",
+				"op1_poststop",
+
+				"op2_close",
+				"op1_close",
+			},
+		},
+		// a failure on stop or prestop shouldn't prevent the other operator to be stopped
+		{
+			name:        "multiple_operators_with_stop_failure",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"stop"},
+				},
+				{
+					name:     "op2",
+					priority: 2,
+				},
+			},
+			expectedCalls: []string{
+				// prestart and start in order
+				"op1_prestart",
+				"op2_prestart",
+
+				"op1_start",
+				"op2_start",
+
+				// stop, pre stop and close in inverse order
+				"op2_stop",
+
+				"op2_poststop",
+				"op1_poststop",
+
+				"op2_close",
+				"op1_close",
+			},
+		},
+		{
+			name:        "multiple_operators_with_poststop_failure",
+			expectedErr: true,
+			ops: []*fakeOperator{
+				{
+					name:     "op1",
+					priority: 1,
+					fails:    []string{"poststop"},
+				},
+				{
+					name:     "op2",
+					priority: 2,
+				},
+			},
+			expectedCalls: []string{
+				// prestart and start in order
+				"op1_prestart",
+				"op2_prestart",
+
+				"op1_start",
+				"op2_start",
+
+				// stop, pre stop and close in inverse order
+				"op2_stop",
+				"op1_stop",
+
+				"op2_poststop",
+
+				"op2_close",
+				"op1_close",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := []string{}
+
+			ops := make([]operators.DataOperator, 0, len(test.ops))
+			for _, op := range test.ops {
+				op.called = &called
+				ops = append(ops, op)
+			}
+			opts := WithDataOperators(ops...)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			gadgetCtx := New(ctx, "x.com/do-not-run-this", opts)
+			require.NotNil(t, gadgetCtx)
+
+			err := gadgetCtx.Run(nil)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, test.expectedCalls, called)
+		})
+	}
+}

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -495,4 +495,8 @@ func (o *cliOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (o *cliOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var CLIOperator = &cliOperator{}

--- a/pkg/operators/combiner/combiner.go
+++ b/pkg/operators/combiner/combiner.go
@@ -334,4 +334,8 @@ func (o *combinerOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error
 	return nil
 }
 
+func (o *combinerOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var CombinerOperator = &combinerOperator{}

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -149,12 +149,10 @@ func (o *ebpfOperator) InstantiateImageOperator(
 
 	err = newInstance.init(gadgetCtx)
 	if err != nil {
+		// be sure to undo all changes done by init(), as we'll return a nil
+		// instance and Close() isn't called by the caller of this function
+		newInstance.Close(gadgetCtx)
 		return nil, fmt.Errorf("initializing ebpf gadget: %w", err)
-	}
-
-	err = newInstance.evaluateMapParams(paramValues)
-	if err != nil {
-		return nil, fmt.Errorf("evaluating map params: %w", err)
 	}
 
 	return newInstance, nil
@@ -345,6 +343,80 @@ func (i *ebpfInstance) init(gadgetCtx operators.GadgetContext) error {
 		return fmt.Errorf("initializing formatters: %w", err)
 	}
 
+	if err := i.evaluateMapParams(i.paramValues); err != nil {
+		return fmt.Errorf("evaluating map params: %w", err)
+	}
+
+	// Create network tracers, one for each socket filter program
+	// The same applies to uprobe / uretprobe as well.
+	for _, p := range i.collectionSpec.Programs {
+		switch p.Type {
+		case ebpf.Kprobe:
+			if strings.HasPrefix(p.SectionName, "uprobe/") ||
+				strings.HasPrefix(p.SectionName, "uretprobe/") ||
+				strings.HasPrefix(p.SectionName, "usdt/") {
+				uprobeTracer, err := uprobetracer.NewTracer[api.GadgetData](gadgetCtx.Logger())
+				if err != nil {
+					return fmt.Errorf("creating uprobe tracer: %w", err)
+				}
+				i.uprobeTracers[p.Name] = uprobeTracer
+			}
+		case ebpf.SocketFilter:
+			if strings.HasPrefix(p.SectionName, "socket") {
+				networkTracer, err := networktracer.NewTracer[api.GadgetData]()
+				if err != nil {
+					return fmt.Errorf("creating network tracer: %w", err)
+				}
+				i.networkTracers[p.Name] = networkTracer
+			}
+		case ebpf.SchedCLS:
+			parts := strings.Split(p.SectionName, "/")
+			if len(parts) != 3 {
+				return fmt.Errorf("invalid section name %q", p.SectionName)
+			}
+			if parts[0] != "classifier" {
+				return fmt.Errorf("invalid section name %q", p.SectionName)
+			}
+
+			var direction tchandler.AttachmentDirection
+
+			switch parts[1] {
+			case "ingress":
+				direction = tchandler.AttachmentDirectionIngress
+			case "egress":
+				direction = tchandler.AttachmentDirectionEgress
+			default:
+				return fmt.Errorf("unsupported hook type %q", parts[1])
+			}
+
+			handler, err := tchandler.NewHandler(direction)
+			if err != nil {
+				return fmt.Errorf("creating tc network tracer: %w", err)
+			}
+
+			i.tcHandlers[p.Name] = handler
+		}
+	}
+
+	if len(i.tcHandlers) > 0 {
+		// For now, override enrichment
+		gadgetCtx.SetVar("NeedContainerEvents", true)
+		i.params["iface"] = &param{
+			Param: &api.Param{
+				Key:         ParamIface,
+				Description: "Network interface to attach to",
+			},
+		}
+	}
+
+	i.params[ParamTraceKernel] = &param{
+		Param: &api.Param{
+			Key:          ParamTraceKernel,
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
+		},
+	}
+
 	return nil
 }
 
@@ -453,91 +525,6 @@ func (i *ebpfInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params
 	return res
 }
 
-func (i *ebpfInstance) Prepare(gadgetCtx operators.GadgetContext) error {
-	for ds, formatters := range i.formatters {
-		for _, formatter := range formatters {
-			formatter := formatter
-			ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
-				return formatter(ds, data)
-			}, 0)
-		}
-	}
-
-	// Create network tracers, one for each socket filter program
-	// The same applies to uprobe / uretprobe as well.
-	for _, p := range i.collectionSpec.Programs {
-		switch p.Type {
-		case ebpf.Kprobe:
-			if strings.HasPrefix(p.SectionName, "uprobe/") ||
-				strings.HasPrefix(p.SectionName, "uretprobe/") ||
-				strings.HasPrefix(p.SectionName, "usdt/") {
-				uprobeTracer, err := uprobetracer.NewTracer[api.GadgetData](gadgetCtx.Logger())
-				if err != nil {
-					i.Close()
-					return fmt.Errorf("creating uprobe tracer: %w", err)
-				}
-				i.uprobeTracers[p.Name] = uprobeTracer
-			}
-		case ebpf.SocketFilter:
-			if strings.HasPrefix(p.SectionName, "socket") {
-				networkTracer, err := networktracer.NewTracer[api.GadgetData]()
-				if err != nil {
-					i.Close()
-					return fmt.Errorf("creating network tracer: %w", err)
-				}
-				i.networkTracers[p.Name] = networkTracer
-			}
-		case ebpf.SchedCLS:
-			parts := strings.Split(p.SectionName, "/")
-			if len(parts) != 3 {
-				return fmt.Errorf("invalid section name %q", p.SectionName)
-			}
-			if parts[0] != "classifier" {
-				return fmt.Errorf("invalid section name %q", p.SectionName)
-			}
-
-			var direction tchandler.AttachmentDirection
-
-			switch parts[1] {
-			case "ingress":
-				direction = tchandler.AttachmentDirectionIngress
-			case "egress":
-				direction = tchandler.AttachmentDirectionEgress
-			default:
-				return fmt.Errorf("unsupported hook type %q", parts[1])
-			}
-
-			handler, err := tchandler.NewHandler(direction)
-			if err != nil {
-				i.Close()
-				return fmt.Errorf("creating tc network tracer: %w", err)
-			}
-
-			i.tcHandlers[p.Name] = handler
-		}
-	}
-
-	if len(i.tcHandlers) > 0 {
-		// For now, override enrichment
-		gadgetCtx.SetVar("NeedContainerEvents", true)
-		i.params["iface"] = &param{
-			Param: &api.Param{
-				Key:         ParamIface,
-				Description: "Network interface to attach to",
-			},
-		}
-	}
-
-	i.params[ParamTraceKernel] = &param{
-		Param: &api.Param{
-			Key:          ParamTraceKernel,
-			DefaultValue: "false",
-			TypeHint:     api.TypeBool,
-		},
-	}
-	return nil
-}
-
 func (i *ebpfInstance) tracePipe(gadgetCtx operators.GadgetContext) error {
 	tracePipe, err := os.Open("/sys/kernel/debug/tracing/trace_pipe")
 	if err != nil {
@@ -556,6 +543,17 @@ func (i *ebpfInstance) tracePipe(gadgetCtx operators.GadgetContext) error {
 			log.Info(scanner.Text())
 		}
 	}()
+	return nil
+}
+
+func (i *ebpfInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, formatters := range i.formatters {
+		for _, formatter := range formatters {
+			ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+				return formatter(ds, data)
+			}, 0)
+		}
+	}
 	return nil
 }
 
@@ -755,7 +753,6 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		i.logger.Debugf("starting tracer %q", tracer.mapName)
 		err := i.runTracer(gadgetCtx, tracer)
 		if err != nil {
-			i.Close()
 			return fmt.Errorf("running tracer %q: %w", tracer.mapName, err)
 		}
 	}
@@ -764,7 +761,6 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 	for progName, p := range i.collectionSpec.Programs {
 		l, err := i.attachProgram(gadgetCtx, p, i.collection.Programs[progName])
 		if err != nil {
-			i.Close()
 			return fmt.Errorf("attaching eBPF program %q: %w", progName, err)
 		}
 
@@ -778,7 +774,6 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		if p.Type == ebpf.Tracing && strings.HasPrefix(p.SectionName, iterPrefix) {
 			lIter, ok := l.(*link.Iter)
 			if !ok {
-				i.Close()
 				return fmt.Errorf("link is not an iterator")
 			}
 
@@ -801,13 +796,11 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 
 	err = i.runSnapshotters()
 	if err != nil {
-		i.Close()
 		return fmt.Errorf("running snapshotters: %w", err)
 	}
 
 	err = i.runMapIterators()
 	if err != nil {
-		i.Close()
 		return fmt.Errorf("running map iterators: %w", err)
 	}
 
@@ -815,38 +808,20 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 }
 
 func (i *ebpfInstance) PreStop(gadgetCtx operators.GadgetContext) error {
-	i.Close()
+	close(i.done)
 	return nil
 }
 
 func (i *ebpfInstance) Stop(gadgetCtx operators.GadgetContext) error {
-	i.bpfOperator.mu.Lock()
-	delete(i.bpfOperator.gadgetObjs, gadgetCtx)
-	i.bpfOperator.mu.Unlock()
-	return nil
-}
-
-func (i *ebpfInstance) Close() {
-	close(i.done)
-
 	for _, t := range i.tracers {
 		t.close()
 	}
+	i.tracers = nil
 
 	for _, l := range i.links {
 		gadgets.CloseLink(l)
 	}
 	i.links = nil
-
-	for _, networkTracer := range i.networkTracers {
-		networkTracer.Close()
-	}
-	for _, handler := range i.tcHandlers {
-		handler.Close()
-	}
-	for _, uprobeTracer := range i.uprobeTracers {
-		uprobeTracer.Close()
-	}
 
 	for _, fd := range i.perfFds {
 		// Disable perf event.
@@ -862,11 +837,30 @@ func (i *ebpfInstance) Close() {
 	}
 
 	i.wg.Wait()
+	return nil
+}
 
+func (i *ebpfInstance) Close(gadgetCtx operators.GadgetContext) error {
 	if i.collection != nil {
 		i.collection.Close()
 		i.collection = nil
 	}
+
+	for _, networkTracer := range i.networkTracers {
+		networkTracer.Close()
+	}
+	for _, handler := range i.tcHandlers {
+		handler.Close()
+	}
+	for _, uprobeTracer := range i.uprobeTracers {
+		uprobeTracer.Close()
+	}
+
+	i.bpfOperator.mu.Lock()
+	delete(i.bpfOperator.gadgetObjs, gadgetCtx)
+	i.bpfOperator.mu.Unlock()
+
+	return nil
 }
 
 // Using Attacher interface for network tracers for now

--- a/pkg/operators/ebpf/stats.go
+++ b/pkg/operators/ebpf/stats.go
@@ -566,6 +566,10 @@ func (i *ebpfOperatorDataInstance) Start(gadgetCtx operators.GadgetContext) erro
 }
 
 func (i *ebpfOperatorDataInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (i *ebpfOperatorDataInstance) Close(gadgetCtx operators.GadgetContext) error {
 	defer close(i.done)
 
 	if err := bpfstats.DisableBPFStats(); err != nil {

--- a/pkg/operators/env/env.go
+++ b/pkg/operators/env/env.go
@@ -142,6 +142,10 @@ func (e *envOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (e *envOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.RegisterDataOperator(&envOperator{})
 }

--- a/pkg/operators/filter/filter.go
+++ b/pkg/operators/filter/filter.go
@@ -138,6 +138,10 @@ func (f *filterOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (f *filterOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func getCompareFunc[T constraints.Ordered](op comparisonType) func(a, b T) bool {
 	switch op {
 	default:

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -552,6 +552,10 @@ func (f *formattersOperatorInstance) Stop(gadgetCtx operators.GadgetContext) err
 	return nil
 }
 
+func (f *formattersOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.RegisterDataOperator(&formattersOperator{})
 }

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
@@ -296,4 +296,8 @@ func (s *gnpOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (s *gnpOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var GNPOperator = &gnpOperator{}

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -327,6 +327,10 @@ func (m *KubeIPResolverInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (m *KubeIPResolverInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.RegisterDataOperator(&KubeIPResolver{})
 }

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -493,6 +493,10 @@ func (m *KubeManagerInstance) Start(gadgetCtx operators.GadgetContext) error {
 }
 
 func (m *KubeManagerInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (m *KubeManagerInstance) Close(gadgetCtx operators.GadgetContext) error {
 	m.manager.gadgetTracerManager.RemoveTracer(m.id)
 
 	if m.containersPublisher != nil {

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -239,6 +239,10 @@ func (m *KubeNameResolverInstance) Stop(gadgetCtx operators.GadgetContext) error
 	return nil
 }
 
+func (m *KubeNameResolverInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.RegisterDataOperator(&KubeNameResolver{})
 }

--- a/pkg/operators/limiter/limiter.go
+++ b/pkg/operators/limiter/limiter.go
@@ -163,6 +163,10 @@ func (l *limiterOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error 
 	return nil
 }
 
+func (l *limiterOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var Operator = &limiterOperator{}
 
 func init() {

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -647,6 +647,10 @@ func (l *localManagerTraceWrapper) Stop(gadgetCtx operators.GadgetContext) error
 		l.containersPublisher.Unsubscribe()
 	}
 
+	return nil
+}
+
+func (l *localManagerTraceWrapper) Close(gadgetCtx operators.GadgetContext) error {
 	return l.PostGadgetRun()
 }
 

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -16,6 +16,7 @@ package ocihandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -446,16 +447,25 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 
 	extraParams := make([]*api.Param, 0)
 	for _, opInst := range o.imageOperatorInstances {
-		err := opInst.Prepare(o.gadgetCtx)
-		if err != nil {
-			return fmt.Errorf("preparing operator %q: %w", opInst.Name(), err)
+		if extra, ok := opInst.(operators.ExtraParams); ok {
+			params := extra.ExtraParams(gadgetCtx)
+			extraParams = append(extraParams, params.AddPrefix(opInst.Name())...)
 		}
-
-		// Add gadget params prefixed with operators' name
-		extraParams = append(extraParams, opInst.ExtraParams(gadgetCtx).AddPrefix(opInst.Name())...)
 	}
 
 	o.extraParams = extraParams
+	return nil
+}
+
+func (o *OciHandlerInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for _, opInst := range o.imageOperatorInstances {
+		if preStart, ok := opInst.(operators.PreStart); ok {
+			err := preStart.PreStart(gadgetCtx)
+			if err != nil {
+				return fmt.Errorf("pre-starting operator %q: %w", opInst.Name(), err)
+			}
+		}
+	}
 	return nil
 }
 
@@ -463,29 +473,21 @@ func (o *OciHandlerInstance) Start(gadgetCtx operators.GadgetContext) error {
 	started := []operators.ImageOperatorInstance{}
 
 	for _, opInst := range o.imageOperatorInstances {
-		preStart, ok := opInst.(operators.PreStart)
-		if !ok {
-			continue
-		}
-		err := preStart.PreStart(gadgetCtx)
-		if err != nil {
-			return fmt.Errorf("pre-starting operator %q: %w", opInst.Name(), err)
-		}
-	}
-
-	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Start(o.gadgetCtx)
 		if err != nil {
-			// Stop all started operators
+			// Stop all operators that were started to be sure they're able to
+			// release resources there
 			for _, startedOp := range started {
 				startedOp.Stop(o.gadgetCtx)
+				if postStop, ok := startedOp.(operators.PostStop); ok {
+					postStop.PostStop(o.gadgetCtx)
+				}
 			}
-
 			return fmt.Errorf("starting operator %q: %w", opInst.Name(), err)
 		}
-
 		started = append(started, opInst)
 	}
+
 	return nil
 }
 
@@ -504,25 +506,41 @@ func (o *OciHandlerInstance) PreStop(gadgetCtx operators.GadgetContext) error {
 }
 
 func (o *OciHandlerInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	var errs []error
+
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Stop(o.gadgetCtx)
 		if err != nil {
-			o.gadgetCtx.Logger().Errorf("stopping operator %q: %v", opInst.Name(), err)
+			errs = append(errs, fmt.Errorf("stopping operator %q: %w", opInst.Name(), err))
 		}
 	}
+
+	return errors.Join(errs...)
+}
+
+func (o *OciHandlerInstance) PostStop(gadgetCtx operators.GadgetContext) error {
+	var errs []error
 
 	for _, opInst := range o.imageOperatorInstances {
-		postStop, ok := opInst.(operators.PostStop)
-		if !ok {
-			continue
-		}
-		err := postStop.PostStop(gadgetCtx)
-		if err != nil {
-			o.gadgetCtx.Logger().Errorf("post-stopping operator %q: %v", opInst.Name(), err)
+		if preStart, ok := opInst.(operators.PostStop); ok {
+			err := preStart.PostStop(gadgetCtx)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("post-stopping operator %q: %w", opInst.Name(), err))
+			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
+}
+
+func (o *OciHandlerInstance) Close(gadgetCtx operators.GadgetContext) error {
+	var errs []error
+
+	for _, opInst := range o.imageOperatorInstances {
+		errs = append(errs, opInst.Close(o.gadgetCtx))
+	}
+
+	return errors.Join(errs...)
 }
 
 type OciHandlerInstance struct {

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -68,10 +68,9 @@ type ImageOperator interface {
 
 type ImageOperatorInstance interface {
 	Name() string
-	Prepare(gadgetCtx GadgetContext) error
 	Start(gadgetCtx GadgetContext) error
 	Stop(gadgetCtx GadgetContext) error
-	ExtraParams(gadgetCtx GadgetContext) api.Params
+	Close(gadgetCtx GadgetContext) error
 }
 
 type DataOperator interface {
@@ -98,10 +97,11 @@ type DataOperatorInstance interface {
 	Name() string
 	Start(gadgetCtx GadgetContext) error
 	Stop(gadgetCtx GadgetContext) error
+	Close(gadgetCtx GadgetContext) error
 }
 
-type DataOperatorExtraParams interface {
-	// ExtraParams can return dynamically created params; they are read after Prepare() has been called
+type ExtraParams interface {
+	// ExtraParams can return dynamically created params
 	ExtraParams(gadgetCtx GadgetContext) api.Params
 }
 

--- a/pkg/operators/otel-logs/otel-logs.go
+++ b/pkg/operators/otel-logs/otel-logs.go
@@ -313,6 +313,10 @@ func (o *otelLogsOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error
 	return nil
 }
 
+func (o *otelLogsOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var Operator = &otelLogsOperator{}
 
 func init() {

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -590,21 +590,6 @@ func (mc *metricsCollector) Collect(ctx context.Context, data datasource.Data) {
 	}
 }
 
-func (m *otelMetricsOperatorInstance) shutdown() {
-	close(m.done)
-	ctx := context.Background()
-	for _, collector := range m.collectors {
-		if collector.meterProvider != nil {
-			collector.meterProvider.Shutdown(ctx)
-			collector.meterProvider = nil
-		}
-		if collector.exporter != nil {
-			collector.exporter.Shutdown(ctx)
-			collector.exporter = nil
-		}
-	}
-}
-
 func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 	for _, ds := range gadgetCtx.GetDataSources() {
 		annotations := ds.Annotations()
@@ -866,9 +851,24 @@ func (m *otelMetricsOperatorInstance) Start(gadgetCtx operators.GadgetContext) e
 }
 
 func (m *otelMetricsOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
-	m.shutdown()
-	m.wg.Wait()
+	return nil
+}
+
+func (m *otelMetricsOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
 	gadgetCtx.Logger().Debug("shutting down metrics")
+	close(m.done)
+	ctx := context.Background()
+	for _, collector := range m.collectors {
+		if collector.meterProvider != nil {
+			collector.meterProvider.Shutdown(ctx)
+			collector.meterProvider = nil
+		}
+		if collector.exporter != nil {
+			collector.exporter.Shutdown(ctx)
+			collector.exporter = nil
+		}
+	}
+	m.wg.Wait()
 	return nil
 }
 

--- a/pkg/operators/process/process.go
+++ b/pkg/operators/process/process.go
@@ -382,6 +382,10 @@ func (p *processOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error 
 	return nil
 }
 
+func (p *processOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func (p *processOperatorInstance) TotalMemory() uint64 {
 	return p.totalMemory
 }

--- a/pkg/operators/simple/simple.go
+++ b/pkg/operators/simple/simple.go
@@ -84,6 +84,10 @@ func (s *simpleOperator) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (s *simpleOperator) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func (s *simpleOperator) PreStart(gadgetCtx operators.GadgetContext) error {
 	if s.onPreStart != nil {
 		return s.onPreStart(gadgetCtx)

--- a/pkg/operators/socketenricher/socketenricher.go
+++ b/pkg/operators/socketenricher/socketenricher.go
@@ -221,6 +221,10 @@ func (i *SocketEnricherInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return i.PostGadgetRun()
 }
 
+func (i *SocketEnricherInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func (i *SocketEnricherInstance) SetSocketEnricherMap(m *ebpf.Map) {
 	i.gadgetCtx.Logger().Debugf("setting sockets map")
 	i.gadgetCtx.SetVar(tracer.SocketsMapName, m)

--- a/pkg/operators/sort/sort.go
+++ b/pkg/operators/sort/sort.go
@@ -262,6 +262,10 @@ func (s *sortOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (s *sortOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 var Operator = &sortOperator{}
 
 func init() {

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -224,7 +224,11 @@ func (m *UidGidResolverInstance) PreStart(gadgetCtx operators.GadgetContext) err
 	// We need to start the cache here because it's too late to start it in
 	// Start() as other operators could be started before and generate events
 	// that need the cache
-	return m.uidGidCache.Start()
+	if err := m.uidGidCache.Start(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *UidGidResolverInstance) Start(gadgetCtx operators.GadgetContext) error {
@@ -233,6 +237,10 @@ func (m *UidGidResolverInstance) Start(gadgetCtx operators.GadgetContext) error 
 
 func (m *UidGidResolverInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	m.uidGidCache.Stop()
+	return nil
+}
+
+func (m *UidGidResolverInstance) Close(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 

--- a/pkg/operators/ustack/ustack.go
+++ b/pkg/operators/ustack/ustack.go
@@ -280,13 +280,6 @@ func (o *OperatorInstance) Name() string {
 	return Name
 }
 
-func (o *OperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
-	if o.symbolizer != nil {
-		o.symbolizer.Close()
-	}
-	return nil
-}
-
 func (o *OperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
 	userStackMapAny, ok := gadgetCtx.GetVar(operators.MapPrefix + ebpftypes.UserStackMapName)
 	if !ok || userStackMapAny == nil {
@@ -306,6 +299,17 @@ func (o *OperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
 		for _, f := range funcs {
 			ds.Subscribe(f, Priority)
 		}
+	}
+	return nil
+}
+
+func (o *OperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (o *OperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	if o.symbolizer != nil {
+		o.symbolizer.Close()
 	}
 	return nil
 }

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -94,13 +94,13 @@ func (w *wasmOperator) InstantiateImageOperator(
 		createdMap:  map[uint32]struct{}{},
 	}
 
-	if err := instance.init(gadgetCtx, target, desc, w.cache); err != nil {
-		instance.close(gadgetCtx)
-		return nil, fmt.Errorf("initializing wasm: %w", err)
-	}
-
 	if configVar, ok := gadgetCtx.GetVar("config"); ok {
 		instance.config, _ = configVar.(*viper.Viper)
+	}
+
+	if err := instance.init(gadgetCtx, target, desc, w.cache); err != nil {
+		instance.Close(gadgetCtx)
+		return nil, fmt.Errorf("initializing wasm: %w", err)
 	}
 
 	if instance.config != nil {
@@ -152,14 +152,6 @@ type wasmOperatorInstance struct {
 
 func (i *wasmOperatorInstance) Name() string {
 	return "wasm"
-}
-
-func (i *wasmOperatorInstance) Prepare(gadgetCtx operators.GadgetContext) error {
-	if err := i.callGuestFunction(gadgetCtx.Context(), "gadgetInit"); err != nil {
-		return fmt.Errorf("initializing wasm guest: %w", err)
-	}
-
-	return nil
 }
 
 func (i *wasmOperatorInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params {
@@ -309,6 +301,10 @@ func (i *wasmOperatorInstance) init(
 
 	i.dataSourceCallback = mod.ExportedFunction("dataSourceCallback")
 
+	if err := i.callGuestFunction(gadgetCtx.Context(), "gadgetInit"); err != nil {
+		return fmt.Errorf("initializing wasm guest: %w", err)
+	}
+
 	return err
 }
 
@@ -363,23 +359,14 @@ func (i *wasmOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	err := i.callGuestFunction(ctx, "gadgetStop")
-
-	// TODO: This should be called directly from the outside, in case prepare or
-	// start fails, this won't be called.
-	i.close(gadgetCtx)
-
-	return err
+	return i.callGuestFunction(ctx, "gadgetStop")
 }
 
 func (i *wasmOperatorInstance) PostStop(gadgetCtx operators.GadgetContext) error {
-	// TODO: reenable it when
-	// https://github.com/inspektor-gadget/inspektor-gadget/pull/3778 is merged
-	// return i.callGuestFunction(gadgetCtx.Context(), "gadgetPostStop")
-	return nil
+	return i.callGuestFunction(gadgetCtx.Context(), "gadgetPostStop")
 }
 
-func (i *wasmOperatorInstance) close(gadgetCtx operators.GadgetContext) error {
+func (i *wasmOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
 	var errs []error
 
 	if i.rt != nil {


### PR DESCRIPTION
1. Implement Close() method: Not having a Close() method was confusing
and led to situations when some resources could be leaked if there was a
failure in the operator.

2. Remove Init() and move that logic intro the corresponding Instantiate
method.