### PR TITLE
wasm: Fix error ambiguity for fieldGetScalar

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -272,7 +272,7 @@ Return value:
 
 ### Fields
 
-#### `fieldGetScalar(u32 field, u32 data, u32 kind) u64`
+#### `fieldGetScalar(u32 field, u32 data, u32 kind, errPtr uint32) u64`
 
 Get the value of a scalar field.
 
@@ -280,10 +280,11 @@ Parameters:
 - `field` (u32): Field handle (as returned by `dataSourceGetField` or `dataSourceAddField`)
 - `data` (u32): Data handle
 - `kind` (u32): Kind of access: How to read the field.
+- `errPtr` (u32): A pointer to an uint32 variable where the error will be
+  stored. If it's 0, then the error is not reported.
 
 Return value:
-- Value of the field: The value of the field or 0 in case of errors
-  - TODO: 0 is ambiguous, find a way to report errors!
+- Value of the field
 
 #### `fieldGetBuffer(u32 field, u32 data, u32 kind, u64 dst) i32`
 

--- a/pkg/operators/wasm/testdata/Makefile
+++ b/pkg/operators/wasm/testdata/Makefile
@@ -6,6 +6,7 @@ TEST_ARTIFACTS = \
 	dataarray \
 	dataemit \
 	badguest \
+	baderrptr \
 	params \
 	config \
 	map \

--- a/pkg/operators/wasm/testdata/baderrptr/build.yaml
+++ b/pkg/operators/wasm/testdata/baderrptr/build.yaml
@@ -1,0 +1,1 @@
+wasm: program.go

--- a/pkg/operators/wasm/testdata/baderrptr/go.mod
+++ b/pkg/operators/wasm/testdata/baderrptr/go.mod
@@ -1,0 +1,8 @@
+module main
+
+go 1.23.0
+
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// use this to be able to compile it locally
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../../../

--- a/pkg/operators/wasm/testdata/baderrptr/program.go
+++ b/pkg/operators/wasm/testdata/baderrptr/program.go
@@ -1,0 +1,31 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+// Invalid ptr: out of bound 17 MB (max memory of the module is 16MB)
+const invalidPtr uint32 = uint32(17 * 1024 * 1024)
+
+//go:wasmimport env fieldGetScalar
+func fieldGetScalar(acc uint32, data uint32, kind uint32, errPtr uint32) uint64
+
+//go:wasmexport gadgetInit
+func gadgetInit() int32 {
+	fieldGetScalar(55, 55, uint32(api.Kind_Uint32), invalidPtr)
+	panic("This should never be reached")
+}

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -37,6 +37,72 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 )
 
+func runGadget(t *testing.T, gadgetCtx *gadgetcontext.GadgetContext, params map[string]string) error {
+	runtime := local.New()
+	err := runtime.Init(nil)
+	if err != nil {
+		return err
+	}
+	t.Cleanup(func() { runtime.Close() })
+
+	if params == nil {
+		params = map[string]string{}
+	}
+
+	params["operator.oci.verify-image"] = "false"
+	return runtime.RunGadget(gadgetCtx, nil, params)
+}
+
+func createGadgetCtx(t *testing.T, name string, ops ...operators.DataOperator) *gadgetcontext.GadgetContext {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	t.Cleanup(cancel)
+
+	ociStore, err := orasoci.NewFromTar(ctx, fmt.Sprintf("testdata/%s.tar", name))
+	require.NoError(t, err, "creating oci store")
+
+	dataOps := []operators.DataOperator{ocihandler.OciHandler}
+	dataOps = append(dataOps, ops...)
+	gadgetCtx := gadgetcontext.New(
+		ctx,
+		fmt.Sprintf("%s:latest", name),
+		gadgetcontext.WithDataOperators(dataOps...),
+		gadgetcontext.WithOrasReadonlyTarget(ociStore),
+	)
+
+	return gadgetCtx
+}
+
+func TestWasm(t *testing.T) {
+	utilstest.RequireRoot(t)
+
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		errExpected bool
+	}{
+		{"map", false},
+		{"mapofmap", false},
+		{"badguest", false},
+		{"syscall", false},
+		{"perf", false},
+		{"kallsyms", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			gadgetCtx := createGadgetCtx(t, test.name)
+			err := runGadget(t, gadgetCtx, nil)
+			if test.errExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestWasmFields(t *testing.T) {
 	utilstest.RequireRoot(t)
 
@@ -177,18 +243,7 @@ func TestWasmFields(t *testing.T) {
 		}),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/fields.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"fields:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
+	gadgetCtx := createGadgetCtx(t, "fields", myOperator)
 
 	// Register data source that will be used by the wasm program to add fields
 	ds, err := gadgetCtx.RegisterDataSource(datasource.TypeSingle, "myds")
@@ -207,15 +262,7 @@ func TestWasmFields(t *testing.T) {
 	},
 	)
 
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
+	err = runGadget(t, gadgetCtx, nil)
 	require.NoError(t, err, "running gadget")
 
 	require.Equal(t, counter, 1)
@@ -280,18 +327,7 @@ func TestWasmDataArray(t *testing.T) {
 		}),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/dataarray.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"dataarray:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
