### PR TITLE
gadgets: Introduce bpfstats gadget

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -111,6 +111,7 @@ var (
 	disallowGadgetsPull   bool
 	otelMetricsListen     bool
 	otelMetricsListenAddr string
+	enableBpfStats        bool
 )
 
 var supportedHooks = []string{"auto", "crio", "podinformer", "nri", "fanotify+ebpf"}
@@ -259,6 +260,9 @@ func init() {
 	deployCmd.PersistentFlags().StringVar(
 		&otelMetricsListenAddr,
 		"otel-metrics-listen-address", "0.0.0.0:2224", "Address and port to create the OpenTelemetry metrics listener (Prometheus compatible) on")
+	deployCmd.PersistentFlags().BoolVar(
+		&enableBpfStats,
+		"enable-bpfstats", false, "Enable capturing eBPF stats")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -815,6 +819,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				}
 				opCfg[gadgettracermanagerconfig.OtelMetrics] = otelMetricsConfig
 			}
+
+			opEbpfCfg := map[string]interface{}{
+				gadgettracermanagerconfig.EnableBPFStats: enableBpfStats,
+			}
+			opCfg[gadgettracermanagerconfig.EBPFOperator] = opEbpfCfg
 
 			data, err := yaml.Marshal(cfg)
 			if err != nil {

--- a/docs/gadgets/bpfstats.mdx
+++ b/docs/gadgets/bpfstats.mdx
@@ -1,0 +1,1 @@
+../../gadgets/bpfstats/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -21,6 +21,7 @@ INTEGRATION_TEST_DIR = test/integration
 GADGETS = \
 	advise_seccomp \
 	audit_seccomp \
+	bpfstats \
 	deadlock \
 	fdpass \
 	fsnotify \

--- a/gadgets/bpfstats/README.md
+++ b/gadgets/bpfstats/README.md
@@ -1,0 +1,6 @@
+# bpfstats
+
+The bpfstats gadget provides statistics about memory and CPU usage for bpf
+programd and gadgets running on the system.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/bpfstats

--- a/gadgets/bpfstats/README.mdx
+++ b/gadgets/bpfstats/README.mdx
@@ -1,0 +1,317 @@
+---
+title: bpfstats
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# bpfstats
+
+The bpfstats Gadget provides CPU and memory usage for Gadgets and eBPF programs.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget run ghcr.io/inspektor-gadget/gadget/bpfstats:%IG_TAG% [flags]
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl run ghcr.io/inspektor-gadget/gadget/bpfstats:%IG_TAG% [flags]
+```
+  </TabItem>
+</Tabs>
+
+## Flags
+
+### `--all`
+
+Collect statistics for all eBPF programs
+
+Default value: "false"
+
+## Guide
+
+In order for this gadget to work, the server needs to be running with the
+`--enable-bpfstats` flag:
+
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget deploy --enable-bpfstats
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo ig daemon --enable-bpfstats
+```
+  </TabItem>
+</Tabs>
+
+Then, let's run the gadget:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl gadget run bpfstats:%IG_TAG%
+NODENAME           GADGETID  GADGETNAME         GADGETIMAGE        PROGID PROGNAME               RUNTIME     RUNCOUNT    MAPMEMORY MAPC…
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl run bpfstats:%IG_TAG%
+GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
+```
+  </TabItem>
+</Tabs>
+
+You can run the gadget with `--help` to get the meaning of the different
+columns:
+
+- gadgetID
+  Unique ID assigned to each Gadget instance
+- gadgetImage
+  Name of the Gadget image (like trace_open, trace_exec, etc.)
+- gadgetName
+  Name of the Gadget instance
+- mapCount
+  Number of maps used by the eBPF program or Gadget
+- mapMemory
+  Memory used by maps in bytes
+- progID
+  eBPF program ID assigned by the Linux kernel
+- progName
+  Name of the eBPF program
+- runcount
+  Number of times the eBPF program or Gadget has run
+- runtime
+  Time that the eBPF program or Gadget has run in nanoseconds
+
+It won't print anything as there are not gadgets running on the system. Let's
+create a couple of gadgets:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget run --name mytraceopen trace_open:%IG_TAG% --detach
+$ kubectl gadget run --name mytraceexec trace_exec:%IG_TAG% --detach
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl run --name mytraceopen trace_open:%IG_TAG% --detach
+$ sudo gadgetctl run --name mytraceexec trace_exec:%IG_TAG% --detach
+```
+  </TabItem>
+</Tabs>
+
+The bpfstats will print the statistics for these two gadgets:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget run bpfstats:%IG_TAG%
+NODENAME           GADGETID  GADGETNAME         GADGETIMAGE        PROGID PROGNAME               RUNTIME     RUNCOUNT    MAPMEMORY MAPC…
+minikube           6bcfcca7a mytraceopen        trace_open:%IG_TAG%     0                        2537846        10798      1710240     6
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%     0                           8265           12      8742176     7
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl run bpfstats:%IG_TAG%
+GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%       0                                    0               0         8742176      7
+bb95fa2c8ab mytraceopen          trace_open:%IG_TAG%       0                                95233             242         1710240      6
+```
+  </TabItem>
+</Tabs>
+
+By default the gadget prints consolidated information for the Gadgets. In this
+case PROGID is 0 and PROGNAME is empty, as a Gadget can have multiple programs.
+It's possible to get per-program statistics by using the `--all` flag. In
+this mode, the statistics for eBPF programs not handled by Inspektor Gadget are
+shown as well.
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget run bpfstats:%IG_TAG% --all
+NODENAME           GADGETID  GADGETNAME         GADGETIMAGE        PROGID PROGNAME               RUNTIME     RUNCOUNT    MAPMEMORY MAPC…
+minikube                                                                2 hid_tail_call                0            0         8512     1
+minikube                                                               38 sched_process_e       89770034        15277      4391808     4
+minikube                                                               39 task_newtask         172413186        91790      4391808     4
+minikube                                                               40 sched_process_e      144593647        91635      4391808     4
+minikube                                                               41 __x64_sys_renam        7185786         2173      1083840     4
+minikube                                                               42 __x64_sys_renam       23368056         2184      6467272     7
+minikube                                                               43 __x64_sys_renam        4649957         2069      1083840     4
+minikube                                                               44 __x64_sys_renam       18957942         2072      6467272     7
+minikube                                                               45 __x64_sys_renam              0            0      1083840     4
+minikube                                                               46 __x64_sys_renam              0            0      6467272     7
+minikube                                                               47 __x64_sys_unlin       37799602        14147      1083840     4
+minikube                                                               48 __x64_sys_unlin      120719371        14370      6467272     7
+minikube                                                               49 __x64_sys_unlin       17037065         9561      1083840     4
+minikube                                                               50 __x64_sys_unlin       56861068         9561      6467272     7
+minikube                                                             1244 ig_execve_e           15430709         3239       849792     2
+minikube                                                             1245 ig_execve_x            1792662         3655       837504     1
+minikube                                                             1246 ig_fa_pick_e           2899018         4581        21632     2
+minikube                                                             1247 ig_fa_pick_x           4478788         4581      1194336     4
+minikube                                                             1248 ig_sched_exec          2759885         2728       837504     1
+minikube           6bcfcca7a mytraceopen        trace_open:%IG_TAG%  1259 ig_open_x                    0            0      1615904     4
+minikube           6bcfcca7a mytraceopen        trace_open:%IG_TAG%  1260 ig_openat_x           14944051        83160      1615904     4
+minikube           6bcfcca7a mytraceopen        trace_open:%IG_TAG%  1261 ig_open_e                    0            0      1098240     3
+minikube           6bcfcca7a mytraceopen        trace_open:%IG_TAG%  1262 ig_openat_e           33097520        83005      1098240     3
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1263 ig_execve_x             200186          570      8647840     5
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1264 ig_execveat_x                0            0      8647840     5
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1265 security_bprm_c         225868          362      8372040     4
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1266 ig_execve_e             340822          518      8372040     4
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1267 ig_execveat_e            37108           52      8372040     4
+minikube           040e3fc1d mytraceexec        trace_exec:%IG_TAG%  1268 ig_sched_exec           226692          362      8647840     1
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl run bpfstats --all
+GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
+                                                           2 hid_tail_call                      0               0            8512      1
+                                                          38 sched_process_e              1212539             180         4391808      4
+                                                         198                                    0               0           48672      1
+                                                         736 ig_execve_e                  1103998             317          849792      2
+                                                         737 ig_execve_x                   160239             317          837504      1
+                                                         738 ig_fa_pick_e                  373093             509           21632      2
+                                                         739 ig_fa_pick_x                  378858             509         1194336      4
+                                                         740 ig_sched_exec                 112317              67          837504      1
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     743 security_bprm_c                49435              67         8372040      4
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     744 ig_execve_e                   140296             317         8372040      4
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     745 ig_execveat_e                      0               0         8372040      4
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     746 ig_execve_x                    89667             317         8647840      5
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     747 ig_sched_exec                  76171              67         8647840      5
+a624bdbf27f mytraceexec          trace_exec:%IG_TAG%     748 ig_execveat_x                      0               0         8647840      5
+bb95fa2c8ab mytraceopen          trace_open:%IG_TAG%     749 ig_open_e                          0               0         1098240      3
+bb95fa2c8ab mytraceopen          trace_open:%IG_TAG%     750 ig_openat_e                 21538317           48300         1098240      3
+bb95fa2c8ab mytraceopen          trace_open:%IG_TAG%     751 ig_open_x                          0               0         1615904      4
+bb95fa2c8ab mytraceopen          trace_open:%IG_TAG%     752 ig_openat_x                  9076187           48503         1615904      4
+```
+  </TabItem>
+</Tabs>
+
+Finally, clean the system:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget remove mytraceexec mytraceopen
+```
+  </TabItem>
+
+  <TabItem value="ig-daemon" label="ig-daemon">
+```bash
+$ sudo gadgetctl remove mytraceexec mytraceopen
+```
+  </TabItem>
+</Tabs>
+
+### Exporting metrics
+
+The `bpfstats` Gadget provides the following metrics for `mapCount`,
+`mapMemory`, `runcount` and `runtime`. To enable the metrics listener, check the
+[Exporting Metrics](../reference/export-metrics.mdx) documentation. To enable
+the collector for this gadget, run the following command:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo gadgetctl run bpfstats --name mystats --otel-metrics-name=bpfstats:bpfstats --annotate=bpfstats:metrics.collect=true --detach
+        INFO[0000] installed as "8423cd8e53339c8d4501ec7cdff436bc"
+        ```
+    </TabItem>
+</Tabs>
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        Unless you configured the metrics listener to do differently, the
+        metrics will be available at `http://localhost:2224/metrics` on the
+        server side. For the `bpfstats` gadget we ran above, you
+        can find the metrics under the `bpfstats` scope:
+
+        ```bash
+        $ curl http://localhost:2224/metrics -s  | grep bpfstats
+        mapCount{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 7
+        mapCount{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 6
+        mapMemory{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 1.83170336e+08
+        mapMemory{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 1.71024e+06
+        otel_scope_info{otel_scope_name="bpfstats",otel_scope_version=""} 1
+        runcount_total{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 636
+        runcount_total{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 219513
+        runtime_total{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 445114
+        runtime_total{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 7.3383934e+07
+        ```
+    </TabItem>
+</Tabs>
+
+Finally, stop metrics collection:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        WIP: Headless mode for kubectl gadget is under development
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo gadgetctl delete mystats
+        8423cd8e53339c8d4501ec7cdff436bc
+        ```
+    </TabItem>
+</Tabs>
+
+### Limitations
+
+#### Memory usage of maps
+
+The shown value for MapMemory is read from `/proc/<pid>/fdinfo/<map_id>`. This
+is the maximum size the map can have, but it doesn't necessarily reflect its
+current memory allocation. Additionally, maps can be used by more than one
+program and would account towards the MapMemory of all those programs.
+
+Also note:
+* BPF_MAP_TYPE_PERF_EVENT_ARRAY: value_size is not counting the ring buffers,
+  but only their file descriptors (i.e. sizeof(int) = 4 bytes)
+* BPF_MAP_TYPE_{HASH,ARRAY}_OF_MAPS: value_size is not counting the inner maps,
+  but only their file descriptors (i.e. sizeof(int) = 4 bytes)
+
+#### bpfstats not disabled for Kernels < 5.8
+
+The bpfstats Gadgets enables collection of eBPF program stats by trying to use
+`BPF_ENABLE_STATS` first (which requires Linux >= 5.8). If that fails, it will
+fall back to trying to enable via sysctl (/proc/sys/kernel/bpf_stats_enabled),
+on this case, the collection of stats will remain active even after stopping
+Inspektor Gadget.
+
+It is a temporary limitation that we're working to fix, in the meanwhile you can
+use `sysctl kernel.bpf_stats_enabled=0` to disable it.

--- a/gadgets/bpfstats/artifacthub-pkg.yml
+++ b/gadgets/bpfstats/artifacthub-pkg.yml
@@ -1,0 +1,29 @@
+# Artifact Hub package metadata file
+version: 0.38.0
+name: "bpfstats"
+category: monitoring-logging
+displayName: "bpfstats"
+createdAt: "2025-03-03T14:38:04Z"
+digest: "2025-03-03T14:38:04Z"
+description: "Get memory and CPU usage of eBPF programs and Gadgets"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/bpfstats"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/bpfstats:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/bpfstats"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/bpfstats:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/bpfstats/gadget.yaml
+++ b/gadgets/bpfstats/gadget.yaml
@@ -1,0 +1,8 @@
+name: bpfstats
+description: Get memory and CPU usage of eBPF programs and Gadgets
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/bpfstats
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/bpfstats
+operator:
+  ebpf:
+    emitstats: true

--- a/gadgets/bpfstats/test/unit/bpfstats_test.go
+++ b/gadgets/bpfstats/test/unit/bpfstats_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type ExpectedBpfstatsEvent struct {
+	GadgetID    string `json:"gadgetID"`
+	GadgetImage string `json:"gadgetImage"`
+	GadgetName  string `json:"gadgetName"`
+	MapCount    int    `json:"mapCount"`
+	MapMemory   int    `json:"mapMemory"`
+	ProgID      int    `json:"progID"`
+	ProgName    string `json:"progName"`
+	Runcount    int    `json:"runcount"`
+	Runtime     int    `json:"runtime"`
+}
+
+type testDef struct {
+	runnerConfig   *utilstest.RunnerConfig
+	allPrograms    bool
+	generateEvent  func(t *testing.T)
+	expectedEvents []ExpectedBpfstatsEvent
+}
+
+const (
+	testGadgetImage = "trace_open"
+)
+
+func TestBpfstatsGadget(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+	runnerConfig := &utilstest.RunnerConfig{}
+
+	testCases := map[string]testDef{
+		"by_gadget": {
+			runnerConfig:  runnerConfig,
+			generateEvent: generateEvent,
+			expectedEvents: []ExpectedBpfstatsEvent{
+				{
+					GadgetImage: gadgetrunner.GetGadgetImageName(testGadgetImage),
+					ProgID:      0,
+				},
+			},
+		},
+		"by_programs": {
+			runnerConfig:  runnerConfig,
+			generateEvent: generateEvent,
+			allPrograms:   true,
+			expectedEvents: []ExpectedBpfstatsEvent{
+				// programs from trace_open gadget. This introduces a dependency
+				// on the trace_open gadget, but it's almost guranteed that this
+				// gadget will have these two programs
+				{
+					GadgetImage: gadgetrunner.GetGadgetImageName(testGadgetImage),
+					ProgName:    "ig_openat_e",
+					ProgID:      utils.NormalizedInt,
+				},
+				{
+					GadgetImage: gadgetrunner.GetGadgetImageName(testGadgetImage),
+					ProgName:    "ig_openat_x",
+					ProgID:      utils.NormalizedInt,
+				},
+				// TODO: test external program
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := utilstest.NewRunnerWithTest(t, testCase.runnerConfig)
+			globalParams := map[string]string{
+				"operator.ebpf.enable-bpfstats": "true",
+			}
+
+			normalizeEvent := func(event *ExpectedBpfstatsEvent) {
+				utils.NormalizeInt(&event.MapCount)
+				utils.NormalizeInt(&event.MapMemory)
+				utils.NormalizeInt(&event.Runcount)
+				utils.NormalizeInt(&event.Runtime)
+				utils.NormalizeInt(&event.ProgID)
+			}
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, func() error {
+					testCase.generateEvent(t)
+					return nil
+				})
+				return nil
+			}
+
+			var paramValues map[string]string
+			if testCase.allPrograms {
+				paramValues = map[string]string{"operator.ebpf.all": "true"}
+			}
+
+			opts := gadgetrunner.GadgetRunnerOpts[ExpectedBpfstatsEvent]{
+				Image:              "bpfstats",
+				Timeout:            5 * time.Second,
+				ParamValues:        paramValues,
+				GlobalParamsValues: globalParams,
+				OnGadgetRun:        onGadgetRun,
+				NormalizeEvent:     normalizeEvent,
+			}
+
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+			gadgetRunner.RunGadget()
+
+			for _, expectedEvent := range testCase.expectedEvents {
+				expectedEvent.MapCount = utils.NormalizedInt
+				expectedEvent.MapMemory = utils.NormalizedInt
+				expectedEvent.Runcount = utils.NormalizedInt
+				expectedEvent.Runtime = utils.NormalizedInt
+
+				require.Contains(t, gadgetRunner.CapturedEvents, expectedEvent)
+			}
+		})
+	}
+}
+
+func generateEvent(t *testing.T) {
+	// Run a gadget so it's captured by the bpstats gadget
+	opts := gadgetrunner.GadgetRunnerOpts[ExpectedBpfstatsEvent]{
+		Image:   testGadgetImage,
+		Timeout: 1 * time.Second,
+	}
+	gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+	gadgetRunner.RunGadget()
+}

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -34,4 +34,6 @@ const (
 	OtelMetrics              = "otel-metrics"
 	OtelMetricsListen        = "otel-metrics-listen"
 	OtelMetricsListenAddress = "otel-metrics-listen-address"
+	EnableBPFStats           = "enable-bpfstats"
+	EBPFOperator             = "ebpf"
 )

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -48,6 +48,7 @@ type GadgetContext struct {
 	ctx                      context.Context
 	cancel                   context.CancelFunc
 	id                       string
+	name                     string
 	gadget                   gadgets.GadgetDesc
 	gadgetParams             *params.Params
 	args                     []string
@@ -142,6 +143,10 @@ func (c *GadgetContext) ID() string {
 
 func (c *GadgetContext) ExtraInfo() bool {
 	return c.requestExtraInfo
+}
+
+func (c *GadgetContext) Name() string {
+	return c.name
 }
 
 func (c *GadgetContext) Context() context.Context {

--- a/pkg/gadget-context/options.go
+++ b/pkg/gadget-context/options.go
@@ -75,3 +75,15 @@ func IncludeExtraInfo(val bool) Option {
 		gadgetCtx.requestExtraInfo = val
 	}
 }
+
+func WithID(id string) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.id = id
+	}
+}
+
+func WithName(name string) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.name = name
+	}
+}

--- a/pkg/gadget-service/instance-manager/instance.go
+++ b/pkg/gadget-service/instance-manager/instance.go
@@ -205,6 +205,8 @@ func (p *GadgetInstance) Run(
 		gadgetcontext.WithLogger(logger),
 		gadgetcontext.WithDataOperators(ops...),
 		gadgetcontext.WithAsRemoteCall(true),
+		gadgetcontext.WithName(p.name),
+		gadgetcontext.WithID(p.id),
 	)
 
 	runtimeParams := runtime.ParamDescs().ToParams()

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -67,8 +67,16 @@ const (
 	AnnotationFlushOnStop = "ebpf.map.flush-on-stop"
 )
 
+type gadgetObjs struct {
+	programIDs []ebpf.ProgramID
+	mapIDs     []ebpf.MapID
+}
+
 // ebpfOperator reads ebpf programs from OCI images and runs them
-type ebpfOperator struct{}
+type ebpfOperator struct {
+	mu         sync.Mutex
+	gadgetObjs map[operators.GadgetContext]gadgetObjs
+}
 
 func (o *ebpfOperator) Name() string {
 	return "ebpf"
@@ -100,8 +108,9 @@ func (o *ebpfOperator) InstantiateImageOperator(
 	// TODO: do some pre-checks in here, maybe validate hashes, signatures, etc.
 
 	newInstance := &ebpfInstance{
-		gadgetCtx: gadgetCtx, // context usually should not be stored, but should we really carry it through all funcs?
-		done:      make(chan struct{}),
+		bpfOperator: o,
+		gadgetCtx:   gadgetCtx, // context usually should not be stored, but should we really carry it through all funcs?
+		done:        make(chan struct{}),
 
 		logger:  gadgetCtx.Logger(),
 		program: program,
@@ -151,7 +160,8 @@ func (o *ebpfOperator) InstantiateImageOperator(
 }
 
 type ebpfInstance struct {
-	mu sync.Mutex
+	mu          sync.Mutex
+	bpfOperator *ebpfOperator
 
 	config *viper.Viper
 
@@ -669,6 +679,36 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 	}
 	i.collection = collection
 
+	if i.bpfOperator.gadgetObjs != nil {
+		// collect program IDs and map IDs for this gadget
+		gadgetObjs := gadgetObjs{}
+
+		for _, p := range i.collection.Programs {
+			info, err := p.Info()
+			if err != nil {
+				i.logger.Warnf("stats for this gadget won't be available: getting program info: %v", err)
+				continue
+			}
+
+			id, _ := info.ID()
+			gadgetObjs.programIDs = append(gadgetObjs.programIDs, id)
+		}
+
+		for _, m := range i.collection.Maps {
+			info, err := m.Info()
+			if err != nil {
+				i.logger.Warnf("stats for this gadget won't be available: getting map info: %v", err)
+				continue
+			}
+
+			id, _ := info.ID()
+			gadgetObjs.mapIDs = append(gadgetObjs.mapIDs, id)
+		}
+		i.bpfOperator.mu.Lock()
+		i.bpfOperator.gadgetObjs[gadgetCtx] = gadgetObjs
+		i.bpfOperator.mu.Unlock()
+	}
+
 	for name, m := range i.collection.Maps {
 		gadgetCtx.SetVar(operators.MapPrefix+name, m)
 
@@ -749,6 +789,9 @@ func (i *ebpfInstance) PreStop(gadgetCtx operators.GadgetContext) error {
 }
 
 func (i *ebpfInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	i.bpfOperator.mu.Lock()
+	delete(i.bpfOperator.gadgetObjs, gadgetCtx)
+	i.bpfOperator.mu.Unlock()
 	return nil
 }
 
@@ -840,6 +883,9 @@ func (i *ebpfInstance) DetachContainer(container *containercollection.Container)
 	return nil
 }
 
+var ebpfOp = &ebpfOperator{}
+
 func init() {
-	operators.RegisterOperatorForMediaType(eBPFObjectMediaType, &ebpfOperator{})
+	operators.RegisterOperatorForMediaType(eBPFObjectMediaType, ebpfOp)
+	operators.RegisterDataOperator(ebpfOp)
 }

--- a/pkg/operators/ebpf/stats.go
+++ b/pkg/operators/ebpf/stats.go
@@ -1,0 +1,514 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpfoperator
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/spf13/viper"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/bpfstats"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const (
+	ParamGadgetStatisticsInterval = "statistics-interval"
+	EmitStatsAnn                  = "emitstats"
+	ParamAllProgramsStats         = "all"
+	StatsDSName                   = "bpfstats"
+	EnableBPFStatsParam           = "enable-bpfstats"
+)
+
+func (o *ebpfOperator) GlobalParams() api.Params {
+	return api.Params{
+		{
+			Key:          EnableBPFStatsParam,
+			Description:  "Enable capturing eBPF stats",
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
+			Title:        "Enable eBPF stats",
+		},
+	}
+}
+
+func (o *ebpfOperator) Init(params *params.Params) error {
+	if !params.Get(EnableBPFStatsParam).AsBool() {
+		return nil
+	}
+
+	o.gadgetObjs = make(map[operators.GadgetContext]gadgetObjs)
+
+	// Enable stats collection
+	// TODO: when to disable it?
+	if err := bpfstats.EnableBPFStats(); err != nil {
+		return fmt.Errorf("enabling bpf stats: %w", err)
+	}
+
+	return nil
+}
+
+func (o *ebpfOperator) InstantiateDataOperator(
+	gadgetCtx operators.GadgetContext, paramValues api.ParamValues,
+) (operators.DataOperatorInstance, error) {
+	cfg, ok := gadgetCtx.GetVar("config")
+	if !ok {
+		return nil, fmt.Errorf("missing configuration")
+	}
+	v, ok := cfg.(*viper.Viper)
+	if !ok {
+		return nil, fmt.Errorf("invalid configuration format")
+	}
+
+	emitStatsAnn := v.GetBool(fmt.Sprintf("operator.%s.%s", o.Name(), EmitStatsAnn))
+	if !emitStatsAnn {
+		return nil, nil
+	}
+
+	if o.gadgetObjs == nil {
+		return nil, fmt.Errorf("bpfstats aren't enabled")
+	}
+
+	var err error
+
+	instance := &ebpfOperatorDataInstance{
+		bpfOperator:      o,
+		done:             make(chan struct{}),
+		allProgramsStats: paramValues[ParamAllProgramsStats] == "true",
+	}
+
+	instance.ds, err = gadgetCtx.RegisterDataSource(datasource.TypeArray, StatsDSName)
+	if err != nil {
+		return nil, err
+	}
+
+	intervalAnn := paramValues[ParamGadgetStatisticsInterval]
+	instance.interval, err = time.ParseDuration(intervalAnn)
+	if err != nil {
+		return nil, fmt.Errorf("parsing duration: %w", err)
+	}
+
+	instance.ds.AddAnnotation(api.FetchIntervalAnnotation, intervalAnn)
+	instance.ds.AddAnnotation("cli.clear-screen-before", "true")
+
+	if nodeName, ok := os.LookupEnv("NODE_NAME"); ok {
+		instance.nodeNameField, err = instance.ds.AddField("nodeName", api.Kind_String,
+			datasource.WithAnnotations(map[string]string{
+				metadatav1.TemplateAnnotation: "node",
+				"metrics.type":                "key",
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
+		instance.nodeName = nodeName
+	}
+
+	// gadget-specific fields
+	instance.gadgetIDField, err = instance.ds.AddField("gadgetID", api.Kind_String,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsWidthAnnotation: "8",
+			metadatav1.DescriptionAnnotation:  "Unique ID assigned to each Gadget instance",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.gadgetNameField, err = instance.ds.AddField("gadgetName", api.Kind_String,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsWidthAnnotation: "16",
+			metadatav1.DescriptionAnnotation:  "Name of the Gadget instance",
+			"metrics.type":                    "key",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.gadgetImageField, err = instance.ds.AddField("gadgetImage", api.Kind_String,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsWidthAnnotation: "16",
+			metadatav1.DescriptionAnnotation:  "Name of the Gadget image (like trace_open, trace_exec, etc.)",
+			"metrics.type":                    "key",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// low-level fields
+	// TODO: how to disable it based on the programs param?
+	instance.progIDField, err = instance.ds.AddField("progID", api.Kind_Uint32,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+			metadatav1.DescriptionAnnotation:      "eBPF program ID assigned by the Linux kernel",
+			metadatav1.ColumnsWidthAnnotation:     "5",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.progNameField, err = instance.ds.AddField("progName", api.Kind_String,
+		datasource.WithAnnotations(map[string]string{
+			// The maximum length provided by the kernel is 16 bytes
+			metadatav1.ColumnsFixedAnnotation: "16",
+			metadatav1.DescriptionAnnotation:  "Name of the eBPF program",
+			"metrics.type":                    "key",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// stats fields
+	instance.runtimeField, err = instance.ds.AddField("runtime", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			// TODO: provide human readable format
+			metadatav1.ColumnsWidthAnnotation:     "12",
+			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+			metadatav1.DescriptionAnnotation:      "Time that the eBPF program or Gadget has run in nanoseconds",
+			"metrics.type":                        "counter",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.runcountField, err = instance.ds.AddField("runcount", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsWidthAnnotation:     "12",
+			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+			metadatav1.DescriptionAnnotation:      "Number of times the eBPF program or Gadget has run",
+			"metrics.type":                        "counter",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.mapMemoryField, err = instance.ds.AddField("mapMemory", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			// TODO provide human readable format
+			metadatav1.ColumnsWidthAnnotation:     "12",
+			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+			metadatav1.DescriptionAnnotation:      "Memory used by maps in bytes",
+			"metrics.type":                        "gauge",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	instance.mapCountField, err = instance.ds.AddField("mapCount", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.ColumnsWidthAnnotation:     "5",
+			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
+			metadatav1.DescriptionAnnotation:      "Number of maps used by the eBPF program or Gadget",
+			"metrics.type":                        "gauge",
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return instance, nil
+}
+
+func (o *ebpfOperator) InstanceParams() api.Params {
+	return api.Params{
+		{
+			Key:          ParamGadgetStatisticsInterval,
+			Description:  "interval in which to provide gadget statistics",
+			DefaultValue: "1000ms",
+			TypeHint:     api.TypeDuration,
+			Title:        "Gadget statistics interval",
+		},
+		{
+			Key:          ParamAllProgramsStats,
+			Description:  "Collect statistics for all eBPF programs",
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
+			Title:        "All programs statistics",
+		},
+	}
+}
+
+func (o *ebpfOperator) Priority() int {
+	return 0
+}
+
+type ebpfOperatorDataInstance struct {
+	bpfOperator *ebpfOperator
+	ds          datasource.DataSource
+	interval    time.Duration
+	done        chan struct{}
+
+	// used to emit incremental values
+	oldProgStats map[ebpf.ProgramID]progStat
+
+	// if true stats are collected with programs granularity
+	allProgramsStats bool
+
+	nodeNameField datasource.FieldAccessor
+	nodeName      string
+
+	// gadget-specific fields
+	gadgetIDField    datasource.FieldAccessor
+	gadgetNameField  datasource.FieldAccessor
+	gadgetImageField datasource.FieldAccessor
+
+	// low-level fields
+	progIDField   datasource.FieldAccessor
+	progNameField datasource.FieldAccessor
+
+	// stats fields
+	runtimeField   datasource.FieldAccessor
+	runcountField  datasource.FieldAccessor
+	mapMemoryField datasource.FieldAccessor
+	mapCountField  datasource.FieldAccessor
+}
+
+func (i *ebpfOperatorDataInstance) Name() string {
+	return "ebpfdataoperator"
+}
+
+type stat struct {
+	gadgetID    string
+	gadgetName  string
+	gadgetImage string
+
+	programID   uint32
+	programName string
+
+	runtime   uint64
+	runcount  uint64
+	mapMemory uint64
+	mapCount  uint64
+}
+
+type progStat struct {
+	runtime  uint64
+	runcount uint64
+}
+
+func (i *ebpfOperatorDataInstance) sendStats(stats []stat) error {
+	arr, err := i.ds.NewPacketArray()
+	if err != nil {
+		return fmt.Errorf("creating new packet: %w", err)
+	}
+
+	for _, stat := range stats {
+		d := arr.New()
+
+		if i.nodeNameField != nil {
+			i.nodeNameField.PutString(d, i.nodeName)
+		}
+		i.gadgetIDField.PutString(d, stat.gadgetID)
+		i.gadgetNameField.PutString(d, stat.gadgetName)
+		i.gadgetImageField.PutString(d, stat.gadgetImage)
+		if i.allProgramsStats {
+			i.progIDField.PutUint32(d, stat.programID)
+			i.progNameField.PutString(d, stat.programName)
+		}
+		i.runtimeField.PutUint64(d, stat.runtime)
+		i.runcountField.PutUint64(d, stat.runcount)
+		i.mapMemoryField.PutUint64(d, stat.mapMemory)
+		i.mapCountField.PutUint64(d, stat.mapCount)
+
+		arr.Append(d)
+	}
+
+	return i.ds.EmitAndRelease(arr)
+}
+
+func getProgramStats(cache map[ebpf.ProgramID]progStat, id ebpf.ProgramID) (progStat, error) {
+	if stat, ok := cache[id]; ok {
+		return stat, nil
+	}
+
+	prog, err := ebpf.NewProgramFromID(id)
+	if err != nil {
+		return progStat{}, err
+	}
+	defer prog.Close()
+
+	pi, err := prog.Info()
+	if err != nil {
+		return progStat{}, err
+	}
+
+	runtime, _ := pi.Runtime()
+	runcount, _ := pi.RunCount()
+
+	stat := progStat{
+		runtime:  uint64(runtime),
+		runcount: runcount,
+	}
+	cache[id] = stat
+
+	return stat, nil
+}
+
+func (i *ebpfOperatorDataInstance) getStats() ([]stat, error) {
+	stats := make([]stat, 0)
+
+	mapSizes, err := bpfstats.GetMapsMemUsage()
+	if err != nil {
+		return nil, fmt.Errorf("getting map memory usage: %w", err)
+	}
+
+	i.bpfOperator.mu.Lock()
+	defer i.bpfOperator.mu.Unlock()
+
+	oldStats := i.oldProgStats
+	i.oldProgStats = make(map[ebpf.ProgramID]progStat)
+
+	// emit consolidated stats for gadgets
+	if !i.allProgramsStats {
+		cache := make(map[ebpf.ProgramID]progStat)
+
+		for ctx, gadgetObjs := range i.bpfOperator.gadgetObjs {
+			stat := stat{
+				gadgetID:    ctx.ID(),
+				gadgetName:  ctx.Name(),
+				gadgetImage: ctx.ImageName(),
+			}
+
+			for _, id := range gadgetObjs.programIDs {
+				progStat, err := getProgramStats(cache, id)
+				if err != nil {
+					return nil, fmt.Errorf("getting program stats: %w", err)
+				}
+
+				i.oldProgStats[id] = progStat
+				oldProgStats := oldStats[id]
+
+				stat.runtime += progStat.runtime - oldProgStats.runtime
+				stat.runcount += progStat.runcount - oldProgStats.runcount
+			}
+
+			for _, mapID := range gadgetObjs.mapIDs {
+				stat.mapMemory += mapSizes[mapID]
+				stat.mapCount += 1
+			}
+
+			stats = append(stats, stat)
+		}
+
+		return stats, nil
+	}
+
+	// emit per ebpf programs stats
+	programToGadget := make(map[ebpf.ProgramID]operators.GadgetContext)
+	for ctx, gadgetObjs := range i.bpfOperator.gadgetObjs {
+		for _, id := range gadgetObjs.programIDs {
+			programToGadget[id] = ctx
+		}
+	}
+
+	var curID ebpf.ProgramID
+	var nextID ebpf.ProgramID
+	for {
+		nextID, err = ebpf.ProgramGetNextID(curID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				break
+			}
+			return nil, fmt.Errorf("getting next program ID: %w", err)
+		}
+		if nextID <= curID {
+			break
+		}
+		curID = nextID
+		prog, err := ebpf.NewProgramFromID(curID)
+		if err != nil {
+			continue
+		}
+		pi, err := prog.Info()
+		if err != nil {
+			prog.Close()
+			continue
+		}
+
+		stat := stat{}
+
+		id, _ := pi.ID()
+		stat.programID = uint32(id)
+		stat.programName = pi.Name
+		runtime, _ := pi.Runtime()
+		stat.runtime = uint64(runtime)
+		stat.runcount, _ = pi.RunCount()
+
+		i.oldProgStats[curID] = progStat{
+			runtime:  stat.runtime,
+			runcount: stat.runcount,
+		}
+
+		oldProgStat := oldStats[curID]
+		stat.runtime -= oldProgStat.runtime
+		stat.runcount -= oldProgStat.runcount
+
+		mapIDs, _ := pi.MapIDs()
+		for _, mapID := range mapIDs {
+			stat.mapMemory += mapSizes[mapID]
+			stat.mapCount += 1
+		}
+
+		// enrich with gadget information if they're part of a gadget
+		if ctx, ok := programToGadget[ebpf.ProgramID(id)]; ok {
+			stat.gadgetID = ctx.ID()
+			stat.gadgetName = ctx.Name()
+			stat.gadgetImage = ctx.ImageName()
+		}
+
+		stats = append(stats, stat)
+
+		prog.Close()
+	}
+
+	return stats, nil
+}
+
+func (i *ebpfOperatorDataInstance) Start(gadgetCtx operators.GadgetContext) error {
+	go func() {
+		ticker := time.NewTicker(i.interval)
+		for {
+			select {
+			case <-i.done:
+				return
+			case <-ticker.C:
+				stats, err := i.getStats()
+				if err != nil {
+					gadgetCtx.Logger().Errorf("Failed to get stats: %v", err)
+					continue
+				}
+				if err := i.sendStats(stats); err != nil {
+					gadgetCtx.Logger().Errorf("Failed to emit stats: %v", err)
+					continue
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (i *ebpfOperatorDataInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	close(i.done)
+	return nil
+}

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -371,13 +371,6 @@ func (k *KubeManager) InstantiateDataOperator(gadgetCtx operators.GadgetContext,
 		eventWrappers: make(map[datasource.DataSource]*compat.EventWrapperBase),
 	}
 
-	// hack - this makes it possible to use the Attacher interface
-	var ok bool
-	traceInstance.gadgetInstance, ok = gadgetCtx.GetVar("ebpfInstance")
-	if !ok {
-		return nil, fmt.Errorf("getting ebpfInstance")
-	}
-
 	activate := false
 
 	// Check, whether the gadget requested a map from us
@@ -421,6 +414,12 @@ func (m *KubeManagerInstance) ParamDescs(gadgetCtx operators.GadgetContext) para
 }
 
 func (m *KubeManagerInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	var ok bool
+	m.gadgetInstance, ok = gadgetCtx.GetVar("ebpfInstance")
+	if !ok {
+		return fmt.Errorf("getting ebpfInstance")
+	}
+
 	compat.Subscribe(
 		m.eventWrappers,
 		m.manager.gadgetTracerManager.ContainerCollection.EnrichEventByMntNs,

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -33,6 +33,7 @@ import (
 
 type GadgetContext interface {
 	ID() string
+	Name() string
 	Context() context.Context
 	GadgetDesc() gadgets.GadgetDesc
 	Logger() logger.Logger

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -36,6 +36,7 @@ const (
 
 type GadgetContext interface {
 	ID() string
+	Name() string
 	Parser() parser.Parser
 	GadgetDesc() gadgets.GadgetDesc
 	Context() context.Context


### PR DESCRIPTION
This PR introduces support for exposing statistics (metrics) about the ebpf programs and gadgets running on the system. 
Check the individual commits to get more details on the implementation.

## Testing 

1. build the gadget

```bash 
$ sudo ig image build gadgets/bpfstats -t bpfstats
```

2. start ig on daemon mode 

```bash 
$ sudo ig daemon --verify-image=false --enable-bpfstats
```

3. Run some gadgets

```bash 
$ sudo gadgetctl run --name mytraceopen trace_open:latest --detach
$ sudo gadgetctl run --name mytraceexec trace_exec:latest --detach
```

### Using the CLI 

4. Run the bpfstats gadget 

```bash 
$ sudo gadgetctl run bpfstats --sort -runtime
WARN[0000] local                | image signature verification is disabled due to using corresponding option
GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
a9b10cf8fd5 mytraceopen          trace_open:latest         0                               100497             258         1710240      6
9da0de911e9 mytraceexec          trace_exec:latest         0                                    0               0       183170336      7
```

By default, the gadget shows the stats aggregated by gadget. Using `--programs` makes it return per-program stats:

```bash
$ sudo gadgetctl run bpfstats --sort -runtime --programs
GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
                                                          51 __x64_sys_socke             55538314           10478         6467272      7
                                                          50 __x64_sys_socke             18184594           10474         1083840      4
                                                          53 __x64_sys_bind_             15679318            4407         6467272      7
                                                          47 __x64_sys_unlin             12154534            1278         6467272      7
                                                          55 __x64_sys_conne             11895276            3375         6467272      7
                                                          52 __x64_sys_bind_              5629158            4407         1083840      4
                                                          39 sched_process_e              4845671            2760         4391808      4
                                                          38 task_newtask                 4841680            2475         4391808      4
                                                          54 __x64_sys_conne              3883108            3341         1083840      4
                                                          46 __x64_sys_unlin              3576277            1278         1083840      4
                                                          41 __x64_sys_renam              3163412             286         6467272      7
                                                          37 sched_process_e              1597635             256         4391808      4
                                                          49 __x64_sys_unlin              1490552             225         6467272      7
a9b10cf8fd5 mytraceopen          trace_open:latest       643 ig_openat_e                  1185322            3154         1098240      3
                                                          59 __x64_sys_accep              1106122             242         6467272      
...
```

### Exporting to Prometheus

Enable the metrics on the daemon

```bash
$ sudo ig daemon --verify-image=false --enable-bpfstats --otel-metrics-listen
```

now run the gadget with the annotations to enable the metrics

```bash 
$ sudo gadgetctl run bpfstats --otel-metrics-name=bpfstats:bpfstats --annotate=bpfstats:metrics.collect=true --detach
INFO[0000] installed as "8423cd8e53339c8d4501ec7cdff436bc"
```

check the available metrics:

```bash 
$ curl http://localhost:2224/metrics -s  | grep bpfstats
mapCount{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 7
mapCount{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 6
mapMemory{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 1.83170336e+08
mapMemory{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 1.71024e+06
otel_scope_info{otel_scope_name="bpfstats",otel_scope_version=""} 1
runcount_total{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 636
runcount_total{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 219513
runtime_total{gadgetImage="trace_exec:latest",gadgetName="mytraceexec",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 445114
runtime_total{gadgetImage="trace_open:latest",gadgetName="mytraceopen",otel_scope_name="bpfstats",otel_scope_version="",progName=""} 7.3383934e+07
```

### Discussion

- Should it be really a gadget? in this case, almost all the work is done by the operator, the gadget is just a template enabling it. I was able to implement a [POC](https://github.com/inspektor-gadget/inspektor-gadget/tree/mauricio/bpfstats-without-gadget) to have this as a first-class citizen in IG:

```bash 
$ sudo gadgetctl stats
preRun
GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
GADGETID    GADGETNAME           GADGETIMAGE          PROGID PROGNAME                     RUNTIME        RUNCOUNT       MAPMEMORY MAPCO…
a9b10cf8fd5 mytraceopen          trace_open:latest         0                              2194531            7884         1710240      6
9da0de911e9 mytraceexec          trace_exec:latest         0                                23245              28       183170336      7
```

### TODO

- [x] Documentation 
- [x] Testing

### Issues to open
- [ ] bpf_metadata (https://github.com/inspektor-gadget/inspektor-gadget/pull/3820#discussion_r1969477020)
- [ ] How to hide columns based on params (https://github.com/inspektor-gadget/inspektor-gadget/pull/3820#discussion_r1951757640)
- [ ] eBPF stats are never disabled 
- [ ] Gadget name and ID missing for attached gadgets (https://github.com/inspektor-gadget/inspektor-gadget/pull/3820#discussion_r2035553258)
- [ ] Provide human version of runtime and map size
- [ ] Test external programs too

Fixes #3759
