### PR TITLE
trace_tcp: Add fd

### DIFF
--- a/gadgets/trace_tcp/ebpf/accept.h
+++ b/gadgets/trace_tcp/ebpf/accept.h
@@ -20,24 +20,24 @@ static __always_inline int handle_sys_accept_e(struct syscall_trace_enter *ctx)
 static __always_inline int handle_sys_accept_x(struct syscall_trace_exit *ctx)
 {
 	__u32 tid = bpf_get_current_pid_tgid();
-	bpf_map_delete_elem(&tcp_tid_fd, &tid);
-	return 0;
-}
-
-static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
-					      struct sock *sk)
-{
-	__u16 family;
 	struct event *event;
 	struct tuple_key_t t = {};
-	__u32 tid;
-	__u32 *fd;
+	struct sock **skpp;
+	struct sock *sk;
+	__u32 *fdPtr;
+	__u32 fd = 0;
+	int ret = (int)ctx->ret; // Might be a error code or fd
+	__u16 family;
 
-	if (!sk)
-		return;
+	fdPtr = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
+	if (fdPtr)
+		fd = *fdPtr;
+	bpf_map_delete_elem(&tcp_tid_fd, &tid);
 
-	if (filter_event(sk, accept))
-		return;
+	skpp = bpf_map_lookup_elem(&tcp_tid_sock, &tid);
+	if (!skpp)
+		return 0;
+	sk = *skpp;
 
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 
@@ -45,21 +45,40 @@ static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
 	/* do not send event if IP address is 0.0.0.0 or port is 0 */
 	if (is_ipv6_zero(&t.src) || is_ipv6_zero(&t.dst) || t.dst.port == 0 ||
 	    t.src.port == 0)
-		return;
+		goto end;
 
-	tid = bpf_get_current_pid_tgid();
-	fd = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
-	if (!fd)
-		return;
-
+	// --------------
 	event = gadget_reserve_buf(&events, sizeof(*event));
 	if (!event)
-		return;
+		goto end;
 
 	fill_event(event, &t, NULL, 0, accept);
-	event->fd = *fd;
+	event->fd = fd;
+
+	if (ret > 0)
+		event->new_fd = ret;
+	else
+		event->new_fd = 0;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+end:
+	bpf_map_delete_elem(&tcp_tid_sock, &tid);
+
+	return 0;
+}
+
+static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
+					      struct sock *sk)
+{
+	__u32 tid = bpf_get_current_pid_tgid();
+
+	if (!sk)
+		return;
+
+	if (filter_event(sk, accept))
+		return;
+
+	bpf_map_update_elem(&tcp_tid_sock, &tid, &sk, 0);
 }
 
 #endif // __IG_TCP_ACCEPT_H

--- a/gadgets/trace_tcp/ebpf/accept.h
+++ b/gadgets/trace_tcp/ebpf/accept.h
@@ -35,6 +35,7 @@ static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
 		return;
 
 	fill_event(event, &t, NULL, 0, accept);
+	event->fd = 0;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 }

