### PR TITLE
docs: pull-secret: more explanations

### DIFF
--- a/docs/spec/operators/oci.md
+++ b/docs/spec/operators/oci.md
@@ -23,7 +23,9 @@ Default: `/var/lib/ig/config.json`
 
 ### `pull-secret`
 
-Secret to use when pulling the gadget image
+[Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/)
+to use when pulling the gadget image. The Kubernetes namespace for the Secret
+is not configurable and is hardcoded to "gadget".
 
 Fully qualified name: `operator.oci.pull-secret`
 

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -117,7 +117,7 @@ func (o *ociHandler) GlobalParams() api.Params {
 		p = append(p, &api.Param{
 			Key:         pullSecret,
 			Title:       "Pull secret",
-			Description: "Secret to use when pulling the gadget image",
+			Description: "Kubernetes secret to use when pulling the gadget image",
 			TypeHint:    api.TypeString,
 		})
 	}


### PR DESCRIPTION
More explanations about the `pull-secret` parameter:
- It is a Kubernetes Secret
- The Kubernetes namespace is not configurable and is hardcoded to "gadget".