### PR TITLE
pkg: Rework error message to cope with code scanning alerts.

### DIFF
--- a/pkg/operators/uidgidresolver/usergroupcache.go
+++ b/pkg/operators/uidgidresolver/usergroupcache.go
@@ -94,7 +94,7 @@ func (cache *userGroupCache) Start() error {
 		cache.groupCache.Clear()
 		passwdFile, err := os.OpenFile(fullPasswdPath, os.O_RDONLY, 0)
 		if err != nil {
-			return fmt.Errorf("UserGroupCache: open %q: %w", fullPasswdPath, err)
+			return fmt.Errorf("UserGroupCache: open /etc/passwd in host file system: %w", err)
 		}
 		defer passwdFile.Close()
 		updateEntries(passwdFile, cache.userCache)


### PR DESCRIPTION
Code scanning alerted about logging of sensitive information but this is actually a false positive as we do not print the content of /etc/passwd in host file system but only its path, so something like /host/etc/passwd.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/security/code-scanning/277