### PR TITLE
Bumped gopacket to contain a fix for the panic of dns parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,6 +230,10 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
+// gopacket/gopacket with:
+// - https://github.com/gopacket/gopacket/pull/101
+replace github.com/gopacket/gopacket => github.com/gopacket/gopacket v1.3.2-0.20241202175635-b43272ae1eb8
+
 // cilium/ebpf with:
 // - https://github.com/cilium/ebpf/pull/1588
 // - https://github.com/cilium/ebpf/pull/1590

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopacket/gopacket v1.3.1 h1:ZppWyLrOJNZPe5XkdjLbtuTkfQoxQ0xyMJzQCqtqaPU=
-github.com/gopacket/gopacket v1.3.1/go.mod h1:3I13qcqSpB2R9fFQg866OOgzylYkZxLTmkvcXhvf6qg=
+github.com/gopacket/gopacket v1.3.2-0.20241202175635-b43272ae1eb8 h1:PoilRl1aPz9JlypuskS97qoGuXbEGBGza7YmXQyAwP8=
+github.com/gopacket/gopacket v1.3.2-0.20241202175635-b43272ae1eb8/go.mod h1:3I13qcqSpB2R9fFQg866OOgzylYkZxLTmkvcXhvf6qg=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=


### PR DESCRIPTION
# Fix dns packet parsing panic

Bumped gopacket

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/commit/1be3c7db7c8837d7d53bb64e580ea187785aad41 ("go: bump github.com/gopacket/gopacket from 1.2.0 to 1.3.1") https://github.com/inspektor-gadget/inspektor-gadget/pull/3698
