### PR TITLE
tree-wide: deprecate built in gadgets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,9 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
+    - text: "Switch to image-based gadgets instead"
+      linters:
+        - staticcheck
 
 linters:
   disable-all: true

--- a/docs/gadgets/builtin/audit/seccomp.md
+++ b/docs/gadgets/builtin/audit/seccomp.md
@@ -5,6 +5,13 @@ description: >
   Trace syscalls that seccomp sent to the audit log.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [audit_seccomp](../../audit_seccomp.mdx)
+image-based one.
+
+:::
+
 The audit seccomp gadget provides a stream of events with syscalls that had
 their seccomp filters generating an audit log. An audit log can be generated in
 one of these two conditions:

--- a/docs/gadgets/builtin/index.mdx
+++ b/docs/gadgets/builtin/index.mdx
@@ -6,11 +6,14 @@ description: This section provides guides for built-in gadgets
 
 import DocCardList from '@theme/DocCardList';
 
+:::warning
+
 Prior to v0.31.0, Inspektor Gadget only shipped gadgets embedded in its
-executable file. As of v0.31.0 these built-in Gadgets are still available and
-work as before, but their use is discouraged as they will be deprecated at some
-point. We encourage users to use [image-based](../) Gadgets going forward, as they
-provide more features and decouple the eBPF programs from the Inspektor Gadget
-release process.
+executable file. These built-in Gadgets are now deprecated and will be removed
+in v0.42.0 (July 2025). We encourage users to use [image-based](../gadgets/)
+Gadgets going forward, as they provide more features and decouple the eBPF
+programs from the Inspektor Gadget release process.
+
+:::
 
 <DocCardList />

--- a/docs/gadgets/builtin/profile/block-io.md
+++ b/docs/gadgets/builtin/profile/block-io.md
@@ -5,6 +5,13 @@ description: >
   Analyze block I/O performance through a latency distribution.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [profile_blockio](../../profile_blockio.mdx)
+image-based one.
+
+:::
+
 The profile block-io gadget gathers information about the usage of the
 block device I/O (disk I/O), generating a histogram distribution of I/O
 latency (time), when the gadget is stopped.

--- a/docs/gadgets/builtin/profile/tcprtt.md
+++ b/docs/gadgets/builtin/profile/tcprtt.md
@@ -5,6 +5,13 @@ description: >
   Analyze TCP connections through an Round-Trip Time (RTT) distribution
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [profile_tcprtt](../../profile_tcprtt.mdx)
+image-based one.
+
+:::
+
 The profile tcprtt gadget generates a histogram distribution of the TCP
 connections' Round-Trip Time (RTT). The RTT values used to create the histogram
 are collected from [the smoothed

--- a/docs/gadgets/builtin/snapshot/process.md
+++ b/docs/gadgets/builtin/snapshot/process.md
@@ -5,6 +5,13 @@ description: >
   Gather information about running processes.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [snapshot_process](../../snapshot_process.mdx)
+image-based one.
+
+:::
+
 ![Screencast of snapshot process compared to calling kubectl exec ps](process.gif)
 
 The snapshot process gadget gathers information about running processes.

--- a/docs/gadgets/builtin/snapshot/socket.md
+++ b/docs/gadgets/builtin/snapshot/socket.md
@@ -5,6 +5,13 @@ description: >
   Gather information about TCP and UDP sockets.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [snapshot_socket](../../snapshot_socket.mdx)
+image-based one.
+
+:::
+
 The snapshot socket gadget gathers information about TCP and UDP sockets.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/top/block-io.md
+++ b/docs/gadgets/builtin/top/block-io.md
@@ -5,6 +5,13 @@ description: >
   Periodically report block device I/O activity.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [top_blockio](../../top_blockio.mdx)
+image-based one.
+
+:::
+
 The top block-io gadget is used to visualize the containers generating
 the most block device input/output.
 

--- a/docs/gadgets/builtin/top/file.md
+++ b/docs/gadgets/builtin/top/file.md
@@ -5,6 +5,13 @@ description: >
   Periodically report read/write activity by file.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [top_file](../../top_file.mdx)
+image-based one.
+
+:::
+
 The top file gadget is used to visualize reads and writes by file, with container details.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/top/tcp.md
+++ b/docs/gadgets/builtin/top/tcp.md
@@ -5,6 +5,13 @@ description: >
   Periodically report TCP activity.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [top_tcp](../../top_tcp.mdx)
+image-based one.
+
+:::
+
 The top tcp gadget is used to visualize active TCP connections.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/bind.md
+++ b/docs/gadgets/builtin/trace/bind.md
@@ -5,6 +5,13 @@ description: >
   Trace the kernel functions performing socket binding.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_bind](../../trace_bind.mdx)
