### PR TITLE
Add warning if gadget is run with a different IG version

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -33,3 +33,7 @@ func init() {
 func Version() semver.Version {
 	return parsedVersion
 }
+
+func VersionString() string {
+	return version
+}

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -33,6 +33,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
 )
 
@@ -48,6 +49,10 @@ const (
 	wasmObjectMediaType = "application/vnd.gadget.wasm.program.v1+binary"
 	btfgenMediaType     = "application/vnd.gadget.btfgen.v1+binary"
 	metadataMediaType   = "application/vnd.gadget.config.v1+yaml"
+)
+
+const (
+	builderVersionAnnotation = "io.inspektor-gadget.builder.version"
 )
 
 type ObjectPath struct {
@@ -181,6 +186,7 @@ func annotationsFromMetadata(metadataBytes []byte) (map[string]string, error) {
 		ocispec.AnnotationURL:           metadata.HomepageURL,
 		ocispec.AnnotationDocumentation: metadata.DocumentationURL,
 		ocispec.AnnotationSource:        metadata.SourceURL,
+		builderVersionAnnotation:        version.VersionString(),
 	}
 
 	for k, v := range metadata.Annotations {


### PR DESCRIPTION
Ideally Inspektor Gagget should allow running gadgets built with different ig versions. However, we haven't been able to implement this feature. To avoid user confusion, print a warning if the gadget is run with a different version of IG than the one it was built with.

### Testing 

1. Compile ig with a fake 0.98.0 version

```bash 
$ make VERSION=v0.98.0 
```

2. Build any gadget using this verison

```bash 
$ sudo ig image build . -t hello-world
```

3. Run the gadget

```bash 
$ sudo ig run hello-world --verify-image=false
WARN[0000] image signature verification is disabled due to using corresponding option
WARN[0000] image signature verification is disabled due to using corresponding option
RUNTIME.CONTAINERNAME                      PID COMM             FILENAME
```

No warning is printed on this case 

4. Compile a fake 0.99.0 version of ig 

```bash 
$ make VERSION=v0.99.0 ig
```

5. Run the gadget again 

```bash 
$ sudo ig run hello-world --verify-image=false
WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] This gadget was built with ig v0.98.0 and it's being run with v0.99.0. Gadget could be incompatible
WARN[0001] image signature verification is disabled due to using corresponding option
WARN[0001] This gadget was built with ig v0.98.0 and it's being run with v0.99.0. Gadget could be incompatible
RUNTIME.CONTAINERNAME                      PID COMM             FILENAME
```

The warning is now printed.

