### PR TITLE
operators: wasm: Have getSyscallID() returns -1 on error.

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -470,7 +470,7 @@ Parameters:
 Return value:
 - (u32) 0 in case of success, 1 otherwise.
 
-#### `getSyscallID(name uint64) uint64`
+#### `getSyscallID(name uint64) int32`
 
 Get the syscall ID for this sycall name.
 
@@ -478,7 +478,7 @@ Parameters:
 - `name` (u64): Syscall name.
 
 Return value:
-- (u64) the syscall ID if the name corresponds to a syscall, math.MaxUint64 otherwise.
+- (i32) the syscall ID if the name corresponds to a syscall, -1 otherwise.
 
 #### `getSyscallDeclaration(name uint64, pointer uint64) uint32`
 

--- a/wasmapi/go/syscall.go
+++ b/wasmapi/go/syscall.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"fmt"
-	"math"
 	"runtime"
 	"unsafe"
 	_ "unsafe"
@@ -28,7 +27,7 @@ func getSyscallName(id uint32, dst uint64) uint32
 
 //go:wasmimport env getSyscallID
 //go:linkname getSyscallID getSyscallID
-func getSyscallID(name uint64) uint64
+func getSyscallID(name uint64) int32
 
 //go:wasmimport env getSyscallDeclaration
 //go:linkname getSyscallDeclaration getSyscallDeclaration
@@ -74,9 +73,9 @@ func GetSyscallName(id uint16) (string, error) {
 	return fromCString(dst), nil
 }
 
-func GetSyscallID(name string) (uint64, error) {
+func GetSyscallID(name string) (int32, error) {
 	id := getSyscallID(uint64(stringToBufPtr(name)))
-	if id == math.MaxUint64 {
+	if id == -1 {
 		return 0, fmt.Errorf("getting syscall ID for syscall %s", name)
 	}
 


### PR DESCRIPTION
Fixes: 62f43ea7b872 ("operators/wasm: Add function to get syscall ID from syscall name.")