### PR TITLE
pkg/gadget-service/api-helpers: Set default values for unset params

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -49,7 +49,13 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
-		err := apihelpers.Validate(globalParams, opParamValues)
+		// Ensure all params are present
+		err := apihelpers.NormalizeWithDefaults(instanceParams, opParamValues)
+		if err != nil {
+			return nil, fmt.Errorf("normalizing instance params for operator %q: %w", op.Name(), err)
+		}
+
+		err = apihelpers.Validate(globalParams, opParamValues)
 		if err != nil {
 			return nil, fmt.Errorf("validating global params for operator %q: %w", op.Name(), err)
 		}

--- a/pkg/gadget-service/api-helpers/apihelpers.go
+++ b/pkg/gadget-service/api-helpers/apihelpers.go
@@ -71,6 +71,16 @@ func ToParamDescs(p api.Params) params.ParamDescs {
 	return res
 }
 
+// NormalizeWithDefaults sets the default value for parameters that are not set
+func NormalizeWithDefaults(p api.Params, v api.ParamValues) error {
+	for _, param := range p {
+		if _, ok := v[param.Key]; !ok {
+			v[param.Key] = param.DefaultValue
+		}
+	}
+	return nil
+}
+
 func Validate(p api.Params, v api.ParamValues) error {
 	for _, param := range p {
 		if v[param.Key] == "" {

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -98,10 +98,11 @@ func (o *ociHandler) GlobalParams() api.Params {
 			TypeHint:    api.TypeStringSlice,
 		},
 		{
-			Key:         disallowPulling,
-			Title:       "Disallow pulling",
-			Description: "Disallow pulling gadgets from registries",
-			TypeHint:    api.TypeBool,
+			Key:          disallowPulling,
+			Title:        "Disallow pulling",
+			Description:  "Disallow pulling gadgets from registries",
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
 		},
 		{
 			Key:          authfileParam,


### PR DESCRIPTION
# Set default values for unset params

## Current situation

`InstantiateDataOperator` is called in three different situations:

- **Using the CLI**: The operators are instantiated twice with different parameters values, which creates two cases:

  - Case 1: During the `GetGadgetInfo` call, operators are instantiated without parameters (`api.ParamValues` is empty)
  - Case 2: During the `RunGadget` call, operators are instantiated with parameters (`api.ParamValues` contains all the operator's parameters with the values set by the user or the default value thanks to cobra/viper package in the CLI). 

- **Using the Go API**: 

  - Case 3: Operators are instantiated only once during the `RunGadget` call and it is done only with the parameters passed by the caller. An example is the GadgetRunner for the unit-tests:

https://github.com/inspektor-gadget/inspektor-gadget/blob/e90d457e4dd6d649f2077dc80b5bd05313bd0f81/pkg/testing/gadgetrunner/gadgetrunner.go#L192

This causes that **each** operator needs to implement a logic to deal with these three cases:

- Case 1: The `InstantiateDataOperator` needs to decide whether the operator has to be instantiated or not based on the data sources characteristics but ignoring the params (they are not present in `api.ParamValues`).
- Case 2: The `InstantiateDataOperator` needs to make the same analysis of case 1 but taking into account the parameters (they are all present).
- Case 3: The `InstantiateDataOperator` needs to make the same analysis of case 1 but taking into account the parameters (some of them might not be present).

Here two examples:

https://github.com/inspektor-gadget/inspektor-gadget/blob/e90d457e4dd6d649f2077dc80b5bd05313bd0f81/pkg/operators/limiter/limiter.go#L67-L80

https://github.com/inspektor-gadget/inspektor-gadget/blob/4d0d32998539152e1156ce3a2cf5fafa15c61cea/pkg/operators/ebpf/stats.go#L106-L124

## Proposal

This PR proposes ensuring that every time `InstantiateDataOperator` is called, `api.ParamValues` contains all the operator's parameters with the value users set or their default value. Doing so, we remain only with the **Case 2**.

Implementation: Given that `InstantiateDataOperator` is always called by `initAndPrepareOperators` in the gadget-context, no matter it is from the CLI or the Go API, we can ensure there the presence of all the parameters.