### PR TITLE
gadgets: Implement advise_seccomp as image-based

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -569,3 +569,17 @@ Parameters:
 
 Return value:
 - (u32) 1 if the symbol exists, 0 otherwise.
+
+
+### Filtering
+
+#### `shouldDiscardMntnsID(mntnsID uint64) uint32`
+
+Check if a mount namespace ID should be discarded. It must only be used in
+`gadgetStart` or after.
+
+Parameters:
+- `mntnsID` (u64): Mount namespace ID
+
+Return value:
+- (u32) 1 if the mount namespace ID should be discarded, 0 otherwise.

--- a/docs/gadgets/advise_seccomp.mdx
+++ b/docs/gadgets/advise_seccomp.mdx
@@ -1,0 +1,1 @@
+../../gadgets/advise_seccomp/README.mdx

--- a/docs/gadgets/files/seccomp-confined.yaml
+++ b/docs/gadgets/files/seccomp-confined.yaml
@@ -1,0 +1,15 @@
+# confined.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default-pod
+  labels:
+    app: default-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: profile.json
+  containers:
+  - name: test-container
+    image: docker.io/library/nginx:latest

--- a/docs/gadgets/files/seccomp-unconfined.yaml
+++ b/docs/gadgets/files/seccomp-unconfined.yaml
@@ -1,0 +1,14 @@
+# unconfined.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default-pod
+  labels:
+    app: default-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: test-container
+    image: docker.io/library/nginx:latest

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -19,6 +19,7 @@ UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
 
 GADGETS = \
+	advise_seccomp \
 	audit_seccomp \
 	deadlock \
 	fdpass \

--- a/gadgets/advise_seccomp/README.md
+++ b/gadgets/advise_seccomp/README.md
@@ -1,0 +1,8 @@
+# advise_seccomp
+
+The seccomp profile advisor gadget records syscalls that are issued in a
+specified container, and then uses this information to generate the
+corresponding seccomp profile.
+
+Check the full documentation on
+https://inspektor-gadget.io/docs/latest/gadgets/advise_seccomp

