### PR TITLE
oci-service: Fix closing logic

### DIFF
--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -149,7 +149,7 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 
 	done := make(chan bool)
 	defer func() {
-		done <- true
+		close(done)
 	}()
 
 	// Build a simple operator that subscribes to all events and forwards them


### PR DESCRIPTION
The previous logic was causing issues when running the gadget failed because the client was handing forever. This is because if `s.runtime.RunGadget` fails early the simple operator won't be initialized and hence the done <- true operation will block as there is not any goroutine reading from the channel.

This commit fixes that by closing the channel instead of writing to it.

Fixes first part of #3453.
Replaces #3863