### PR TITLE
trace_dns: add fields cwd & exepath (--paths)

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -6,6 +6,18 @@ sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadget
 datasources:
   dns:
     fields:
+      cwd:
+        annotations:
+          description: The current working directory of the process (require --paths flag)
+          columns.width: 64
+          columns.hidden: "true"
+          columns.alignment: left
+      exepath:
+        annotations:
+          description: The executable file of the process (require --paths flag)
+          columns.width: 64
+          columns.hidden: "true"
+          columns.alignment: left
       anaddr:
         annotations:
           columns.width: "16"
@@ -71,3 +83,9 @@ datasources:
         annotations:
           description: Source endpoint
           template: l4endpoint
+params:
+  ebpf:
+    paths:
+      key: paths
+      defaultValue: "false"
+      description: Show current working directory and executable path.


### PR DESCRIPTION
The cwd and exepath are already known by the socket enricher. This patch adds them in the events with --paths.

Since it makes the events bigger, it can no longer fit on the stack, so we use a temporary map.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/3804

## How to use

```
$ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_dns:latest --verify-image=false --paths=true -o yaml
...
cwd: /home
exepath: /bin/ping
```

## Testing done

