### PR TITLE
oci: Fix image list crash

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -474,6 +474,7 @@ func getGadgetImages(ctx context.Context, store *oci.Store) ([]*GadgetImageDesc,
 			image, err := getGadgetImageDescriptor(ctx, store, fullTag)
 			if err != nil {
 				log.Debugf("getting gadget image descriptor for %s: %v", fullTag, err)
+				continue
 			}
 
 			images = append(images, image)


### PR DESCRIPTION
Avoid crashing if the returned descriptor is nil.


## Testing 

0. Create a wrong index.json file (pointing to a non-existing index)

```json
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:b26f752fc5b5e2a15d8b5b90d87b036aa12e3a2715d1cf17e6c0d45b596b40d1",
      "size": 728,
      "annotations": {
        "org.opencontainers.image.created": "2025-01-17T16:44:31-05:00",
        "org.opencontainers.image.ref.name": "non-existing-foo"
      }
    }
  ]
}
```

Copy it to the index.json file of the ig oci store:

> [!WARNING]  
> This will destroy your oci-store, backup it first if you have anything important there

```bash
$ sudo cp index.json /var/lib/ig/oci-store/index.json
```

### Before this PR 

```bash 
$ sudo ig image list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x333480d]

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/oci.GetGadgetImages({0x4fe8ca0, 0x79e1e40})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/oci/oci.go:500 +0x10d
github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.NewListCmd.func1(0xc0006f6f08, {0x79e1e40?, 0x4?, 0x493a76d?})
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/common/image/list.go:47 +0x6e
github.com/spf13/cobra.(*Command).execute(0xc0006f6f08, {0x79e1e40, 0x0, 0x0})
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000177508)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/mauriciov/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        /home/mauriciov/kinvolk/ebpf/inspektor-gadget/cmd/ig/main.go:109 +0x4a7
```

### After this PR 

```bash 
$ sudo ig image list -v
DEBU[0000] getting gadget image descriptor for non-existing-foo: getting manifest for "non-existing-foo": getting index: getting image list descriptor: resolving image "ghcr.io/inspektor-gadget/gadget/non-existing-foo:latest": not found
REPOSITORY                                TAG                                      DIGEST       CREATED
```