### PR TITLE
Add predefined operator priority constants

### DIFF
--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -55,6 +55,12 @@ type (
 	EnricherFunc func(any) error
 )
 
+const (
+	PrioritySource      = 100
+	PrioritySink        = 1000
+	PriorityPostprocess = 500
+)
+
 // MapPrefix is used to avoid clash with maps and other eBPF objects when added
 // to gadget context.
 const MapPrefix string = "map/"


### PR DESCRIPTION
# Add Operator Priority Constants

Operators currently use hardcoded priority values between 0 and 10000, which can be confusing when adding new operators.

Introduce predefined priority constants:
- `PrioritySource`: 100 (for data generation)
- `PriorityPostprocess`: 500 (for data modification)
- `PrioritySink`: 1000 (for final data processing)

