### PR TITLE
pkg/oci: Use a file lock to avoid concurrency issues

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1512,13 +1512,13 @@ jobs:
           GADGET_REPOSITORY: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
           GADGET_TAG: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
         run: |
-          make build-gadgets -o install/ig
+          make build-gadgets -o install/ig -j$(nproc)
 
           # Check that metadata files are updated
           git diff --exit-code HEAD --
 
           # Avoid building the gadgets again
-          make -C gadgets/ push -o build
+          make -C gadgets/ push-existing -j$(nproc)
       - name: Sign the gadgets
         if: needs.check-secrets.outputs.cosign == 'true'
         env:
@@ -1527,7 +1527,7 @@ jobs:
           GADGET_REPOSITORY: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
           GADGET_TAG: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
         run: |
-          make -C gadgets/ sign -o push
+          make -C gadgets/ sign-existing -j$(nproc)
 
   gadgets-unittest:
     name: Gadgets unit tests

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -120,6 +120,8 @@ github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -86,25 +86,39 @@ $(GADGETS_README):
 		ln -sf ../../gadgets/$@ $(ROOT_DIR)../docs/gadgets/$(shell dirname $@).mdx ; \
 	fi
 
-.PHONY:
-push: build
-	@echo "Pushing all gadgets"
-	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image push $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) || exit 1 ; \
-	done
-
-sign: push
-	@echo "Signing all gadgets"
-	for GADGET in $(GADGETS); do \
-		digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG) -o json | jq -r .Digest) ; \
-		cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$$GADGET@$$digest || exit 1 ; \
-	done
+%-push: %-build
+	@echo "Pushing $*"
+	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
-clean:
-	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
-	done
+push: $(addsuffix -push,$(GADGETS))
+
+%-push-existing: %
+	@echo "Pushing existing $*"
+	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+
+.PHONY:
+push-existing: $(addsuffix -push-existing,$(GADGETS))
+
+%-sign: %-push
+	@echo "Signing $*"
+	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+
+sign: $(addsuffix -sign,$(GADGETS))
+
+%-sign-existing:
+	@echo "Signing existing $*"
+	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+
+sign-existing: $(addsuffix -sign-existing,$(GADGETS))
+
+%-clean:
+	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+
+.PHONY:
+clean: $(addsuffix -clean,$(GADGETS))
 
 .PHONY:
 pull:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/giantswarm/crd-docs-generator v0.11.2
 	github.com/godbus/dbus/v5 v5.1.0
+	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+
+	"github.com/gofrs/flock"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+type localOciStore struct {
+	*oci.Store
+
+	indexPath  string
+	oldIndex   *ocispec.Index
+	indexFlock *flock.Flock
+}
+
+// newLocalOciStore returns a localOciStore that is safe when executed
+// concurrently, even from different processes.
+func newLocalOciStore() (*localOciStore, error) {
+	if err := os.MkdirAll(filepath.Dir(defaultOciStore), 0o700); err != nil {
+		return nil, err
+	}
+
+	indexPath := path.Join(defaultOciStore, "index.json")
+	indexLock := flock.New(path.Join(defaultOciStore, "index.json.lock"))
+
+	// lock the file before reading the index below
+	indexLock.RLock()
+	defer indexLock.Unlock()
+
+	ociStore, err := oci.New(defaultOciStore)
+	if err != nil {
+		return nil, err
+	}
+	ociStore.AutoSaveIndex = false
+
+	oldIndex, err := readIndexFile(indexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &localOciStore{
+		Store:      ociStore,
+		indexPath:  indexPath,
+		oldIndex:   oldIndex,
+		indexFlock: indexLock,
+	}, nil
+}
+
+func (o *localOciStore) saveIndexWithLock() error {
+	o.indexFlock.Lock()
+	defer o.indexFlock.Unlock()
+
+	currentIndex, err := readIndexFile(o.indexPath)
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(currentIndex, o.oldIndex) {
+		return errRetry
+	}
+
+	if err := o.SaveIndex(); err != nil {
+		return fmt.Errorf("saving index: %w", err)
+	}
+
+	// Update the old index to the new one. Ideally we should get index from
+	// oci.Store but it's not exposed, so read this from the index file instead.
+	indexUpdated, err := readIndexFile(o.indexPath)
+	if err != nil {
+		return err
+	}
+
+	o.oldIndex = indexUpdated
+
+	return nil
+}
+
+// readIndexFile reads index.json from the file system.
+func readIndexFile(indexPath string) (*ocispec.Index, error) {
+	indexFile, err := os.Open(indexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer indexFile.Close()
+
+	var index ocispec.Index
+	if err := json.NewDecoder(indexFile).Decode(&index); err != nil {
+		return nil, fmt.Errorf("decoding index file: %w", err)
+	}
+
+	return &index, nil
+}

--- a/pkg/oci/retry.go
+++ b/pkg/oci/retry.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"errors"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	retryLimit = 20
+	retryDelay = 500 * time.Millisecond
+)
+
+// errRetry hints that the function can safely be tried again after a small
+// time.
+var errRetry = errors.New("retry")
+
+// ErrRetryLimitExceeded indicates the function was retried too many times.
+var ErrRetryLimitExceeded = errors.New("retry limit exceeded")
+
+// retry calls the fn callback multiple times until it succeeds.
+//
+// The fn callback should return errRetry to indicate that it failed but it is
+// safe to try it again after waiting a small time. If the retry limit is
+// reached, the function returns ErrRetryLimitExceeded.
+func retry(name string, fn func() error) error {
+	for i := 0; i < retryLimit; i++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, errRetry) {
+			return err
+		}
+
+		log.Debugf("retrying %s (%d of %d)", name, i+1, retryLimit)
+		time.Sleep(retryDelay)
+	}
+
+	return ErrRetryLimitExceeded
+}


