### PR TITLE
artifacthub: add missing description for profile_qdisc_latency

### DIFF
--- a/gadgets/profile_qdisc_latency/artifacthub-pkg.yml
+++ b/gadgets/profile_qdisc_latency/artifacthub-pkg.yml
@@ -3,8 +3,9 @@ version: 0.37.0
 name: "profile qdisc latency"
 category: monitoring-logging
 displayName: "profile qdisc latency"
-createdAt: "2024-11-06T19:00:00Z"
-digest: "2024-11-06T19:00:00Z"
+createdAt: "2025-02-13T00:00:00Z"
+digest: "2025-02-13T00:00:00Z"
+description: "profile network scheduler latency"
 logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
 license: ""
 homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/profile_qdisc_latency/"


### PR DESCRIPTION
See https://github.com/inspektor-gadget/inspektor-gadget/pull/3659#issuecomment-2671299658

> error getting package metadata (path: /tmp/artifact-hub1557883500/gadgets/profile_qdisc_latency): error validating package metadata file: 1 error occurred:
> invalid metadata: description not provided

Fixes: 76d79825e440 ("gadgets: add qdisc_latency tracer") #3659

cc @patrickpichler 