--- a/gadgets/advise_seccomp/README.mdx
+++ b/gadgets/advise_seccomp/README.mdx
@@ -1,0 +1,507 @@
+---
+title: advise_seccomp
+sidebar_position: 0
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The seccomp profile advisor gadget records syscalls that are issued in a
+specified container, and then uses this information to generate the corresponding
+seccomp profile.
+
+## Getting started
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/advise_seccomp:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/advise_seccomp:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+No Flags.
+
+## Guide
+
+We need to start the advise_seccomp gadget before running our workload, so it's
+able to capture all the syscalls the container uses.
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl gadget run advise_seccomp:%IG_TAG% --map-fetch-count=0 --map-fetch-interval=0 --podname default-pod
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ sudo ig run advise_seccomp:%IG_TAG% --map-fetch-count=0 --map-fetch-interval=0 --containername mycontainer
+```
+
+</TabItem>
+</Tabs>
+
+The --map-fetch-count=0 --map-fetch-interval=0 parameters indicate the policy
+will be generated once and only when the gadget is stopped.
+
+Then, start our application and interact with it to be sure it generates all the
+syscalls it needs to work.
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+import unconfined from '!!raw-loader!./files/seccomp-unconfined.yaml';
+
+<CodeBlock language="yaml">{unconfined}</CodeBlock>
+
+```bash
+$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/refs/heads/%IG_BRANCH%/docs/gadgets/files/seccomp-unconfined.yaml
+```
+
+Use port-forward to access the server from the client machine
+
+```bash
+$ kubectl -n default port-forward default-pod 3000:80 &
+
+$ curl localhost:3000
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ docker run --name mycontainer --rm -d docker.io/library/nginx
+e6bc6e02989054f4984c04b7213d304767faffa295b277e8f36a5b2422409e18
+
+$ curl $(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mycontainer)
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+```
+
+</TabItem>
+</Tabs>
+
+Now, go back and stop the gadget. It'll print to the terminal the seccomp policy
+for all container running on the system:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl gadget run advise_seccomp:%IG_TAG% --map-fetch-count=0 --map-fetch-interval=0 --podname default-pod
+^C
+// test-container
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept4",
+        "access",
+        "arch_prctl",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chown",
+        "clone",
+        "close",
+        "connect",
+        "dup2",
+        "epoll_create",
+        "epoll_ctl",
+        "epoll_pwait",
+        "epoll_wait",
+        "eventfd2",
+        "execve",
+        "exit_group",
+        "faccessat2",
+        "fadvise64",
+        "fchdir",
+        "fchown",
+        "fcntl",
+        "fgetxattr",
+        "fsetxattr",
+        "fstat",
+        "fstatfs",
+        "futex",
+        "getcwd",
+        "getdents64",
+        "getegid",
+        "geteuid",
+        "getgid",
+        "getpid",
+        "getppid",
+        "getrandom",
+        "gettid",
+        "getuid",
+        "io_setup",
+        "ioctl",
+        "listen",
+        "lseek",
+        "mkdir",
+        "mmap",
+        "mprotect",
+        "munmap",
+        "nanosleep",
+        "newfstatat",
+        "openat",
+        "pipe2",
+        "prctl",
+        "pread64",
+        "prlimit64",
+        "pwrite64",
+        "read",
+        "recvfrom",
+        "recvmsg",
+        "rename",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigprocmask",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "sched_getaffinity",
+        "sendfile",
+        "sendmsg",
+        "set_robust_list",
+        "set_tid_address",
+        "setgid",
+        "setgroups",
+        "setsockopt",
+        "setuid",
+        "sigaltstack",
+        "socket",
+        "socketpair",
+        "statfs",
+        "syscall_1f4",
+        "sysinfo",
+        "tgkill",
+        "umask",
+        "uname",
+        "utimensat",
+        "vfork",
+        "wait4",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ sudo ig run advise_seccomp:%IG_TAG% --map-fetch-count=0 --map-fetch-interval=0 --containername mycontainer
+// mycontainer
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept4",
+        "access",
+        "arch_prctl",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chown",
+        "clone",
+        "close",
+        "connect",
+        "dup2",
+        "epoll_create",
+        "epoll_ctl",
+        "epoll_pwait",
+        "epoll_wait",
+        "eventfd2",
+        "execve",
+        "exit_group",
+        "faccessat2",
+        "fadvise64",
+        "fchdir",
+        "fchown",
+        "fcntl",
+        "fgetxattr",
+        "fsetxattr",
+        "fstat",
+        "fstatfs",
+        "futex",
+        "getcwd",
+        "getdents64",
+        "getegid",
+        "geteuid",
+        "getgid",
+        "getpid",
+        "getppid",
+        "getrandom",
+        "gettid",
+        "getuid",
+        "io_setup",
+        "ioctl",
+        "listen",
+        "lseek",
+        "mkdir",
+        "mmap",
+        "mprotect",
+        "munmap",
+        "nanosleep",
+        "newfstatat",
+        "openat",
+        "pipe2",
+        "prctl",
+        "pread64",
+        "prlimit64",
+        "pwrite64",
+        "read",
+        "recvfrom",
+        "recvmsg",
+        "rename",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigprocmask",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "sched_getaffinity",
+        "sendfile",
+        "sendmsg",
+        "set_robust_list",
+        "set_tid_address",
+        "setgid",
+        "setgroups",
+        "setsockopt",
+        "setuid",
+        "sigaltstack",
+        "socket",
+        "socketpair",
+        "statfs",
+        "syscall_1f4",
+        "sysinfo",
+        "umask",
+        "uname",
+        "utimensat",
+        "vfork",
+        "wait4",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}
+```
+
+</TabItem>
+</Tabs>
+
+Now, let's configure our container to use that policy.
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+For Kubernetes, we can follow [Restrict a Container's Syscalls with
+seccomp](https://kubernetes.io/docs/tutorials/security/seccomp/).
+
+Copy the profile to the node:
+
+```bash
+$ minikube cp profile.json /var/lib/kubelet/seccomp/profile.json
+```
+
+And then deploy a pod using that profile:
+
+import confined from '!!raw-loader!./files/seccomp-confined.yaml';
+
+<CodeBlock language="yaml">{confined}</CodeBlock>
+
+```bash
+$ kubectl delete -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/refs/heads/%IG_BRANCH%/docs/gadgets/files/seccomp-unconfined.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/refs/heads/%IG_BRANCH%/docs/gadgets/files/seccomp-confined.yaml
+
+$ kubectl -n default port-forward default-pod 3000:80 &
+
+$ curl localhost:3000
+<!DOCTYPE html>
+<html>
+....
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+For Docker, we can follow this intructions in [Seccomp security profiles for
+Docker](https://docs.docker.com/engine/security/seccomp/).
+
+Save the profile in a file (removing the first line with the container name), and run the container as:
+
+```bash
+$ docker stop mycontainer
+mycontainer
+$ docker run --name mycontainer --rm -d --security-opt seccomp=<PATH-TO-profile.json> docker.io/library/nginx
+921e6b33c6660c27d2fc2ca27ef817a66b893c345226d517bad2ebeb90083a07
+$ curl $(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mycontainer)
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+```
+
+</TabItem>
+</Tabs>
+
+If you try to open a bash to the pod, you'll get an error as it tries to execute
+syscall not allowed by the profile.
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl exec -it default-pod -- bash
+bash: initialize_job_control: getpgrp failed: No such file or directory
+command terminated with exit code 1
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ docker exec -it mycontainer bash
+bash: initialize_job_control: getpgrp failed: No such file or directory
+```
+
+</TabItem>
+</Tabs>
+
+
+To finish, let's clean up the environment:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl delete -f confined.yaml
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ docker stop mycontainer
+```
+
+</TabItem>
+</Tabs>
+
+## Limitations:
+
+- The gadget generates a profile for each container, if you're running multiple
+instances of a container (by using a ReplicaSet or DaemonSet), you'll need to
+combine the profiles manually.
+- The current implementation relies on the implementation of `runc` to detect
+when to start recording syscalls, hence it might not work well with other
+container runtimes like `crun`.
+- This approach requires the workload to execute all the syscalls it might use
+when running the gadget. Please be sure you run the application long enough so
+all possible code paths needed to work are captured.
+
+## Related project:
+
+- SPO's Profile Recording:
+https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md#record-seccomp-profile
+- https://github.com/containers/oci-seccomp-bpf-hook (podman only)

--- a/gadgets/advise_seccomp/artifacthub-pkg.yml
+++ b/gadgets/advise_seccomp/artifacthub-pkg.yml
@@ -1,0 +1,29 @@
+# Artifact Hub package metadata file
+version: 0.39.0
+name: "advise seccomp"
+category: monitoring-logging
+displayName: "advise seccomp"
+createdAt: "2025-04-07T08:31:55Z"
+digest: "2025-04-07T08:31:55Z"
+description: "Suggest a seccomp profile"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/advise_seccomp"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/advise_seccomp:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/advise_seccomp"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/advise_seccomp:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/advise_seccomp/build.yaml
+++ b/gadgets/advise_seccomp/build.yaml
@@ -1,0 +1,1 @@
+wasm: go/program.go

--- a/gadgets/advise_seccomp/gadget.yaml
+++ b/gadgets/advise_seccomp/gadget.yaml
@@ -1,0 +1,14 @@
+name: advise seccomp
+description: Suggest a seccomp profile
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/advise_seccomp
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/advise_seccomp
+datasources:
+  syscalls:
+    annotations:
+      cli.supported-output-modes: none
+      ebpf.map.flush-on-stop: true
+  advise:
+    annotations:
+      cli.supported-output-modes: advise
+      cli.default-output-mode: advise

--- a/gadgets/advise_seccomp/go/go.mod
+++ b/gadgets/advise_seccomp/go/go.mod
@@ -1,0 +1,9 @@
+module main
+
+go 1.23.0
+
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// Only needed by in-tree gadgets
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/advise_seccomp/go/program.go
+++ b/gadgets/advise_seccomp/go/program.go
@@ -1,0 +1,186 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+var (
+	textds    api.DataSource
+	textField api.Field
+)
+
+type SeccompProfile struct {
+	DefaultAction string     `json:"defaultAction"`
+	Architectures []string   `json:"architectures"`
+	Syscalls      []Syscalls `json:"syscalls"`
+}
+
+type Syscalls struct {
+	Names  []string `json:"names"`
+	Action string   `json:"action"`
+}
+
+//go:wasmexport gadgetInit
+func gadgetInit() int32 {
+	var err error
+	textds, err = api.NewDataSource("advise", api.DataSourceTypeSingle)
+	if err != nil {
+		api.Errorf("creating datasource: %s", err)
+		return 1
+	}
+
+	textField, err = textds.AddField("text", api.Kind_String)
+	if err != nil {
+		api.Errorf("adding field: %s", err)
+		return 1
+	}
+
+	return 0
+}
+
+//go:wasmexport gadgetPreStart
+func gadgetPreStart() int32 {
+	syscallds, err := api.GetDataSource("syscalls")
+	if err != nil {
+		api.Errorf("getting datasource: %s", err)
+		return 1
+	}
+
+	syscallsF, err := syscallds.GetField("syscalls")
+	if err != nil {
+		api.Errorf("getting syscalls field: %s", err)
+		return 1
+	}
+
+	K8sContainerF, err := syscallds.GetField("k8s.containerName")
+	if err != nil {
+		api.Errorf("getting k8s.containerName field: %s", err)
+		return 1
+	}
+
+	runtimeContainerF, err := syscallds.GetField("runtime.containerName")
+	if err != nil {
+		api.Errorf("getting runtime.containerName field: %s", err)
+		return 1
+	}
+
+	mntnsidF, err := syscallds.GetField("mntns_id_raw")
+	if err != nil {
+		api.Errorf("getting mntns_id_raw field: %s", err)
+		return 1
+	}
+
+	// keep in sync with SYSCALLS_MAP_VALUE_SIZE in program.bpf.c
+	syscallsBuffer := make([]byte, 500+1)
+
+	err = syscallds.SubscribeArray(func(source api.DataSource, dataArr api.DataArray) error {
+		// Get all fields sent by ebpf
+		for j := 0; j < dataArr.Len(); j++ {
+			data := dataArr.Get(j)
+
+			if _, err := syscallsF.Bytes(data, syscallsBuffer); err != nil {
+				api.Warnf("reading syscalls: %s", err)
+				continue
+			}
+
+			// The name of the container is only used as an informative comment
+			// on the output
+			K8sContainer, err := K8sContainerF.String(data, 512)
+			if err != nil {
+				api.Warnf("reading container name: %s", err)
+				continue
+			}
+
+			runtimeContainer, err := runtimeContainerF.String(data, 512)
+			if err != nil {
+				api.Warnf("reading container name: %s", err)
+				continue
+			}
+
+			containerName := K8sContainer
+			if containerName == "" {
+				containerName = runtimeContainer
+			}
+
+			mntnsid, err := mntnsidF.Uint64(data)
+			if err != nil {
+				api.Warnf("reading mntnsid: %s", err)
+				continue
+			}
+
+			if api.ShouldDiscardMntNsID(mntnsid) {
+				continue
+			}
+
+			syscallStrings := make([]string, 0)
+			for i := range syscallsBuffer {
+				if syscallsBuffer[i] > 0 {
+					syscallName, err := api.GetSyscallName(uint16(i))
+					if err != nil {
+						syscallName = fmt.Sprintf("unknown_syscall_%d", i)
+					}
+					syscallStrings = append(syscallStrings, syscallName)
+				}
+			}
+
+			slices.Sort(syscallStrings)
+
+			var out strings.Builder
+			out.WriteString(fmt.Sprintf("// %s\n", containerName))
+
+			profile := SeccompProfile{
+				DefaultAction: "SCMP_ACT_ERRNO",
+				Architectures: []string{
+					"SCMP_ARCH_X86_64",
+					"SCMP_ARCH_X86",
+					"SCMP_ARCH_X32",
+				},
+				Syscalls: []Syscalls{
+					{
+						Names:  syscallStrings,
+						Action: "SCMP_ACT_ALLOW",
+					},
+				},
+			}
+
+			jsonText, _ := json.MarshalIndent(profile, "", "  ")
+			out.Write(jsonText)
+			out.WriteRune('\n')
+
+			nd, err := textds.NewPacketSingle()
+			if err != nil {
+				api.Warnf("creating new packet: %s", err)
+				continue
+			}
+			textField.SetString(api.Data(nd), out.String())
+			textds.EmitAndRelease(api.Packet(nd))
+		}
+		return nil
+	}, 9999)
+	if err != nil {
+		api.Warnf("subscribing to syscalls: %s", err)
+		return 1
+	}
+	return 0
+}
+
+func main() {}

--- a/gadgets/advise_seccomp/program.bpf.c
+++ b/gadgets/advise_seccomp/program.bpf.c
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 The Inspektor Gadget authors */
+
+/* This BPF program uses the GPL-restricted function bpf_probe_read*().
+ */
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/types.h>
+#include <gadget/macros.h>
+#include <gadget/mntns.h>
+// Include this to force the filtering map to be created. It's not directly used
+// by the ebpf code but it's needed by the wasm module.
+#include <gadget/mntns_filter.h>
+#include <gadget/maps.bpf.h>
+
+#define SYSCALLS_COUNT 500
+#define SYSCALLS_MAP_VALUE_FOOTER_SIZE 1
+#define SYSCALLS_MAP_VALUE_SIZE \
+	(SYSCALLS_COUNT + SYSCALLS_MAP_VALUE_FOOTER_SIZE)
+
+#define TASK_COMM_LEN 16
+#define TS_COMPAT 0x0002
+
+// prctl syscall number from
+// https://github.com/seccomp/libseccomp/blob/abad8a8f41fc13efbb95fc1ccaa3e181342bade7/src/syscalls.csv#L265
+#ifndef __NR_prctl
+#if defined(bpf_target_x86)
+#define __NR_prctl 157
+#elif defined(bpf_target_arm64)
+#define __NR_prctl 167
+#else
+#error "Unsupported architecture"
+#endif
+#endif
+
+// prclt syscall parameters from
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L10
+// https://github.com/torvalds/linux/blob/5147da902e0dd162c6254a61e4c57f21b60a9b1c/include/uapi/linux/prctl.h#L175
+#ifndef PR_GET_PDEATHSIG
+#define PR_GET_PDEATHSIG 2
+#endif
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+
+// Seccomp syscall number from
+// https://github.com/torvalds/linux/blob/v5.12/tools/testing/selftests/seccomp/seccomp_bpf.c#L115
+// Only x86_64 is supported for now.
+#ifndef __NR_seccomp
+#if defined(bpf_target_x86)
+#define __NR_seccomp 317
+#elif defined(bpf_target_arm64)
+#define __NR_seccomp 277
+#else
+#error "Unsupported architecture"
+#endif
+#endif
+
+struct key_t {
+	gadget_mntns_id mntns_id_raw;
+};
+
+struct val_t {
+	unsigned char syscalls[SYSCALLS_MAP_VALUE_SIZE];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct key_t);
+	__type(value, struct val_t);
+	__uint(max_entries, 1024);
+} syscalls_per_mntns SEC(".maps");
+
+GADGET_MAPITER(syscalls, syscalls_per_mntns);
+
+const struct val_t blank_bitmap = {};
+
+#ifdef __TARGET_ARCH_x86
+static __always_inline int is_x86_compat(struct task_struct *task)
+{
+	return !!(BPF_CORE_READ(task, thread_info.status) & TS_COMPAT);
+}
+#endif
+
+SEC("raw_tracepoint/sys_enter")
+int ig_seccomp_e(struct bpf_raw_tracepoint_args *ctx)
+{
+	// We cannot filter by container at this point because the container
+	// filtering mechanism is configured after runc has done some syscalls to
+	// setup the container. Hence, if we filter by container, the generated
+	// seccomp profile will be missing some syscalls and the container creation
+	// will fail.
+
+	struct pt_regs regs = {};
+	unsigned int id;
+
+#ifdef __TARGET_ARCH_x86
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+	if (is_x86_compat(task))
+		return 0;
+#endif
+
+	bpf_probe_read(&regs, sizeof(struct pt_regs), (void *)ctx->args[0]);
+	id = ctx->args[1];
+	if (id < 0 || id >= SYSCALLS_COUNT)
+		return 0;
+
+	char comm[TASK_COMM_LEN];
+	bpf_get_current_comm(comm, sizeof(comm));
+	int is_runc = comm[0] == 'r' && comm[1] == 'u' && comm[2] == 'n' &&
+		      comm[3] == 'c';
+
+	u64 mntns = gadget_get_current_mntns_id();
+	struct key_t key = {
+		.mntns_id_raw = mntns,
+	};
+
+	struct val_t *syscall_bitmap = bpf_map_lookup_or_try_init(
+		&syscalls_per_mntns, &key, &blank_bitmap);
+	if (!syscall_bitmap)
+		return 0;
+
+	// If it is runc, we want to record only the syscalls executed after the
+	// seccomp profile is actually installed. However, if we are running the
+	// seccomp-advisor gadget, it is very probably that the pod does not have
+	// a seccomp profile yet, so seccomp() will not be called. Therefore, we
+	// decide to start recording from the prctl(PR_GET_PDEATHSIG) call on. It
+	// is a safe place right before all the seccomp() calls that will be always
+	// executed during the runc initialisation:
+	// https://github.com/opencontainers/runc/blob/8b4a8f093d0dbdf45100597f710d16777845ee83/libcontainer/standard_init_linux.go#L148
+	if (is_runc) {
+		if (syscall_bitmap->syscalls[SYSCALLS_COUNT] == 0) {
+			if (id == __NR_prctl &&
+			    PT_REGS_PARM1(&regs) == PR_GET_PDEATHSIG) {
+				// Start recording the runc syscalls from now on.
+				syscall_bitmap->syscalls[SYSCALLS_COUNT] = 1;
+			}
+			return 0;
+		}
+
+		// Record all the runc syscalls after prctl(PR_GET_PDEATHSIG) except
+		// for seccomp() and prctl(PR_SET_NO_NEW_PRIVS) because we know they
+		// are executed before the seccomp profile is installed.
+		if ((id == __NR_prctl &&
+		     PT_REGS_PARM1(&regs) == PR_SET_NO_NEW_PRIVS) ||
+		    (id == __NR_seccomp)) {
+			return 0;
+		}
+	}
+
+	// Record the syscall
+	syscall_bitmap->syscalls[id] = 0x01;
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/gadgets/advise_seccomp/test/unit/advise_seccomp_test.go
+++ b/gadgets/advise_seccomp/test/unit/advise_seccomp_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+)
+
+const (
+	adviseDsName  = "advise"
+	containerName = "mycontainer"
+)
+
+type SeccompProfile struct {
+	DefaultAction string     `json:"defaultAction"`
+	Architectures []string   `json:"architectures"`
+	Syscalls      []Syscalls `json:"syscalls"`
+}
+
+type Syscalls struct {
+	Names  []string `json:"names"`
+	Action string   `json:"action"`
+}
+
+type testDef struct {
+	runnerConfig   *utilstest.RunnerConfig
+	mntnsFilterMap func(info *utilstest.RunnerInfo) *ebpf.Map
+	validate       func(t *testing.T, info *utilstest.RunnerInfo, policies map[string]SeccompProfile)
+}
+
+func TestAdviseSeccompGadget(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+
+	// see https://github.com/inspektor-gadget/inspektor-gadget/issues/3751
+	gadgettesting.MinimumKernelVersion(t, "5.6")
+
+	testCases := map[string]testDef{
+		"all_containers": {
+			runnerConfig: &utilstest.RunnerConfig{},
+			validate: func(t *testing.T, info *utilstest.RunnerInfo, policies map[string]SeccompProfile) {
+				require.GreaterOrEqual(t, len(policies), 1)
+			},
+		},
+		"specific_container": {
+			runnerConfig: &utilstest.RunnerConfig{},
+			mntnsFilterMap: func(info *utilstest.RunnerInfo) *ebpf.Map {
+				return utilstest.CreateMntNsFilterMap(t, info.MountNsID)
+			},
+			validate: func(t *testing.T, info *utilstest.RunnerInfo, policies map[string]SeccompProfile) {
+				policy, ok := policies[containerName]
+				require.True(t, ok)
+
+				require.Len(t, policy.Syscalls, 1)
+				syscalls := policy.Syscalls[0]
+
+				require.Contains(t, syscalls.Names, "getpid")
+				require.Contains(t, syscalls.Names, "getppid")
+				require.Contains(t, syscalls.Names, "getuid")
+				require.Contains(t, syscalls.Names, "geteuid")
+				require.Contains(t, syscalls.Names, "openat")
+				require.Contains(t, syscalls.Names, "close")
+				require.Contains(t, syscalls.Names, "sysinfo")
+				require.Contains(t, syscalls.Names, "chdir")
+				require.Contains(t, syscalls.Names, "mmap")
+				require.Contains(t, syscalls.Names, "munmap")
+
+				// check syscalls that should not be present
+				require.NotContains(t, syscalls.Names, "unshare")
+				require.NotContains(t, syscalls.Names, "mkdir")
+				require.NotContains(t, syscalls.Names, "reboot")
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runner := utilstest.NewRunnerWithTest(t, testCase.runnerConfig)
+			var mntnsFilterMap *ebpf.Map
+			if testCase.mntnsFilterMap != nil {
+				mntnsFilterMap = testCase.mntnsFilterMap(runner.Info)
+			}
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, executeSyscalls)
+				return nil
+			}
+			opts := gadgetrunner.GadgetRunnerOpts[any]{
+				Image:          "advise_seccomp",
+				Timeout:        5 * time.Second,
+				MntnsFilterMap: mntnsFilterMap,
+				OnGadgetRun:    onGadgetRun,
+				ParamValues: map[string]string{
+					"operator.oci.ebpf.map-fetch-count":    "0",
+					"operator.oci.ebpf.map-fetch-interval": "0",
+				},
+			}
+
+			policies := make(map[string]SeccompProfile)
+
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+			// this gadget requires the runtime.containerName to be present, add
+			// a simple operator to set it only for the runner that generates
+			// the events
+			myOp := simple.New("myop",
+				simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+					syscallsDs := gadgetCtx.GetDataSources()["syscalls"]
+					require.NotNil(t, syscallsDs)
+
+					runtimeContainerNameF, err := syscallsDs.AddField("runtime.containerName", api.Kind_String)
+					require.NoError(t, err)
+
+					k8sContainerNameF, err := syscallsDs.AddField("k8s.containerName", api.Kind_String)
+					require.NoError(t, err)
+
+					syscallsDs.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+						mntnsidF := ds.GetField("mntns_id_raw")
+						require.NotNil(t, mntnsidF)
+
+						mntnsid, err := mntnsidF.Uint64(data)
+						require.NoError(t, err)
+
+						if mntnsid != runner.Info.MountNsID {
+							return nil
+						}
+
+						err = runtimeContainerNameF.PutString(data, containerName)
+						require.NoError(t, err)
+						k8sContainerNameF.PutString(data, containerName)
+						require.NoError(t, err)
+
+						return nil
+					}, 100)
+
+					return nil
+				}),
+			)
+
+			gadgetRunner.DataOperator = append(gadgetRunner.DataOperator, myOp)
+			gadgetRunner.DataFunc = func(ds datasource.DataSource, data datasource.Data) error {
+				if ds.Name() != adviseDsName {
+					return nil
+				}
+
+				textField := ds.GetField("text")
+				require.NotNil(t, textField)
+
+				text, err := textField.String(data)
+				require.NoError(t, err)
+
+				subparts := strings.SplitN(text, "\n", 2)
+				require.Len(t, subparts, 2)
+
+				name := strings.TrimPrefix(subparts[0], `// `)
+				content := subparts[1]
+
+				var policy SeccompProfile
+				err = json.Unmarshal([]byte(content), &policy)
+				require.NoError(t, err)
+
+				policies[name] = policy
+
+				return nil
+			}
+
+			gadgetRunner.RunGadget()
+
+			testCase.validate(t, runner.Info, policies)
+		})
+	}
+}
+
+// executeSyscalls executes the following syscalls: Getpid, Getppid, Getuid,
+// Geteuid, Open, Close, Sysinfo, Chdir, Getcwd, Mmap and Munmap.
+func executeSyscalls() error {
+	syscall.Getpid()
+	syscall.Getppid()
+	syscall.Getuid()
+	syscall.Geteuid()
+
+	fd, err := syscall.Open("/dev/null", syscall.O_WRONLY, 0o644)
+	if err == nil {
+		syscall.Close(fd)
+	}
+
+	var info syscall.Sysinfo_t
+	syscall.Sysinfo(&info)
+
+	if err := syscall.Chdir("/"); err == nil {
+		cwd := make([]byte, 256)
+		syscall.Getcwd(cwd)
+	}
+
+	mem, err := syscall.Mmap(-1, 0, 4096, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err == nil {
+		syscall.Munmap(mem)
+	}
+
+	return nil
+}

--- a/pkg/operators/wasm/filter.go
+++ b/pkg/operators/wasm/filter.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"context"
+
+	"github.com/tetratelabs/wazero"
+	wapi "github.com/tetratelabs/wazero/api"
+)
+
+func (i *wasmOperatorInstance) addFilterFuncs(env wazero.HostModuleBuilder) {
+	exportFunction(env, "shouldDiscardMntnsID", i.shouldDiscardMntnsID,
+		[]wapi.ValueType{
+			wapi.ValueTypeI64, // MntNS ID
+		},
+		[]wapi.ValueType{wapi.ValueTypeI32}, // Discard the event, 1 if true, 0 if false
+	)
+}
+
+// shouldDiscardMntnsID returns 1 if the mount ns ID should be filtered out.
+// Params:
+// - stack[0]: mount ns ID
+// Return value:
+// - 1 if the mount ns ID should be filter out, 0 otherwise
+func (i *wasmOperatorInstance) shouldDiscardMntnsID(ctx context.Context, m wapi.Module, stack []uint64) {
+	// if the filtering map is not configured, we assume the gadget wants to get
+	// all data
+	if i.mntNsIDMap == nil {
+		stack[0] = 0
+		return
+	}
+
+	ret := uint32(0)
+
+	mntnsID := uint64(stack[0])
+	if err := i.mntNsIDMap.Lookup(mntnsID, &ret); err != nil {
+		stack[0] = 1
+		return
+	}
+
+	stack[0] = 0
+}

