### PR TITLE
feat: added gitinfo and compiler info for kubectl-gadget version field

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,6 +17,8 @@
 package version
 
 import (
+	"fmt"
+	"runtime"
 	"github.com/blang/semver"
 )
 
@@ -32,4 +34,18 @@ func init() {
 
 func Version() semver.Version {
 	return parsedVersion
+}
+
+func GetMajorMinorVersion() (string, string) {
+    return fmt.Sprintf("%d", parsedVersion.Major), 
+           fmt.Sprintf("%d", parsedVersion.Minor)
+}
+
+func GetVersionDetails() map[string]string {
+    return map[string]string{
+        "gitVersion": version,
+        "goVersion": runtime.Version(),
+        "compiler":  runtime.Compiler,
+        "platform":  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+    }
 }


### PR DESCRIPTION
Added the gitinfo and compiler info for kubectl-gadget version field



## How to use

by running the cli


## Testing done

![image](https://github.com/user-attachments/assets/e1fa5682-ba36-4229-8196-73fd4f24dae2)

Related to #2565 
