### PR TITLE
[test]:crete tests for retry.go in pkg/oci

### DIFF
--- a/pkg/oci/retry_test.go
+++ b/pkg/oci/retry_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetry(t *testing.T) {
+	tests := []struct {
+		name          string
+		fn            func(int *int) error
+		expectedErr   error
+		expectedCalls int
+	}{
+		{
+			name: "success on first try",
+			fn: func(calls *int) error {
+				*calls++
+				return nil
+			},
+			expectedErr:   nil,
+			expectedCalls: 1,
+		},
+		{
+			name: "success after retries",
+			fn: func(calls *int) error {
+				*calls++
+				if *calls < 3 {
+					return errRetry
+				}
+				return nil
+			},
+			expectedErr:   nil,
+			expectedCalls: 3,
+		},
+		{
+			name: "non-retry error",
+			fn: func(calls *int) error {
+				*calls++
+				return errors.New("permanent error")
+			},
+			expectedErr:   errors.New("permanent error"),
+			expectedCalls: 1,
+		},
+		{
+			name: "exceeds retry limit",
+			fn: func(calls *int) error {
+				*calls++
+				return errRetry
+			},
+			expectedErr:   ErrRetryLimitExceeded,
+			expectedCalls: retryLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			err := retry(tt.name, func() error {
+				return tt.fn(&calls)
+			})
+
+			if tt.expectedErr == nil && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			} else if tt.expectedErr != nil && err == nil {
+				t.Errorf("expected error %v, got nil", tt.expectedErr)
+			} else if tt.expectedErr != nil && err != nil && tt.expectedErr.Error() != err.Error() {
+				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			}
+
+			if calls != tt.expectedCalls {
+				t.Errorf("expected %d calls, got %d", tt.expectedCalls, calls)
+			}
+		})
+	}
+}
+
+func TestRetryTiming(t *testing.T) {
+	start := time.Now()
+
+	err := retry("timing-test", func() error {
+		return errRetry
+	})
+
+	duration := time.Since(start)
+
+	if !errors.Is(err, ErrRetryLimitExceeded) {
+		t.Errorf("expected ErrRetryLimitExceeded, got %v", err)
+	}
+
+	expectedMinDuration := time.Duration(retryLimit-1) * retryDelay
+
+	if duration < expectedMinDuration {
+		t.Errorf("retry finished too quickly. Expected at least %v, got %v", expectedMinDuration, duration)
+	}
+
+	maxDuration := expectedMinDuration + (2 * time.Second)
+	if duration > maxDuration {
+		t.Errorf("retry took too long. Expected less than %v, got %v", maxDuration, duration)
+	}
+}


### PR DESCRIPTION
# Add unit tests for retry functionality in pkg/oci

This PR adds comprehensive unit tests for the retry functionality in pkg/oci package. The tests cover various scenarios including success cases, retry attempts, error handling, and timing verification. This improves the overall test coverage of the codebase and ensures the retry mechanism works as expected.

## How to use
Reviewers can validate this PR by running the unit tests for the oci package:
```bash
go test ./pkg/oci/
```

Additionally, to check the test coverage:
```bash
go test -coverprofile=coverage.out ./pkg/oci/
go tool cover -html=coverage.out
```

## Testing done
I have run the following tests:

```bash
$ go test ./pkg/oci/
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/oci    21.033s

$ go test -coverprofile=coverage.out ./pkg/oci/
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/oci    21.033s
```

The tests verify:
- Success on first attempt
- Success after multiple retries
- Non-retryable error handling
- Retry limit exceeded cases
- Proper timing between retry attempts

Part of #3835