### PR TITLE
ci: Use different name for test-report artifacts

### DIFF
--- a/.github/actions/prepare-and-publish-test-reports/action.yml
+++ b/.github/actions/prepare-and-publish-test-reports/action.yml
@@ -39,5 +39,5 @@ runs:
     - name: Upload test reports summary as artifacts
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
-        name: test-reports
+        name: test-reports-${{ github.job }}-${{ inputs.test-summary-suffix }}
         path: ./test-report_*_*.json

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2177,8 +2177,8 @@ jobs:
     - name: Get all reports
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
-        name: "test-reports"
-    - name: Store test reports
+        patterns: "test-reports-*-*"
+    - name: Store test report
       shell: bash {0}
       run: ./tools/store-test-reports.sh
       env:

--- a/tools/store-test-reports.sh
+++ b/tools/store-test-reports.sh
@@ -35,7 +35,7 @@ function store-reports {
     mkdir -p data
     echo '{}' > data/workflows.json
   fi
-  for i in ../test-report_*_*.json; do
+  for i in ../test-reports-*-*/test-report_*_*.json; do
       job_key=$(basename $i .json | sed 's/test-report_//')
       jq --slurpfile obj $i \
       --arg job_key ${job_key} \


### PR DESCRIPTION
As mentioned here https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes we shouldn't be using same artifact name for a workflow run. This change uses the suffix to ensure we don't use the same artifact name for all the reports.

Fixes: #3177