### PR TITLE
kubectl-gadget: return client version when server not available

### DIFF
--- a/cmd/kubectl-gadget/version.go
+++ b/cmd/kubectl-gadget/version.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -58,7 +59,7 @@ var versionCmd = &cobra.Command{
 		// Get server version information
 		gadgetNamespaces, err := utils.GetRunningGadgetNamespaces()
 		if err != nil {
-			return fmt.Errorf("getting running Inspektor Gadget instances: %w", err)
+			fmt.Fprintf(os.Stderr, "Error: getting running Inspektor Gadget instances: %s\n", err)
 		}
 
 		if len(gadgetNamespaces) == 1 {
@@ -66,13 +67,14 @@ var versionCmd = &cobra.Command{
 			runtimeGlobalParams.Set(grpcruntime.ParamGadgetNamespace, gadgetNamespaces[0])
 			info, err := grpcRuntime.InitDeployInfo()
 			if err != nil {
-				return fmt.Errorf("loading deploy info: %w", err)
-			}
-			versionInfo.ServerVersion = &Version{
-				Version: info.ServerVersion,
+				fmt.Fprintf(os.Stderr, "Error: loading deploy info: %s\n", err)
+			} else {
+				versionInfo.ServerVersion = &Version{
+					Version: info.ServerVersion,
+				}
 			}
 		} else if len(gadgetNamespaces) > 1 {
-			return fmt.Errorf("multiple Inspektor Gadget instances found in namespaces: %v", gadgetNamespaces)
+			fmt.Fprintf(os.Stderr, "Error: multiple Inspektor Gadget instances found in namespaces: %s\n", gadgetNamespaces)
 		}
 
 		// Output based on format


### PR DESCRIPTION
# Return client version when server not available

Before https://github.com/inspektor-gadget/inspektor-gadget/pull/3651, running `kubectl-gadget version` would still show the client version even if there was no server available -- we use this in nixpkgs CI to verify that the version passed by `ldflags` is used correctly [here](https://github.com/NixOS/nixpkgs/blob/5df43628fdf08d642be8ba5b3625a6c70731c19c/pkgs/by-name/ku/kubectl-gadget/package.nix#L33). 
Currently, `kubectl-gadget version` only returns an error when run with no server as
```
❯ kubectl-gadget version        
Error: getting running Inspektor Gadget instances: Get "http://localhost:8080/apis/apps/v1/daemonsets?fieldSelector=metadata.name%3Dgadget&labelSelector=k8s-app%3Dgadget": dial tcp [::1]:8080: connect: connection refused
```
This PR does not fail `version` when no server is available -- instead, it prints the error to `stderr`, but still prints the version to `stdout`
```
❯ kubectl-gadget version 
Error: getting running Inspektor Gadget instances: Get "http://localhost:8080/apis/apps/v1/daemonsets?fieldSelector=metadata.name%3Dgadget&labelSelector=k8s-app%3Dgadget": dial tcp [::1]:8080: connect: connection refused
Client version: v0.36.0
Server version: not available
```
and also works as JSON
```
Error: getting running Inspektor Gadget instances: Get "http://localhost:8080/apis/apps/v1/daemonsets?fieldSelector=metadata.name%3Dgadget&labelSelector=k8s-app%3Dgadget": dial tcp [::1]:8080: connect: connection refused
{
  "clientVersion": {
    "version": "0.36.0"
  }
}
```

## How to use

Run `kubectl-gadget version` with no server available.

## Testing done

Ran `kubectl-gadget version` and `kubectl-gadget version -o json` without a server available.
