### PR TITLE
docs: Add missing symbolic link for _gadgets

### DIFF
--- a/docs/api/_gadgets
+++ b/docs/api/_gadgets
@@ -1,0 +1,1 @@
+../../examples/gadgets/


### PR DESCRIPTION
This is needed to embeed the examples in the API documentation.

Fixes: 07141dcc5f2f ("docs/api: Improve Golang API documentation")

--- 

Ideally we should be able to include the file from the examples repository, but I wasn't able to make it work...
