### PR TITLE
ci: Update unit test kernel versions

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -752,8 +752,8 @@ jobs:
   analyze-ig-memory:
     name: IG memory analysis with pprof
     runs-on: ubuntu-latest
-    needs: 
-      - build-ig 
+    needs:
+      - build-ig
       - build-and-push-gadgets
     steps:
       - name: Set up Go
@@ -798,7 +798,7 @@ jobs:
             awk 'NR > 6 { printf "| %s | %s | %s | %s | %s | %s |\n", $1, $2, $3, $4, $5, $6 }' $file | tee -a $GITHUB_STEP_SUMMARY
             echo '' | tee -a $GITHUB_STEP_SUMMARY
           done
-          
+
   scan-gadget-container-images:
     name: Scan gadget img
     # level: 2
@@ -1580,8 +1580,8 @@ jobs:
       fail-fast: false
       matrix:
         kernel:
-          - "6.8"
-          - "6.7"
+          - "6.11"
+          - "6.10"
           - "6.6"
           - "6.1"
           - "5.15"


### PR DESCRIPTION
Follow versions used in https://github.com/cilium/ci-kernels/

These are the new versions pushed on https://github.com/mauriciovasquezbernal/ci-kernels/actions/runs/13205395012.