+image-based one.
+
+:::
+
 ![Screencast of the trace bind gadget](bind.gif)
 
 The trace bind gadget is used to stream socket binding syscalls.

--- a/docs/gadgets/builtin/trace/capabilities.md
+++ b/docs/gadgets/builtin/trace/capabilities.md
@@ -5,6 +5,13 @@ description: >
   Trace security capability checks.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_capabilities](../../trace_capabilities.mdx)
+image-based one.
+
+:::
+
 ![Screencast of the trace capabilities gadget](capabilities.gif)
 
 The trace capabilities gadget allows us to see what capability security checks

--- a/docs/gadgets/builtin/trace/dns.md
+++ b/docs/gadgets/builtin/trace/dns.md
@@ -5,6 +5,13 @@ description: >
   Trace DNS queries and responses.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_dns](../../trace_dns.mdx)
+image-based one.
+
+:::
+
 ![Screencast of the trace dns gadget](dns.gif)
 
 The trace dns gadget prints information about DNS queries and responses sent

--- a/docs/gadgets/builtin/trace/exec.md
+++ b/docs/gadgets/builtin/trace/exec.md
@@ -5,6 +5,13 @@ description: >
   Trace new processes.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_exec](../../trace_exec.mdx)
+image-based one.
+
+:::
+
 ![Screencast of the trace exec gadget](exec.gif)
 
 The trace exec gadget streams new processes creation events.

--- a/docs/gadgets/builtin/trace/fsslower.md
+++ b/docs/gadgets/builtin/trace/fsslower.md
@@ -5,6 +5,13 @@ description: >
   Trace open, read, write and fsync operations slower than a threshold.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_fsslower](../../trace_fsslower.mdx)
+image-based one.
+
+:::
+
 ![Screencast of the trace fsslower gadget](fsslower.gif)
 
 The trace fsslower gadget streams file operations (open, read, write and

--- a/docs/gadgets/builtin/trace/mount.md
+++ b/docs/gadgets/builtin/trace/mount.md
@@ -5,6 +5,13 @@ description: >
   Trace mount and umount system calls.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_mount](../../trace_mount.mdx)
+image-based one.
+
+:::
+
 The trace mount gadget is used to monitor `mount` and `umount` syscalls.
 In this guide, we will learn how to use it by running a small Kubernetes cluster inside `minikube`.
 

--- a/docs/gadgets/builtin/trace/oomkill.md
+++ b/docs/gadgets/builtin/trace/oomkill.md
@@ -5,6 +5,13 @@ description: >
   Trace when OOM killer is triggered and kills a process.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_oomkill](../../trace_oomkill.mdx)
+image-based one.
+
+:::
+
 The trace oomkill gadget is used to monitor when out-of-memory killer kills a process.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/open.md
+++ b/docs/gadgets/builtin/trace/open.md
@@ -5,6 +5,13 @@ description: >
   Trace open system calls.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_open](../../trace_open.mdx)
+image-based one.
+
+:::
+
 The trace open gadget streams events related to files opened inside pods.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/signal.md
