### PR TITLE
 wasm: Remove malloc requirement for guest

### DIFF
--- a/gadgets/deadlock/go/program.go
+++ b/gadgets/deadlock/go/program.go
@@ -189,7 +189,7 @@ func gadgetInit() int32 {
 
 			// Record process information for the PID
 			if _, exists := pidInfo[pid]; !exists {
-				comm, err := commF.String(datum)
+				comm, err := commF.String(datum, 16)
 				if err != nil {
 					api.Warnf("failed to get comm: %s", err)
 					continue

--- a/gadgets/trace_dns/go/program.go
+++ b/gadgets/trace_dns/go/program.go
@@ -237,9 +237,14 @@ func gadgetInit() int32 {
 			return
 		}
 
-		n := dataF.BytesToSlice(data, payload)
+		n, err := dataF.Bytes(data, payload)
+		if err != nil {
+			api.Warnf("failed to get data: %s", err)
+			return
+		}
+
 		if n == 0 {
-			api.Warnf("failed to get data")
+			api.Warnf("empty data")
 			return
 		}
 

--- a/gadgets/trace_exec/go/program.go
+++ b/gadgets/trace_exec/go/program.go
@@ -55,9 +55,14 @@ func gadgetInit() int32 {
 
 	ds.Subscribe(func(source api.DataSource, data api.Data) {
 		// Get all fields sent by ebpf
-		n := argsF.BytesToSlice(data, payload)
+		n, err := argsF.Bytes(data, payload)
+		if err != nil {
+			api.Warnf("failed to get args: %s", err)
+			return
+		}
+
 		if n == 0 {
-			api.Warnf("failed to get args")
+			api.Warnf("empty args")
 			return
 		}
 

--- a/gadgets/trace_fsslower/go/program.go
+++ b/gadgets/trace_fsslower/go/program.go
@@ -75,7 +75,7 @@ var fsConfMap = map[string]fsConf{
 
 //go:wasmexport gadgetPreStart
 func gadgetPreStart() int32 {
-	value, err := api.GetParamValue("filesystem")
+	value, err := api.GetParamValue("filesystem", 32)
 	if err != nil {
 		api.Errorf("failed to get param value: %s", err)
 		return 1

--- a/gadgets/trace_mount/go/program.go
+++ b/gadgets/trace_mount/go/program.go
@@ -93,12 +93,12 @@ func gadgetInit() int32 {
 	}
 
 	ds.Subscribe(func(source api.DataSource, data api.Data) {
-		flags, _ := flagsField.String(data)
+		flags, _ := flagsField.String(data, 512)
 		opRaw, _ := opRawField.Int32(data)
-		src, _ := srcField.String(data)
-		dest, _ := destField.String(data)
-		fs, _ := fsField.String(data)
-		dataStr, _ := dataField.String(data)
+		src, _ := srcField.String(data, 4096)
+		dest, _ := destField.String(data, 4096)
+		fs, _ := fsField.String(data, 4096)
+		dataStr, _ := dataField.String(data, 512)
 		errorRaw, _ := errorRawField.Uint32(data)
 
 		callField.SetString(data, getCallStr(opRaw, src, dest, fs, flags, dataStr, errorRaw))

--- a/pkg/operators/wasm/testdata/badguest/program.go
+++ b/pkg/operators/wasm/testdata/badguest/program.go
@@ -102,14 +102,14 @@ func dataArrayLen(d uint32) uint32
 //go:wasmimport env dataArrayGet
 func dataArrayGet(d uint32, index uint32) uint32
 
-//go:wasmimport env fieldGet
-func fieldGet(acc uint32, data uint32, kind uint32) uint64
+//go:wasmimport env fieldGetScalar
+func fieldGetScalar(acc uint32, data uint32, kind uint32) uint64
 
 //go:wasmimport env fieldSet
 func fieldSet(acc uint32, data uint32, kind uint32, value uint64) uint32
 
 //go:wasmimport env getParamValue
-func getParamValue(key uint64) uint64
+func getParamValue(key uint64, dst uint64) uint32
 
 //go:wasmimport env setConfig
 func setConfig(key uint64, val uint64, kind uint32) uint32
@@ -300,14 +300,15 @@ func gadgetInit() int32 {
 	assertNonZero(fieldSet(fieldHandle, fieldHandle, uint32(api.Kind_Uint32), 1234), "fieldSet: bad data handle")
 	assertNonZero(fieldSet(dataHandle, dataHandle, uint32(api.Kind_Uint32), 1234), "fieldSet: bad field handle")
 
-	assertEqual(uint32(fieldGet(fieldHandle, dataHandle, uint32(api.Kind_Uint32))), 1234, "fieldGet: ok")
-	fieldGet(fieldHandle, dataHandle, 1005)
-	fieldGet(fieldHandle, fieldHandle, uint32(api.Kind_Uint32))
-	fieldGet(dataHandle, dataHandle, uint32(api.Kind_Uint32))
+	assertEqual(uint32(fieldGetScalar(fieldHandle, dataHandle, uint32(api.Kind_Uint32))), 1234, "fieldGetScalar: ok")
+	fieldGetScalar(fieldHandle, dataHandle, 1005)
+	fieldGetScalar(fieldHandle, fieldHandle, uint32(api.Kind_Uint32))
+	fieldGetScalar(dataHandle, dataHandle, uint32(api.Kind_Uint32))
 
 	/* Params */
-	assertZero(getParamValue(stringToBufPtr("non-existing-param")), "getParamValue: not-found")
-	assertZero(getParamValue(invalidStrPtr), "getParamValue: invalid key ptr")
+	paramBuf := bytesToBufPtr(make([]byte, 512))
+	assertNonZero(getParamValue(stringToBufPtr("non-existing-param"), paramBuf), "getParamValue: not-found")
+	assertNonZero(getParamValue(invalidStrPtr, paramBuf), "getParamValue: invalid key ptr")
 
 	/* Config */
 	assertZero(setConfig(stringToBufPtr("key"), stringToBufPtr("value"), uint32(api.Kind_String)), "setConfig: ok")

--- a/pkg/operators/wasm/testdata/params/program.go
+++ b/pkg/operators/wasm/testdata/params/program.go
@@ -24,7 +24,7 @@ import (
 
 //go:wasmexport gadgetStart
 func gadgetStart() int32 {
-	val, err := api.GetParamValue("param-key")
+	val, err := api.GetParamValue("param-key", 32)
 	if err != nil {
 		api.Errorf("failed to get param: %v", err)
 		return 1
@@ -36,7 +36,7 @@ func gadgetStart() int32 {
 		return 1
 	}
 
-	_, err = api.GetParamValue("non-existing-param")
+	_, err = api.GetParamValue("non-existing-param", 32)
 	if err == nil {
 		api.Errorf("looking for non-existing-param succeeded")
 		return 1

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -107,9 +107,6 @@ type wasmOperatorInstance struct {
 
 	logger logger.Logger
 
-	// malloc function exported by the guest
-	guestMalloc wapi.Function
-
 	dataSourceCallback wapi.Function
 
 	// Golang objects are exposed to the wasm module by using a handleID
@@ -272,12 +269,6 @@ func (i *wasmOperatorInstance) init(
 
 	if ret[0] != apiVersion {
 		return fmt.Errorf("unsupported gadget API version: %d, expected: %d", ret[0], apiVersion)
-	}
-
-	// We need to call malloc on the guest to pass strings
-	i.guestMalloc = mod.ExportedFunction("malloc")
-	if i.guestMalloc == nil {
-		return errors.New("wasm module doesn't export malloc")
 	}
 
 	i.dataSourceCallback = mod.ExportedFunction("dataSourceCallback")

--- a/wasmapi/go/config.go
+++ b/wasmapi/go/config.go
@@ -17,9 +17,11 @@ package api
 import (
 	"fmt"
 	"runtime"
+	_ "unsafe"
 )
 
 //go:wasmimport env setConfig
+//go:linkname setConfig setConfig
 func setConfig(key uint64, val uint64, kind uint32) uint32
 
 func SetConfig(key string, val any) error {

--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -18,54 +18,71 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	_ "unsafe"
 )
 
 //go:wasmimport env newDataSource
+//go:linkname newDataSource newDataSource
 func newDataSource(name uint64, typ uint32) uint32
 
 //go:wasmimport env getDataSource
+//go:linkname getDataSource getDataSource
 func getDataSource(name uint64) uint32
 
 //go:wasmimport env dataSourceSubscribe
+//go:linkname dataSourceSubscribe dataSourceSubscribe
 func dataSourceSubscribe(ds uint32, typ uint32, prio uint32, cb uint64) uint32
 
 //go:wasmimport env dataSourceGetField
+//go:linkname dataSourceGetField dataSourceGetField
 func dataSourceGetField(ds uint32, name uint64) uint32
 
 //go:wasmimport env dataSourceAddField
+//go:linkname dataSourceAddField dataSourceAddField
 func dataSourceAddField(ds uint32, name uint64, kind uint32) uint32
 
 //go:wasmimport env dataSourceNewPacketSingle
+//go:linkname dataSourceNewPacketSingle dataSourceNewPacketSingle
 func dataSourceNewPacketSingle(ds uint32) uint32
 
 //go:wasmimport env dataSourceNewPacketArray
+//go:linkname dataSourceNewPacketArray dataSourceNewPacketArray
 func dataSourceNewPacketArray(ds uint32) uint32
 
 //go:wasmimport env dataSourceEmitAndRelease
+//go:linkname dataSourceEmitAndRelease dataSourceEmitAndRelease
 func dataSourceEmitAndRelease(ds uint32, packet uint32) uint32
 
 //go:wasmimport env dataSourceRelease
+//go:linkname dataSourceRelease dataSourceRelease
 func dataSourceRelease(ds uint32, packet uint32) uint32
 
 //go:wasmimport env dataSourceUnreference
+//go:linkname dataSourceUnreference dataSourceUnreference
 func dataSourceUnreference(ds uint32) uint32
 
 //go:wasmimport env dataSourceIsReferenced
+//go:linkname dataSourceIsReferenced dataSourceIsReferenced
 func dataSourceIsReferenced(ds uint32) uint32
 
 //go:wasmimport env dataArrayNew
+//go:linkname dataArrayNew dataArrayNew
 func dataArrayNew(d uint32) uint32
 
 //go:wasmimport env dataArrayAppend
+//go:linkname dataArrayAppend dataArrayAppend
 func dataArrayAppend(d uint32, data uint32) uint32
 
 //go:wasmimport env dataArrayRelease
+//go:linkname dataArrayRelease dataArrayRelease
 func dataArrayRelease(d uint32, data uint32) uint32
 
 //go:wasmimport env dataArrayLen
+//go:linkname dataArrayLen dataArrayLen
 func dataArrayLen(d uint32) uint32
 
 //go:wasmimport env dataArrayGet
+//go:linkname dataArrayGet dataArrayGet
 func dataArrayGet(d uint32, index uint32) uint32
 
 type (

--- a/wasmapi/go/handle.go
+++ b/wasmapi/go/handle.go
@@ -16,9 +16,11 @@ package api
 
 import (
 	"errors"
+	_ "unsafe"
 )
 
 //go:wasmimport env releaseHandle
+//go:linkname releaseHandle releaseHandle
 func releaseHandle(handle uint32) uint32
 
 func ReleaseHandle[T ~uint32](handle T) error {

--- a/wasmapi/go/helpers.go
+++ b/wasmapi/go/helpers.go
@@ -14,30 +14,17 @@
 
 package api
 
-// TODO: is it possible to make it work without cgo?
-
-// #include <stdlib.h>
-import "C"
-
 import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
 	"slices"
-	"strings"
 	"unsafe"
 )
 
 // bufPtr encodes the pointer and length of a buffer as a uint64
 // The pointer is stored in the lower 32 bits and the length in the upper 32 bits
 type bufPtr uint64
-
-func (b bufPtr) free() {
-	if b == 0 {
-		return
-	}
-	C.free(unsafe.Pointer(uintptr(b & 0xFFFFFFFF)))
-}
 
 // stringToBufPtr returns a bufPtr that encodes the pointer and length of the
 // input string. Callers must guarantee that the passed string is kept alive
@@ -87,18 +74,6 @@ func anyToBufPtr(a any) (bufPtr, error) {
 func bytesToBufPtr(b []byte) bufPtr {
 	unsafePtr := unsafe.Pointer(unsafe.SliceData(b))
 	return bufPtr(uint64(len(b))<<32 | uint64(uintptr(unsafePtr)))
-}
-
-// string returns a copy of the string stored in the buffer.
-// The caller must call free() on the buffer when done.
-func (b bufPtr) string() string {
-	if b == 0 {
-		return ""
-	}
-	// create a string that users the pointer as storage
-	orig := unsafe.String((*byte)(unsafe.Pointer(uintptr(b&0xFFFFFFFF))), int(b>>32))
-	// clone it
-	return strings.Clone(orig)
 }
 
 // bytes returns a copy of the bytes stored in the buffer.

--- a/wasmapi/go/kallsyms.go
+++ b/wasmapi/go/kallsyms.go
@@ -16,9 +16,11 @@ package api
 
 import (
 	"runtime"
+	_ "unsafe"
 )
 
 //go:wasmimport env kallsymsSymbolExists
+//go:linkname kallsymsSymbolExists kallsymsSymbolExists
 func kallsymsSymbolExists(symbol uint64) uint32
 
 func KallsymsSymbolExists(symbol string) bool {

--- a/wasmapi/go/log.go
+++ b/wasmapi/go/log.go
@@ -17,9 +17,11 @@ package api
 import (
 	"fmt"
 	"runtime"
+	_ "unsafe"
 )
 
 //go:wasmimport env gadgetLog
+//go:linkname gadgetLog gadgetLog
 func gadgetLog(level uint32, str uint64)
 
 type logLevel uint32

--- a/wasmapi/go/map.go
+++ b/wasmapi/go/map.go
@@ -23,21 +23,27 @@ import (
 )
 
 //go:wasmimport env newMap
+//go:linkname newMap newMap
 func newMap(name uint64, typ uint32, keySize uint32, valueSize uint32, maxEntries uint32) uint32
 
 //go:wasmimport env getMap
+//go:linkname getMap getMap
 func getMap(name uint64) uint32
 
 //go:wasmimport env mapLookup
+//go:linkname mapLookup mapLookup
 func mapLookup(m uint32, keyptr uint64, valueptr uint64) uint32
 
 //go:wasmimport env mapUpdate
+//go:linkname mapUpdate mapUpdate
 func mapUpdate(m uint32, keyptr uint64, valueptr uint64, flags uint64) uint32
 
 //go:wasmimport env mapDelete
+//go:linkname mapDelete mapDelete
 func mapDelete(m uint32, keyptr uint64) uint32
 
 //go:wasmimport env mapRelease
+//go:linkname mapRelease mapRelease
 func mapRelease(m uint32) uint32
 
 type Map uint32


### PR DESCRIPTION
    Malloc() was required to be able to allocate and write data into the
    guest memory. This requirement was a bit strict as:
    - malloc() is exposed when using tinygo by a obscure undocumented way
    - This isn't exposed when using go 1.24
    - It can be challenging to expose on another programming languages

    This commit removes this requirement. The main change is that the guest
    now has to pass a preallocated buffer where the host will write the data.
    It can be suboptimal for some cases when the guest doesn't know the
    size, but it can help to reduce the allocations if the guest passes a
    static buffer in multiple calls. (As it was done in the trace_exec and
    trace_dns gadgets).

After applying this change, we can use go 1.24 to compile our gadgets as experimented on https://github.com/inspektor-gadget/inspektor-gadget/issues/4000#issuecomment-2656096773 by @burak-ok 

Fixes #3073