### PR TITLE
pkg/gadget-context/run: Remove superfluous global params validation

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -45,7 +45,6 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		opParamPrefix := fmt.Sprintf("operator.%s", op.Name())
 
 		// Get and fill params
-		globalParams := op.GlobalParams().AddPrefix(opParamPrefix)
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
@@ -53,11 +52,6 @@ func (c *GadgetContext) initAndPrepareOperators(paramValues api.ParamValues) ([]
 		err := apihelpers.NormalizeWithDefaults(instanceParams, opParamValues)
 		if err != nil {
 			return nil, fmt.Errorf("normalizing instance params for operator %q: %w", op.Name(), err)
-		}
-
-		err = apihelpers.Validate(globalParams, opParamValues)
-		if err != nil {
-			return nil, fmt.Errorf("validating global params for operator %q: %w", op.Name(), err)
 		}
 
 		err = apihelpers.Validate(instanceParams, opParamValues)


### PR DESCRIPTION
As discussed in [Slack](https://kubernetes.slack.com/archives/CSYL75LF6/p1739481635834429), it's superfluous to validate operators' global parameters [here](https://github.com/inspektor-gadget/inspektor-gadget/blob/f02cd39705574a628588338b919c86a8a866fbec/pkg/gadget-context/run.go#L52-L55) because the operators were already initialized in the [gadget-service](https://github.com/inspektor-gadget/inspektor-gadget/blob/f02cd39705574a628588338b919c86a8a866fbec/pkg/gadget-service/service.go#L388-L391) either when the [ig daemon](https://github.com/inspektor-gadget/inspektor-gadget/blob/f02cd39705574a628588338b919c86a8a866fbec/cmd/ig/daemon.go#L187) or the [gadgettracermanager](https://github.com/inspektor-gadget/inspektor-gadget/blob/f02cd39705574a628588338b919c86a8a866fbec/gadget-container/gadgettracermanager/main.go#L408), or when the [ig run command](https://github.com/inspektor-gadget/inspektor-gadget/blob/f02cd39705574a628588338b919c86a8a866fbec/cmd/common/oci.go#L169) started.
 