### PR TITLE
CI/Integration tests: Skip building gadgets

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -85,12 +85,17 @@ runs:
         trap 'cleanup SIGTERM' SIGTERM
 
         # https://mywiki.wooledge.org/SignalTrap#When_is_the_signal_handled.3F
-        echo "IntegrationTestsJob: Start"
+        echo "BuiltinIntegrationTestsJob: Start"
         set -o pipefail
         make \
-          IG_PATH=/home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget \
+          integration-tests -o kubectl-gadget |& tee integration.log & wait $!
+        echo "BuiltinIntegrationTestsJob: Done"
+
+        echo "IntegrationTestsJob: Start"
+        make \
+          KUBECTL_GADGET=/home/runner/work/inspektor-gadget/inspektor-gadget/kubectl-gadget \
           IG_RUNTIME=kubernetes \
-          -o kubectl-gadget integration-tests integration-test-gadgets |& tee integration.log & wait $!
+          -C gadgets/ test-k8s -o build |& tee -a integration.log & wait $!
         echo "IntegrationTestsJob: Done"
     - name: Undeploy Inspektor Gadget
       id: undeploy-ig


### PR DESCRIPTION
Fixes: c6dda023212e1126f4715595140ac3f842a485a6

We want to run the integration tests for builtin gadgets and image based gadgets.
This PR fixes the part for the image based gadgets. It skips building the gadgets again in this testing step. Instead it will just use/pull the gadgets that were built in `Build and push gadgets`