### PR TITLE
ebpf-builder.Dockerfile: remove workaround on software-properties-common

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -35,9 +35,7 @@ ARG TINYGO_VERSION
 RUN apt-get update \
 	&& apt-get install -y libc-dev lsb-release wget gnupg xz-utils \
 	&& if [ "$(dpkg --print-architecture)" = 'amd64' ]; then apt-get install -y libc6-dev-i386; fi
-
-# Hack to install software-properties-common separately because of dpkg errors
-RUN apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common|| sudo dpkg --configure -a && apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common || sudo dpkg --configure -a && apt install -y -f software-properties-common
+RUN apt install -y software-properties-common
 
 # Install clang 15
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LLVM_VERSION all \


### PR DESCRIPTION
The workaround was introduced in a64e9228d3c6 ("ebpf-builder.Dockerfile: workaround to install software-properties-common") #4084.

---

Let's check the CI to see if the error described in #4084 is fixed.