### PR TITLE
Adding support for non unix:// prefix in socket paths

### DIFF
--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -234,10 +234,12 @@ func getContainerRuntimeSocketPath(clientset *kubernetes.Clientset, nodeName str
 	if err != nil {
 		return "", fmt.Errorf("getting /configz: %w", err)
 	}
-	socketPath, found := strings.CutPrefix(kubeletConfig.ContainerRuntimeEndpoint, "unix://")
-	if !found {
-		return "", fmt.Errorf("socket path does not start with unix://")
+
+	socketPath := strings.TrimPrefix(kubeletConfig.ContainerRuntimeEndpoint, "unix://")
+	if socketPath == "" {
+		return "", fmt.Errorf("container runtime socket path is empty")
 	}
+
 	log.Infof("using the detected container runtime socket path from Kubelet's config: %s", socketPath)
 	return socketPath, nil
 }


### PR DESCRIPTION
# Adding support for non unix:// prefixed socket paths

For some environments like k8s in openshift over cri-o and microk8s the socket path isn't prefixed with unix:// 

For example: [cri-o setup](https://docs.openshift.com/container-platform/3.11/crio/crio_runtime.html).
