### PR TITLE
snapshot_process: Increase timeout to fix test

### DIFF
--- a/gadgets/snapshot_process/test/unit/snapshot_process_test.go
+++ b/gadgets/snapshot_process/test/unit/snapshot_process_test.go
@@ -146,7 +146,7 @@ func TestSnapshotProcessGadget(t *testing.T) {
 }
 
 func generateEvent() (int, error) {
-	cmd := exec.Command("/bin/sleep", "5")
+	cmd := exec.Command("/bin/sleep", "30")
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The TestSnapshotProcessGadget/captures_events_with_no_filter is failing a lot because it's not able to capture the event. Increase the timeout to be sure sleep lasts long enough to be captured by the gadget.
