### PR TITLE
fsnotify: reduce map size

### DIFF
--- a/gadgets/fsnotify/program.bpf.c
+++ b/gadgets/fsnotify/program.bpf.c
@@ -154,7 +154,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, void *); // struct fsnotify_event *event
 	__type(value, struct enriched_event);
-	__uint(max_entries, 10240);
+	__uint(max_entries, 1024);
 } enriched_fsnotify_events SEC(".maps");
 
 const volatile u64 tracer_group = 0;


### PR DESCRIPTION
Reduce max_entries of enriched_fsnotify_events map from 10240 to 1024. This reduces the size from 42 MiB to 4 MiB.

Part of #4069

## How to use

No changes.

## Testing done

Before:
```
$ sudo bpftool map show -j | jq -r '.[] | {id: .id, type: .type, name: .name, bytes_memlock: .bytes_memlock, comms: (if .pids then (.pids | map(.comm) | unique | join(",")) else "" end)} | [.id, .type, .name, .bytes_memlock, .comms] | @tsv' | sort -k4n | column -t -s $'\t'|grep ig
19598  hash          ig_fa_pick_ctx   6368      ig
19605  hash          fsnotify_remove  6368      ig
19602  hash          fsnotify_insert  6912      ig
19608  array         .bss             8192      ig
19607  array         .rodata          12288     ig
19609  percpu_array  gadget_heap      41288     ig
19601  hash          mntnsset_f6e864  83168     ig
19604  percpu_array  bufs             131400    ig
19606  ringbuf       events           275800    ig
19599  queue         ig_fa_records    335200    ig
19596  hash          exec_args        690496    ig
19591  hash          containers       1127616   ig
19603  hash          enriched_fsnoti  44599168  ig
```

After:
```
$ sudo bpftool map show -j | jq -r '.[] | {id: .id, type: .type, name: .name, bytes_memlock: .bytes_memlock, comms: (if .pids then (.pids | map(.comm) | unique | join(",")) else "" end)} | [.id, .type, .name, .bytes_memlock, .comms] | @tsv' | sort -k4n | column -t -s $'\t'|grep ig
19624  hash          ig_fa_pick_ctx   6368     ig
19631  hash          fsnotify_remove  6368     ig
19630  hash          fsnotify_insert  6912     ig
19635  array         .bss             8192     ig
19634  array         .rodata          12288    ig
19628  percpu_array  gadget_heap      41288    ig
19627  hash          mntnsset_1bb8c0  83168    ig
19629  percpu_array  bufs             131400   ig
19633  ringbuf       events           275800   ig
19625  queue         ig_fa_records    335200   ig
19622  hash          exec_args        690496   ig
19617  hash          containers       1127616  ig
19632  hash          enriched_fsnoti  4466560  ig
```

cc @yaeltz 