### PR TITLE
trace_exec: reduce maps size

### DIFF
--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -79,14 +79,14 @@ static const struct event empty_event = {};
 // - tracepoint/syscalls/sys_exit_execve is always called
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 10240);
+	__uint(max_entries, 1024);
 	__type(key, pid_t);
 	__type(value, struct event);
 } execs SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 10240);
+	__uint(max_entries, 1024);
 	__type(key, pid_t);
 	__type(value, __u8);
 } security_bprm_hit_map SEC(".maps");


### PR DESCRIPTION
# Reduce Memory Usage in `trace_exec` Gadget

This resolves issue #4057.

This PR changes the eBPF maps in the `trace_exec` gadget from `BPF_MAP_TYPE_HASH` to `BPF_MAP_TYPE_PERCPU_HASH` and reduces their max_entries from `10240` to `1`. These modifications aim to lower memory usage by drastically shrinking the size of each map, which can help in resource-constrained environments or when the data stored in these maps is minimal.

## How to use
```
 sudo -E ig image build $IG_SOURCE_PATH/gadgets/trace_exec -t trace_exec
 sudo -E ig run trace_exec:latest --host --verify-image=false
```

## Testing done
Built `ig` cli and the gadget program locally on a Linux environment with kernel version 6.8. I was able to successfully star the gadget using `ig run` (as described above):
<img width="751" alt="image" src="https://github.com/user-attachments/assets/1074861c-c0b5-4852-b722-f76931195682" />

I wrote a "benchmarking" program that calls `execve("/bin/true", args, envp);` to test exec contention. The benchmarking program executed 10K calls from multiple threads from all available CPUs. I observed contention at 8 threads - thus setting the `max_entries` to 8 which resulted at no loss.

In addition, observing the memory using `ig top ebpf` showing the map memory is at 3MB~.
