### PR TITLE
ebpf-builder.Dockerfile: workaround to install software-properties-common

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -33,8 +33,12 @@ ARG TINYGO_VERSION
 # lsb-release wget software-properties-common gnupg are needed by llvm.sh script
 # xz-utils is needed by btfgen makefile
 RUN apt-get update \
-	&& apt-get install -y libc-dev lsb-release wget software-properties-common gnupg xz-utils \
+	&& apt-get install -y libc-dev lsb-release wget gnupg xz-utils \
 	&& if [ "$(dpkg --print-architecture)" = 'amd64' ]; then apt-get install -y libc6-dev-i386; fi
+
+# Hack to install software-properties-common separately because of dpkg errors
+RUN apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common|| sudo dpkg --configure -a && apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common
+
 # Install clang 15
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LLVM_VERSION all \
 	&& update-alternatives --install /usr/local/bin/llvm-strip llvm-strip $(which llvm-strip-$CLANG_LLVM_VERSION) 100 \


### PR DESCRIPTION
The CI failed with this error:
```
dpkg: dependency problems prevent configuration of python3-oauthlib:
 python3-oauthlib depends on python3-jwt; however:
  Package python3-jwt is not configured yet.

dpkg: error processing package python3-oauthlib (--configure):
 dependency problems - leaving unconfigured
```

See https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/13387061178/job/37390293339?pr=4004

This patch is a workaround for installing software-properties-common.

https://askubuntu.com/questions/1482407/cant-install-software-properties-common-on-ubuntu-20-04-docker-image