### PR TITLE
WASM: Use Go 1.24 for the wasmylayer instead of TinyGo

### DIFF
--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -1,12 +1,11 @@
 ARG CLANG_LLVM_VERSION=18
 ARG BPFTOOL_VERSION=v7.3.0
 ARG LIBBPF_VERSION=v1.3.0
-ARG TINYGO_VERSION=0.35.0
 
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 
-FROM golang:1.23.6@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
+FROM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 AS builder
 ARG BPFTOOL_VERSION
 ARG LIBBPF_VERSION
 
@@ -23,9 +22,9 @@ RUN \
 	tar -C /usr/local/bin -xzf bpftool-${BPFTOOL_VERSION}-${ARCH}.tar.gz && \
 	chmod +x /usr/local/bin/bpftool
 
-FROM golang:1.23.6@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959
+# We use Go version >1.24 here for the WASM layers, because it is the first version to support exporting functions
+FROM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418
 ARG CLANG_LLVM_VERSION
-ARG TINYGO_VERSION
 # libc-dev is needed for various headers, among others
 # /usr/include/arch-linux-gnu/asm/types.h.
 # libc-dev-i386 is needed on amd64 to provide <gnu/stubs-32.h>.
@@ -45,23 +44,6 @@ RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LL
 
 COPY --from=builder /usr/include/bpf /usr/include/bpf
 COPY --from=builder /usr/local/bin/bpftool /usr/local/bin/bpftool
-
-# Install tinygo
-RUN \
-	DEB=tinygo.deb && \
-	ARCH=$(dpkg --print-architecture) && \
-	wget --quiet https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_${ARCH}.deb -O $DEB && \
-	if [ "${ARCH}" = 'amd64' ] ; then \
-		SHA='ca33e87d1716ba58890d6cd6e8dd33c685427724c53e64fc4237bcf3101747a35d5059718e88dce9095608585898a4a85d36206daf7e290af5bcf9c2a9230ab3'; \
-	elif [ "${ARCH}" = 'arm64' ] ; then \
-		SHA='d6cebaf444bed7a1a8d39c04e58d2138418776b75b87110c02299baa1d59c2cb4c835f685c0829eead6fc4b89bffe1ede922db408755c30e57c460d31ed54491'; \
-	else \
-		echo "${ARCH} is not supported" 2>&1 ; \
-		exit 1; \
-	fi && \
-	echo $SHA $DEB | sha512sum -c && \
-	dpkg -i $DEB && \
-	rm -f $DEB
 
 # To avoid hitting this:
 # failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied

--- a/cmd/common/image/helpers/Makefile.build
+++ b/cmd/common/image/helpers/Makefile.build
@@ -1,7 +1,6 @@
 # This makefile is used by the build command, don't execute it manually
 
 CLANG ?= clang
-TINYGO ?= tinygo
 LLVM_STRIP ?= llvm-strip
 BASECFLAGS = -target bpf -Wall -g -O2
 CFLAGS ?=
@@ -27,7 +26,7 @@ else ifeq (go,$(patsubst %.go,go,$(WASM)))
 wasm: $(WASM)
 	# -buildmode=c-shared to build the wasm as a reactor module. See https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi
 	cd $(dir $(WASM)) && \
-	$(TINYGO) build -o $(OUTPUTDIR)/program.wasm -target=wasip1 --no-debug -buildmode=c-shared $(notdir $(WASM))
+	CGO_ENABLED=0 GOOS=wasip1 GOARCH=wasm go build -o $(OUTPUTDIR)/program.wasm -buildmode=c-shared -ldflags "-w -s" $(notdir $(WASM))
 else ifeq (wasm,$(patsubst %.wasm,wasm,$(WASM)))
 wasm:
 	# Wasm file already compiled. Nothing to do.

--- a/docs/gadget-devel/building.md
+++ b/docs/gadget-devel/building.md
@@ -54,7 +54,7 @@ The building process is controlled by the `build.yaml` file. The following param
 - `metadata`: File containing metadata about the gadget. It defaults to `gadget.yaml`.
 - `wasm`: Wasm module. It is unset by default. This field supports two kind of files:
     - `*.wasm`: prebuilt Wasm module
-    - `*.go`: automatically built with tinygo
+    - `*.go`: automatically built
 - `cflags`: The C flags used to compile the eBPF program. It is unset by default.
 
 By default, the build command looks for `build.yaml` in PATH. It can be changed with the `--file` flag:

--- a/pkg/operators/wasm/testdata/baderrptr/program.go
+++ b/pkg/operators/wasm/testdata/baderrptr/program.go
@@ -29,3 +29,5 @@ func gadgetInit() int32 {
 	fieldGetScalar(55, 55, uint32(api.Kind_Uint32), invalidPtr)
 	panic("This should never be reached")
 }
+
+func main() {}

--- a/pkg/operators/wasm/testdata/badguest/program.go
+++ b/pkg/operators/wasm/testdata/badguest/program.go
@@ -40,8 +40,8 @@ const (
 	subscriptionTypePacket subscriptionType = 3
 )
 
-// Invalid string: Too big (4GB) and offset too big (64MB)
-const invalidStrPtr uint64 = uint64(1024 * 1024 << 32)
+// Invalid string: Too big (17 MB, we only provide 16MB to WASM programs)
+const invalidStrPtr uint64 = uint64(1024 * 1024 * 17 << 32)
 
 // Keep in sync with pkg/operators/wasm/syscalls.go.
 type syscallParam struct {

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -54,7 +54,7 @@ func runGadget(t *testing.T, gadgetCtx *gadgetcontext.GadgetContext, params map[
 }
 
 func createGadgetCtx(t *testing.T, name string, ops ...operators.DataOperator) *gadgetcontext.GadgetContext {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	t.Cleanup(cancel)
 
 	ociStore, err := orasoci.NewFromTar(ctx, fmt.Sprintf("testdata/%s.tar", name))

--- a/wasmapi/go/doc.go
+++ b/wasmapi/go/doc.go
@@ -16,9 +16,5 @@
 Package api contains the reference implementation of the wasm API for Inspektor
 Gadget. It's designed to be used by gadgets and not by any other internal
 component of Inspektor Gadget.
-
-This package requires TinyGo to ensure that stacks are not dynamically moved
-between unsafe.StringData and calls to wasm host functions. It doesn't work with
-the official Golang compiler.
 */
 package api


### PR DESCRIPTION
## WASM: Use Go 1.24 for the wasmylayer instead of TinyGo

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/4000

