### PR TITLE
[Tests]: Unit Test for pkg/utils/protocols

### DIFF
--- a/pkg/utils/protocols/protocols_test.go
+++ b/pkg/utils/protocols/protocols_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package protocols
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProtocolNameByNumber(t *testing.T) {
+	protocols := []struct {
+		description string
+		number      int
+		name        string
+		ok          bool
+	}{
+		{
+			description: "TCP was found",
+			number:      6,
+			name:        "TCP",
+			ok:          true,
+		},
+		{
+			description: "SCTP was found",
+			number:      132,
+			name:        "SCTP",
+			ok:          true,
+		},
+		{
+			description: "number was not found",
+			number:      999,
+			name:        "",
+			ok:          false,
+		},
+		{
+			description: "number was not found",
+			number:      -1,
+			name:        "",
+			ok:          false,
+		},
+	}
+
+	for _, protocol := range protocols {
+		t.Run(protocol.description, func(t *testing.T) {
+			name, ok := GetProtocolNameByNumber(protocol.number)
+			assert.Equal(t, protocol.name, name)
+			assert.Equal(t, protocol.ok, ok)
+		})
+	}
+}


### PR DESCRIPTION
# [Test]: Unit Test of pkg/utils/protocols
Fixes #3835
This Test ``GetProtocolNameFromNumber``. It has Two cases :- 
1. If number was found in ``protoNumberToName = map[int]string``. It will give true and Name of protocol
2.  If number was found in ``protoNumberToName = map[int]string``. It will give false and empty array


## How to use
Run
```
go test  ./... -v
```

## Testing done
```
=== RUN   TestGetProtocolNameByNumber
=== RUN   TestGetProtocolNameByNumber/number_was_found
=== RUN   TestGetProtocolNameByNumber/number_was_not_found
--- PASS: TestGetProtocolNameByNumber (0.00s)
    --- PASS: TestGetProtocolNameByNumber/number_was_found (0.00s)
    --- PASS: TestGetProtocolNameByNumber/number_was_not_found (0.00s)
PASS
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/utils/protocols        0.002s
```

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
