### PR TITLE
ci: Enable workflow_dispatch

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -28,6 +28,7 @@ on:
     - 'citest/**'
     tags:
     - 'v*'
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
TL;DR: There are cases when we want to run the CI manually in case something bad has happened.

--- 

I used the `@dependabot merge` command to merge a PR in https://github.com/inspektor-gadget/inspektor-gadget/pull/3784#issuecomment-2536826436, this caused the GitHub Actions actor to be dependabot, since it doesn't have access to our private key, all signing related things failed: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/12277729656/attempts/1. 

This caused the CI to push images without signing. 

For gadgets the current "latest" images fail to be run without disabling image verification:

```bash 
$  sudo ig run trace_exec:latest --pull always
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "trace_exec:latest": getting signing information: getting signature: getting signature bytes: ghcr.io/inspektor-gadget/gadget/trace_exec:sha256-dc59c05ae9e291c749a2731681ba5641b1b7b74b8c718e4c4f9b12ec61f9489b.sig: not found
```

It's also causing new CI jobs to fail as the ebpf-builder isn't signed https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/12292305218/job/34302846713?pr=3791 (#3791)

Rerun the CI didn't help as it seem the actor is still dependabot https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/12277729656

This PR creates a escape hatch for these situations, allowing the CI to be run manually in case something bad has happened.

We still need to look at the root issue, one solution would be to give access to the private key to dependabot, but I'm not too confident about it. Perhaps the easiest way for now is to avoid using `dependabot merge`. 
