### PR TITLE
kallsyms: implement just in time lookups without allocations

### DIFF
--- a/pkg/gadgets/top/block-io/tracer/tracer.go
+++ b/pkg/gadgets/top/block-io/tracer/tracer.go
@@ -109,11 +109,6 @@ func (t *Tracer) install() error {
 		return fmt.Errorf("loading ebpf spec: %w", err)
 	}
 
-	kernelSymbols, err := kallsyms.NewKAllSyms()
-	if err != nil {
-		return fmt.Errorf("loading kernel symbols: %w", err)
-	}
-
 	// blk_account_io_start and blk_account_io_done were moved in:
 	// 450b7879e345 ("block: move blk_account_io_{start,done} to blk-mq.c")
 	// which was included in kernel 5.17.
@@ -130,7 +125,7 @@ func (t *Tracer) install() error {
 		// which was included in kernel 5.16.
 		// So let's be future proof and check if these symbols do not exist.
 		blkAccountIoStartFunction := "__blk_account_io_start"
-		if !kernelSymbols.SymbolExists(blkAccountIoStartFunction) {
+		if !kallsyms.SymbolExists(blkAccountIoStartFunction) {
 			blkAccountIoStartFunction = "blk_account_io_start"
 		}
 
@@ -151,7 +146,7 @@ func (t *Tracer) install() error {
 	})
 	if err != nil {
 		blkAccountIoDoneFunction := "__blk_account_io_done"
-		if !kernelSymbols.SymbolExists(blkAccountIoDoneFunction) {
+		if !kallsyms.SymbolExists(blkAccountIoDoneFunction) {
 			blkAccountIoDoneFunction = "blk_account_io_done"
 		}
 

--- a/pkg/kallsyms/kallsyms.go
+++ b/pkg/kallsyms/kallsyms.go
@@ -135,11 +135,6 @@ func (k *KAllSyms) LookupByInstructionPointer(ip uint64) string {
 }
 
 // SymbolExists returns true if the given symbol exists in the kernel.
-func (k *KAllSyms) SymbolExists(symbol string) bool {
-	_, ok := k.symbolsMap[symbol]
-	return ok
-}
-
 func SymbolExists(symbol string) bool {
 	_, _, err := KernelSymbolAddress(symbol)
 	return err == nil

--- a/pkg/kallsyms/kallsyms.go
+++ b/pkg/kallsyms/kallsyms.go
@@ -17,6 +17,8 @@ package kallsyms
 
 import (
 	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +30,8 @@ import (
 
 	ebpfutils "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/ebpf"
 )
+
+var ErrAmbiguousKsym = errors.New("multiple kernel symbols with the same name")
 
 type KAllSyms struct {
 	// symbols is a slice of kernel symbols. Order is preserved.
@@ -43,6 +47,10 @@ type kernelSymbol struct {
 }
 
 // NewKAllSyms reads /proc/kallsyms and returns a KAllSyms.
+//
+// It is meant to be used when all the symbols need to be permanently loaded.
+// It comes with a big resource penalty. For looking up only a few symbols, it
+// is more efficient to use SymbolExists or KernelSymbolAddress.
 func NewKAllSyms() (*KAllSyms, error) {
 	file, err := os.Open("/proc/kallsyms")
 	if err != nil {
@@ -130,6 +138,99 @@ func (k *KAllSyms) LookupByInstructionPointer(ip uint64) string {
 func (k *KAllSyms) SymbolExists(symbol string) bool {
 	_, ok := k.symbolsMap[symbol]
 	return ok
+}
+
+func SymbolExists(symbol string) bool {
+	_, _, err := KernelSymbolAddress(symbol)
+	return err == nil
+}
+
+// KernelSymbolAddress looks up a symbol from /proc/kallsyms.
+//
+// symbol: the symbol to lookup
+//
+// Returns the address of the symbol and its module if any
+func KernelSymbolAddress(symbol string) (uint64, string, error) {
+	file, err := os.Open("/proc/kallsyms")
+	if err != nil {
+		return 0, "", err
+	}
+	defer file.Close()
+
+	return kernelSymbolAddressFromReader(file, symbol)
+}
+
+// kernelSymbolAddressFromReader looks up a symbol from the reader.
+//
+// reader: source; it should be in the same file format as /proc/kallsyms
+// symbol: the symbol to lookup
+//
+// Returns the address of the symbol and its module if any
+func kernelSymbolAddressFromReader(r io.Reader, symbol string) (uint64, string, error) {
+	var (
+		count int
+		addr  uint64
+		mod   string
+		err   error
+	)
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		// Lines looks like:
+		// ffffffff906e97e0 T security_bprm_check
+		// ffffffffc1cb5010 T netem_module_init    [sch_netem]
+
+		line := scanner.Bytes()
+		typeIdx := bytes.IndexByte(line, byte(' '))
+		if typeIdx == -1 || typeIdx+1 >= len(line) {
+			return 0, "", fmt.Errorf("parsing line %q: no type", line)
+		}
+		nameIdx := bytes.IndexByte(line[typeIdx+1:], byte(' '))
+		if nameIdx == -1 || typeIdx+1+nameIdx+1 >= len(line) {
+			return 0, "", fmt.Errorf("parsing line %q: no symbol", line)
+		}
+		modIdx := bytes.IndexByte(line[typeIdx+1+nameIdx+1:], byte('\t'))
+		var nameBytes []byte
+		if modIdx == -1 {
+			// no module
+			nameBytes = line[typeIdx+1+nameIdx+1:]
+		} else {
+			// module found
+			nameBytes = line[typeIdx+1+nameIdx+1 : typeIdx+1+nameIdx+1+modIdx]
+		}
+		if !bytes.Equal([]byte(symbol), nameBytes) {
+			continue
+		}
+
+		addr, err = strconv.ParseUint(string(line[:typeIdx]), 16, 64)
+		if err != nil {
+			return 0, "", fmt.Errorf("parsing line %q: invalid address: %w", line, err)
+		}
+		if modIdx != -1 {
+			mod = string(line[typeIdx+1+nameIdx+1+modIdx+1:])
+			mod = strings.Trim(mod, "[]")
+		}
+		count++
+		if count > 1 {
+			break
+		}
+	}
+
+	if err = scanner.Err(); err != nil {
+		return 0, "", fmt.Errorf("reading kallsyms: %w", err)
+	}
+
+	switch count {
+	case 0:
+		return 0, "", os.ErrNotExist
+	case 1:
+		return addr, mod, nil
+	default:
+		// Multiple addresses for a symbol have been found. Like libbpf
+		// and cilium/ebpf, reject referring to ambiguous symbols.
+		return 0, "", fmt.Errorf("symbol %s: duplicate found at address 0x%x: %w",
+			symbol, addr, ErrAmbiguousKsym)
+	}
 }
 
 var (

--- a/pkg/kallsyms/kallsyms_test.go
+++ b/pkg/kallsyms/kallsyms_test.go
@@ -80,3 +80,30 @@ func TestRealKAllSyms(t *testing.T) {
 	// Since we use RequireRoot, it should not happen.
 	require.NotEqual(t, 0, addr, "bpf_prog_fops has a zero address")
 }
+
+// BenchmarkKernelSymbolAddressJITParsing searches for the symbol while
+// reading the kallsyms file
+func BenchmarkKernelSymbolAddressJITParsing(b *testing.B) {
+	utilstest.RequireRoot(b)
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		exists := SymbolExists("security_bprm_check")
+		require.Equal(b, true, exists, "exists")
+	}
+}
+
+// BenchmarkKernelSymbolAddressPreLoading loads the full kallsyms before
+// looking up the symbol
+func BenchmarkKernelSymbolAddressPreLoading(b *testing.B) {
+	utilstest.RequireRoot(b)
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		k, err := NewKAllSyms()
+		require.NoError(b, err)
+		require.NotNil(b, k)
+		exists := k.SymbolExists("security_bprm_check")
+		require.Equal(b, true, exists)
+	}
+}

--- a/pkg/kallsyms/kallsyms_test.go
+++ b/pkg/kallsyms/kallsyms_test.go
@@ -23,11 +23,6 @@ import (
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 )
 
-func resetState() {
-	symbolsMap = map[string]uint64{}
-	triedGetAddr = map[string]error{}
-}
-
 func TestCustomKAllSyms(t *testing.T) {
 	kAllSymsStr := strings.Join([]string{
 		"0000000000000000 A fixed_percpu_data",

--- a/pkg/kallsyms/kallsyms_test.go
+++ b/pkg/kallsyms/kallsyms_test.go
@@ -15,6 +15,7 @@
 package kallsyms
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -23,7 +24,7 @@ import (
 	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
 )
 
-func TestCustomKAllSyms(t *testing.T) {
+func TestCustomKAllSymsInstructionPointer(t *testing.T) {
 	kAllSymsStr := strings.Join([]string{
 		"0000000000000000 A fixed_percpu_data",
 		"ffffffffb4231f40 D bpf_prog_fops",
@@ -33,10 +34,6 @@ func TestCustomKAllSyms(t *testing.T) {
 	kAllSymsReader := strings.NewReader(kAllSymsStr)
 	kAllSyms, err := NewKAllSymsFromReader(kAllSymsReader)
 	require.Nil(t, err, "NewKAllSymsFromReader failed: %v", err)
-	require.True(t, kAllSyms.SymbolExists("bpf_prog_fops"),
-		"SymbolExists should have found bpf_prog_fops")
-	require.False(t, kAllSyms.SymbolExists("abcde_bad_name"),
-		"SymbolExists should not have found abcde_bad_name")
 
 	lookupByInstructionPointerTests := []struct {
 		instructionPointer uint64
@@ -57,23 +54,148 @@ func TestCustomKAllSyms(t *testing.T) {
 	}
 }
 
-func TestRealKAllSyms(t *testing.T) {
+func TestCustomKAllSymsParsing(t *testing.T) {
+	kAllSymsStr := strings.Join([]string{
+		"0000000000000000 A fixed_percpu_data",
+		"ffffffffb4231f40 D bpf_prog_fops",
+		"ffffffffb43723e0 d socket_file_ops",
+		"ffffffff906e97e0 T security_bprm_check",
+		"ffffffffc1b26010 T veth_init	[veth]",
+		"ffffffffc1cb5010 T netem_module_init	[sch_netem]",
+		"",
+	}, "\n")
+
+	tests := []struct {
+		symbol     string
+		expectErr  bool
+		expectAddr uint64
+		expectKmod string
+	}{
+		{
+			symbol:     "bpf_prog_fops",
+			expectErr:  false,
+			expectAddr: 0xffffffffb4231f40,
+			expectKmod: "",
+		},
+		{
+			symbol:     "socket_file_ops",
+			expectErr:  false,
+			expectAddr: 0xffffffffb43723e0,
+			expectKmod: "",
+		},
+		{
+			symbol:     "veth_init",
+			expectErr:  false,
+			expectAddr: 0xffffffffc1b26010,
+			expectKmod: "veth",
+		},
+		{
+			symbol:     "netem_module_init",
+			expectErr:  false,
+			expectAddr: 0xffffffffc1cb5010,
+			expectKmod: "sch_netem",
+		},
+		{
+			symbol:     "abcde_bad_name",
+			expectErr:  true,
+			expectAddr: 0,
+			expectKmod: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.symbol, func(t *testing.T) {
+			r := strings.NewReader(kAllSymsStr)
+			addr, kmod, err := kernelSymbolAddressFromReader(r, test.symbol)
+
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, test.expectAddr, addr, "addr")
+			require.Equal(t, test.expectKmod, kmod, "kmod")
+		})
+	}
+}
+
+func TestRealKAllSymsParsing(t *testing.T) {
+	path := "/proc/kallsyms"
 	utilstest.RequireRoot(t)
-	utilstest.RequireFileContains(t, "/proc/kallsyms", "bpf_prog_fops")
-	utilstest.RequireFileContains(t, "/proc/kallsyms", "socket_file_ops")
+	utilstest.RequireFileContains(t, path, "bpf_prog_fops")
+	utilstest.RequireFileContains(t, path, "socket_file_ops")
 
-	kAllSyms, err := NewKAllSyms()
-	require.Nil(t, err, "NewKAllSyms failed: %v", err)
-	require.True(t, kAllSyms.SymbolExists("bpf_prog_fops"),
-		"SymbolExists should have found bpf_prog_fops")
-	require.False(t, kAllSyms.SymbolExists("abcde_bad_name"),
-		"SymbolExists should not have found abcde_bad_name")
+	type testT struct {
+		name           string
+		symbol         string
+		expectedKmod   string
+		expectedExists bool
+	}
 
-	addr, ok := kAllSyms.symbolsMap["bpf_prog_fops"]
-	require.True(t, ok, "bpf_prog_fops not found in symbolsMap")
-	// /proc/kallsyms contains the address 0 without CAP_SYSLOG.
-	// Since we use RequireRoot, it should not happen.
-	require.NotEqual(t, 0, addr, "bpf_prog_fops has a zero address")
+	tests := []testT{
+		{
+			name:           "simple_symbol1",
+			symbol:         "bpf_prog_fops",
+			expectedKmod:   "",
+			expectedExists: true,
+		},
+		{
+			name:           "simple_symbol2",
+			symbol:         "socket_file_ops",
+			expectedKmod:   "",
+			expectedExists: true,
+		},
+		{
+			name:           "symbol_from_veth_kmod",
+			symbol:         "veth_init",
+			expectedKmod:   "veth",
+			expectedExists: true,
+		},
+		{
+			name:           "symbol_from_netem_kmod",
+			symbol:         "netem_module_init",
+			expectedKmod:   "sch_netem",
+			expectedExists: true,
+		},
+		{
+			name:           "symbol_from_overlay_kmod",
+			symbol:         "ovl_inode_init",
+			expectedKmod:   "overlay",
+			expectedExists: true,
+		},
+		{
+			name:           "nonexistent_symbol",
+			symbol:         "abcde_bad_name",
+			expectedKmod:   "",
+			expectedExists: false,
+		},
+	}
+
+	kallsymsBytes, err := os.ReadFile(path)
+	require.Nil(t, err, "Failed to read %q: %s", path, err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.expectedExists &&
+				test.expectedKmod != "" &&
+				!strings.Contains(string(kallsymsBytes), test.expectedKmod) {
+				t.Skipf("Test requires kernel module %q", test.expectedKmod)
+			}
+
+			require.Equal(t, test.expectedExists, SymbolExists(test.symbol), "exists")
+			addr, kmod, err := KernelSymbolAddress(test.symbol)
+			if test.expectedExists {
+				require.NoError(t, err)
+				require.NotEqual(t, uint64(0), addr, "addr")
+				require.Equal(t, test.expectedKmod, kmod, "kmod")
+			} else {
+				require.Error(t, err)
+				require.Equal(t, uint64(0), addr, "addr")
+				require.Equal(t, "", kmod, "kmod")
+			}
+		})
+	}
 }
 
 // BenchmarkKernelSymbolAddressJITParsing searches for the symbol while

--- a/pkg/kallsyms/kallsyms_test.go
+++ b/pkg/kallsyms/kallsyms_test.go
@@ -220,7 +220,7 @@ func BenchmarkKernelSymbolAddressPreLoading(b *testing.B) {
 		k, err := NewKAllSyms()
 		require.NoError(b, err)
 		require.NotNil(b, k)
-		exists := k.SymbolExists("security_bprm_check")
+		_, exists := k.symbolsMap["security_bprm_check"]
 		require.Equal(b, true, exists)
 	}
 }


### PR DESCRIPTION
# kallsyms: implement just in time lookups without allocations

This implements kernel symbol lookups in /proc/kallsyms without unnecessary dynamic memory allocations.

This is 2x faster and almost completely removes dynamic memory allocations.

```
$ go test -exec=sudo -run=Benchmark -bench=. ./pkg/kallsyms/... -count 1
goos: linux
goarch: amd64
pkg: github.com/inspektor-gadget/inspektor-gadget/pkg/kallsyms
cpu: Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
BenchmarkKernelSymbolAddressJITParsing-4               5         208193754 ns/op            4688 B/op         19 allocs/op
BenchmarkKernelSymbolAddressPreLoading-4               3         425194186 ns/op        105551938 B/op    639608 allocs/op
PASS
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/kallsyms       4.746s
```

Once this PR is merged, I will make use of it in #3871.

## How to use

No changes.

## Testing done

Let's run the CI.
