### PR TITLE
gadgetctl/kubectl-gadget: fixes crash when running attach right after run 

### DIFF
--- a/pkg/gadget-service/instance-manager/instance.go
+++ b/pkg/gadget-service/instance-manager/instance.go
@@ -59,9 +59,11 @@ type GadgetInstance struct {
 	cancel               func()
 	state                gadgetState
 	error                error
+	ready                chan struct{}
 }
 
 func (p *GadgetInstance) GadgetInfo() (*api.GadgetInfo, error) {
+	<-p.ready
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.gadgetInfo, p.error
@@ -186,6 +188,7 @@ func (p *GadgetInstance) Run(
 				Payload: d,
 			}
 			p.gadgetInfo = gi
+			close(p.ready)
 			return nil
 		}),
 	)

--- a/pkg/gadget-service/instance-manager/manager.go
+++ b/pkg/gadget-service/instance-manager/manager.go
@@ -101,6 +101,7 @@ func (m *Manager) RunGadget(instance *api.GadgetInstance) {
 		eventBufferOffs: 0,
 		cancel:          cancel,
 		clients:         map[*GadgetInstanceClient]struct{}{},
+		ready:           make(chan struct{}),
 	}
 	m.mu.Lock()
 	m.gadgetInstances[gi.id] = gi


### PR DESCRIPTION
### Fixes #3678
Uses a channel to signal completion of `Run` function in `instance.go` before returning gadgetinfo. Earlier this returned null, leading to a null pointer dereferencing error.

### Testing done

![image](https://github.com/user-attachments/assets/5df3fb8b-609c-4d5c-b46c-75dafdbe35f2)
