### PR TITLE
gadget trace_open: add user stacks

### DIFF
--- a/gadgets/trace_open/README.mdx
+++ b/gadgets/trace_open/README.mdx
@@ -29,6 +29,12 @@ $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:%IG_TAG% [flags]
 </Tabs>
 ## Flags
 
+### `--collect-ustack`
+
+Collect user stack traces
+
+Default value: "false"
+
 ### `--failed`
 
 Show only failed events

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -32,8 +32,20 @@ datasources:
         annotations:
           columns.width: 32
           columns.minwidth: 24
+      ustack_raw:
+        annotations:
+          columns.hidden: true
+      ustack:
+        annotations:
+          description: User stack
+          columns.hidden: true
+          columns.width: 20
 params:
   ebpf:
+    collect_ustack:
+      key: collect-ustack
+      defaultValue: "false"
+      description: Collect user stack traces
     targ_failed:
       key: failed
       defaultValue: "false"

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -11,6 +11,7 @@
 #include <gadget/filter.h>
 #include <gadget/macros.h>
 #include <gadget/types.h>
+#include <gadget/user_stack_map.h>
 
 #define TASK_RUNNING 0
 #define NAME_MAX 255
@@ -29,11 +30,15 @@ struct event {
 	__u32 fd;
 	int flags_raw;
 	__u16 mode_raw;
+	struct gadget_user_stack ustack_raw;
 	char fname[NAME_MAX];
 };
 
 const volatile bool targ_failed = false;
 GADGET_PARAM(targ_failed);
+
+const volatile bool collect_ustack = false;
+GADGET_PARAM(collect_ustack);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -112,6 +117,8 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 
 	/* event data */
 	gadget_process_populate(&event->proc);
+	if (collect_ustack)
+		gadget_get_user_stack(ctx, &event->ustack_raw);
 
 	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
 	event->flags_raw = ap->flags;


### PR DESCRIPTION
Example of output for a simple Go program opening a file:

```
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:alban_trace_open_ustack \
        --pull=never --verify-image=false \
        --host --comm=gocat --collect-ustack -o yaml
...
ustack: '[0]internal/runtime/syscall.Syscall6; [1]syscall.Syscall6; [2]syscall.openat;
  [3]os.open; [4]os.openFileNolog; [5]os.OpenFile; [6]main.main; [7]runtime.main;
  [8]runtime.goexit.abi0; '
```

This is the same implementation as:
- trace_malloc in commit d33e3325b2c30ca0884b1d30028213f56a379b32
- trace_capabilities in commit 0b76243b4c6ae4cd1270324fdf3eea944d8e1397
