### PR TITLE
Update entrypoint logic for gadget-container 

### DIFF
--- a/Dockerfiles/gadget.Dockerfile
+++ b/Dockerfiles/gadget.Dockerfile
@@ -32,7 +32,6 @@ LABEL org.opencontainers.image.description="Inspektor Gadget is a collection of 
 LABEL org.opencontainers.image.documentation="https://inspektor-gadget.io/docs"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-COPY --from=builder /gadget/gadget-container/bin/entrypoint /
 COPY --from=builder /gadget/gadget-container/bin/cleanup /
 
 COPY --from=builder /gadget/gadget-container/bin/gadgettracermanager /bin/

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: {{ .Values.image.repository }}:{{ include "gadget.image.tag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/entrypoint" ]
+          command: [ "/bin/gadgettracermanager", "-serve", "-controller" ]
           lifecycle:
             preStop:
               exec:

--- a/gadget-container/Makefile
+++ b/gadget-container/Makefile
@@ -1,18 +1,9 @@
 .PHONY: gadget-container-deps
-gadget-container-deps: entrypoint cleanup ocihookgadget gadgettracermanager nrigadget
+gadget-container-deps: cleanup ocihookgadget gadgettracermanager nrigadget
 
 
 TARGET_ARCH ?= $(shell go env GOHOSTARCH)
 VERSION ?= $(shell git describe --tags --always --dirty)
-
-# Entrypoint
-
-.PHONY: entrypoint
-entrypoint:
-	mkdir -p bin
-	GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build \
-		-o bin/entrypoint \
-		./entrypoint/entrypoint.go
 
 .PHONY: cleanup
 cleanup:

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -158,7 +158,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           image: ghcr.io/inspektor-gadget/inspektor-gadget:latest
           imagePullPolicy: Always
-          command: [ "/entrypoint" ]
+          command: [ "/bin/gadgettracermanager", "-serve", "-controller" ]
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
 ### Fixes #3742 
Updates the entrypoint logic of gadgettracermanager. The main function now directly handles the program's execution, eliminating the need for a standalone binary. This change simplifies the structure and improves maintainability.