### PR TITLE
trace_dns: TCP support w/o reassembly 

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1707,6 +1707,7 @@ jobs:
         GADGET_REPOSITORY: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
         GADGET_TAG: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
         VERIFY_IMAGE: ${{ needs.check-secrets.outputs.cosign }}
+        DNSTESTER_IMAGE: ${{ needs.build-helper-images.outputs.dnstester_image }}
       run: |
           set -o pipefail
           make \

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -168,6 +168,7 @@ test-unit: build
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
+	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
 	go test -v -exec 'sudo -E' ./$*/$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
@@ -177,6 +178,7 @@ test-integration: build
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
+	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
 	go test -v -exec 'sudo -E' ./.../$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:

--- a/gadgets/trace_dns/README.mdx
+++ b/gadgets/trace_dns/README.mdx
@@ -215,3 +215,8 @@ Finally, clean the system:
         ```
     </TabItem>
 </Tabs>
+
+
+## Limitations
+
+DNS over TCP support is limited since it doesn't support TCP stream reassembly. This means that the gadget will not be able to trace DNS requests that are sent over multiple TCP packets.

--- a/integration/ig/non-k8s/trace_dns_test.go
+++ b/integration/ig/non-k8s/trace_dns_test.go
@@ -27,10 +27,6 @@ import (
 )
 
 func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
-	// dnsTesterImage (image dnstester) has the following symlink:
-	// /usr/bin/nslookup -> /bin/busybox
-	exepath := "/bin/busybox"
-
 	traceDNSCmd := &Command{
 		Name:         "TraceDns",
 		Cmd:          fmt.Sprintf("./ig trace dns --paths -o json --runtimes=%s -c %s", *runtime, cn),
@@ -50,8 +46,8 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 					Qr:         dnsTypes.DNSPktTypeQuery,
 					Cwd:        "/",
 					Pcomm:      "sh",
-					Exepath:    exepath,
-					Comm:       "nslookup",
+					Exepath:    "/usr/bin/nslookup",
+					Comm:       "isc-net-0000", // one of the threads of the nslookup
 					Nameserver: "127.0.0.1",
 					PktType:    "OUTGOING",
 					DNSName:    "fake.test.com.",
@@ -72,8 +68,8 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 					Qr:         dnsTypes.DNSPktTypeResponse,
 					Cwd:        "/",
 					Pcomm:      "sh",
-					Exepath:    exepath,
-					Comm:       "nslookup",
+					Exepath:    "/usr/bin/nslookup",
+					Comm:       "isc-net-0000", // one of the threads of the nslookup
 					Nameserver: "127.0.0.1",
 					PktType:    "HOST",
 					DNSName:    "fake.test.com.",
@@ -98,8 +94,8 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 					Qr:         dnsTypes.DNSPktTypeQuery,
 					Cwd:        "/",
 					Pcomm:      "sh",
-					Exepath:    exepath,
-					Comm:       "nslookup",
+					Exepath:    "/usr/bin/nslookup",
+					Comm:       "isc-net-0000", // one of the threads of the nslookup
 					Nameserver: "127.0.0.1",
 					PktType:    "OUTGOING",
 					DNSName:    "fake.test.com.",
@@ -120,8 +116,8 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 					Qr:         dnsTypes.DNSPktTypeResponse,
 					Cwd:        "/",
 					Pcomm:      "sh",
-					Exepath:    exepath,
-					Comm:       "nslookup",
+					Exepath:    "/usr/bin/nslookup",
+					Comm:       "isc-net-0000", // one of the threads of the nslookup
 					Nameserver: "127.0.0.1",
 					PktType:    "HOST",
 					DNSName:    "fake.test.com.",
@@ -171,8 +167,8 @@ func newTraceDnsSteps(cn string, dnsServerArgs string) []TestStep {
 
 	dnsCmds := []string{
 		fmt.Sprintf("/dnstester %s & sleep 2", dnsServerArgs), // wait to ensure dns server is running
-		"nslookup -type=a fake.test.com. 127.0.0.1",
-		"nslookup -type=aaaa fake.test.com. 127.0.0.1",
+		"/usr/bin/nslookup -type=a fake.test.com. 127.0.0.1",
+		"/usr/bin/nslookup -type=aaaa fake.test.com. 127.0.0.1",
 		"sleep 2", // give time to the tracer to capture events before the container is done
 	}
 

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -98,9 +98,9 @@ func (d *DockerContainer) Run(t *testing.T) {
 	}
 
 	resp, err := d.client.ContainerCreate(d.options.ctx, &container.Config{
-		Image: d.options.image,
-		Cmd:   []string{"/bin/sh", "-c", d.cmd},
-		Tty:   false,
+		Image:      d.options.image,
+		Entrypoint: []string{"/bin/sh", "-c", d.cmd},
+		Tty:        false,
 	}, hostConfig, nil, nil, d.name)
 	if err != nil {
 		t.Fatalf("Failed to create container: %s", err)

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -9,5 +9,6 @@ RUN GOARCH=${TARGETARCH} go build -o /dnstester /go/src/github.com/inspektor-gad
 # Final image
 FROM alpine:3.18@sha256:1875c923b73448b558132e7d4a44b815d078779ed7a73f76209c6372de95ea8d
 COPY --from=builder /dnstester /dnstester
+RUN apk --no-cache upgrade -a && apk --no-cache add bind-tools
 
 CMD ["/dnstester"]

--- a/tools/dnstester/dnstester.go
+++ b/tools/dnstester/dnstester.go
@@ -21,11 +21,14 @@ import (
 	"github.com/miekg/dns"
 )
 
-var uncompress = flag.Bool("uncompress", false, "Uncompress DNS messages")
+var (
+	tcp        = flag.Bool("tcp", false, "Use TCP")
+	uncompress = flag.Bool("uncompress", false, "Uncompress DNS messages")
+)
 
 func main() {
 	flag.Parse()
-	log.Printf("Starting dns server with uncompress=%v\n", *uncompress)
+	log.Printf("Starting dns server with uncompress=%v tcp=%v\n ", *uncompress, *tcp)
 
 	dns.Handle(".", dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)
@@ -55,7 +58,11 @@ func main() {
 
 	}))
 
-	server := &dns.Server{Addr: ":53", Net: "udp"}
+	protocol := "udp"
+	if *tcp {
+		protocol = "tcp"
+	}
+	server := &dns.Server{Addr: ":53", Net: protocol}
 	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("Failed to start dns server %s\n", err)
 	}


### PR DESCRIPTION
This change add support for TCP with per packet approach. It doesn't support to reassemble the segments but would be helpful since  nodelocaldns always uses TCP to resolve DNS on K8s nodes.

Ref: https://datatracker.ietf.org/doc/html/rfc7766#section-8


Related: https://github.com/inspektor-gadget/inspektor-gadget/issues/1416

## Testing done

```
/ # dig +tcp +short microsoft.com.
20.231.239.246
20.76.201.171
20.70.246.20
20.236.44.162
20.112.250.133
```

```
→ go run -exec sudo ./cmd/ig run trace_dns:qasim-dns-over-tcp --verify-image=false
WARN[0001] image signature verification is disabled due to using corresponding option 
WARN[0001] This gadget was built with ig v0.37.0-93-gf451011af-dirty and it's being run with v0.0.0. Gadget could be incompatible 
WARN[0002] image signature verification is disabled due to using corresponding option 
WARN[0002] This gadget was built with ig v0.37.0-93-gf451011af-dirty and it's being run with v0.0.0. Gadget could be incompatible 
RUNTIME.CONTAINERNAME                           SRC                                                  DST                                                  COMM                    PID        TID QR   QTYPE                      NAME                                           RCODE        ADDRESSES                                      LATENCY_NS
e66800e2296c59440687a10239b9fea7ab9552b088a240c 172.17.0.2:34535                                     192.168.0.1:53                                       isc-net-0000         191321     191322 Q    A                          microsoft.com.                                                                                                    0ns
e66800e2296c59440687a10239b9fea7ab9552b088a240c 192.168.0.1:53                                       172.17.0.2:34535                                     isc-net-0000         191321     191322 R    A                          microsoft.com.                                 Success      20.231.239.246,20.76.201…                         36.09ms

