### PR TITLE
treewide: Format eBPF code using clang-format-18.

### DIFF
--- a/gadgets/top_file/stat.h
+++ b/gadgets/top_file/stat.h
@@ -16,12 +16,12 @@
 #define S_ISGID 0002000
 #define S_ISVTX 0001000
 
-#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
-#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
-#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
-#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
-#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
-#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
-#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
+#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
 
 #endif /* __STAT_H */

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -18,7 +18,7 @@
 #define ARGSIZE 256
 #define TOTAL_MAX_ARGS 20
 #define FULL_MAX_ARGS_ARR (TOTAL_MAX_ARGS * ARGSIZE)
-#define INVALID_UID ((uid_t)-1)
+#define INVALID_UID ((uid_t) - 1)
 #define BASE_EVENT_SIZE (size_t)(&((struct event *)0)->args)
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -14,7 +14,7 @@
 
 #define TASK_RUNNING 0
 #define NAME_MAX 255
-#define INVALID_UID ((uid_t)-1)
+#define INVALID_UID ((uid_t) - 1)
 
 struct args_t {
 	const char *fname;

--- a/pkg/container-hook/bpf/execruntime.h
+++ b/pkg/container-hook/bpf/execruntime.h
@@ -6,7 +6,7 @@
 #define TASK_COMM_LEN 16
 #define TOTAL_MAX_ARGS 20
 #define FULL_MAX_ARGS_ARR (TOTAL_MAX_ARGS * ARGSIZE)
-#define INVALID_UID ((uid_t)-1)
+#define INVALID_UID ((uid_t) - 1)
 #define BASE_EVENT_SIZE (size_t)(&((struct event *)0)->args)
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)

--- a/pkg/gadgets/top/file/tracer/bpf/stat.h
+++ b/pkg/gadgets/top/file/tracer/bpf/stat.h
@@ -16,12 +16,12 @@
 #define S_ISGID 0002000
 #define S_ISVTX 0001000
 
-#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
-#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
-#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
-#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
-#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
-#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
-#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
+#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
 
 #endif /* __STAT_H */

--- a/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
+++ b/pkg/gadgets/trace/exec/tracer/bpf/execsnoop.h
@@ -6,7 +6,7 @@
 #define TASK_COMM_LEN 16
 #define TOTAL_MAX_ARGS 20
 #define FULL_MAX_ARGS_ARR (TOTAL_MAX_ARGS * ARGSIZE)
-#define INVALID_UID ((uid_t)-1)
+#define INVALID_UID ((uid_t) - 1)
 #define BASE_EVENT_SIZE (size_t)(&((struct event *)0)->args)
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)

--- a/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
+++ b/pkg/gadgets/trace/open/tracer/bpf/opensnoop.h
@@ -5,7 +5,7 @@
 #define TASK_COMM_LEN 16
 #define NAME_MAX 255
 #define PATH_MAX 4096
-#define INVALID_UID ((uid_t)-1)
+#define INVALID_UID ((uid_t) - 1)
 
 struct start_t {
 	int flags;


### PR DESCRIPTION
CI uses clang-format-18 to check that eBPF code is correctly formatted [1]. Let's use the same to fix errors discovered by CI.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/12349927639/job/34461748991?pr=3803#step:3:151
Signed-off-by: Francis Laniel <flaniel@linux.microsoft.com>
[1]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/12349927639/job/34461748991?pr=3803#step:3:91