### PR TITLE
Adds dev and inode number field in trace_exec

### DIFF
--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -24,6 +24,24 @@ datasources:
           columns.width: 64
           columns.hidden: "true"
           columns.alignment: left
+      dev_major:
+        annotations:
+          description: The major number of the device where the file is located. For scripts, this refers to the script, not the interpreter (requires --paths flag)
+          columns.width: 5
+          columns.hidden: "true"
+          columns.alignment: right
+      dev_minor:
+        annotations:
+          description: The minor number of the device where the file is located. For scripts, this refers to the script, not the interpreter (requires --paths flag)
+          columns.width: 5
+          columns.hidden: "true"
+          columns.alignment: right
+      inode:
+        annotations:
+          description: The inode number of the file. For scripts, this refers to the script, not the interpreter (require --paths flag)
+          columns.width: 5
+          columns.hidden: "true"
+          columns.alignment: right
       loginuid:
         annotations:
           template: uid

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -45,6 +45,9 @@ type traceExecEvent struct {
 	File        string `json:"file"`
 	Cwd         string `json:"cwd"`
 	Args        string `json:"args"`
+	DevMajor    uint32 `json:"dev_major"`
+	DevMinor    uint32 `json:"dev_minor"`
+	Inode       uint64 `json:"inode"`
 }
 
 func TestTraceExec(t *testing.T) {
@@ -110,6 +113,9 @@ func TestTraceExec(t *testing.T) {
 						UpperLayer: false,
 						Exepath:    "/bin/sh",
 						File:       "/bin/sh",
+						DevMajor:   utils.NormalizedInt,
+						DevMinor:   utils.NormalizedInt,
+						Inode:      utils.NormalizedInt,
 
 						// Check the existence of the following fields
 						Timestamp: utils.NormalizedStr,
@@ -125,6 +131,9 @@ func TestTraceExec(t *testing.T) {
 						UpperLayer: true,
 						Exepath:    "/usr/bin/sh",
 						File:       "/usr/bin/sh",
+						DevMajor:   utils.NormalizedInt,
+						DevMinor:   utils.NormalizedInt,
+						Inode:      utils.NormalizedInt,
 
 						// Check the existence of the following fields
 						Timestamp: utils.NormalizedStr,
@@ -141,6 +150,9 @@ func TestTraceExec(t *testing.T) {
 						PupperLayer: true,
 						Exepath:     "/bin/sleep",
 						File:        "/bin/sleep",
+						DevMajor:    utils.NormalizedInt,
+						DevMinor:    utils.NormalizedInt,
+						Inode:       utils.NormalizedInt,
 
 						// Check the existence of the following fields
 						Timestamp: utils.NormalizedStr,
@@ -155,6 +167,10 @@ func TestTraceExec(t *testing.T) {
 					utils.NormalizeProc(&e.Proc)
 					utils.NormalizeInt(&e.Loginuid)
 					utils.NormalizeInt(&e.Sessionid)
+					// Don't use NormalizeInt() because 0 is a valid device major for overlayfs
+					e.DevMajor = utils.NormalizedInt
+					utils.NormalizeInt(&e.DevMinor)
+					utils.NormalizeInt(&e.Inode)
 
 					// We can't know the parent process of the first process inside
 					// the container as it depends on the container runtime


### PR DESCRIPTION
### Fixes #3837

This PR adds three additional fields `dev_major`, `dev_minor` and `inode_no` in `trace_exec` gadget which can be accessed by `--fields` flag

## How to use
```
$ sudo ./ig image build ./gadgets/trace_exec --local --tag trace_exec_local
$ sudo ./ig run trace_exec_local --verify-image=false  --paths --fields comm,args,error,exepath,file,dev_no,inode_no --host --ignore-failed=false
```