### PR TITLE
trace_tcp: Add fd (updated from Burak's #3850)

### DIFF
--- a/gadgets/trace_tcp/ebpf/accept.h
+++ b/gadgets/trace_tcp/ebpf/accept.h
@@ -9,18 +9,26 @@
 
 #include "common.h"
 
-static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
-					      struct sock *sk)
+static __always_inline int handle_sys_accept_x(struct syscall_trace_exit *ctx)
 {
-	__u16 family;
+	__u32 tid = bpf_get_current_pid_tgid();
 	struct event *event;
 	struct tuple_key_t t = {};
+	struct sock **skpp;
+	struct sock *sk;
+	__u32 *fd_ptr;
+	int fd = -1;
+	__u16 family;
 
-	if (!sk)
-		return;
+	fd_ptr = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
+	if (fd_ptr)
+		fd = *fd_ptr;
+	bpf_map_delete_elem(&tcp_tid_fd, &tid);
 
-	if (filter_event(sk, accept))
-		return;
+	skpp = bpf_map_lookup_elem(&tcp_tid_sock, &tid);
+	if (!skpp)
+		return 0;
+	sk = *skpp;
 
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 
@@ -28,15 +36,37 @@ static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
 	/* do not send event if IP address is 0.0.0.0 or port is 0 */
 	if (is_ipv6_zero(&t.src) || is_ipv6_zero(&t.dst) || t.dst.port == 0 ||
 	    t.src.port == 0)
-		return;
+		goto end;
 
 	event = gadget_reserve_buf(&events, sizeof(*event));
 	if (!event)
-		return;
+		goto end;
 
 	fill_event(event, &t, NULL, 0, accept);
+	event->fd = fd;
+
+	if (ctx->ret >= 0)
+		event->accept_fd = (int)ctx->ret;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+end:
+	bpf_map_delete_elem(&tcp_tid_sock, &tid);
+
+	return 0;
+}
+
+static __always_inline void handle_tcp_accept(struct pt_regs *ctx,
+					      struct sock *sk)
+{
+	__u32 tid = bpf_get_current_pid_tgid();
+
+	if (!sk)
+		return;
+
+	if (filter_event(sk, accept))
+		return;
+
+	bpf_map_update_elem(&tcp_tid_sock, &tid, &sk, 0);
 }
 
 #endif // __IG_TCP_ACCEPT_H

--- a/gadgets/trace_tcp/ebpf/connect.h
+++ b/gadgets/trace_tcp/ebpf/connect.h
@@ -10,70 +10,86 @@
 #include "common.h"
 #include <linux/errno.h>
 
+struct extended_info {
+	struct gadget_process proc;
+	__u32 fd;
+};
+
 /*
+ * Hash tuple->extended_info
+ *
  * tcp_set_state doesn't run in the context of the process that initiated the
- * connection so we need to store a map TUPLE -> PID to send the right PID on
- * the event.
+ * connection so we need to store a map TUPLE -> extended info to send the
+ * right process information on the event.
+ *
+ * Entries are inserted in:
+ * - kretprobe/tcp_v4_connect
+ * - kretprobe/tcp_v6_connect
+ *
+ * Entries are deleted in a kprobe, so there are no kretprobe maxactive issues:
+ * - kprobe/tcp_set_state
  */
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct tuple_key_t);
-	__type(value, struct gadget_process);
+	__type(value, struct extended_info);
 } tuplepid SEC(".maps");
-
-/*
- * We store the socket pointer in a map to be able to retrieve it in the
- * kretprobe.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, MAX_ENTRIES);
-	__type(key, u32); // tid
-	__type(value, struct sock *);
-} tcp_connect_sockets SEC(".maps");
 
 static __always_inline int enter_tcp_connect(struct pt_regs *ctx,
 					     struct sock *sk)
 {
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	__u32 tid = pid_tgid;
+	__u32 tid = bpf_get_current_pid_tgid();
 
 	if (filter_event(sk, connect))
 		return 0;
 
-	bpf_map_update_elem(&tcp_connect_sockets, &tid, &sk, 0);
+	bpf_map_update_elem(&tcp_tid_sock, &tid, &sk, 0);
 	return 0;
 }
 
 static __always_inline int exit_tcp_connect(struct pt_regs *ctx, int ret,
 					    __u16 family)
 {
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	__u32 tid = pid_tgid;
+	__u32 tid;
 	struct tuple_key_t tuple = {};
-	struct gadget_process proc = {};
+	struct extended_info ei = {};
 	struct sock **skpp;
 	struct sock *sk;
+	__u32 *fd;
 
-	skpp = bpf_map_lookup_elem(&tcp_connect_sockets, &tid);
+	if (ret)
+		return 0;
+
+	tid = bpf_get_current_pid_tgid();
+	skpp = bpf_map_lookup_elem(&tcp_tid_sock, &tid);
 	if (!skpp)
 		return 0;
 
-	if (ret)
-		goto end;
+	fd = bpf_map_lookup_elem(&tcp_tid_fd, &tid);
+	if (!fd)
+		return 0;
+	ei.fd = *fd;
 
 	sk = *skpp;
 
 	if (!fill_tuple(&tuple, sk, family))
-		goto end;
+		return 0;
 
-	gadget_process_populate(&proc);
-	bpf_map_update_elem(&tuplepid, &tuple, &proc, 0);
+	gadget_process_populate(&ei.proc);
+	bpf_map_update_elem(&tuplepid, &tuple, &ei, 0);
 
-end:
-	bpf_map_delete_elem(&tcp_connect_sockets, &tid);
+	return 0;
+}
+
+static __always_inline int handle_sys_connect_x(struct syscall_trace_exit *ctx)
+{
+	// Clean up maps in tracepoint instead of kretprobe, so it is always
+	// executed even when we reach the kretprobe maxactive limit.
+	__u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_delete_elem(&tcp_tid_sock, &tid);
+	bpf_map_delete_elem(&tcp_tid_fd, &tid);
 	return 0;
 }
 
@@ -82,7 +98,7 @@ static __always_inline void handle_tcp_set_state(struct pt_regs *ctx,
 {
 	struct tuple_key_t tuple = {};
 	struct event *event;
-	struct gadget_process *p;
+	struct extended_info *ei;
 	__u16 family;
 	int err;
 
@@ -98,8 +114,8 @@ static __always_inline void handle_tcp_set_state(struct pt_regs *ctx,
 	if (!fill_tuple(&tuple, sk, family))
 		return;
 
-	p = bpf_map_lookup_elem(&tuplepid, &tuple);
-	if (!p)
+	ei = bpf_map_lookup_elem(&tuplepid, &tuple);
+	if (!ei)
 		return; /* missed entry */
 
 	event = gadget_reserve_buf(&events, sizeof(*event));