+++ b/docs/gadgets/builtin/trace/signal.md
@@ -5,6 +5,13 @@ description: >
   Trace signals received by processes.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_signal](../../trace_signal.mdx)
+image-based one.
+
+:::
+
 The trace signal gadget is used to trace system signals received by the
 pods.
 

--- a/docs/gadgets/builtin/trace/sni.md
+++ b/docs/gadgets/builtin/trace/sni.md
@@ -5,6 +5,13 @@ description: >
   Trace Server Name Indication (SNI) from TLS requests.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_sni](../../trace_sni.mdx)
+image-based one.
+
+:::
+
 The trace sni gadget is used to trace the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) requests sent as part of TLS handshakes.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/tcp.md
+++ b/docs/gadgets/builtin/trace/tcp.md
@@ -5,6 +5,13 @@ description: >
   Trace tcp connect, accept and close.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_tcp](../../trace_tcp.mdx)
+image-based one.
+
+:::
+
 The trace tcp gadget can be used to monitor tcp connections, as it shows
 connect, accept and close events related to TCP connections.
 

--- a/docs/gadgets/builtin/trace/tcpconnect.md
+++ b/docs/gadgets/builtin/trace/tcpconnect.md
@@ -5,6 +5,13 @@ description: >
   Trace connect system calls.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_tcp](../../trace_tcp.mdx)
+image-based one.
+
+:::
+
 The trace tcpconnect gadget traces TCP connect calls.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/tcpdrop.md
+++ b/docs/gadgets/builtin/trace/tcpdrop.md
@@ -5,6 +5,13 @@ description: >
     Trace TCP kernel-dropped packets/segments.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_tcpdrop](../../trace_tcpdrop.mdx)
+image-based one.
+
+:::
+
 The trace tcpdrop gadget traces TCP packets dropped by the kernel.
 
 ### On Kubernetes

--- a/docs/gadgets/builtin/trace/tcpretrans.md
+++ b/docs/gadgets/builtin/trace/tcpretrans.md
@@ -5,6 +5,13 @@ description: >
     Trace TCP retransmissions.
 ---
 
+:::warning
+
+This Gadget is deprecated, please use the [trace_tcpretrans](../../trace_tcpretrans.mdx)
+image-based one.
+
+:::
+
 The trace tcpretrans gadget traces TCP retransmissions by the kernel.
 
 ### On Kubernetes

--- a/docs/gadgets/index.mdx
+++ b/docs/gadgets/index.mdx
@@ -6,11 +6,25 @@ description: Documentation about the official Gadgets"
 
 import DocCardList from '@theme/DocCardList';
 
