### PR TITLE
filter: Allow escaping commas

### DIFF
--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -172,6 +172,8 @@ This filters for commands starting with the letter "c".
 --filter comm==cat,uid==0
 ```
 
+Also, you can use backslash (`\`) to escape comma in the filter values.
+
 ## Output Format
 
 The `-o` or `--output` flag lets us decide the output format. The default

--- a/docs/spec/operators/filter.md
+++ b/docs/spec/operators/filter.md
@@ -35,3 +35,4 @@ Fully qualified name: `operator.filter.filter`
 ### multiple filters
 
 You can specify multiple filters by separating them with a comma. The filter `field1==value1,field2==value2` will match only events where `field1` equals `value1` and `field2` equals `value2`.
+Also, you can use backslash (`\`) to escape comma in the value.

--- a/pkg/gadget-service/api/helpers.go
+++ b/pkg/gadget-service/api/helpers.go
@@ -94,3 +94,29 @@ func (pv ParamValues) ExtractPrefixedValues(prefix string) ParamValues {
 	}
 	return res
 }
+
+func SplitStringWithEscape(s string, sep rune) []string {
+	var result []string
+	var part string
+	var escape bool
+	for _, c := range s {
+		if escape {
+			escape = false
+			part += string(c)
+			continue
+		}
+		switch c {
+		case '\\':
+			escape = true
+		case sep:
+			result = append(result, part)
+			part = ""
+		default:
+			part += string(c)
+		}
+	}
+	if part != "" {
+		result = append(result, part)
+	}
+	return result
+}

--- a/pkg/operators/filter/filter.go
+++ b/pkg/operators/filter/filter.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"golang.org/x/exp/constraints"
 
@@ -86,7 +85,7 @@ func (f *filterOperator) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 		ffns: map[datasource.DataSource][]func(datasource.DataSource, datasource.Data) bool{},
 	}
 
-	filters := strings.Split(filterCfg, ",")
+	filters := api.SplitStringWithEscape(filterCfg, ',')
 	for _, filter := range filters {
 		if filter == "" {
 			continue


### PR DESCRIPTION
As discussed in the review: https://github.com/inspektor-gadget/inspektor-gadget/pull/3899#discussion_r1918914740 we need a way to escape commas in the filter values. This PR adds support for escaping commas in the filter values by using a backslash (`\`).

### Testing Done

```bash
# cat /tmp/a,b
$ go run -exec sudo ./cmd/ig run trace_open --host -F 'fname==/tmp/a\,b'
RUNTIME.CONTAINERNAME                                                                COMM                    PID        TID  FD FNAME                                                                                    MODE                                         ERROR                            
                                                                                     cat                   13519      13519   3 /tmp/a,b                                                                                 ----------                                                         
```

Also, `filter_test.go` has been updated to handle the new case! 