### PR TITLE
 Added tests under pkg/oci/

### DIFF
--- a/pkg/oci/retry_test.go
+++ b/pkg/oci/retry_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRetry(t *testing.T) {
+	permanentErr := errors.New("permanent error")
+
+	testCases := []struct {
+		name          string
+		mockFn        func(*int) error
+		expectedErr   error
+		expectedCalls int
+	}{
+		{
+			name: "success on first call",
+			mockFn: func(calls *int) error {
+				*calls++
+				return nil
+			},
+			expectedErr:   nil,
+			expectedCalls: 1,
+		},
+		{
+			name: "permanent error on first call",
+			mockFn: func(calls *int) error {
+				*calls++
+				return permanentErr
+			},
+			expectedErr:   permanentErr,
+			expectedCalls: 1,
+		},
+		{
+			name: "succeeds after three retries",
+			mockFn: func(calls *int) error {
+				*calls++
+				if *calls <= 3 {
+					return errRetry
+				}
+				return nil
+			},
+			expectedErr:   nil,
+			expectedCalls: 4,
+		},
+		{
+			name: "exceeds retry limit",
+			mockFn: func(calls *int) error {
+				*calls++
+				return errRetry
+			},
+			expectedErr:   ErrRetryLimitExceeded,
+			expectedCalls: retryLimit,
+		},
+		{
+			name: "mixed retry and permanent error",
+			mockFn: func(calls *int) error {
+				*calls++
+				if *calls == 1 {
+					return errRetry
+				}
+				return permanentErr
+			},
+			expectedErr:   permanentErr,
+			expectedCalls: 2,
+		},
+		{
+			name: "succeeds on last attempt",
+			mockFn: func(calls *int) error {
+				*calls++
+				if *calls < retryLimit {
+					return errRetry
+				}
+				return nil
+			},
+			expectedErr:   nil,
+			expectedCalls: retryLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			err := retry(tc.name, func() error {
+				return tc.mockFn(&calls)
+			})
+
+			if tc.expectedErr != nil {
+				if !errors.Is(err, tc.expectedErr) {
+					t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			}
+
+			if calls != tc.expectedCalls {
+				t.Errorf("expected %d calls, got %d", tc.expectedCalls, calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Add unit tests for retry logic in OCI package

This PR introduces unit tests for the retry logic in the `oci` package. The tests cover various scenarios, including immediate success, permanent errors, retrying up to a success threshold, exceeding retry limits, and a mix of retriable and permanent errors. These test cases ensure the robustness of the retry mechanism by validating expected outcomes under different failure and success conditions.

## How to use

Reviewers can validate this PR by running the unit tests using the standard Go test framework. The tests cover multiple edge cases, ensuring correct retry behavior. Please verify that all test cases pass and that the retry logic behaves as expected.

## Testing done


```
=== RUN   TestRetry
=== RUN   TestRetry/success_on_first_call
=== RUN   TestRetry/permanent_error_on_first_call
=== RUN   TestRetry/succeeds_after_three_retries
=== RUN   TestRetry/exceeds_retry_limit
=== RUN   TestRetry/mixed_retry_and_permanent_error
=== RUN   TestRetry/succeeds_on_last_attempt
--- PASS: TestRetry (21.52s)
    --- PASS: TestRetry/success_on_first_call (0.00s)
    --- PASS: TestRetry/permanent_error_on_first_call (0.00s)
    --- PASS: TestRetry/succeeds_after_three_retries (1.50s)
    --- PASS: TestRetry/exceeds_retry_limit (10.01s)
    --- PASS: TestRetry/mixed_retry_and_permanent_error (0.50s)
    --- PASS: TestRetry/succeeds_on_last_attempt (9.51s)

PASS
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/oci    21.874s
```
