### PR TITLE
pkg/operators: Simplify perf buffer testing.

### DIFF
--- a/pkg/operators/wasm/testdata/perf/program.bpf.c
+++ b/pkg/operators/wasm/testdata/perf/program.bpf.c
@@ -14,7 +14,8 @@ struct {
 	__uint(value_size, sizeof(__u32));
 } events SEC(".maps");
 
-static __always_inline int trace_enter(struct syscall_trace_enter *ctx)
+SEC("tracepoint/syscalls/sys_enter_write")
+int test_write_e(struct syscall_trace_enter *ctx)
 {
 	struct event event = { .a = 42, .b = 42, .c = 43 };
 
@@ -22,20 +23,6 @@ static __always_inline int trace_enter(struct syscall_trace_enter *ctx)
 			      sizeof(event));
 
 	return 0;
-}
-
-#ifndef __TARGET_ARCH_arm64
-SEC("tracepoint/syscalls/sys_enter_open")
-int test_open_e(struct syscall_trace_enter *ctx)
-{
-	return trace_enter(ctx);
-}
-#endif /* !__TARGET_ARCH_arm64 */
-
-SEC("tracepoint/syscalls/sys_enter_openat")
-int test_openat_e(struct syscall_trace_enter *ctx)
-{
-	return trace_enter(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/operators/wasm/testdata/perf/program.go
+++ b/pkg/operators/wasm/testdata/perf/program.go
@@ -54,6 +54,11 @@ func gadgetStart() int32 {
 		return 1
 	}
 
+	for range 10 {
+		// Let's generate some events by calling indirectly the write() syscall.
+		api.Infof("testing perf array")
+	}
+
 	err = perfReader.Pause()
 	if err != nil {
 		api.Errorf("pausing perf reader")

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -17,7 +17,6 @@ package wasm_test
 import (
 	"context"
 	"fmt"
-	"syscall"
 	"testing"
 	"time"
 
@@ -638,26 +637,10 @@ func TestPerf(t *testing.T) {
 	require.NoError(t, err, "runtime init")
 	t.Cleanup(func() { runtime.Close() })
 
-	stop := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				// Generate events to fill the perf buffer.
-				fd, err := syscall.Creat("/tmp/test-perf-array", 0)
-				require.NoError(t, err, "opening file to generate gadget events")
-				syscall.Close(fd)
-			}
-		}
-	}()
-
 	params := map[string]string{
 		"operator.oci.verify-image": "false",
 	}
 	err = runtime.RunGadget(gadgetCtx, nil, params)
-	stop <- true
 	require.NoError(t, err, "running gadget")
 }
 


### PR DESCRIPTION
    We now generate the events in guest instead of generating them in host.
    This avoid having timing issues and flakyness.
    
    Fixes: 7386530c3378 ("operators/wasm: Add functions to interact with perf buffer.")