--- a/gadgets/trace_tcp/ebpf/close.h
+++ b/gadgets/trace_tcp/ebpf/close.h
@@ -30,7 +30,7 @@ static __always_inline void handle_tcp_close(struct pt_regs *ctx,
 	struct tuple_key_t tuple = {};
 	struct event *event;
 	u16 family;
-	__u32 tid;
+	__u32 tid = bpf_get_current_pid_tgid();
 	__u32 *fd;
 
 	if (filter_event(sk, close))
@@ -54,8 +54,8 @@ static __always_inline void handle_tcp_close(struct pt_regs *ctx,
 		goto end;
 
 	fill_event(event, &tuple, NULL, 0, close);
+	event->new_fd = 0;
 
-	tid = bpf_get_current_pid_tgid();
 	fd = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
 	// Best effor approach to see if we can find it through the sock
 	if (!fd)

--- a/gadgets/trace_tcp/ebpf/close.h
+++ b/gadgets/trace_tcp/ebpf/close.h
@@ -9,15 +9,32 @@
 
 #include "common.h"
 
+static __always_inline int handle_sys_close_e(struct syscall_trace_enter *ctx)
+{
+	__u32 fd = (__u32)ctx->args[0];
+	__u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&tcp_tid_fd, &tid, &fd, 0);
+	return 0;
+}
+
+static __always_inline int handle_sys_close_x(struct syscall_trace_exit *ctx)
+{
+	__u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_delete_elem(&tcp_tid_fd, &tid);
+	return 0;
+}
+
 static __always_inline void handle_tcp_close(struct pt_regs *ctx,
 					     struct sock *sk)
 {
 	struct tuple_key_t tuple = {};
 	struct event *event;
 	u16 family;
+	__u32 tid;
+	__u32 *fd;
 
 	if (filter_event(sk, close))
-		return;
+		goto end;
 
 	/*
 	 * Don't generate close events for connections that were never
@@ -26,19 +43,35 @@ static __always_inline void handle_tcp_close(struct pt_regs *ctx,
 	u8 oldstate = BPF_CORE_READ(sk, __sk_common.skc_state);
 	if (oldstate == TCP_SYN_SENT || oldstate == TCP_SYN_RECV ||
 	    oldstate == TCP_NEW_SYN_RECV)
-		return;
+		goto end;
 
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	if (!fill_tuple(&tuple, sk, family))
-		return;
+		goto end;
 
 	event = gadget_reserve_buf(&events, sizeof(*event));
 	if (!event)
-		return;
+		goto end;
 
 	fill_event(event, &tuple, NULL, 0, close);
 
+	tid = bpf_get_current_pid_tgid();
+	fd = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
+	// Best effor approach to see if we can find it through the sock
+	if (!fd)
+		fd = bpf_map_lookup_elem(&tcp_sock_fd, &sk);
+
+	if (fd)
+		event->fd = *fd;
+	else {
+		// We only have a fd when we go through sys_close
+		// and we should not discard the event in the other case
+		event->fd = 0;
+	}
+
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+end:
+	bpf_map_delete_elem(&tcp_sock_fd, &sk);
 }
 
 #endif // __IG_TCP_CLOSE_H

--- a/gadgets/trace_tcp/ebpf/common.h
+++ b/gadgets/trace_tcp/ebpf/common.h
@@ -37,6 +37,7 @@ struct event {
 	enum event_type type_raw;
 	gadget_errno error_raw;
 	__u32 fd;
+	__u32 new_fd;
 };
 
 struct tuple_key_t {
@@ -67,6 +68,19 @@ struct {
 	__type(key, __u32); // tid
 	__type(value, __u32); // fd
 } tcp_tid_fd SEC(".maps");
+
+/*
+ * We need to store the sock in kprobes where its available and retrieve it later
+ * in "higher" functions, where we don't have access to it anymore.
+ * It should be said that the entrys are only short lived and used in a single call
+ * chain of a system call.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u32); // tid
+	__type(value, struct sock *);
+} tcp_tid_sock SEC(".maps");
 
 __u8 ip_v6_zero[16] = {
 	0,

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -21,6 +21,10 @@ datasources:
       error_raw:
         annotations:
           columns.hidden: true
+      fd:
+        annotations:
+          description: The FD where the operation happened on
+          columns.hidden: true
 params:
   ebpf:
     connect_only:

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -25,6 +25,10 @@ datasources:
         annotations:
           description: The FD where the operation happened on
           columns.hidden: true
+      new_fd:
+        annotations:
+          description: The FD of the new connection returned by accept
+          columns.hidden: true
 params:
   ebpf:
     connect_only:

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -78,4 +78,28 @@ int BPF_KRETPROBE(ig_tcp_accept, struct sock *sk)
 	return 0;
 }
 
+SEC("tracepoint/syscalls/sys_enter_accept")
+int sys_accept_e(struct syscall_trace_enter *ctx)
+{
+	return handle_sys_accept_e(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_enter_accept4")
+int sys_accept4_e(struct syscall_trace_enter *ctx)
+{
+	return handle_sys_accept_e(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept")
+int sys_accept_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_accept_x(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept4")
+int sys_accept4_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_accept_x(ctx);
+}
+
 char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -42,6 +42,12 @@ int BPF_KPROBE(ig_tcp_state, struct sock *sk, int state)
 	return 0;
 }
 
+SEC("tracepoint/syscalls/sys_enter_connect")
+int sys_connect_e(struct syscall_trace_enter *ctx)
+{
+	return handle_sys_connect_e(ctx);
+}
+
 // kprobe for TCP close events
 
 SEC("kprobe/tcp_close")
@@ -49,6 +55,18 @@ int BPF_KPROBE(ig_tcp_close, struct sock *sk)
 {
 	handle_tcp_close(ctx, sk);
 	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_close")
+int sys_close_e(struct syscall_trace_enter *ctx)
+{
+	return handle_sys_close_e(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_exit_close")
+int sys_close_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_close_x(ctx);
 }
 
 // kprobe for TCP accept events

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -130,11 +130,11 @@ func TestTraceTCP(t *testing.T) {
 					},
 					Type:  "accept",
 					Error: "",
-					Fd:    0, // The fd is always 0 for the accept event
 
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
 					NetNsID:   utils.NormalizedInt,
+					Fd:        utils.NormalizedInt,
 				},
 				{
 					CommonData: utils.BuildCommonData(containerName, commonDataOpts...),

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -39,6 +39,7 @@ type traceTCPEvent struct {
 	Dst   utils.L4Endpoint `json:"dst"`
 	Type  string           `json:"type"`
 	Error string           `json:"error"`
+	Fd    int              `json:"fd"`
 }
 
 func TestTraceTCP(t *testing.T) {
@@ -110,6 +111,7 @@ func TestTraceTCP(t *testing.T) {
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
 					NetNsID:   utils.NormalizedInt,
+					Fd:        utils.NormalizedInt,
 				},
 				{
 					CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
@@ -128,6 +130,7 @@ func TestTraceTCP(t *testing.T) {
 					},
 					Type:  "accept",
 					Error: "",
+					Fd:    0, // The fd is always 0 for the accept event
 
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
@@ -154,6 +157,7 @@ func TestTraceTCP(t *testing.T) {
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
 					NetNsID:   utils.NormalizedInt,
+					Fd:        utils.NormalizedInt,
 				},
 			}
 
@@ -167,6 +171,7 @@ func TestTraceTCP(t *testing.T) {
 				// https://github.com/curl/curl/issues/6288
 				utils.NormalizeInt(&e.Src.Port)
 				utils.NormalizeInt(&e.Dst.Port)
+				utils.NormalizeInt(&e.Fd)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntries...)

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -40,6 +40,7 @@ type traceTCPEvent struct {
 	Type  string           `json:"type"`
 	Error string           `json:"error"`
 	Fd    int              `json:"fd"`
+	NewFd int              `json:"new_fd"`
 }
 
 func TestTraceTCP(t *testing.T) {
@@ -107,6 +108,7 @@ func TestTraceTCP(t *testing.T) {
 					},
 					Type:  "connect",
 					Error: "",
+					NewFd: 0,
 
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
@@ -135,6 +137,7 @@ func TestTraceTCP(t *testing.T) {
 					Timestamp: utils.NormalizedStr,
 					NetNsID:   utils.NormalizedInt,
 					Fd:        utils.NormalizedInt,
+					NewFd:     utils.NormalizedInt,
 				},
 				{
 					CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
@@ -153,6 +156,7 @@ func TestTraceTCP(t *testing.T) {
 					},
 					Type:  "close",
 					Error: "",
+					NewFd: 0,
 
 					// Check only the existence of these fields
 					Timestamp: utils.NormalizedStr,
@@ -172,6 +176,7 @@ func TestTraceTCP(t *testing.T) {
 				utils.NormalizeInt(&e.Src.Port)
 				utils.NormalizeInt(&e.Dst.Port)
 				utils.NormalizeInt(&e.Fd)
+				utils.NormalizeInt(&e.NewFd)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntries...)


### PR DESCRIPTION
This PR adds the `fd` which the syscall operates on. Furthermore it adds the fd of the new connection returned by `accept`

Part of #3565