--- a/pkg/operators/wasm/testdata/Makefile
+++ b/pkg/operators/wasm/testdata/Makefile
@@ -14,6 +14,7 @@ TEST_ARTIFACTS = \
 	syscall \
 	perf \
 	kallsyms \
+	filtering \
 	#
 
 all: $(TEST_ARTIFACTS)

--- a/pkg/operators/wasm/testdata/filtering/build.yaml
+++ b/pkg/operators/wasm/testdata/filtering/build.yaml
@@ -1,0 +1,1 @@
+wasm: program.go

--- a/pkg/operators/wasm/testdata/filtering/go.mod
+++ b/pkg/operators/wasm/testdata/filtering/go.mod
@@ -1,0 +1,8 @@
+module main
+
+go 1.23.0
+
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// use this to be able to compile it locally
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../../../

--- a/pkg/operators/wasm/testdata/filtering/program.go
+++ b/pkg/operators/wasm/testdata/filtering/program.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+// Keep in sync with pkg/operators/wasm/wasm_test.go TestFiltering
+const (
+	mntnsDiscarded    = uint64(555)
+	mntnsNotDiscarded = uint64(777)
+)
+
+//go:wasmexport gadgetStart
+func gadgetStart() int32 {
+	if ret := api.ShouldDiscardMntNsID(mntnsDiscarded); !ret {
+		api.Errorf("mntns should be discarded")
+		return 1
+	}
+	if ret := api.ShouldDiscardMntNsID(mntnsNotDiscarded); ret {
+		api.Errorf("mntns should not be discarded")
+		return 1
+	}
+	return 0
+}
+
+func main() {}

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
@@ -465,4 +466,15 @@ func TestConfig(t *testing.T) {
 	require.True(t, ok, "invalid configuration format")
 
 	require.Equal(t, "myvalue", v.GetString("foo.bar.zas"))
+}
+
+func TestFiltering(t *testing.T) {
+	gadgetCtx := createGadgetCtx(t, "filtering")
+
+	// Keep in sync with testdata/filtering/program.go
+	mntNsMap := utilstest.CreateMntNsFilterMap(t, 777)
+	gadgetCtx.SetVar(gadgets.MntNsFilterMapName, mntNsMap)
+
+	err := runGadget(t, gadgetCtx, nil)
+	require.NoError(t, err, "running gadget")
 }

