### PR TITLE
ci: Mirror dockerhub images to our repo

### DIFF
--- a/.github/workflows/dockerhub-mirror.yml
+++ b/.github/workflows/dockerhub-mirror.yml
@@ -1,0 +1,51 @@
+# taken from https://github.com/rblaine95/dockerhub-mirror/
+
+name: Mirror Dockerhub
+env:
+  REGISTRY: ghcr.io
+  CONTAINER_REPO: ${{ github.repository }}
+  GO_VERSION: 1.23.4
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  mirror:
+    name: Mirror
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: alpine:latest
+            repo: docker.io/library
+          - image: busybox:latest
+            repo: docker.io/library
+          - image: gcc:latest
+            repo: docker.io/library
+          - image: nginx:latest
+            repo: docker.io/library
+          - image: registry:2
+            repo: docker.io/library
+          - image: network-multitool:latest
+            repo: docker.io/wbitt
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+         go-version: ${{ env.GO_VERSION }}
+      - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+      - name: Mirror
+        run: |
+          crane copy \
+            ${{ matrix.repo }}/${{ matrix.image }} \
+            ghcr.io/${{ github.repository_owner }}/ci/${{ matrix.image }}


### PR DESCRIPTION
Dockerhub pull rate limits are a problem for our CI/CD pipelines. This PR adds a workflow that mirrors the images we use from Dockerhub to our own container registry. This way, we can avoid the rate limits and have more control over the images we use.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
