### PR TITLE
examples/instance-manifest: Add examples

### DIFF
--- a/docs/reference/manifests.mdx
+++ b/docs/reference/manifests.mdx
@@ -47,6 +47,16 @@ their IDs.
 
 :::
 
+## Remote Manifests
+
+You can also use a remote manifest file by providing a URL instead of a local file path. The URL must be prefixed with `http://` or `https://`.
+
+```bash
+kubectl gadget run -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/%IG_BRANCH%/examples/instance-manifests/dns/failed-dns-requests-all.yaml
+```
+
+Feel free to check out the [example manifests](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/examples/instance-manifests) in the repository for more examples.
+
 ## Running a single gadget interactively
 
 When running interactively, you are limited to one gadget instance spec per manifest. This applies to `ig` as well as

--- a/examples/instance-manifests/README.md
+++ b/examples/instance-manifests/README.md
@@ -1,0 +1,3 @@
+# instance-manifests
+
+This directory contains examples of [instance manifests](https://www.inspektor-gadget.io/docs/latest/reference/manifests) to run a gadget or a set of gadgets for a specific use case.

--- a/examples/instance-manifests/dns/failed-dns-requests-all.yaml
+++ b/examples/instance-manifests/dns/failed-dns-requests-all.yaml
@@ -1,0 +1,25 @@
+# Trace DNS requests that are not successful (rcode!=Success) and are responses (qr==R) in all namespaces.
+# Gadgets used:
+# - trace_dns (https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns)
+apiVersion: 1
+kind: instance-spec
+image: trace_dns:latest
+name: failed-dns-requests-all
+paramValues:
+  # The following parameter is used to trace DNS requests in all namespaces
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/kubemanager
+  operator.KubeManager.all-namespaces: true
+  # The following parameter is used to filter the DNS requests that are:
+  #   1. Not successful (rcode!=Success)
+  #   2. Responses only (qr==R)
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/filter
+  operator.filter.filter: rcode!=Success,qr==R
+  # The following parameter is used to display the following fields in the output:
+  #   1. Namespace of the pod
+  #   2. Name of the pod
+  #   3. Source endpoint of the DNS request
+  #   4. Destination endpoint of the DNS request
+  #   5. Name in the DNS request
+  #   6. Response code of the DNS request
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/cli
+  operator.cli.fields: k8s.namespace,k8s.podname,src,dst,name,rcode

--- a/examples/instance-manifests/dns/failed-dns-requests-default.yaml
+++ b/examples/instance-manifests/dns/failed-dns-requests-default.yaml
@@ -1,0 +1,23 @@
+# Trace DNS requests that are not successful (rcode!=Success) and are responses (qr==R) in default namespace.
+# Gadgets used:
+# - trace_dns (https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns)
+apiVersion: 1
+kind: instance-spec
+image: trace_dns:latest
+name: failed-dns-requests-default
+paramValues:
+  # The following parameter is used to trace DNS requests in the default namespace
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/kubemanager
+  operator.KubeManager.namespace: default
+  # The following parameter is used to filter the DNS requests that are:
+  #   1. Not successful (rcode!=Success)
+  #   2. Responses only (qr==R)
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/filter
+  operator.filter.filter: rcode!=Success,qr==R
+  # The following parameter is used to display the following fields in the output:
+  #   1. Name of the pod
+  #   2. Source endpoint of the DNS request
+  #   3. Destination endpoint of the DNS request
+  #   4. Name in the DNS request
+  #   5. Response code of the DNS request
+  operator.cli.fields: k8s.podname,src,dst,name,rcode

--- a/examples/instance-manifests/security/modified-files-all.yaml
+++ b/examples/instance-manifests/security/modified-files-all.yaml
@@ -1,0 +1,17 @@
+# Trace the execution of all processes that have been modified in container in all namespaces.
+# Gadgets used:
+# - trace_exec (https://www.inspektor-gadget.io/docs/latest/gadgets/trace_exec)
+apiVersion: 1
+kind: instance-spec
+image: trace_exec:latest
+name: modified-files-all
+paramValues:
+  # The following parameter is used to trace the execution of all processes in all namespaces
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/kubemanager
+  operator.KubeManager.all-namespaces: true
+  # The following parameter is used to filter the processes that have been modified in container images
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/filter
+  operator.filter.filter: upper_layer==true
+  # The following parameter is used to display events as JSON in a pretty format
+  # See: https://www.inspektor-gadget.io/docs/latest/spec/operators/cli
+  operator.cli.output: jsonpretty


### PR DESCRIPTION
Include example instance manifest files for running gadgets in the `examples/instance-manifests` directory.

## Testing Done

```
$ kubectl gadget run -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/fab472ddcf2268c061416b9b19f878f578ab2dc3/examples/instance-manifests/failed-dns-requests-all.yaml
$ kubectl gadget run -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/fab472ddcf2268c061416b9b19f878f578ab2dc3/examples/instance-manifests/failed-dns-requests-default.yaml
$ kubectl gadget run -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/fab472ddcf2268c061416b9b19f878f578ab2dc3/examples/instance-manifests/modified-files-all.yaml
```

After merge we can use the repository paths.  