-This section provides documentation for *some* of the Gadgets that are hosted in
-the
+This section provides documentation for the Gadgets hosted in the
 [gadgets](https://github.com/inspektor-gadget/inspektor-gadget/tree/%IG_BRANCH%/gadgets)
 folder of the Inspektor Gadget source tree. Check [Artifact
 HUB](https://artifacthub.io/packages/search?kind=22) to get a more complete list
 of Gadgets.
+
+Almost all [built-in](./builtin) gadgets have been ported, however we're
+still missing few of them:
+- [seccomp profile
+  advise](https://github.com/inspektor-gadget/inspektor-gadget/issues/3890)
+- [network policy
+  advisor](https://github.com/inspektor-gadget/inspektor-gadget/issues/3891)
+- [traceloop](https://github.com/inspektor-gadget/inspektor-gadget/issues/2822)
+- [profile
+  CPU](https://github.com/inspektor-gadget/inspektor-gadget/issues/3001)
+- [top ebpf](https://github.com/inspektor-gadget/inspektor-gadget/issues/3443)
+
+The ported [built-in gadgets](./builtin) have been deprecated in v0.37.0
+(February 2025) and will be removed in v0.42.0 (July 2025). Read [Switching to
+image-based gadgets](./switching_to_image_based_gadgets.mdx) to learn more.
 
 <DocCardList />

--- a/docs/gadgets/switching_to_image_based_gadgets.mdx
+++ b/docs/gadgets/switching_to_image_based_gadgets.mdx
@@ -1,0 +1,303 @@
+---
+title: Swithing to image-based Gadgets
+sidebar_position: 1
+---
+
+This guide covers how to switch from built-in Gadgets to image-based Gadgets.
+
+### CLI Users
+
+Image-based Gadgets are executed with the [`run`](../reference/run) command:
+
+```bash
+$ ig run gadget_name
+$ kubectl gadget run gadget_name
+```
+
+For each built-in Gadget we have a corresponding image-based Gadget:
+
+```bash
+$ ig trace open # built-in
+$ ig run trace_open # image-based
+
+$ ig snapshot process # built-in
+$ ig run snapshot_process # image-based
+```
+
+Usually the name is the concatenation of the gadget category and the gadget
+name: `trace exec` corresponds to `trace_exec`, `top file` corresponds to
+`top_file` and so on.
+
+This section describes the biggest differences between that kind of gadgets.
+
+#### Columns Output
+
+We tuned the output of different Gadgets to be more user friendly, we changed
+the size of some columns and show or hide some of them by default. For instance,
+this is the output for the trace open gadget:
+
+Built-in:
+
+```bash
+$ sudo ig trace open
+RUNTIME.CONTAINERNAME   PID        TID        COMM        FD ERR PATH
+determined_kapitsa      42364      42364      cat         0  2   /lib/x86_64/x86_64/libm…
+determined_kapitsa      42364      42364      cat         0  2   /lib/x86_64/libm.so.6
+determined_kapitsa      42364      42364      cat         0  2   /lib/x86_64/libm.so.6
+determined_kapitsa      42364      42364      cat         3  0   /lib/libm.so.6
+determined_kapitsa      42364      42364      cat         3  0   /lib/libresolv.so.2
+determined_kapitsa      42364      42364      cat         3  0   /lib/libc.so.6
+determined_kapitsa      42364      42364      cat         0  2   /tmp/foo
+```
+
+Image-based:
+
+```bash
+$ sudo ig run trace_open
+RUNTIME.CONTAIN… COMM           PID      TID  FD FNAME                    MODE     ERROR
+determined_kapit cat          42364    42364   0 /lib/x86_64/x86_64/libm… -------… ENOENT
+determined_kapit cat          42364    42364   0 /lib/x86_64/libm.so.6    -------… ENOENT
+determined_kapit cat          42364    42364   0 /lib/x86_64/libm.so.6    -------… ENOENT
+determined_kapit cat          42364    42364   3 /lib/libm.so.6           -------…
+determined_kapit cat          42364    42364   3 /lib/libresolv.so.2      -------…
+determined_kapit cat          42364    42364   3 /lib/libc.so.6           -------…
+determined_kapit cat          42364    42364   0 /tmp/foo                 -------… ENOENT
+```
+
+#### Json (and Yaml) Output
+
+The output for both kind of Gadgets is very similar. Let's analyse the output of
+`trace open` to compare the differences:
+
+Built-in:
+
+```bash
+$ ig trace open -o jsonpretty
+{
+  "runtime": {
+    "runtimeName": "docker",
+    "containerId": "b092854647ae52c4582204be7978052c2bb5ea8bd572e99f630d04b04ed4c9e1",
+    "containerName": "determined_kapitsa",
+    "containerPid": 37591,
+    "containerImageName": "busybox",
+    "containerImageDigest": "sha256:2919d0172f7524b2d8df9e50066a682669e6d170ac0f6a49676d54358fe970b5",
+    "containerStartedAt": 1737640953449803500
+  },
+  "k8s": {
+    "owner": {}
+  },
+  "timestamp": 1737641591294238200,
+  "type": "normal",
+  "mountnsid": 4026534388,
+  "pid": 39733,
+  "tid": 39733,
+  "gid": 0,
+  "comm": "cat",
+  "err": 2,
+  "flags": [
+    "O_RDONLY"
+  ],
+  "mode": "----------",
+  "path": "/tmp/foo"
+}
+```
+
+Image-based:
+
+```bash
+$ ig run trace_open -o jsonpretty
+{
+  "error": "ENOENT",
+  "error_raw": 2,
+  "fd": 0,
+  "flags": "O_RDONLY",
+  "flags_raw": 0,
+  "fname": "/tmp/foo",
+  "k8s": {
+    "containerName": "",
+    "hostnetwork": false,
+    "namespace": "",
+    "node": "",
+    "owner": {
+      "kind": "",
+      "name": ""
+    },
+    "podLabels": "",
+    "podName": ""
+  },
+  "mode": "----------",
+  "mode_raw": 0,
+  "proc": {
+    "comm": "cat",
+    "creds": {
+      "gid": 0,
+      "group": "root",
+      "uid": 0,
+      "user": "root"
+    },
+    "mntns_id": 4026534388,
+    "parent": {
+      "comm": "sh",
+      "pid": 37591
+    },
+    "pid": 39733,
+    "tid": 39733
+  },
+  "runtime": {
+    "containerId": "b092854647ae52c4582204be7978052c2bb5ea8bd572e99f630d04b04ed4c9e1",
+    "containerImageDigest": "sha256:2919d0172f7524b2d8df9e50066a682669e6d170ac0f6a49676d54358fe970b5",
+    "containerImageName": "busybox",
+    "containerName": "determined_kapitsa",
+    "containerPid": 37591,
+    "containerStartedAt": 1737640953449803500,
+    "runtimeName": "docker"
+  },
+  "timestamp": "2025-01-23T09:13:11.294236963-05:00",
+  "timestamp_raw": 1737641591294237000
+}
+```
+
+- **proccess information**: The image-based one has all the process related
+information such as command name (comm), process identifier (pid), thread
+identifier (tid), user identifier (uid), group identifier (gid), parent process
+(pcomm) and mount namespace inode id (mntns_id) consolidated on the "proc" node.
+- **enriched fields**: The image-based gadgets contains both the raw version and
+the enriched (human friendly version) of fields like timestamp, mode, flags etc.
+- **fields renamed**: The name of some fields were changed, for instance in this
+case the path of the file being open is now called fname instead of path.
+
+#### Filtering events in user space with `--filter`
+
+The syntax is a bit different for both cases.
+
+Built-in:
+
+```bash
+A filter can match any column using the following syntax
+  columnName:value       - matches, if the content of columnName equals exactly value
+  columnName:!value      - matches, if the content of columnName does not equal exactly value
+  columnName:>=value     - matches, if the content of columnName is greater than or equal to the value
+  columnName:>value      - matches, if the content of columnName is greater than the value
+  columnName:<=value     - matches, if the content of columnName is less than or equal to the value
+  columnName:<value      - matches, if the content of columnName is less than the value
+  columnName:~value      - matches, if the content of columnName matches the regular expression 'value'
+                            see [https://github.com/google/re2/wiki/Syntax] for more information on the syntax
+This flag can be specified multiple times to combine multiple filters e.g. -F column1:value1 -F column2:value2
+```
+
+```bash
+# built-in
+$ sudo ig trace open -F 'path:/tmp/foo'
+
+# image-based
+# In this case the field was also renamed
+$ sudo ig run trace_open -F 'fname==/tmp/foo'
+```
+
+[Image-based](../reference/run.mdx#filtering-in-user-space):
+
+```
+A filter can match any field using the following syntax:
+  field==value     - matches, if the content of field equals exactly value
+  field!=value     - matches, if the content of field does not equal exactly value
+  field>=value     - matches, if the content of field is greater than or equal to the value
+  field>value      - matches, if the content of field is greater than the value
+  field<=value     - matches, if the content of field is less than or equal to the value
+  field<value      - matches, if the content of field is less than the value
+  field~value      - matches, if the content of field matches the regular expression 'value'
+               see [https://github.com/google/re2/wiki/Syntax] for more information on the syntax
+Multiple filters can be combined using a comma: field1==value1,field2==value2
+```
+
+#### Showing or hidding columns
+
+In the built-in gadgets, the `-o columns=foo,bar` syntax was available for
+selecting which columns are shown. In the image-based gadgets this is done with
+the [--fields](../reference/run.mdx#selecting-specific-fields) flag:
+
+```bash
+# built-in
+$ sudo ig trace open -o columns=comm,path
+COMM             PATH
+...
+cat              /lib/libm.so.6
+cat              /lib/libresolv.so.2
+cat              /lib/libc.so.6
+cat              /tmp/foo
+
+# image-based
+$ sudo ig run trace_open --fields proc.comm,fname
+COMM             FNAME
+...
+cat              /lib/libm.so.6
+cat              /lib/libresolv.so.2
+cat              /lib/libc.so.6
+cat              /tmp/foo
+```
+
+#### Pulling Gadget Images
+
+Image-based Gadgets aren't shipped with the `ig` binary, they are instead stored
+as OCI artifacts on OCI registries. It means they need to be pulled from
+the internet when running them for the first time. If you're running in an
+environment where it's not possible to reach the internet while running the
+gadgets, you have the following options:
+
+##### Use your own OCI registry
+
+Mirror the Gadget images to your own OCI registry.
+
+```bash
+$ sudo ig image pull trace_open:v0.36.0
+$ sudo ig image tag trace_open:v0.36.0 myoci_registry/trace_open:v0.36.0
+$ sudo ig image push myoci_registry/trace_open:v0.36.0
+```
+
+Then, run the image from a machine with access to your OCI registry
+
+```bash
+$ sudo ig run myoci_registry/trace_open:v0.36.0
+```
+
+##### Use the image export and import functionality
+
+Download a local copy of the images on a machine with internet access:
+
+```bash
+$ sudo ig image pull trace_open:v0.36.0
+$ sudo ig image pull trace_exec:v0.36.0
+# ...
+
+# export the images to a file
+$ sudo ig image export trace_open:v0.36.0 trace_exec:v0.36.0 > myimages.tar
+```
+
+Then, transfer `myimages.tar` to the machine where you want to run the Gadgets,
+import and run them:
+
+```bash
+$ sudo ig image import myimages.tar
+$ sudo ig run trace_open:v0.36.0
+```
+
+#### New Features
+
+This is a raw list of features that are only available with the image-based
+gadgets. Please check the individual documentation for each one of them to get
+more information.
+
+- [**Headless mode**](../reference/headless): Run Gadgets on background.
+- [**Gadget Instance Manifests**](../reference/manifests): Run a Gadget from a
+  file containing its configuration.
+- [**Metrics**](../reference/export-metrics): Export metrics to Prometheus and
+  OpenTelemetry.
+- **Uniform filtering**: Filtering by common fields like command name, pid, tid,
+  etc. in the kernel directly.
+- [**Creating your own Gadgets**](../gadget-devel/): You can now create your own
+  Gadgets without requiring any changes on the project.
+
+### Golang API Users
+
+The main difference for the users of the Golang API is that image-based Gadgets
+don't provide a Golang package, instead a generic runner needs to be used to run
+them. Check the [Golang API](../api/golang) to learn more about it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,14 +42,13 @@ directory and third-party Gadgets).
 
 See the [Gadget documentation](./gadgets/) for more information.
 
-:::warning For versions prior to v0.31.0
+:::warning
 
 Prior to v0.31.0, Inspektor Gadget only shipped gadgets embedded in its
-executable file. As of v0.31.0 these ***built-in*** Gadgets are still available
-and work as before, but their use is discouraged as they will be deprecated at
-some point. We encourage users to use ***image-based*** Gadgets going forward,
-as they provide more features and decouple the eBPF programs from the Inspektor
-Gadget release process.
+executable file. These built-in Gadgets are now deprecated and will be removed
+in v0.42.0 (July 2025). We encourage users to use [image-based](./gadgets/)
+Gadgets going forward, as they provide more features and decouple the eBPF
+programs from the Inspektor Gadget release process.
 
 :::
 

--- a/gadgets/README.md
+++ b/gadgets/README.md
@@ -9,10 +9,8 @@ documentation to get more details:
 
 Almost all [built-in](../pkg/gadgets/) gadgets have been converted, however
 we're still missing few of them:
-- [Advisors](https://github.com/inspektor-gadget/inspektor-gadget/issues/3003)
+- [seccomp profile advise](https://github.com/inspektor-gadget/inspektor-gadget/issues/3890)
+- [network policy advisor](https://github.com/inspektor-gadget/inspektor-gadget/issues/3891)
 - [traceloop](https://github.com/inspektor-gadget/inspektor-gadget/issues/2822)
 - [profile CPU](https://github.com/inspektor-gadget/inspektor-gadget/issues/3001)
-- [top block-io](https://github.com/inspektor-gadget/inspektor-gadget/issues/2989)
 - [top ebpf](https://github.com/inspektor-gadget/inspektor-gadget/issues/3443)
-- [profile tcprtt](https://github.com/inspektor-gadget/inspektor-gadget/issues/3002)
-- [trace fsslower](https://github.com/inspektor-gadget/inspektor-gadget/issues/2994)

--- a/gadgets/trace_lsm/README.mdx
+++ b/gadgets/trace_lsm/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: trace lsm
+title: trace_lsm
 sidebar_position: 0
 ---
 

--- a/gadgets/trace_malloc/README.mdx
+++ b/gadgets/trace_malloc/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: trace malloc
+title: trace_malloc
 sidebar_position: 0
 ---
 

--- a/gadgets/trace_signal/README.mdx
+++ b/gadgets/trace_signal/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: trace signal
+title: trace_signal
 sidebar_position: 0
 ---
 

--- a/gadgets/trace_ssl/README.mdx
+++ b/gadgets/trace_ssl/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: trace ssl
+title: trace_ssl
 sidebar_position: 0
 ---
 

--- a/pkg/gadgets/audit/seccomp/tracer/gadget.go
+++ b/pkg/gadgets/audit/seccomp/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "seccomp"

--- a/pkg/gadgets/deprecated.go
+++ b/pkg/gadgets/deprecated.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gadgets
+
+type GadgetDeprecated struct{}
+
+func (g *GadgetDeprecated) IsDeprecated() bool {
+	return true
+}

--- a/pkg/gadgets/interface.go
+++ b/pkg/gadgets/interface.go
@@ -159,6 +159,10 @@ type InitCloseGadget interface {
 
 type Gadget any
 
+type GadgetDeprecatedI interface {
+	IsDeprecated() bool
+}
+
 // GadgetInstantiate is the same interface as Gadget but adds one call to instantiate an actual
 // tracer
 type GadgetInstantiate interface {

--- a/pkg/gadgets/profile/block-io/tracer/gadget.go
+++ b/pkg/gadgets/profile/block-io/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -25,7 +29,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "block-io"

--- a/pkg/gadgets/profile/tcprtt/tracer/gadget.go
+++ b/pkg/gadgets/profile/tcprtt/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -38,7 +42,9 @@ const (
 	ParamFilterRemoteAddressV6 = "raddrv6"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcprtt"

--- a/pkg/gadgets/prometheus/tracer/gadget.go
+++ b/pkg/gadgets/prometheus/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -28,7 +32,9 @@ const (
 
 type fakeEvent struct{}
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "prometheus"

--- a/pkg/gadgets/snapshot/process/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/process/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -29,7 +33,9 @@ const (
 	ParamThreads = "threads"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "process"

--- a/pkg/gadgets/snapshot/socket/tracer/gadget.go
+++ b/pkg/gadgets/snapshot/socket/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -30,7 +34,9 @@ const (
 	ParamExtend = "extend"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "socket"

--- a/pkg/gadgets/top/block-io/tracer/gadget.go
+++ b/pkg/gadgets/top/block-io/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "block-io"

--- a/pkg/gadgets/top/file/tracer/gadget.go
+++ b/pkg/gadgets/top/file/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "file"

--- a/pkg/gadgets/top/tcp/tracer/gadget.go
+++ b/pkg/gadgets/top/tcp/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcp"

--- a/pkg/gadgets/trace/bind/tracer/gadget.go
+++ b/pkg/gadgets/trace/bind/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -28,7 +32,9 @@ const (
 	ParamIgnoreErrors = "ignore-errors"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "bind"

--- a/pkg/gadgets/trace/capabilities/tracer/gadget.go
+++ b/pkg/gadgets/trace/capabilities/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -27,7 +31,9 @@ const (
 	ParamUnique    = "unique"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "capabilities"

--- a/pkg/gadgets/trace/dns/tracer/gadget.go
+++ b/pkg/gadgets/trace/dns/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -31,7 +35,9 @@ const (
 	ParamPaths      = "paths"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "dns"

--- a/pkg/gadgets/trace/exec/tracer/gadget.go
+++ b/pkg/gadgets/trace/exec/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -27,7 +31,9 @@ const (
 	ParamIgnoreErrors = "ignore-errors"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "exec"

--- a/pkg/gadgets/trace/fsslower/tracer/gadget.go
+++ b/pkg/gadgets/trace/fsslower/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -29,7 +33,9 @@ const (
 	ParamMinLatency = "min"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "fsslower"

--- a/pkg/gadgets/trace/mount/tracer/gadget.go
+++ b/pkg/gadgets/trace/mount/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "mount"

--- a/pkg/gadgets/trace/oomkill/tracer/gadget.go
+++ b/pkg/gadgets/trace/oomkill/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "oomkill"

--- a/pkg/gadgets/trace/open/tracer/gadget.go
+++ b/pkg/gadgets/trace/open/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -27,7 +31,9 @@ const (
 	ParamPrefixes = "prefixes"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "open"

--- a/pkg/gadgets/trace/signal/tracer/gadget.go
+++ b/pkg/gadgets/trace/signal/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -26,7 +30,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "signal"

--- a/pkg/gadgets/trace/sni/tracer/gadget.go
+++ b/pkg/gadgets/trace/sni/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "sni"

--- a/pkg/gadgets/trace/tcp/tracer/gadget.go
+++ b/pkg/gadgets/trace/tcp/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcp"

--- a/pkg/gadgets/trace/tcpconnect/tracer/gadget.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -27,7 +31,9 @@ const (
 	ParamLatency = "latency"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcpconnect"

--- a/pkg/gadgets/trace/tcpdrop/tracer/gadget.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcpdrop"

--- a/pkg/gadgets/trace/tcpretrans/tracer/gadget.go
+++ b/pkg/gadgets/trace/tcpretrans/tracer/gadget.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracer is deprecated.
+//
+// Deprecated: Switch to image-based gadgets instead. Check
+// https://github.com/inspektor-gadget/inspektor-gadget/tree/main/examples/gadgets
 package tracer
 
 import (
@@ -22,7 +26,9 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/parser"
 )
 
-type GadgetDesc struct{}
+type GadgetDesc struct {
+	gadgets.GadgetDeprecated
+}
 
 func (g *GadgetDesc) Name() string {
 	return "tcpretrans"


### PR DESCRIPTION
- Deprecate built-in gadgets adding a warning when running them 
- Create guide guiding folks to switch from built-in to image-based gadgets

### TODO
- [X] Deprecate also Golang packages (in tracer.go?)
- [X] Make https://www.inspektor-gadget.io/docs/latest/api/golang better (ref #3310) (handled in #3948)
- [X] Add warning in documentation for each gadget?

Fixes #3872