### PR TITLE
oci: remote manifest file

### DIFF
--- a/cmd/common/utils/http.go
+++ b/cmd/common/utils/http.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func DownloadFile(rawURL string) (io.ReadCloser, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL: %w", err)
+	}
+
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	switch u.Scheme {
+	case "http", "https":
+		resp, err := client.Get(rawURL)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		return resp.Body, nil
+	default:
+		return nil, fmt.Errorf("unsupported scheme: %s", u.Scheme)
+	}
+}


### PR DESCRIPTION
This change allows getting manifest file remotely. It should help us host sample manifest files and share them with different use-cases:

```
$ go run ./cmd/kubectl-gadget run -f https://gist.githubusercontent.com/mqasimsarfraz/dcc1521afebdcc5708fb16efb9de2677/raw/f5b5a3d2737b44142c9f52792b170c8415a3e057/failed-dns-requests.yaml
K8S.PODNAME                                           SRC                                                  DST                                                  NAME                                                  RCODE
```
