### PR TITLE
Adding fupper layer field for trace_exec image-based gadget

### DIFF
--- a/gadgets/trace_exec/README.mdx
+++ b/gadgets/trace_exec/README.mdx
@@ -146,8 +146,6 @@ Finally, clean the system:
  correctly (ret=0). For example, if the executable does not have the "execute"
  permission, the execution will fail and the upper layer field will not be
  defined.
-- In case of a shell script, the upper layer field will refer to the location
- of the shell program (e.g. `/bin/sh`) and not the script file.
 - The file path might not be set when the execution fails (ret!=0), depending
  on the error.
 - The exepath is set to the current process and not the new process when the

--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -68,14 +68,17 @@ datasources:
           columns.width: 16
       upper_layer:
         annotations:
-          description: Whether the executable is in the upper layer of the overlay filesystem
+          description: Whether the executable file of the process (interpreter in case of script) is in the upper layer of the overlay filesystem. Only initialized when the execution succeeded.
           columns.width: 5
           columns.hidden: true
       pupper_layer:
         annotations:
-          description: Whether the executable's parent in the process hierarchy
-            is in the upper layer of the overlay filesystem. Only initialized when
-            the execution succeeded.
+          description: Whether the executable's parent in the process hierarchy (interpreter in case of script) is in the upper layer of the overlay filesystem. Only initialized when the execution succeeded.
+          columns.width: 5
+          columns.hidden: true
+      fupper_layer:
+        annotations:
+          description: Whether the executable file of the process (script in case of script) is in the upper layer of the overlay filesystem. Initialized when the execution succeeded or failed with the -ENOEXEC error ("Exec format error"). Notice that to get failed executions, you need to set ignore_failed to false.
           columns.width: 5
           columns.hidden: true
 params:


### PR DESCRIPTION
# Adding fupper layer field for trace_exec image-based gadget
fupper_laer field provides an indication for whether the executable file of the process is in the upper layer of the overlay filesystem. This can be useful information when exepath != filepath, such as in a case of a script.

In response to https://github.com/inspektor-gadget/inspektor-gadget/issues/3838

## Testing done
* Unit tests
![image](https://github.com/user-attachments/assets/3a5e34f3-6f15-4dd7-b4ee-aaabf628dd97)