### PR TITLE
[Tests]: unit test for pkg/utils/netns

### DIFF
--- a/pkg/utils/netns/netns_test.go
+++ b/pkg/utils/netns/netns_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFromPidWithAltProcfs(t *testing.T) {
+	tests := []struct {
+		name          string
+		pid           int
+		procfs        string
+		expectSuccess bool
+	}{
+		{
+			name:          "getting network namespace from pid with alt procfs",
+			pid:           1,
+			procfs:        "/proc",
+			expectSuccess: true,
+		},
+		{
+			name:          `getting network namespace from pid with alt procfs`,
+			pid:           1,
+			procfs:        "/procfs",
+			expectSuccess: true,
+		},
+		{
+			name:          "error",
+			pid:           2,
+			procfs:        "/procdf",
+			expectSuccess: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, err := GetFromPidWithAltProcfs(test.pid, test.procfs)
+			if test.expectSuccess {
+				assert.GreaterOrEqual(t, int(ns), 0)
+				assert.NoError(t, err)
+			} else {
+				assert.Less(t, int(ns), 0)
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestGetFromThreadWithAltProcfs(t *testing.T) {
+	tests := []struct {
+		name          string
+		pid           int
+		tid           int
+		procfs        string
+		expectSuccess bool
+	}{
+		{
+			name:          "getting network namespace from thread with alt procfs",
+			pid:           1,
+			tid:           1,
+			procfs:        "/proc",
+			expectSuccess: true,
+		},
+		{
+			name:          `getting network namespace from thread with alt procfs`,
+			pid:           1,
+			tid:           1,
+			procfs:        "/procfs",
+			expectSuccess: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, err := GetFromThreadWithAltProcfs(test.pid, test.tid, test.procfs)
+			if test.expectSuccess {
+				assert.GreaterOrEqual(t, int(ns), 0)
+				assert.NoError(t, err)
+			} else {
+				assert.Less(t, int(ns), 0, "Expected an invalid namespace handle")
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# [Tests]: Unit Test case for pkg/utils/netns

[ describe the change in 1 - 3 paragraphs ]
In this i have added unit test case for the directory pkg/utils/netns. It has two functions ``TestGetFromPidWithAltProcfs`` and ``TestGetFromThreadWithAltProcfs``. Each Test functions have multiple scenerios for ``procfs`` if it is present or not. 
which is then compared later while running ``test cases``. 

While writing test cases i got stuck into a problem in which the ``netns.NsHandle's`` value was giving me different output when i am running test cases by using ``go test ./....`` and ``go test -coverprofile=c.out``. To ensure test cases work properly i compare ``netns.NetHandle`` by checking if they are positive or not.



## How to use
**To check the test**

Note: If you are linux user pls run ``sudo`` before command as it will give ``permission denied`` error

```
go test ./... -v
```
**For getting test coverage of each functions**
```
go test ./... coverprofile=c.out
go tool cover -func=c.out
```



## Testing done
```
=== RUN   TestGetFromPidWithAltProcfs
=== RUN   TestGetFromPidWithAltProcfs/getting_network_namespace_from_pid_with_alt_procfs
=== RUN   TestGetFromPidWithAltProcfs/getting_network_namespace_from_pid_with_alt_procfs#01
=== RUN   TestGetFromPidWithAltProcfs/error
--- PASS: TestGetFromPidWithAltProcfs (0.00s)
    --- PASS: TestGetFromPidWithAltProcfs/getting_network_namespace_from_pid_with_alt_procfs (0.00s)
    --- PASS: TestGetFromPidWithAltProcfs/getting_network_namespace_from_pid_with_alt_procfs#01 (0.00s)
    --- PASS: TestGetFromPidWithAltProcfs/error (0.00s)
=== RUN   TestGetFromThreadWithAltProcfs
=== RUN   TestGetFromThreadWithAltProcfs/getting_network_namespace_from_thread_with_alt_procfs
=== RUN   TestGetFromThreadWithAltProcfs/getting_network_namespace_from_thread_with_alt_procfs#01
--- PASS: TestGetFromThreadWithAltProcfs (0.00s)
    --- PASS: TestGetFromThreadWithAltProcfs/getting_network_namespace_from_thread_with_alt_procfs (0.00s)
    --- PASS: TestGetFromThreadWithAltProcfs/getting_network_namespace_from_thread_with_alt_procfs#01 (0.00s)
PASS
coverage: 100.0% of statements
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/utils/netns    0.003s  coverage: 100.0% of statements
````
