### PR TITLE
gadgets: Update url of ci-kernels

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -5,8 +5,7 @@ ROOT_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
-# currently use mauriciovasquezbernal/ci-kernels as default
-KERNEL_REPOSITORY ?= ghcr.io/mauriciovasquezbernal/ci-kernels
+KERNEL_REPOSITORY ?= ghcr.io/inspektor-gadget/ci-kernels
 IG ?= ig
 KUBECTL_GADGET ?= kubectl-gadget
 IG_RUNTIME ?= docker


### PR DESCRIPTION
The repository was transferred to the inspektor-gadget org.


