### PR TITLE
ci: check links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,24 @@
+name: Links check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  check-link:
+    name: Links check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check that there are not broken links
+      uses: gaurav-nelson/github-action-markdown-link-check@1b916f2cf6c36510a6059943104e3c42ce6c16bc # v1.0.16
+      with:
+        config-file: .github/workflows/mlc_config.json
+        use-quiet-mode: 'yes'
+        # check if a web page has been deleted or moved, so we can update our documentation accordingly
+        check-modified-files-only: 'no'
+        base-branch: 'main'

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -53,15 +53,13 @@ jobs:
       run: |
         make manifests generate generate-documentation
         git diff --exit-code HEAD --
-    - name: Replace tag constant
-      run: |
-        # Replace tag and branch constants to be able to check links
-        find docs/ -type f -exec sed -i 's/%IG_BRANCH%/main/g' {} +
-        find docs/ -type f -exec sed -i 's/%IG_TAG%/latest/g' {} +
     - name: Check that there are not broken links
-      uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+      uses: gaurav-nelson/github-action-markdown-link-check@1b916f2cf6c36510a6059943104e3c42ce6c16bc # v1.0.16
       with:
+        config-file: .github/workflows/mlc_config.json
         use-quiet-mode: 'yes'
+        check-modified-files-only: 'yes'
+        base-branch: 'main'
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       id: filter
       with:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,13 @@
+{
+   "ignorePatterns" : [],
+   "replacementPatterns" : [
+      {
+         "pattern" : "%IG_BRANCH%",
+         "replacement" : "main"
+      },
+      {
+         "pattern" : "%IG_TAG%",
+         "replacement" : "latest"
+      }
+   ]
+}


### PR DESCRIPTION
The link check action was often failing due to repeatitive checks. This was annoying because it makes PRs fail due to links unrelated to the PR being tested.

This patch uses the check-modified-files-only parameter, so pull requests will only check the links that were modified in the PR.

This also adds a daily job to test all the links, so we learn about links that become broken.