### PR DESCRIPTION
Invoking multiple instances of the ig binary on parallel causes issues
as the oras library doesn't provide any multi process syncronization
guarantees on the index.json file. This commit fixes that by using a
file lock and some logic to detect when this file has been updated by
another process.

Specifically, this commit:
- Disables AutoSaveIndex to have control over when the index.json file
  is written.
- Uses a file lock to be sure only one process is writing to the
  index.json file at a time.
- Adds some logic to retry an operation when the index.json file has been
  updated by another process.

Different alternatives were considered:
- big lock: It caused issues as the critical section was too big and
  different instances of ig timeout while running gadgets.
- merge index: Instead of retry the whole operation when the index.json
  file was written by another process, we could merge it with the changes.
  However it's difficult to implement as it'll need the oras library to
  provide a list of changes on the index to apply.
- use a db to store the index: It probably requires a lot of changes to
  the oras library.

## Testing 

All the cases described here work fine with this PR, but fail before it

### Multiple ig instances run on parallel 

Try executing `ig image` commands at the same time, like building multiple gadgets and listing all gadgets:

#### ig build on parallel

terminal 1:

```bash 
$ while true; do sudo ig image list > /dev/null; done
```

terminal 2

```bash 
$ make -C gadgets/ -j 8 build
...
```

#### Running multiple gadgets at the same time with the oci store is empty

```bash 
$ sudo rm -rf /var/lib/ig
$ sudo ig run trace_open & sudo ig run trace_exec
[1] 139772
RUNTIME.CONTAINERNAME          COMM                          PID              TID               FD FNAME                            MODE             ERROR
RUNTIME.CONTAINERNAME                                    COMM                    PID        TID ARGS                               ERRO
```

## ig-k8s/ig daemon and ig run at the same time 

Let's start with an empty oci store

```bash 
$ sudo rm -rf /var/lib/ig
$ sudo ig image list
REPOSITORY                                TAG                                      DIGEST       CREATED
```

Then, run ig daemon

```bash 
$ sudo ig daemon
INFO[0000] starting Inspektor Gadget daemon at "unix:///var/run/ig/ig.socket"
WARN[0000] reading config: open /root/.ig/config.yaml: no such file or directory
WARN[0000] no TLS configuration provided, communication between daemon and CLI will not be encrypted
```

On another terminal, try to run a gadget without pulling the image:

```bash 
$ sudo gadgetctl run trace_open --pull never
Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: resolving image "ghcr.io/inspektor-gadget/gadget/trace_open:latest" on local registry: not found
```

Pull the image with ig 

```bash 
$ sudo ig image pull trace_open
Pulling trace_open...
Successfully pulled ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:b4deed0f11ddc4b365aa492d2b1c73f9e7d3cb3ad2138a83024c6414ea68a120
```

Running the gadget again works:

```bash
$ sudo gadgetctl run trace_open --pull never
RUNTIME.CONTAINERNAME          COMM                    PID        TID  FD FNAME                            MODE             ERROR
```

It means `ig daemon` has visibility on the changes make by ig to the store without having to restart it.

Fixes #3554

Ref https://github.com/oras-project/oras-go/issues/472#issuecomment-1876251180
Ref https://github.com/oras-project/oras-go/issues/286
Ref https://github.com/ratify-project/ratify/issues/1110
Ref https://github.com/opencontainers/umoci/issues/216#issuecomment-343332733
Ref https://github.com/opencontainers/umoci/issues/146