### PR TITLE
trace_capabilities: support for Linux < 6.1

### DIFF
--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -247,6 +247,7 @@ SEC("kretprobe/cap_capable")
 int BPF_KRETPROBE(ig_trace_cap_x)
 {
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tid = pid_tgid;
 	struct args_t *ap;
 	struct cap_event *event;
 
@@ -280,7 +281,7 @@ int BPF_KRETPROBE(ig_trace_cap_x)
 	}
 
 	struct syscall_context *sc_ctx;
-	sc_ctx = bpf_map_lookup_elem(&current_syscall, &event->proc.pid);
+	sc_ctx = bpf_map_lookup_elem(&current_syscall, &tid);
 	if (sc_ctx) {
 		event->syscall_raw = sc_ctx->nr;
 	} else {


### PR DESCRIPTION
Before this patch, the trace_capabilities gadget didn't work on AKS and EKS. It failed with:

> rpc error: code = Unknown desc = starting operators: starting operator "oci": starting operator "ebpf": creating eBPF collection: program ig_trace_cap_x: load program: permission denied: 138: (85) call bpf_map_lookup_elem#1: R2 type=alloc_mem expected=fp, pkt, pkt_meta, map_value (232 line(s) omitted)

This is because of the following code pattern:

```c
	event = gadget_reserve_buf(&events, sizeof(struct cap_event));
	if (!event)
		return 0;

	gadget_process_populate(&event->proc);

	sc_ctx = bpf_map_lookup_elem(&current_syscall, &event->proc.pid);
```

Arg2 is a pointer to a ringbuf allocated memory.

With that code pattern, we need Linux 6.1 for https://github.com/torvalds/linux/commit/894f2a8b1673a355a1a7507a4dfa6a3c836d07c1

This patch avoids using ringbuf allocated memory as key for bpf_map_lookup_elem, making it work for older Linux versions.

Partially addresses https://github.com/inspektor-gadget/inspektor-gadget/issues/4093 but not completely.

