### PR TITLE
trace_tcp: add option to see only failed connections

### DIFF
--- a/gadgets/trace_tcp/ebpf/accept.h
+++ b/gadgets/trace_tcp/ebpf/accept.h
@@ -28,8 +28,12 @@ static __always_inline int handle_sys_accept_x(struct syscall_trace_exit *ctx)
 	skpp = bpf_map_lookup_elem(&tcp_tid_sock, &tid);
 	if (!skpp)
 		return 0;
-	sk = *skpp;
 
+	// User does not want to see successful events
+	if (failure_only && ctx->ret >= 0)
+		goto end;
+
+	sk = *skpp;
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
 
 	fill_tuple(&t, sk, family);

--- a/gadgets/trace_tcp/ebpf/close.h
+++ b/gadgets/trace_tcp/ebpf/close.h
@@ -16,6 +16,11 @@ static __always_inline void handle_tcp_close(struct pt_regs *ctx,
 	struct event *event;
 	u16 family;
 
+	// Close events don't have errors.
+	// User does not want to see successful events.
+	if (failure_only)
+		return;
+
 	if (filter_event(sk, close))
 		return;
 

--- a/gadgets/trace_tcp/ebpf/common.h
+++ b/gadgets/trace_tcp/ebpf/common.h
@@ -102,8 +102,10 @@ __u8 ip_v6_zero[16] = {
 };
 
 const volatile bool connect_only = false;
+const volatile bool failure_only = false;
 
 GADGET_PARAM(connect_only);
+GADGET_PARAM(failure_only);
 
 /* Define here, because there are conflicts with include files */
 #define AF_INET 2

--- a/gadgets/trace_tcp/ebpf/connect.h
+++ b/gadgets/trace_tcp/ebpf/connect.h
@@ -118,11 +118,15 @@ static __always_inline void handle_tcp_set_state(struct pt_regs *ctx,
 	if (!ei)
 		return; /* missed entry */
 
+	err = BPF_CORE_READ(sk, sk_err);
+
+	// User does not want to see successful events
+	if (failure_only && err == 0)
+		goto end;
+
 	event = gadget_reserve_buf(&events, sizeof(*event));
 	if (!event)
 		goto end;
-
-	err = BPF_CORE_READ(sk, sk_err);
 
 	fill_event(event, &tuple, &ei->proc, err, connect);
 	event->fd = ei->fd;

--- a/gadgets/trace_tcp/gadget.yaml
+++ b/gadgets/trace_tcp/gadget.yaml
@@ -35,3 +35,7 @@ params:
       key: connect-only
       defaultValue: "false"
       description: Show only connect events
+    failure_only:
+      key: failure-only
+      defaultValue: "false"
+      description: Don't show successful events


### PR DESCRIPTION
# trace_tcp: add option to see only failed connections

When using trace_tcp to monitor connection issues, we don't want to see successful connections. Currently, users can use a filter like `--filter ret!=0` but this implements a filter in userspace, which is less efficient than in ebpf. This patch adds a filter in ebpf to save cpu cycles.

## How to use

Use `--failure-only` on the command line.

## Testing done

Tested with the following:
```
echo|nc 1.1.1.1 80     # successful connect
echo|nc 127.0.0.1 8181 # failed connect
```

Results without and with `--failure-only`:
```
$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest --verify-image=false -F proc.comm==nc --host --connect-only
WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
RUNTIME.CONTAINER… COMM              PID        TID SRC                      DST                     TYPE      ERROR
                   nc             601382     601382 192.168.0.22:40316       1.1.1.1:80              connect
                   nc             601391     601391 127.0.0.1:51788          127.0.0.1:8181          connect   ECONNRE

$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_tcp:latest --verify-image=false -F proc.comm==nc --host --connect-only --failure-only
WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
RUNTIME.CONTAINER… COMM              PID        TID SRC                      DST                     TYPE      ERROR
                   nc             601438     601438 127.0.0.1:38594          127.0.0.1:8181          connect   ECONNRE
```

cc @johananl 