### PR TITLE
export the whole RuntimeConfig in K8sClient

### DIFF
--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -41,11 +41,11 @@ import (
 )
 
 type K8sClient struct {
-	clientset         *kubernetes.Clientset
-	nodeName          string
-	fieldSelector     string
-	runtimeClient     runtimeclient.ContainerRuntimeClient
-	RuntimeSocketPath string
+	clientset     *kubernetes.Clientset
+	nodeName      string
+	fieldSelector string
+	runtimeClient runtimeclient.ContainerRuntimeClient
+	RuntimeConfig *containerutilsTypes.RuntimeConfig
 }
 
 func NewK8sClient(nodeName string) (*K8sClient, error) {
@@ -84,22 +84,22 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 			log.Warnf("Failed to retrieve socket path for runtime client from config: %v. Falling back to default container runtime", err)
 		}
 	}
-	runtimeClient, err := containerutils.NewContainerRuntimeClient(
-		&containerutilsTypes.RuntimeConfig{
-			Name:            types.String2RuntimeName(list[0]),
-			SocketPath:      socketPath,
-			RuntimeProtocol: containerutilsTypes.RuntimeProtocolCRI,
-		})
+	runtimeConfig := &containerutilsTypes.RuntimeConfig{
+		Name:            types.String2RuntimeName(list[0]),
+		SocketPath:      socketPath,
+		RuntimeProtocol: containerutilsTypes.RuntimeProtocolCRI,
+	}
+	runtimeClient, err := containerutils.NewContainerRuntimeClient(runtimeConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	return &K8sClient{
-		clientset:         clientset,
-		nodeName:          nodeName,
-		fieldSelector:     fieldSelector,
-		runtimeClient:     runtimeClient,
-		RuntimeSocketPath: socketPath,
+		clientset:     clientset,
+		nodeName:      nodeName,
+		fieldSelector: fieldSelector,
+		runtimeClient: runtimeClient,
+		RuntimeConfig: runtimeConfig,
 	}, nil
 }
 


### PR DESCRIPTION
# export K8sClient.runtimeClient

Instead of just exporting RuntimeSocketPath it would be nice to have access to the whole config to reuse it for example in `containercollection.WithContainerRuntimeEnrichment()`

## How to use

N/A

## Testing done

Currently in use in our node-agent https://github.com/kubescape/node-agent/pull/438/commits/70bc3b859403b43d5ffb51631ac239c43395c832
