### PR TITLE
[Tests]: Add unit tests for runtime.go in pkg/runtime

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,0 +1,60 @@
+// Copyright 2022-2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCombinedGadgetResult(t *testing.T) {
+	t.Run("empty result", func(t *testing.T) {
+		r := make(CombinedGadgetResult)
+		require.NoError(t, r.Err())
+	})
+
+	t.Run("result with errors", func(t *testing.T) {
+		err1 := errors.New("error1")
+		err2 := errors.New("error2")
+		r := CombinedGadgetResult{
+			"node1": &GadgetResult{Error: err1},
+			"node2": &GadgetResult{Error: err2},
+		}
+
+		combinedErr := r.Err()
+		require.Error(t, combinedErr)
+
+		// Test error unwrapping
+		ce := &combinedErrors{}
+		if errors.As(combinedErr, &ce) {
+			errs := ce.Unwrap()
+			require.Contains(t, errs, err1)
+			require.Contains(t, errs, err2)
+		}
+	})
+}
+
+func TestCombinedErrors(t *testing.T) {
+	t.Run("error string formatting", func(t *testing.T) {
+		errs := []error{
+			errors.New("error1"),
+			errors.New("error2"),
+		}
+		ce := &combinedErrors{errs: errs}
+		require.Equal(t, "error1\nerror2", ce.Error())
+	})
+}


### PR DESCRIPTION
# [Feat] Add Unit Tests for runtime.go Error Handling

This PR adds comprehensive unit tests for error handling in `runtime.go`, focusing on the `CombinedGadgetResult` and `combinedErrors` types. The tests ensure proper error aggregation, formatting, and unwrapping functionality across different scenarios.

## How to use

Reviewers can validate this PR by:
1. Running the unit tests:
```bash
go test ./pkg/runtime -v -coverprofile=coverage.out
```

2. Examining the coverage report:
```bash
go tool cover -html=coverage.out
```

## Testing done

Added test cases covering:
```bash
=== RUN   TestCombinedGadgetResult
=== RUN   TestCombinedGadgetResult/empty_result
=== RUN   TestCombinedGadgetResult/result_with_errors
--- PASS: TestCombinedGadgetResult (0.00s)
    --- PASS: TestCombinedGadgetResult/empty_result (0.00s)
    --- PASS: TestCombinedGadgetResult/result_with_errors (0.00s)
=== RUN   TestCombinedErrors
=== RUN   TestCombinedErrors/error_string_formatting
--- PASS: TestCombinedErrors (0.00s)
    --- PASS: TestCombinedErrors/error_string_formatting (0.00s)
PASS
 
```

## Screenshots

 
![Screenshot from 2025-02-03 15-01-59](https://github.com/user-attachments/assets/fccca9a8-0ac6-4d76-a64b-b6cebe41e838)

This PR contributes to #3835 by improving test coverage in the pkg/runtime directory. The added tests help ensure reliable error handling and improve code maintainability.
 