### PR TITLE
KubeNameResolver: Add support for image based gadgets

### DIFF
--- a/docs/spec/operators/kubenameresolver.md
+++ b/docs/spec/operators/kubenameresolver.md
@@ -1,0 +1,74 @@
+---
+title: KubeNameResolver
+---
+
+The KubeNameResolver operator uses the `K8s.PodName` and `K8s.Namespace` fields to enrich the event with `K8s.PodIp` and `K8s.HostIp` fields. 
+This operator is disabled by default (See [annotation](#annotation) for how to enable it).
+
+The example below shows a request from `test-pod` pod in json format:
+
+Without `KubeNameResolver`:
+```json
+{
+  ...
+  "k8s": {
+    "containerName": "test-pod",
+    "hostnetwork": false,
+    "namespace": "default",
+    "node": "minikube-docker",
+    "owner": {
+      "kind": "",
+      "name": ""
+    },
+    "podLabels": "run=test-pod",
+    "podName": "test-pod"
+  },
+  "proc": {
+    "comm": "wget",
+    ...
+  },
+  ...
+}
+```
+
+With `KubeNameResolver`:
+```json
+{
+  ...
+  "k8s": {
+    "containerName": "test-pod",
+    "hostIP": "192.168.58.2",
+    "hostnetwork": false,
+    "namespace": "default",
+    "node": "minikube-docker",
+    "owner": {
+      "kind": "",
+      "name": ""
+    },
+    "podIP": "10.244.0.29",
+    "podLabels": "run=test-pod",
+    "podName": "test-pod"
+  },
+  "proc": {
+    "comm": "wget",
+    ...
+  },
+  ...
+}
+```
+
+## Priority
+
+11
+
+## Parameters
+
+None
+
+## Annotation
+
+This operator is disabled by default and is only activated for a datasource if it has the following annotations:
+datasource_name:
+  annotations:
+    kubenameresolver.enable: true    
+```

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
@@ -31,6 +33,7 @@ import (
 
 const (
 	OperatorName = "KubeNameResolver"
+	priority     = 11
 )
 
 type KubeNameResolverInterface interface {
@@ -92,6 +95,7 @@ func (k *KubeNameResolver) Instantiate(gadgetCtx operators.GadgetContext, gadget
 type KubeNameResolverInstance struct {
 	gadgetCtx      operators.GadgetContext
 	k8sInventory   common.K8sInventoryCache
+	accessors      map[datasource.DataSource]k8sAccesors
 	gadgetInstance any
 }
 
@@ -134,6 +138,136 @@ func (m *KubeNameResolverInstance) EnrichEvent(ev any) error {
 	return nil
 }
 
+func (k *KubeNameResolver) GlobalParams() api.Params {
+	return nil
+}
+
+func (k *KubeNameResolver) InstanceParams() api.Params {
+	return nil
+}
+
+func (k *KubeNameResolver) Priority() int {
+	return priority
+}
+
+type k8sAccesors struct {
+	PodName   datasource.FieldAccessor
+	Namespace datasource.FieldAccessor
+	PodIP     datasource.FieldAccessor
+	HostIP    datasource.FieldAccessor
+}
+
+func (k *KubeNameResolver) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	logger := gadgetCtx.Logger()
+	accessors := make(map[datasource.DataSource]k8sAccesors)
+	for _, ds := range gadgetCtx.GetDataSources() {
+		logger.Debugf("KubeNameResolverOperator inspecting datasource %q", ds.Name())
+
+		if ds.Annotations()["kubenameresolver.enable"] != "true" {
+			logger.Debugf("KubeNameResolverOperator not enabled by annotation")
+			continue
+		}
+
+		k8sField := ds.GetField("k8s")
+		if k8sField == nil {
+			logger.Debugf("> no k8s fields found")
+			continue
+		}
+
+		k8sAccesors := k8sAccesors{}
+		var err error
+
+		k8sAccesors.PodName = ds.GetField("k8s.podName")
+		if k8sAccesors.PodName == nil {
+			logger.Warnf("No podName field found in datasource %q", ds.Name())
+			continue
+		}
+
+		k8sAccesors.Namespace = ds.GetField("k8s.namespace")
+		if k8sAccesors.Namespace == nil {
+			logger.Warnf("No namespace field found in datasource %q", ds.Name())
+			continue
+		}
+
+		// Create 2 new fields
+		k8sAccesors.HostIP, err = k8sField.AddSubField("hostIP", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
+		if err != nil {
+			return nil, fmt.Errorf("adding field %q: %w", "hostIP", err)
+		}
+		k8sAccesors.PodIP, err = k8sField.AddSubField("podIP", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
+		if err != nil {
+			return nil, fmt.Errorf("adding field %q: %w", "podIP", err)
+		}
+
+		logger.Debugf("> Found fields for DS %q", ds.Name())
+		accessors[ds] = k8sAccesors
+	}
+
+	// No endpoints found, nothing to do
+	if len(accessors) == 0 {
+		return nil, nil
+	}
+
+	k8sInventory, err := common.GetK8sInventoryCache()
+	if err != nil {
+		return nil, fmt.Errorf("creating k8s inventory cache: %w", err)
+	}
+
+	return &KubeNameResolverInstance{
+		k8sInventory: k8sInventory,
+		accessors:    accessors,
+	}, nil
+}
+
+func (m *KubeNameResolverInstance) enrichSingle(data datasource.Data, accessor k8sAccesors) error {
+	podName, err := accessor.PodName.String(data)
+	if err != nil {
+		return fmt.Errorf("getting podName: %w", err)
+	}
+	namespace, err := accessor.Namespace.String(data)
+	if err != nil {
+		return fmt.Errorf("getting namespace: %w", err)
+	}
+
+	pod := m.k8sInventory.GetPodByName(namespace, podName)
+	if pod == nil {
+		return nil
+	}
+
+	accessor.HostIP.PutString(data, pod.Status.HostIP)
+	accessor.PodIP.PutString(data, pod.Status.PodIP)
+	return nil
+}
+
+func (m *KubeNameResolverInstance) PreStart(gadgetCtx operators.GadgetContext) error {
+	m.k8sInventory.Start()
+
+	for ds, accessor := range m.accessors {
+		err := ds.Subscribe(func(source datasource.DataSource, data datasource.Data) error {
+			return m.enrichSingle(data, accessor)
+		}, priority)
+		if err != nil {
+			return fmt.Errorf("subscribing to data source %q: %w", ds.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func (m *KubeNameResolverInstance) Start(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (m *KubeNameResolverInstance) PostStop(gadgetCtx operators.GadgetContext) error {
+	m.k8sInventory.Stop()
+	return nil
+}
+
+func (m *KubeNameResolverInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
 func init() {
 	operators.Register(&KubeNameResolver{})
+	operators.RegisterDataOperator(&KubeNameResolver{})
 }


### PR DESCRIPTION
This will be needed for `advise networkpolicy`

This Operator will now be always active for K8s deployments.
Is this okay? Should it be configurable instead? Or are we still waiting for the config to selectivly disable operators in general