--- a/pkg/testing/gadgetrunner/gadgetrunner.go
+++ b/pkg/testing/gadgetrunner/gadgetrunner.go
@@ -167,7 +167,7 @@ func (g *GadgetRunner[T]) RunGadget() {
 		gadgetOperatorOpts = append(gadgetOperatorOpts, simple.OnStart(g.onGadgetRun))
 	}
 
-	g.DataOperator = []operators.DataOperator{ocihandler.OciHandler}
+	g.DataOperator = append(g.DataOperator, ocihandler.OciHandler)
 	for _, dataOperator := range operators.GetDataOperators() {
 		g.DataOperator = append(g.DataOperator, dataOperator)
 	}

--- a/wasmapi/go/filter.go
+++ b/wasmapi/go/filter.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	_ "unsafe"
+)
+
+//go:wasmimport ig shouldDiscardMntnsID
+//go:linkname shouldDiscardMntnsID shouldDiscardMntnsID
+func shouldDiscardMntnsID(mntNsID uint64) uint32
+
+func ShouldDiscardMntNsID(mntNsID uint64) bool {
+	ret := shouldDiscardMntnsID(mntNsID)
+	return ret != 0
+}


### PR DESCRIPTION
Implement the advise_seccomp as image-based

This is heavily based on #3718.  
- adds a PreStop() lifecycle hook to do things "last minute"
- fixes lifecycle of WASM instances
- adds "flush-on-stop" annotation for map fetching in PreStop()

