### PR TITLE
operators/env: introduce operator to create new fields from environment variables

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 The Inspektor Gadget authors
+// Copyright 2019-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import (
 	// Another blank import for the used operator
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/env"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager"

--- a/docs/spec/operators/env.md
+++ b/docs/spec/operators/env.md
@@ -1,0 +1,46 @@
+---
+title: Environment Variables
+---
+
+The Environment Variable operator lets you add fields containing environment variables to datasources. This helps with
+adding host related information to events.
+
+In order to do so, you first need to add the names of allowed environment variables to the `--env-vars` parameter and
+then add an annotation to the datasource you want to contain the new field like so:
+
+```yaml
+datasources:
+  mydatasource:
+    annotations:
+      env.fields.myfieldname: MYENVVAR
+```
+
+This example will add a field named `myfieldname` to the datasource `mydatasource` with the static value of the
+environment variable called `MYENVVAR`.
+
+It is important to note that environment variables will always be read from the host that runs the gadget and _not_
+on the client side.
+
+## Priority
+
+1
+
+## Parameters
+
+### Global Parameters
+
+#### `env-vars`
+
+Comma-separated list of environment variables that are allowed to be included in datasources.
+
+Default: empty
+
+## Annotations
+
+### Data Source Annotations
+
+#### `env.fields.FIELDNAME`
+
+You can use multiple annotations like this (having distinctive `FIELDNAME` values) to add new fields to a
+datasource. The value of the annotation should be the name of the environment variable that you want the field to
+contain.

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 The Inspektor Gadget authors
+// Copyright 2019-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import (
 	// Blank import for some operators
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/env"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubeipresolver"

--- a/pkg/operators/env/env.go
+++ b/pkg/operators/env/env.go
@@ -1,0 +1,147 @@
+// Copyright 2024-2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+)
+
+const (
+	Name     = "env"
+	Priority = 1
+
+	AnnotationPrefix = "env.fields."
+
+	ParamEnvVars = "env-vars"
+)
+
+type Config struct {
+	AllowedVars []string
+}
+
+type envOperator struct {
+	config Config
+}
+
+func (e *envOperator) Name() string {
+	return Name
+}
+
+func (e *envOperator) Init(params *params.Params) error {
+	e.config.AllowedVars = strings.Split(params.Get(ParamEnvVars).AsString(), ",")
+	return nil
+}
+
+func (e *envOperator) GlobalParams() api.Params {
+	return api.Params{
+		{
+			Key:         "env-vars",
+			Description: "Comma-separated list of environment variables to allow to be included",
+			Title:       "Allowed Environment Variables",
+		},
+	}
+}
+
+func (e *envOperator) InstanceParams() api.Params {
+	return nil
+}
+
+func (e *envOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	instance := &envOperatorInstance{
+		op:     e,
+		fields: make(map[datasource.DataSource][]datasource.DataFunc),
+	}
+	err := instance.init(gadgetCtx)
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}
+
+func (e *envOperator) Priority() int {
+	return Priority
+}
+
+type envOperatorInstance struct {
+	op     *envOperator
+	fields map[datasource.DataSource][]datasource.DataFunc
+}
+
+func (e *envOperatorInstance) Name() string {
+	return Name
+}
+
+func (e *envOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
+	e.fields = make(map[datasource.DataSource][]datasource.DataFunc)
+	for _, ds := range gadgetCtx.GetDataSources() {
+		annotations := ds.Annotations()
+		for k, v := range annotations {
+			fieldName, ok := strings.CutPrefix(k, AnnotationPrefix)
+			if !ok {
+				continue
+			}
+
+			// check, if the environment variable is allowed
+			if !slices.Contains(e.op.config.AllowedVars, v) {
+				return fmt.Errorf("environment var %q not in allowed vars: %v", fieldName, e.op.config.AllowedVars)
+			}
+
+			nf, err := ds.AddField(fieldName, api.Kind_String)
+			if err != nil {
+				return fmt.Errorf("adding field %s: %w", fieldName, err)
+			}
+
+			ct := os.Getenv(v)
+
+			gadgetCtx.Logger().Debugf("adding field %s with content %q from environment variable %q", fieldName, ct, v)
+			e.fields[ds] = append(e.fields[ds], func(ds datasource.DataSource, data datasource.Data) error {
+				return nf.PutString(data, ct)
+			})
+		}
+	}
+	return nil
+}
+
+func (e *envOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	for ds, funcs := range e.fields {
+		for _, f := range funcs {
+			err := ds.Subscribe(f, 0)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *envOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (e *envOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func init() {
+	operators.RegisterDataOperator(&envOperator{})
+}

--- a/pkg/operators/env/env_test.go
+++ b/pkg/operators/env/env_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024-2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+)
+
+func TestEnv(t *testing.T) {
+	demoEnvVar := "DEMO_ENV_VAR"
+	demoEnvVal := "Ahoy!"
+	demoFieldName := "env"
+	os.Setenv(demoEnvVar, demoEnvVal)
+	o := &envOperator{}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	globalParams.Set(ParamEnvVars, demoEnvVar)
+	err := o.Init(globalParams)
+	require.NoError(t, err)
+
+	var ds datasource.DataSource
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "test")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationPrefix+demoFieldName, demoEnvVar)
+		require.NoError(t, err)
+		return nil
+	}
+	produce := func(operators.GadgetContext) error {
+		data, err := ds.NewPacketSingle()
+		assert.NoError(t, err)
+		err = ds.EmitAndRelease(data)
+		assert.NoError(t, err)
+		cancel()
+		return nil
+	}
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+
+	success := false
+	consume := func(gadgetCtx operators.GadgetContext) error {
+		ds := gadgetCtx.GetDataSources()["test"]
+		require.NotNil(t, ds)
+
+		field := ds.GetField(demoFieldName)
+		require.NotNil(t, field)
+
+		ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
+			sv, err := field.String(data)
+			require.NoError(t, err)
+			assert.Equal(t, demoEnvVal, sv)
+			success = true
+			return nil
+		}, 1000)
+		return nil
+	}
+	consumer := simple.New("consumer",
+		simple.WithPriority(Priority-1),
+		simple.OnPreStart(consume),
+	)
+
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer, consumer))
+	err = gadgetCtx.Run(nil)
+	require.NoError(t, err)
+
+	assert.True(t, success)
+}
+
+func TestEnvForbidden(t *testing.T) {
+	demoEnvVar := "DEMO_ENV_VAR"
+	demoEnvVal := "Ahoy!"
+	demoFieldName := "env"
+	os.Setenv(demoEnvVar, demoEnvVal)
+	o := &envOperator{}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	// Omitting setting ParamEnvVars here
+	err := o.Init(globalParams)
+	require.NoError(t, err)
+
+	var ds datasource.DataSource
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeSingle, "test")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationPrefix+demoFieldName, demoEnvVar)
+		require.NoError(t, err)
+		return nil
+	}
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+	)
+
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+	err = gadgetCtx.Run(nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This operator lets you add new fields to datasources and fill it with contents of environment variables. For security reasons, environment variables that should be read by the operator need to be configured explicitly using the `--env-vars` parameter.

Annotations need to look like this:
```yaml
datasources:
  myds:
    annotations:
      env.fields.my-new-field: ENV_VAR_1
```
