### PR TITLE
trace_exec, trace_dns: remove dynamic allocations from wasm module

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -284,7 +284,7 @@ Return value:
 
 #### `fieldGet(u32 field, u32 data, u32 kind) u64`
 
-Get the value of a field.
+Get the value of a field into a newly allocated buffer.
 
 Parameters:
 - `field` (u32): Field handle (as returned by `dataSourceGetField` or `dataSourceAddField`)
@@ -304,6 +304,18 @@ Return value:
   reference implementation, you don't have to call free.
   - The function returns 0 in case of errors (ambiguous with scalar types like u32).
   TODO: Find a way to report errors!
+
+#### `fieldGetToBuffer(u32 field, u32 data, u32 kind, u64 dst) u32`
+
+Get the value of a field of type String or Bytes into an existing buffer.
+
+Parameters:
+- `field` (u32): Field handle (as returned by `dataSourceGetField` or `dataSourceAddField`)
+- `data` (u32): Data handle
+- `kind` (u32): Kind of access: How to read the field.
+
+Return value:
+- Value of the field: the number of bytes copied or 0 in case of errors.
 
 #### `fieldSet(u32 field, u32 data, u32 kind, u64 value)`
 

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -17,7 +17,10 @@
 
 #define ARGSIZE 256
 #define TOTAL_MAX_ARGS 20
+
+// Keep in sync with fullMaxArgsArr in program.go
 #define FULL_MAX_ARGS_ARR (TOTAL_MAX_ARGS * ARGSIZE)
+
 #define BASE_EVENT_SIZE (size_t)(&((struct event *)0)->args)
 #define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)

--- a/wasmapi/go/fields.go
+++ b/wasmapi/go/fields.go
@@ -23,6 +23,9 @@ import (
 //go:wasmimport env fieldGet
 func fieldGet(field uint32, data uint32, kind uint32) uint64
 
+//go:wasmimport env fieldGetToBuffer
+func fieldGetToBuffer(field uint32, data uint32, kind uint32, dst uint64) uint32
+
 //go:wasmimport env fieldSet
 func fieldSet(field uint32, data uint32, kind uint32, value uint64) uint32
 
@@ -177,11 +180,18 @@ func (f Field) SetString(data Data, str string) error {
 	return nil
 }
 
+// Bytes get the bytes of a field of any type into a newly allocated slice.
 func (f Field) Bytes(data Data) ([]byte, error) {
 	buf := bufPtr(fieldGet(uint32(f), uint32(data), uint32(Kind_Bytes)))
 	ret := buf.bytes()
 	buf.free()
 	return ret, nil
+}
+
+// BytesToSlice get the bytes of a field of type string or []byte into an
+// existing slice. It returns the number of bytes copied.
+func (f Field) BytesToSlice(data Data, dst []byte) uint32 {
+	return fieldGetToBuffer(uint32(f), uint32(data), uint32(Kind_Bytes), uint64(bytesToBufPtr(dst)))
 }
 
 func (f Field) SetBytes(data Data, buf []byte) error {


### PR DESCRIPTION
# wasmapi: implement Field.BytesToSlice without dynamic allocations

Profiling of the wasm modules in the trace_exec and trace_dns gadgets revealed that more than 95% of the cpu time is spent in dynamic allocations done by the `Field.Bytes()` helper from the wasm API. See profiling in #3992.

This patch introduces an alternative way to get the bytes of a field without dynamic allocations for fields of type `string` or `[]byte`:
- `Field.BytesToSlice()` (wasm go API)
- `fieldGetToBuffer()` (underlying wasm helper)

## How to use

No changes

## Testing done

See profiling in #3992.

```
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_exec:alban_fieldGet --verify-image=false
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_dns:alban_fieldGet --verify-image=false 
```

cc @mqasimsarfraz 