### How it works
- The eBPF code collects syscalls in a per mount namespace map. It's registered as a map-iter. 
- The wasm module subscribes to that map, and also creates a new text datasource with the seccomp policy output.
- When the gadget is stopped, the ebpf map is read and emitted, then the wasm module generates the seccomp policy

### Testing

The gadget needs to be run with some specific params, when it's stopped, prints a seccomp policy for each container on the system that was allowed by the filtering options:

```bash 
$ sudo ig run advise_seccomp --verify-image=false --map-fetch-count=0 --map-fetch-interval=0
WARN[0000] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
^C// mycontainer2
{
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "defaultAction": "SCMP_ACT_ERRNO",
  "syscalls": [
    "access",
    "arch_prctl",
    "brk",
    "clone",
    "close",
    "dup2",
    "execve",
    "fcntl",
    "getcwd",
    "geteuid",
    "getpgrp",
    "getpid",
    "getppid",
    "getrandom",
    "getuid",
    "ioctl",
    "lseek",
    "mmap",
    "mprotect",
    "newfstatat",
    "openat",
    "poll",
    "pread64",
    "prlimit64",
    "read",
    "recvfrom",
    "rseq",
    "rt_sigaction",
    "rt_sigreturn",
    "sendto",
    "set_robust_list",
    "set_tid_address",
    "setitimer",
    "setpgid",
    "setsockopt",
    "socket",
    "wait4",
    "write"
  ]
}
// mycontainer
{
  "architectures": [
    "SCMP_ARCH_X86_64",
    "SCMP_ARCH_X86",
    "SCMP_ARCH_X32"
  ],
  "defaultAction": "SCMP_ACT_ERRNO",
  "syscalls": [
    "access",
    "arch_prctl",
    "brk",
    "clone",
    "close",
    "execve",
    "exit_group",
    "geteuid",
    "getpid",
    "getrandom",
    "getuid",
    "ioctl",
    "mmap",
    "mprotect",
    "newfstatat",
    "openat",
    "poll",
    "pread64",
    "prlimit64",
    "read",
    "rseq",
    "rt_sigaction",
    "rt_sigreturn",
    "sendfile",
    "set_robust_list",
    "set_tid_address",
    "setpgid",
    "wait4",
    "write"
  ]
}
```

### Discussions
#### params needed

In order to work properly, the gadget requires `--map-fetch-count=0` and `--map-fetch-interval=0`, ideally these params shouldn't be required.

#### output format

The gadget prints a seccomp policy for each container. I'm not so sure about this, perhaps it should print a single seccomp policy with all syscalls captured by the filter configuration. This will help to generate policies for deamonsets and replicas, but will require to run the gadget multiple times to generate the policies for multiple containers.

### TODO 
- [x] Documentation

#### Requisites 
- [x] #4159
- [x] #4160
- [x] #4161

--- 

Replaces #3718 
Fixes #3890
