### PR TITLE
gadgets: port profile_cpu to image based gadget

### DIFF
--- a/docs/gadget-devel/program-types.md
+++ b/docs/gadget-devel/program-types.md
@@ -47,8 +47,28 @@ You can find the list of iterator types supported by Linux with:
 
 #### Fentry / Fexit
 
-The section name must use the `fentry/<function_name` or `fexit/<function_name>`. As in kprobes,
-`<function_name>` is the kernel function that the kprobe will be attached to.
+The section name must use the `fentry/<function_name>` or `fexit/<function_name>`. As in kprobes,
+`<function_name>` is the kernel function that the program will be attached to.
+
+### PerfEvents
+
+The section name must be `perf_event/<name>`, where `<name>` is used to apply parameters to the
+program using the `gadget.yaml` file.
+
+Currently, we only support the following settings (`<name>` is `myPerfEvent` in this case):
+
+```yaml
+programs:
+  myPerfEvent:
+    perf:
+      type: software
+      config: count_sw_cpu_clock
+      sampleType: sample_raw
+    sampler:
+      frequency: 49
+```
+
+All parameters are mandatory for now.
 
 ### Raw Tracepoints
 

--- a/docs/gadgets/profile_cpu.mdx
+++ b/docs/gadgets/profile_cpu.mdx
@@ -1,0 +1,125 @@
+---
+title: profile_cpu
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# profile_cpu
+
+The profile cpu gadget takes samples of stack traces.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --map-fetch-interval 0 [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --map-fetch-interval 0 [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Guide
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        Here we deploy a small demo pod "random":
+
+        ```bash
+        $ kubectl run --restart=Never --image=busybox random -- sh -c 'cat /dev/urandom > /dev/null'
+        pod/random created
+        ```
+
+        Using the profile cpu gadget, we can see the list of stack traces.
+        The following command filters only for pods named "random", execute the command
+        and interrupt it after ~30 seconds. The `--kernel-stacks-only` option is passed to show only the
+        kernel stack traces.
+
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --podname random --kernel-stacks-only --map-fetch-interval 0
+        ```
+
+        After a while press with Ctrl-C to stop trace collection
+
+        ```
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --timeout 5 --podname random --kernel-stacks-only
+        K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME             K8S.CONTAINERNAME              PID COMM             SAMPLES              KERN_STACK
+        minikube-docker          default                  random                  random                       38130 containerd-shim  5                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_block_generic;…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        ```
+
+        From the traces above, you can see that the pod is spending CPU time in the
+        Linux function `urandom_read`.
+
+        Instead of waiting, you can use the `--timeout` argument:
+
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --timeout 5 --podname random --kernel-stacks-only --map-fetch-interval 0
+        K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME             K8S.CONTAINERNAME              PID COMM             SAMPLES              KERN_STACK
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]_copy_to_iter; [1]get…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  5                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]get_random_bytes_user…
+        ```
+
+        Finally, we need to clean up our pod:
+
+        ```bash
+        $ kubectl delete pod random
+        ```
+    </TabItem>
+    <TabItem value="ig" label="ig">
+        * Generate some kernel load:
+
+        ```bash
+        $ docker run -d --rm --name random busybox cat /dev/urandom > /dev/null
+        ```
+
+        * Start `ig`:
+
+        ```bash
+        $ sudo ./ig profile cpu --kernel-stacks-only --containername random --runtimes docker --map-fetch-interval 0
+        ```
+
+        * Observe the results:
+
+        ```bash
+        RUNTIME.CONTAINERNAME     KERNEL_IP            COMM                    PID        TID SAMPLES              KERN_STACK
+        random                    18446603336363922440 cat                   83451      83451 2                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336357767960 cat                   83451      83451 1                    [0]rcu_all_qs; [1]__cond_resched; [2]get_random_bytes_user; [3]ura…
+        random                    18446603336363922292 cat                   83451      83451 2                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922360 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922208 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922380 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363862956 cat                   83451      83451 1                    [0]push_pipe; [1]_copy_to_iter; [2]get_random_bytes_user; [3]urand…
+        random                    18446603336363922252 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922260 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336357585584 cat                   83451      83451 1                    [0]mutex_spin_on_owner; [1]__mutex_lock.constprop.0; [2]__mutex_lo…
+        random                    18446603336363922196 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922444 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        ```
+
+        * Remove the docker container:
+
+        ```bash
+        $ docker stop random
+        ```
+
+    </TabItem>
+</Tabs>

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -27,6 +27,7 @@ GADGETS = \
 	fdpass \
 	fsnotify \
 	profile_blockio \
+	profile_cpu \
 	profile_qdisc_latency \
 	profile_tcprtt \
 	trace_bind \

--- a/gadgets/profile_cpu/README.md
+++ b/gadgets/profile_cpu/README.md
@@ -1,0 +1,5 @@
+# profile_cpu
+
+The `profile_cpu` gadget profiles the CPU.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/profile_cpu

--- a/gadgets/profile_cpu/README.mdx
+++ b/gadgets/profile_cpu/README.mdx
@@ -1,0 +1,125 @@
+---
+title: profile_cpu
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# profile_cpu
+
+The profile cpu gadget takes samples of stack traces.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --map-fetch-interval 0 [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --map-fetch-interval 0 [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Guide
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        Here we deploy a small demo pod "random":
+
+        ```bash
+        $ kubectl run --restart=Never --image=busybox random -- sh -c 'cat /dev/urandom > /dev/null'
+        pod/random created
+        ```
+
+        Using the profile cpu gadget, we can see the list of stack traces.
+        The following command filters only for pods named "random", execute the command
+        and interrupt it after ~30 seconds. The `--kernel-stacks-only` option is passed to show only the
+        kernel stack traces.
+
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --podname random --kernel-stacks-only --map-fetch-interval 0
+        ```
+
+        After a while press with Ctrl-C to stop trace collection
+
+        ```
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --timeout 5 --podname random --kernel-stacks-only
+        K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME             K8S.CONTAINERNAME              PID COMM             SAMPLES              KERN_STACK
+        minikube-docker          default                  random                  random                       38130 containerd-shim  5                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_block_generic;…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        ```
+
+        From the traces above, you can see that the pod is spending CPU time in the
+        Linux function `urandom_read`.
+
+        Instead of waiting, you can use the `--timeout` argument:
+
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/profile_cpu:%IG_TAG% --timeout 5 --podname random --kernel-stacks-only --map-fetch-interval 0
+        K8S.NODE                 K8S.NAMESPACE            K8S.PODNAME             K8S.CONTAINERNAME              PID COMM             SAMPLES              KERN_STACK
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]_copy_to_iter; [1]get…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  2                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  5                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]chacha_permute; [1]ge…
+        minikube-docker          default                  random                  random                       38130 containerd-shim  1                    [0]get_random_bytes_user…
+        ```
+
+        Finally, we need to clean up our pod:
+
+        ```bash
+        $ kubectl delete pod random
+        ```
+    </TabItem>
+    <TabItem value="ig" label="ig">
+        * Generate some kernel load:
+
+        ```bash
+        $ docker run -d --rm --name random busybox cat /dev/urandom > /dev/null
+        ```
+
+        * Start `ig`:
+
+        ```bash
+        $ sudo ./ig profile cpu --kernel-stacks-only --containername random --runtimes docker --map-fetch-interval 0
+        ```
+
+        * Observe the results:
+
+        ```bash
+        RUNTIME.CONTAINERNAME     KERNEL_IP            COMM                    PID        TID SAMPLES              KERN_STACK
+        random                    18446603336363922440 cat                   83451      83451 2                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336357767960 cat                   83451      83451 1                    [0]rcu_all_qs; [1]__cond_resched; [2]get_random_bytes_user; [3]ura…
+        random                    18446603336363922292 cat                   83451      83451 2                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922360 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922208 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922380 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363862956 cat                   83451      83451 1                    [0]push_pipe; [1]_copy_to_iter; [2]get_random_bytes_user; [3]urand…
+        random                    18446603336363922252 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922260 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336357585584 cat                   83451      83451 1                    [0]mutex_spin_on_owner; [1]__mutex_lock.constprop.0; [2]__mutex_lo…
+        random                    18446603336363922196 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        random                    18446603336363922444 cat                   83451      83451 1                    [0]chacha_permute; [1]get_random_bytes_user; [2]urandom_read_iter;…
+        ```
+
+        * Remove the docker container:
+
+        ```bash
+        $ docker stop random
+        ```
+
+    </TabItem>
+</Tabs>

--- a/gadgets/profile_cpu/artifacthub-pkg.yml
+++ b/gadgets/profile_cpu/artifacthub-pkg.yml
@@ -1,0 +1,29 @@
+# Artifact Hub package metadata file
+version: 0.39.0
+name: "profile cpu"
+category: monitoring-logging
+displayName: "profile cpu"
+createdAt: "2025-05-02T09:29:22Z"
+digest: "2025-05-02T09:29:22Z"
+description: "Profile CPU"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/profile_cpu/"
+containersImages:
+  - name: gadget
+    image: "ghcr.io/inspektor-gadget/gadget/profile_cpu:latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+keywords:
+  - gadget
+links:
+  - name: source
+    url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/profile_cpu"
+install: |
+  # Run
+  ```bash
+  sudo ig run ghcr.io/inspektor-gadget/gadget/profile_cpu:latest
+  ```
+provider:
+  name: Inspektor Gadget

--- a/gadgets/profile_cpu/gadget.yaml
+++ b/gadgets/profile_cpu/gadget.yaml
@@ -1,0 +1,50 @@
+name: profile cpu
+description: The profile cpu gadget takes samples of the stack traces.
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/profile_cpu
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/profile_cpu
+programs:
+  profiler:
+    perf:
+      type: software
+      config: count_sw_cpu_clock
+      sampleType: sample_raw
+    sampler:
+      frequency: 49
+datasources:
+  samples:
+    annotations:
+      views.modes.flamegraph: true
+      views.defaults.mode: flamegraph
+      ebpf.map.flush-on-stop: true
+    fields:
+      runtime.containerName:
+        annotations:
+          flamegraph.level: 0
+          flamegraph.type: single
+      proc.comm:
+        annotations:
+          flamegraph.level: 10
+          flamegraph.type: single
+      user_stack:
+        annotations:
+          flamegraph.level: 20
+          flamegraph.type: stack
+      kern_stack:
+        annotations:
+          flamegraph.level: 30
+          flamegraph.type: stack
+params:
+  ebpf:
+    kernel_stacks_only:
+      key: kernel-stacks-only
+      defaultValue: "false"
+      description: Only include the kernel stack
+    user_stacks_only:
+      key: user-stacks-only
+      defaultValue: "false"
+      description: Only include the user stack
+    include_idle:
+      key: include-idle
+      defaultValue: "false"
+      description: Include time the cpu is idle

--- a/gadgets/profile_cpu/program.bpf.c
+++ b/gadgets/profile_cpu/program.bpf.c
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/* Copyright (c) 2022 LG Electronics */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include <gadget/maps.bpf.h>
+#include <gadget/mntns_filter.h>
+#include <gadget/filter.h>
+#include <gadget/types.h>
+#include <gadget/macros.h>
+#include <gadget/common.h>
+#include <gadget/kernel_stack_map.h>
+#include <gadget/user_stack_map.h>
+
+#define MAX_ENTRIES 10240
+
+struct key_t {
+	__u64 kernel_ip;
+	struct gadget_user_stack user_stack_raw;
+	gadget_kernel_stack kern_stack_raw;
+	struct gadget_process proc;
+};
+
+const volatile bool kernel_stacks_only = false;
+GADGET_PARAM(kernel_stacks_only);
+
+const volatile bool user_stacks_only = false;
+GADGET_PARAM(user_stacks_only);
+
+const volatile bool include_idle = false;
+GADGET_PARAM(include_idle);
+
+struct values {
+	__u64 samples;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct key_t);
+	__type(value, struct values);
+	__uint(max_entries, MAX_ENTRIES);
+} counts SEC(".maps");
+
+GADGET_MAPITER(samples, counts);
+
+/*
+ * If PAGE_OFFSET macro is not available in vmlinux.h, determine ip whose MSB
+ * (Most Significant Bit) is 1 as the kernel address.
+ * TODO: use end address of user space to determine the address space of ip
+ */
+#if defined(__TARGET_ARCH_arm64) || defined(__TARGET_ARCH_x86)
+#define BITS_PER_ADDR (64)
+#define MSB_SET_ULONG (1UL << (BITS_PER_ADDR - 1))
+static __always_inline bool is_kernel_addr(u64 addr)
+{
+	return !!(addr & MSB_SET_ULONG);
+}
+#else
+static __always_inline bool is_kernel_addr(u64 addr)
+{
+	return false;
+}
+#endif /* __TARGET_ARCH_arm64 || __TARGET_ARCH_x86 */
+
+SEC("perf_event/profiler")
+int ig_prof_cpu(struct bpf_perf_event_data *ctx)
+{
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	u64 id = bpf_get_current_pid_tgid();
+
+	u32 tid = id;
+	struct values *valp;
+	static const struct values zero = {
+		0,
+	};
+	struct key_t key = {};
+
+	if (!include_idle && tid == 0)
+		return 0;
+
+	gadget_process_populate(&key.proc);
+
+	if (user_stacks_only)
+		key.kern_stack_raw = -1;
+	else
+		key.kern_stack_raw = bpf_get_stackid(&ctx->regs, &ig_kstack, 0);
+
+	if (!kernel_stacks_only)
+		gadget_get_user_stack(ctx, &key.user_stack_raw);
+
+	if (key.kern_stack_raw >= 0) {
+		// populate extras to fix the kernel stack
+		u64 ip = PT_REGS_IP(&ctx->regs);
+
+		if (is_kernel_addr(ip))
+			key.kernel_ip = ip;
+	}
+
+	valp = bpf_map_lookup_or_try_init(&counts, &key, &zero);
+	if (valp)
+		__sync_fetch_and_add(&valp->samples, 1);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ package ebpfoperator
 import (
 	"fmt"
 	"net"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/uprobetracer"
@@ -32,6 +35,7 @@ const (
 	iterPrefix      = "iter/"
 	fentryPrefix    = "fentry/"
 	fexitPrefix     = "fexit/"
+	perfEventPrefix = "perf_event/"
 	tpBtfPrefix     = "tp_btf/"
 	uprobePrefix    = "uprobe/"
 	uretprobePrefix = "uretprobe/"
@@ -145,6 +149,82 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 		return link.AttachLSM(link.LSMOptions{
 			Program: prog,
 		})
+	case ebpf.PerfEvent:
+		perfType := uint32(unix.PERF_TYPE_SOFTWARE)
+		perfConfig := uint64(unix.PERF_COUNT_SW_CPU_CLOCK)
+		perfSampleType := uint64(unix.PERF_SAMPLE_RAW)
+		frequency := uint64(0)
+		name, ok := strings.CutPrefix(p.SectionName, perfEventPrefix)
+		if !ok {
+			return nil, fmt.Errorf("perf_event programs require a name")
+		}
+
+		switch tmp := i.config.GetString("programs." + name + ".perf.type"); tmp {
+		case "":
+			return nil, fmt.Errorf("perf.type not specified for program %q", name)
+		case "software":
+			perfType = unix.PERF_TYPE_SOFTWARE
+		default:
+			return nil, fmt.Errorf("unsupported perf.type %q", tmp)
+		}
+		switch tmp := i.config.GetString("programs." + name + ".perf.config"); tmp {
+		case "":
+			return nil, fmt.Errorf("perf.config not specified for program %q", name)
+		case "count_sw_cpu_clock":
+			perfConfig = unix.PERF_COUNT_SW_CPU_CLOCK
+		default:
+			return nil, fmt.Errorf("unsupported perf.config %q", tmp)
+		}
+		switch tmp := i.config.GetString("programs." + name + ".perf.sampleType"); tmp {
+		case "":
+			return nil, fmt.Errorf("perf.sampleType not specified for program %q", name)
+		case "sample_raw":
+			perfSampleType = unix.PERF_SAMPLE_RAW
+		default:
+			return nil, fmt.Errorf("unsupported perf.sampleType %q", tmp)
+		}
+		if tmpFrequency := i.config.GetString("programs." + name + ".sampler.frequency"); tmpFrequency != "" {
+			var err error
+			frequency, err = strconv.ParseUint(tmpFrequency, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing frequency %q for program %q: %w", tmpFrequency, name, err)
+			}
+		} else {
+			return nil, fmt.Errorf("sampler.frequency not specified for program %q", name)
+		}
+		if frequency == 0 {
+			return nil, fmt.Errorf("sampler.frequency is zero for program %q", name)
+		}
+		for cpu := 0; cpu < runtime.NumCPU(); cpu++ {
+			fd, err := unix.PerfEventOpen(
+				&unix.PerfEventAttr{
+					Type:        perfType,
+					Config:      perfConfig,
+					Sample_type: perfSampleType,
+					Sample:      frequency,
+					Bits:        unix.PerfBitFreq,
+				},
+				-1,
+				cpu,
+				-1,
+				unix.PERF_FLAG_FD_CLOEXEC,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("opening perf event: %w", err)
+			}
+			i.perfFds = append(i.perfFds, fd)
+
+			// Attach program to perf event.
+			if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_SET_BPF, prog.FD()); err != nil {
+				return nil, fmt.Errorf("attaching eBPF program to perf fd: %w", err)
+			}
+
+			// Start perf event.
+			if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+				return nil, fmt.Errorf("enabling perf fd: %w", err)
+			}
+		}
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unsupported program %q of type %q", p.Name, p.Type)
 	}

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
 	"oras.land/oras-go/v2"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
@@ -184,7 +185,8 @@ type ebpfInstance struct {
 	// map from ebpf variable name to ebpfVar struct
 	vars map[string]*ebpfVar
 
-	links []link.Link
+	links   []link.Link
+	perfFds []int
 
 	containers map[string]*containercollection.Container
 
@@ -816,6 +818,19 @@ func (i *ebpfInstance) Close() {
 	}
 	for _, uprobeTracer := range i.uprobeTracers {
 		uprobeTracer.Close()
+	}
+
+	for _, fd := range i.perfFds {
+		// Disable perf event.
+		err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
+		if err != nil {
+			i.logger.Errorf("disabling perf fd: %v", err)
+		}
+
+		err = unix.Close(fd)
+		if err != nil {
+			i.logger.Errorf("closing perf fd: %v", err)
+		}
 	}
 
 	i.wg.Wait()


### PR DESCRIPTION
While converting the gadget was pretty straightforward, the actual program type allows many different settings to be applied. We need to discuss what and how we want to support those. I think it's wrong to just hardcode the values for our specific use-case (but I'm not familiar enough with the actual capabilities to decide).

The biggest question is: should we support just forwarding raw values (integers) from the configuration or abstract it with `count_sw_cpu_clock` etc. to always use the values defined in the `unix` package (for compatibility reasons)?

~~Also, this will make more sense after the addition of `flush-on-stop` in #4089.~~

The gadget now uses `flush-on-stop`, so it currently also needs `--map-fetch-interval 0s` set.

Fixes #3001