```

Also, added integration tests! 


## Note

I tested this change with a large payload i.e `~500` record to see how it behaves if DNS payload is fragmented and I am getting `WARN[0034] failed to unpack dns message: Name: segment prefix is reserved` warning for second segment. Perhaps fine to keep things like this? Thoughts?

```
RUNTIME.CONTAINERN… SRC                       DST                       COMM              PID        TID QR QTYPE      NAME                RCODE    ADDRESSES   LATENCY_NS
81d0328dcf2d3be4cb8 127.0.0.1:45021           127.0.0.1:53              isc-net-0…      87764      87765 Q  A          fake.test.com.                                  0ns
81d0328dcf2d3be4cb8 127.0.0.1:45021           127.0.0.1:53              dnstester       87212      87212 Q  A          fake.test.com.                                  0ns
81d0328dcf2d3be4cb8 127.0.0.1:53              127.0.0.1:45021           dnstester       87212      87212 R  A          fake.test.com.      Success  127.0.0.…          0ns
81d0328dcf2d3be4cb8 127.0.0.1:53              127.0.0.1:45021           isc-net-0…      87764      87765 R  A          fake.test.com.      Success  127.0.0.…       4.36ms
WARN[0034] failed to unpack dns message: Name: segment prefix is reserved 
81d0328dcf2d3be4cb8 127.0.0.1:53              127.0.0.1:45021           dnstester       87212      87212                                                               0ns
WARN[0034] failed to unpack dns message: Name: segment prefix is reserved 
81d0328dcf2d3be4cb8 127.0.0.1:53              127.0.0.1:45021           isc-net-0…      87764      87765                                                               0ns

```