### PR TITLE
ci: Fix location of ci images

### DIFF
--- a/.github/workflows/dockerhub-mirror.yml
+++ b/.github/workflows/dockerhub-mirror.yml
@@ -1,8 +1,12 @@
+# This workflow mirrors few container images we use on the CI from Dockerhub to
+# ghcr.io to avoid pull rate limit issues. Images are mirrored to
+# ghcr.io/inspektor-gadget/ci/<image-name>.
+#
 # based on https://github.com/rblaine95/dockerhub-mirror/
 name: Mirror Dockerhub
 env:
   REGISTRY: ghcr.io
-  CONTAINER_REPO: ${{ github.repository }}
+  CONTAINER_REPO: ${{ github.repository_owner }}
   GO_VERSION: 1.23.4
 on:
   workflow_dispatch:


### PR DESCRIPTION
Location should be ghcr.io/inspektor-gadget/ci/foo instead of ghcr.io/inspektor-gadget/inspektor-gadget/ci/foo.

Fixes: 3175b3db4bd6 ("ci: Mirror dockerhub images to our repo")

Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/4122#discussion_r1969867592
