### PR TITLE
operators/KubeIPResolver: Set kind to raw when its not a pod and svc

### DIFF
--- a/gadgets/top_tcp/test/integration/top_tcp_test.go
+++ b/gadgets/top_tcp/test/integration/top_tcp_test.go
@@ -125,8 +125,17 @@ func TestTopTcp(t *testing.T) {
 					Tid:     utils.NormalizedInt,
 				}
 
+				if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+					expectedEntry.Src.K8s = utils.K8s{
+						Kind: "raw",
+					}
+					expectedEntry.Dst.K8s = expectedEntry.Src.K8s
+				}
+
 				normalize := func(e *topTcpEntry) {
 					utils.NormalizeCommonData(&e.CommonData)
+					utils.NormalizeEndpoint(&e.Src)
+					utils.NormalizeEndpoint(&e.Dst)
 					utils.NormalizeInt(&e.MntNsID)
 					utils.NormalizeInt(&e.Pid)
 					utils.NormalizeInt(&e.Tid)

--- a/gadgets/trace_bind/test/integration/trace_bind_test.go
+++ b/gadgets/trace_bind/test/integration/trace_bind_test.go
@@ -98,8 +98,16 @@ func TestTraceBind(t *testing.T) {
 				Timestamp: utils.NormalizedStr,
 			}
 
+			if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+				expectedEntry.Addr.K8s = utils.K8s{
+					Kind: "raw",
+				}
+			}
+
 			normalize := func(e *traceBindEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
+				utils.NormalizeEndpoint(&e.Addr)
+				utils.NormalizeEndpoint(&e.Addr)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeProc(&e.Proc)
 			}

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -165,8 +165,19 @@ func TestTraceTCP(t *testing.T) {
 				},
 			}
 
+			if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+				for _, expectedEntry := range expectedEntries {
+					expectedEntry.Src.K8s = utils.K8s{
+						Kind: "raw",
+					}
+					expectedEntry.Dst.K8s = expectedEntry.Src.K8s
+				}
+			}
+
 			normalize := func(e *traceTCPEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
+				utils.NormalizeEndpoint(&e.Src)
+				utils.NormalizeEndpoint(&e.Dst)
 				utils.NormalizeString(&e.Timestamp)
 				utils.NormalizeProc(&e.Proc)
 				utils.NormalizeInt(&e.NetNsID)

--- a/gadgets/trace_tcpretrans/test/integration/trace_tcpretrans_test.go
+++ b/gadgets/trace_tcpretrans/test/integration/trace_tcpretrans_test.go
@@ -108,6 +108,14 @@ func TestTraceTCPretrans(t *testing.T) {
 				Timestamp: utils.NormalizedStr,
 				NetNs:     utils.NormalizedInt,
 			}
+
+			if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+				expectedEntries.Src.K8s = utils.K8s{
+					Kind: "raw",
+				}
+				expectedEntries.Dst.K8s = expectedEntries.Src.K8s
+			}
+
 			normalize := func(e *traceTCPretransEvent) {
 				utils.NormalizeCommonData(&e.CommonData)
 				utils.NormalizeString(&e.Timestamp)

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -333,6 +333,14 @@ func (m *KubeIPResolverInstance) Start(gadgetCtx operators.GadgetContext) error 
 						v := fmt.Sprintf("s/%s/%s:%d", svc.Namespace, svc.Name, p)
 						a.column.Set(data, []byte(v))
 					}
+					continue
+				}
+
+				a.subK8sKind.Set(data, []byte("raw"))
+				if a.column != nil && a.port != nil {
+					p, _ := a.port.Uint16(data)
+					v := fmt.Sprintf("r/%s:%d", addrStr, p)
+					a.column.Set(data, []byte(v))
 				}
 			}
 			return errs

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -125,6 +125,17 @@ func NormalizeCommonData(e *eventtypes.CommonData) {
 	}
 }
 
+func NormalizeEndpoint(e *L4Endpoint) {
+	// Information about the endpoint is not enriched when running ig, since it needs
+	// to connect to the kubeapiserver to get this information.
+	if CurrentTestComponent != KubectlGadgetTestComponent {
+		e.K8s.Kind = ""
+		e.K8s.Name = ""
+		e.K8s.Namespace = ""
+		e.K8s.Labels = ""
+	}
+}
+
 func BuildProc(comm string, uid, gid uint32) Process {
 	return Process{
 		Comm:    comm,


### PR DESCRIPTION
operators/KubeIPResolver: Set kind to `raw` when its not a `pod` and `svc`