### PR TITLE
operators: Add pre stop lifecycle

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -119,13 +119,24 @@ func (c *GadgetContext) stop(dataOperatorInstances []operators.DataOperatorInsta
 	// Stop/DeInit in reverse order
 	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
 		opInst := dataOperatorInstances[i]
+		preStop, ok := opInst.(operators.PreStop)
+		if !ok {
+			continue
+		}
+		c.Logger().Debugf("pre-stopping op %q", opInst.Name())
+		err := preStop.PreStop(c)
+		if err != nil {
+			c.Logger().Errorf("pre-stopping operator %q: %v", opInst.Name(), err)
+		}
+	}
+	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
+		opInst := dataOperatorInstances[i]
 		c.Logger().Debugf("stopping op %q", opInst.Name())
 		err := opInst.Stop(c)
 		if err != nil {
 			c.Logger().Errorf("stopping operator %q: %v", opInst.Name(), err)
 		}
 	}
-	// Stop/DeInit in reverse order
 	for i := len(dataOperatorInstances) - 1; i >= 0; i-- {
 		opInst := dataOperatorInstances[i]
 		postStop, ok := opInst.(operators.PostStop)

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -445,6 +445,20 @@ func (o *OciHandlerInstance) Start(gadgetCtx operators.GadgetContext) error {
 	return nil
 }
 
+func (o *OciHandlerInstance) PreStop(gadgetCtx operators.GadgetContext) error {
+	for _, opInst := range o.imageOperatorInstances {
+		preStop, ok := opInst.(operators.PreStop)
+		if !ok {
+			continue
+		}
+		err := preStop.PreStop(gadgetCtx)
+		if err != nil {
+			o.gadgetCtx.Logger().Errorf("pre-stopping operator %q: %v", opInst.Name(), err)
+		}
+	}
+	return nil
+}
+
 func (o *OciHandlerInstance) Stop(gadgetCtx operators.GadgetContext) error {
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Stop(o.gadgetCtx)

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -149,6 +149,10 @@ type PreStart interface {
 	PreStart(gadgetCtx GadgetContext) error
 }
 
+type PreStop interface {
+	PreStop(gadgetCtx GadgetContext) error
+}
+
 type PostStop interface {
 	PostStop(gadgetCtx GadgetContext) error
 }

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -334,7 +334,10 @@ func (i *wasmOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
 }
 
 func (i *wasmOperatorInstance) PostStop(gadgetCtx operators.GadgetContext) error {
-	return i.callGuestFunction(gadgetCtx.Context(), "gadgetPostStop")
+	// TODO: reenable it when
+	// https://github.com/inspektor-gadget/inspektor-gadget/pull/3778 is merged
+	// return i.callGuestFunction(gadgetCtx.Context(), "gadgetPostStop")
+	return nil
 }
 
 func (i *wasmOperatorInstance) close(gadgetCtx operators.GadgetContext) error {


### PR DESCRIPTION
Add new hook that can be used by gadgets that need to print their output just before stopping as advise seccomp developed in #4089