+	gadgetCtx := createGadgetCtx(t, "dataarray", myOperator)
 
 	// Register data source that will be used by the wasm program to add fields
 	ds, err := gadgetCtx.RegisterDataSource(datasource.TypeArray, "myds")
@@ -300,15 +336,7 @@ func TestWasmDataArray(t *testing.T) {
 	_, err = ds.AddField("foo", api.Kind_Uint32)
 	require.NoError(t, err)
 
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
+	err = runGadget(t, gadgetCtx, nil)
 	require.NoError(t, err, "running gadget")
 
 	require.Equal(t, counter, 1)
@@ -369,18 +397,7 @@ func TestWasmDataEmit(t *testing.T) {
 		}),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/dataemit.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"dataemit:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
+	gadgetCtx := createGadgetCtx(t, "dataemit", myOperator)
 
 	// Register data source that will be used by the wasm program to add fields
 	ds, err := gadgetCtx.RegisterDataSource(datasource.TypeArray, "old_ds")
@@ -389,48 +406,10 @@ func TestWasmDataEmit(t *testing.T) {
 	_, err = ds.AddField("foo", api.Kind_Uint32)
 	require.NoError(t, err)
 
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
+	err = runGadget(t, gadgetCtx, nil)
 	require.NoError(t, err, "running gadget")
 
 	require.Equal(t, counter, 1) // as only 1 of the two packets emitted by the `old_ds` will be passed on to the `new_ds`
-}
-
-func TestBadGuest(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/badguest.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"badguest:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
 }
 
 func TestWasmParams(t *testing.T) {
@@ -461,29 +440,12 @@ func TestWasmParams(t *testing.T) {
 		}),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/params.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"params:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
+	gadgetCtx := createGadgetCtx(t, "params", myOperator)
 	params := map[string]string{
-		"operator.oci.verify-image":   "false",
 		"operator.oci.wasm.param-key": "param-value",
 	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
+
+	err := runGadget(t, gadgetCtx, params)
 	require.NoError(t, err, "running gadget")
 }
 
@@ -492,28 +454,8 @@ func TestConfig(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/config.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"config:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
+	gadgetCtx := createGadgetCtx(t, "config")
+	err := runGadget(t, gadgetCtx, nil)
 	require.NoError(t, err, "running gadget")
 
 	cfg, ok := gadgetCtx.GetVar("config")
@@ -522,154 +464,4 @@ func TestConfig(t *testing.T) {
 	require.True(t, ok, "invalid configuration format")
 
 	require.Equal(t, "myvalue", v.GetString("foo.bar.zas"))
-}
-
-func TestMap(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/map.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"map:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
-}
-
-func TestMapOfMap(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/mapofmap.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"mapofmap:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
-}
-
-func TestSyscall(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/syscall.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"syscall:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
-}
-
-func TestPerf(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/perf.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"perf:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
-}
-
-func TestKallsyms(t *testing.T) {
-	utilstest.RequireRoot(t)
-
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	t.Cleanup(cancel)
-
-	ociStore, err := orasoci.NewFromTar(ctx, "testdata/kallsyms.tar")
-	require.NoError(t, err, "creating oci store")
-
-	gadgetCtx := gadgetcontext.New(
-		ctx,
-		"kallsyms:latest",
-		gadgetcontext.WithDataOperators(ocihandler.OciHandler),
-		gadgetcontext.WithOrasReadonlyTarget(ociStore),
-	)
-
-	runtime := local.New()
-	err = runtime.Init(nil)
-	require.NoError(t, err, "runtime init")
-	t.Cleanup(func() { runtime.Close() })
-
-	params := map[string]string{
-		"operator.oci.verify-image": "false",
-	}
-	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
 }

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -84,6 +84,7 @@ func TestWasm(t *testing.T) {
 		{"map", false},
 		{"mapofmap", false},
 		{"badguest", false},
+		{"baderrptr", true},
 		{"syscall", false},
 		{"perf", false},
 		{"kallsyms", false},

--- a/wasmapi/go/fields.go
+++ b/wasmapi/go/fields.go
@@ -39,134 +39,107 @@ func fieldAddTag(field uint32, tag uint64) uint32
 
 var errSetField = errors.New("error setting field")
 
+func (f Field) getScalar(data Data, kind FieldKind) (uint64, error) {
+	val := fieldGetScalar(uint32(f), uint32(data), uint32(kind))
+	return val, nil
+}
+
+func (f Field) set(data Data, kind FieldKind, value uint64) error {
+	ret := fieldSet(uint32(f), uint32(data), uint32(kind), value)
+	if ret != 0 {
+		return errSetField
+	}
+	return nil
+}
+
 func (f Field) Int8(data Data) (int8, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Int8))
-	return int8(val), nil
+	val, err := f.getScalar(data, Kind_Int8)
+	return int8(val), err
 }
 
 func (f Field) SetInt8(data Data, value int8) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Int8), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Int8, uint64(value))
 }
 
 func (f Field) Int16(data Data) (int16, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Int16))
