### PR TITLE
perf/ring buffer: Continue reading in case of errors

### DIFF
--- a/pkg/gadgets/audit/seccomp/tracer/tracer.go
+++ b/pkg/gadgets/audit/seccomp/tracer/tracer.go
@@ -108,9 +108,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/bind/tracer/tracer.go
+++ b/pkg/gadgets/trace/bind/tracer/tracer.go
@@ -223,9 +223,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/capabilities/tracer/tracer.go
+++ b/pkg/gadgets/trace/capabilities/tracer/tracer.go
@@ -234,9 +234,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/exec/tracer/tracer.go
+++ b/pkg/gadgets/trace/exec/tracer/tracer.go
@@ -214,9 +214,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/fsslower/tracer/tracer.go
+++ b/pkg/gadgets/trace/fsslower/tracer/tracer.go
@@ -258,9 +258,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/mount/tracer/tracer.go
+++ b/pkg/gadgets/trace/mount/tracer/tracer.go
@@ -141,9 +141,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/oomkill/tracer/tracer.go
+++ b/pkg/gadgets/trace/oomkill/tracer/tracer.go
@@ -118,9 +118,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		bpfEvent := (*oomkillDataT)(unsafe.Pointer(&record.RawSample[0]))

--- a/pkg/gadgets/trace/open/tracer/tracer.go
+++ b/pkg/gadgets/trace/open/tracer/tracer.go
@@ -206,9 +206,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/signal/tracer/tracer.go
+++ b/pkg/gadgets/trace/signal/tracer/tracer.go
@@ -191,9 +191,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/tcp/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcp/tracer/tracer.go
@@ -165,9 +165,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpconnect/tracer/tracer.go
@@ -162,9 +162,9 @@ func (t *Tracer) run() {
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpdrop/tracer/tracer.go
@@ -165,8 +165,8 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
+++ b/pkg/gadgets/trace/tcpretrans/tracer/tracer.go
@@ -144,8 +144,8 @@ func (t *Tracer) run() {
 			}
 
 			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
-			t.eventCallback(types.Base(eventtypes.Err(msg)))
-			return
+			t.eventCallback(types.Base(eventtypes.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples > 0 {

--- a/pkg/networktracer/tracer.go
+++ b/pkg/networktracer/tracer.go
@@ -326,9 +326,9 @@ func (t *Tracer[Event]) listen(
 				return
 			}
 
-			msg := fmt.Sprintf("Error reading perf ring buffer: %s", err)
-			t.eventHandler(baseEvent(types.Err(msg)))
-			return
+			msg := fmt.Sprintf("reading perf ring buffer: %s", err)
+			t.eventHandler(baseEvent(types.Warn(msg)))
+			continue
 		}
 
 		if record.LostSamples != 0 {


### PR DESCRIPTION
As discussed in https://github.com/cilium/ebpf/issues/1633 we should continue reading the perf ring buffer in case of errors. Some examples from cilium/ebpf repository:
- https://github.com/cilium/ebpf/blob/main/examples/uretprobe/main.go#L96-L97
- https://github.com/cilium/ebpf/blob/9f201154004369b0bc1b99a06ee578aa46c6aab4/examples/fentry/main.go#L89-L90