### PR TITLE
wasmapi: Bump available map to reflect cilium/ebpf 0.17.1.

### DIFF
--- a/pkg/operators/wasm/maps.go
+++ b/pkg/operators/wasm/maps.go
@@ -80,7 +80,7 @@ func (i *wasmOperatorInstance) addMapFuncs(env wazero.HostModuleBuilder) {
 
 func isMapTypeKnown(typ ebpf.MapType) bool {
 	// Keep in sync with with wasmapi/go/map.go.
-	return typ <= ebpf.TaskStorage
+	return typ <= ebpf.Arena
 }
 
 func isMapTypeFDArray(typ ebpf.MapType) bool {

--- a/wasmapi/go/map.go
+++ b/wasmapi/go/map.go
@@ -56,7 +56,7 @@ const (
 type MapType uint32
 
 // Taken from:
-// https://github.com/cilium/ebpf/blob/061e86d8f5e9/types.go#L15-L98
+// https://github.com/cilium/ebpf/blob/6d6c5e3225732525434b0c192c97950488a4051b/types.go#L13-L105
 const (
 	UnspecifiedMap MapType = iota
 	Hash
@@ -88,6 +88,10 @@ const (
 	RingBuf
 	InodeStorage
 	TaskStorage
+	BloomFilter
+	UserRingbuf
+	CgroupStorage
+	Arena
 )
 
 type MapSpec struct {


### PR DESCRIPTION
New map types were added in the latest cilium/ebpf release [1]. Let's add them to our WASM API.

[1]: https://github.com/cilium/ebpf/commit/d340f32a007b
