### PR TITLE
Updated trace_open gadget description and added use cases (#4030)

### DIFF
--- a/docs/gadgets/trace_open.mdx
+++ b/docs/gadgets/trace_open.mdx
@@ -1,1 +1,26 @@
-../../gadgets/trace_open/README.mdx
+# trace_open
+
+## Description
+The `trace_open` gadget monitors and logs which processes open specific files. It helps security teams, DevOps engineers, and system administrators track file access in real time.
+
+## Use Cases
+### 🔹 **Security Monitoring**
+- Detect unauthorized access to critical system files (e.g., `/etc/shadow`, `/var/log/auth.log`).
+- Identify potential data exfiltration attempts.
+
+### 🔹 **Malware Detection**
+- Catch cryptojacking scripts dropping malicious binaries into directories.
+- Detect ransomware attempting to encrypt user files.
+
+### 🔹 **Compliance Auditing**
+- Ensure sensitive files are accessed only by authorized applications.
+- Help organizations meet security compliance requirements (e.g., **GDPR, HIPAA, PCI DSS**).
+
+### 🔹 **Debugging & Troubleshooting**
+- Debug application errors caused by missing or restricted files.
+- Investigate unexpected file access patterns.
+
+## Examples
+To run the `trace_open` gadget and monitor file access:
+```bash
+kubectl gadget trace open


### PR DESCRIPTION
## Description
This PR updates the documentation for the `trace_open` gadget by:
- Improving the description to clearly explain what the gadget does.
- Adding real-world use cases, including security monitoring, malware detection, compliance auditing, and debugging.
- Including an example command for using `trace_open`.

These changes will help users better understand how to utilize the `trace_open` gadget for observability and security.

## How to use
Reviewers can validate this PR by:
1. Checking the updated `docs/gadgets/trace_open.mdx` file.
2. Ensuring the description and use cases are clear, accurate, and well-structured.
3. Running the following command to confirm that `trace_open` behaves as expected:
   ```bash
   kubectl gadget trace open
