### PR TITLE
otel: allow overriding key/name

### DIFF
--- a/pkg/datasource/helpers.go
+++ b/pkg/datasource/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,12 +82,16 @@ func AsFloat64(f FieldAccessor) (func(Data) float64, error) {
 // and b) it is too costly when done in here. Instead, on error, the default values will be returned.
 func GetKeyValueFunc[S ~string, T any](
 	f FieldAccessor,
+	nameOverride string,
 	int64Fn func(int64) T,
 	float64Fn func(float64) T,
 	stringFn func(string) T,
 ) (func(Data) (S, T), error) {
 	emptyVal := *new(T)
 	name := f.Name()
+	if nameOverride != "" {
+		name = nameOverride
+	}
 	switch f.Type() {
 	default:
 		return nil, fmt.Errorf("unsupported field type for key: %s", f.Type())

--- a/pkg/operators/otel-logs/otel-logs.go
+++ b/pkg/operators/otel-logs/otel-logs.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -268,7 +268,7 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 				continue
 			}
 
-			kvf, err := datasource.GetKeyValueFunc[string, otellog.Value](f, otellog.Int64Value, otellog.Float64Value, otellog.StringValue)
+			kvf, err := datasource.GetKeyValueFunc[string, otellog.Value](f, name, otellog.Int64Value, otellog.Float64Value, otellog.StringValue)
 			if err != nil {
 				return fmt.Errorf("getting key/val func for %s.%s: %w", ds.Name(), f.Name(), err)
 			}

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -320,7 +320,7 @@ type metricsCollector struct {
 }
 
 func (mc *metricsCollector) addKeyFunc(f datasource.FieldAccessor) error {
-	vf, err := datasource.GetKeyValueFunc[attribute.Key, attribute.Value](f, attribute.Int64Value, attribute.Float64Value, attribute.StringValue)
+	vf, err := datasource.GetKeyValueFunc[attribute.Key, attribute.Value](f, "", attribute.Int64Value, attribute.Float64Value, attribute.StringValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows properly overriding the keys of metrics/log fields with for example a name coming from an annotation.

This is only used for otel-logs currently, but might be added to otel-metrics in the future.