### PR TITLE
oci: Error out when handling wrong image

### DIFF
--- a/pkg/operators/ebpf/ebpf_test.go
+++ b/pkg/operators/ebpf/ebpf_test.go
@@ -56,5 +56,5 @@ func TestEmpty(t *testing.T) {
 		"operator.oci.verify-image": "false",
 	}
 	err = runtime.RunGadget(gadgetCtx, nil, params)
-	require.NoError(t, err, "running gadget")
+	require.Error(t, err, "running gadget")
 }

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -387,7 +387,7 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		log.Debugf("found image op %q", op.Name())
 		opInst, err := op.InstantiateImageOperator(gadgetCtx, target, layer, o.paramValues.ExtractPrefixedValues(op.Name()))
 		if err != nil {
-			log.Errorf("instantiating operator %q: %v", op.Name(), err)
+			return fmt.Errorf("instantiating operator %q: %w", op.Name(), err)
 		}
 		if opInst == nil {
 			log.Debugf("> skipped %s", op.Name())


### PR DESCRIPTION
If loading an image operator fails, then make the whole thing fail.

Fixes: 83cb51de48f7 ("pkg/operators/oci: add OCI handler")

### Testing 

Create an image with an invalid wasm layer:

```diff
diff --git a/pkg/operators/wasm/testdata/badguest/program.go b/pkg/operators/wasm/testdata/badguest/program.go
index 6cd2e2b1..cc74b45c 100644
--- a/pkg/operators/wasm/testdata/badguest/program.go
+++ b/pkg/operators/wasm/testdata/badguest/program.go
@@ -109,7 +109,7 @@ func fieldGet(acc uint32, data uint32, kind uint32) uint64
 func fieldSet(acc uint32, data uint32, kind uint32, value uint64) uint32

 //go:wasmimport env getParamValue
-func getParamValue(key uint64) uint64
+func getParamValue(key uint64) uint32

 //go:wasmimport env setConfig
 func setConfig(key uint64, val uint64, kind uint32) uint32
```

```bash 
$ make -C pkg/operators/wasm/testdata/ badguest
```

### Before this PR 

Test passes fine only printing a warning:

```bash 
$ go test -exec sudo ./pkg/operators/wasm/ -run TestBadGuest -v
=== RUN   TestBadGuest
=== PAUSE TestBadGuest
=== CONT  TestBadGuest
time="2025-02-21T17:26:44-05:00" level=warning msg="Builder version not found in the gadget image. Gadget could be incompatible"
time="2025-02-21T17:26:44-05:00" level=error msg="instantiating operator \"wasm\": initializing wasm: instantiating wasm: import func[env.getParamValue]: signature mismatch: i64_i32 != i64_i64"
--- PASS: TestBadGuest (2.00s)
PASS
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm 2.044s
```

### After this PR 

Test fails:

```bash 
$ go test -exec sudo ./pkg/operators/wasm/ -run TestBadGuest
time="2025-02-21T17:26:14-05:00" level=warning msg="Builder version not found in the gadget image. Gadget could be incompatible"
--- FAIL: TestBadGuest (0.23s)
    wasm_test.go:433:
                Error Trace:    /home/mauriciov/kinvolk/ebpf/inspektor-gadget/pkg/operators/wasm/wasm_test.go:433
                Error:          Received unexpected error:
                                initializing and preparing operators: instantiating operator "oci": instantiating operator "wasm": initializing wasm: instantiating wasm: import func[env.getParamValue]: signature mismatch: i64_i32 != i64_i64
                Test:           TestBadGuest
                Messages:       running gadget
FAIL
FAIL    github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm 0.272s
FAIL
```