@@ -108,7 +124,8 @@ static __always_inline void handle_tcp_set_state(struct pt_regs *ctx,
 
 	err = BPF_CORE_READ(sk, sk_err);
 
-	fill_event(event, &tuple, p, err, connect);
+	fill_event(event, &tuple, &ei->proc, err, connect);
+	event->fd = ei->fd;
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 end:

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -17,9 +17,17 @@ datasources:
           columns.hidden: true
       type:
         annotations:
-          description: Type of TCP connection event
+          description: Type of TCP connection event (connect, accept, close)
       error_raw:
         annotations:
+          columns.hidden: true
+      fd:
+        annotations:
+          description: The FD where the operation happened on (connect, accept)
+          columns.hidden: true
+      accept_fd:
+        annotations:
+          description: The FD of the new connection returned by accept, or -1 for errors cases or other events
           columns.hidden: true
 params:
   ebpf:

--- a/gadgets/trace_tcp/program.bpf.c
+++ b/gadgets/trace_tcp/program.bpf.c
@@ -35,11 +35,23 @@ int BPF_KRETPROBE(ig_tcp_v6_co_x, int ret)
 	return exit_tcp_connect(ctx, ret, AF_INET6);
 }
 
+SEC("tracepoint/syscalls/sys_exit_connect")
+int sys_connect_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_connect_x(ctx);
+}
+
 SEC("kprobe/tcp_set_state")
 int BPF_KPROBE(ig_tcp_state, struct sock *sk, int state)
 {
 	handle_tcp_set_state(ctx, sk, state);
 	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_connect")
+int sys_connect_e(struct syscall_trace_enter *ctx)
+{
+	return update_tcp_tid_fd_map((__u32)ctx->args[0]);
 }
 
 // kprobe for TCP close events
@@ -58,6 +70,30 @@ int BPF_KRETPROBE(ig_tcp_accept, struct sock *sk)
 {
 	handle_tcp_accept(ctx, sk);
 	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_accept")
+int sys_accept_e(struct syscall_trace_enter *ctx)
+{
+	return update_tcp_tid_fd_map((__u32)ctx->args[0]);
+}
+
+SEC("tracepoint/syscalls/sys_enter_accept4")
+int sys_accept4_e(struct syscall_trace_enter *ctx)
+{
+	return update_tcp_tid_fd_map((__u32)ctx->args[0]);
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept")
+int sys_accept_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_accept_x(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept4")
+int sys_accept4_x(struct syscall_trace_exit *ctx)
+{
+	return handle_sys_accept_x(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
# trace_tcp: Add fds for connect and accept

Supersedes #3850.
Part of #3565

The fields are documented in gadget.yaml:

- The 'fd' field is the fd where the operation happened on (connect, accept)
- The 'accept_fd' field is the FD of the new connection returned by accept, or -1 for errors cases or other events

The gadget uses maps to store context. Map cleanup is always done in a tracepoint or a kprobe, avoiding kretprobe. This ensures it does not miss a cleanup because the kretprobe overflows the maxactive.

TCP close events don't include a fd because this is not always well-defined: a fd can be "renamed" with dup2() so it cannot be matched with the fd from connect or accept events.

## How to use

```bash
$ nc -k -l -p 8080 &
[1] 588902
$ echo|nc 127.0.0.1 8080
```

```bash
$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:alban_trace_tcp_fd2 --verify-image=false --host --fields proc.comm,proc.pid,proc.tid,src,dst,type,fd,accept_fd,error
WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
COMM     PID     TID SRC               DST               TYPE     FD  ACCEPT_FD ERROR
nc    588910  588910 127.0.0.1:49380   127.0.0.1:8080    connect  3   -1
nc    588902  588902 127.0.0.1:8080    127.0.0.1:49380   accept   4   5
nc    588902  588902 127.0.0.1:8080    127.0.0.1:49380   close    -1  -1
nc    588910  588910 127.0.0.1:49380   127.0.0.1:8080    close    -1  -1
```

## Testing done

The CI is green