-	return int16(val), nil
+	val, err := f.getScalar(data, Kind_Int16)
+	return int16(val), err
 }
 
 func (f Field) SetInt16(data Data, value int16) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Int16), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Int16, uint64(value))
 }
 
 func (f Field) Int32(data Data) (int32, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Int32))
-	return int32(val), nil
+	val, err := f.getScalar(data, Kind_Int32)
+	return int32(val), err
 }
 
 func (f Field) SetInt32(data Data, value int32) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Int32), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Int32, uint64(value))
 }
 
 func (f Field) Int64(data Data) (int64, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Int64))
-	return int64(val), nil
+	val, err := f.getScalar(data, Kind_Int64)
+	return int64(val), err
 }
 
 func (f Field) SetInt64(data Data, value int64) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Int64), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Int64, uint64(value))
 }
 
 func (f Field) Uint8(data Data) (uint8, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Uint8))
-	return uint8(val), nil
+	val, err := f.getScalar(data, Kind_Uint8)
+	return uint8(val), err
 }
 
 func (f Field) SetUint8(data Data, value uint8) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Uint8), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Uint8, uint64(value))
 }
 
 func (f Field) Uint16(data Data) (uint16, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Uint16))
-	return uint16(val), nil
+	val, err := f.getScalar(data, Kind_Uint16)
+	return uint16(val), err
 }
 
 func (f Field) SetUint16(data Data, value uint16) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Uint16), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Uint16, uint64(value))
 }
 
 func (f Field) Uint32(data Data) (uint32, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Uint32))
-	return uint32(val), nil
+	val, err := f.getScalar(data, Kind_Uint32)
+	return uint32(val), err
 }
 
 func (f Field) SetUint32(data Data, value uint32) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Uint32), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Uint32, uint64(value))
 }
 
 func (f Field) Uint64(data Data) (uint64, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Uint64))
-	return uint64(val), nil
+	val, err := f.getScalar(data, Kind_Uint64)
+	return uint64(val), err
 }
 
 func (f Field) SetUint64(data Data, value uint64) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Uint64), uint64(value))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Uint64, uint64(value))
 }
 
 func (f Field) Float32(data Data) (float32, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Float32))
-	return math.Float32frombits(uint32(val)), nil
+	val, err := f.getScalar(data, Kind_Float32)
+	return math.Float32frombits(uint32(val)), err
 }
 
 func (f Field) SetFloat32(data Data, value float32) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Float32), uint64(math.Float32bits(value)))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Float32, uint64(math.Float32bits(value)))
 }
 
 func (f Field) Float64(data Data) (float64, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Float64))
-	return math.Float64frombits(uint64(val)), nil
+	val, err := f.getScalar(data, Kind_Float64)
+	return math.Float64frombits(uint64(val)), err
 }
 
 func (f Field) SetFloat64(data Data, value float64) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Float64), uint64(math.Float64bits(value)))
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Float64, uint64(math.Float64bits(value)))
 }
 
 func (f Field) String(data Data, maxSize uint32) (string, error) {
@@ -179,12 +152,9 @@ func (f Field) String(data Data, maxSize uint32) (string, error) {
 }
 
 func (f Field) SetString(data Data, str string) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_String), uint64(stringToBufPtr(str)))
+	err := f.set(data, Kind_String, uint64(stringToBufPtr(str)))
 	runtime.KeepAlive(str)
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return err
 }
 
 // Bytes get the bytes of a field of type string or []byte into an
@@ -198,17 +168,14 @@ func (f Field) Bytes(data Data, dst []byte) (uint32, error) {
 }
 
 func (f Field) SetBytes(data Data, buf []byte) error {
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Bytes), uint64(bytesToBufPtr(buf)))
+	err := f.set(data, Kind_Bytes, uint64(bytesToBufPtr(buf)))
 	runtime.KeepAlive(buf)
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return err
 }
 
 func (f Field) Bool(data Data) (bool, error) {
-	val := fieldGetScalar(uint32(f), uint32(data), uint32(Kind_Bool))
-	return val == 1, nil
+	val, err := f.getScalar(data, Kind_Bool)
+	return val == 1, err
 }
 
 func (f Field) SetBool(data Data, b bool) error {
@@ -216,11 +183,7 @@ func (f Field) SetBool(data Data, b bool) error {
 	if b {
 		value = 1
 	}
-	ret := fieldSet(uint32(f), uint32(data), uint32(Kind_Bool), value)
-	if ret != 0 {
-		return errSetField
-	}
-	return nil
+	return f.set(data, Kind_Bool, uint64(value))
 }
 
 func (f Field) AddTag(tag string) error {


### PR DESCRIPTION
Before this commit it wasn't possible to distinguish between an error
and a field with value 0. This commit introduces a new error parameter
to report the error value instead of having the return value used for
both purposes.

Fixes #3071
Requires  #4097 to be merged first