### PR TITLE
ustack: add --symbolizers parameter

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -341,11 +341,7 @@ Symbolize the kernel stack from `gadget_get_kernel_stack(ctx)` (see [kernel-stac
 
 ### `gadget_user_stack`
 
-Symbolize the user stack from `gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack)` (see [user-stack-traces](#user-stack-traces)).
-
-#### Annotations
-
-- `ebpf.formatter.ustack`: Name of the new field. If the annotation is not set and the source field name has a `_raw` suffix, the target name will be set to the source name without that suffix.
+Symbolize the user stack from `gadget_get_user_stack(ctx, &event->ustack, collect_ustack)` (see [user-stack-traces](#user-stack-traces)).
 
 ### `gadget_uid` and `gadget_gid`
 
@@ -611,14 +607,14 @@ struct {
 Then, add a field in the event structure with the type of `gadget_user_stack`,
 designated for storing the stack id along with identifiers for the executable
 so that the stack can be symbolised in userspace.
-`gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack)` could be used
+`gadget_get_user_stack(ctx, &event->ustack, collect_ustack)` could be used
 to populate this field, this helper function will store the kernel stack into
-`ig_ustack` and fill the field passed as parameter. When collect_ustack is
-false, ustack_raw is initialized to zero and ig will ignore the stack trace.
+`ig_ustack` and fill the field passed as parameter. When `collect_ustack` is
+false, `ustack` is initialized to zero and ig will ignore the stack trace.
 
 ```C
 struct event {
-	struct gadget_user_stack ustack_raw;
+	struct gadget_user_stack ustack;
 	/* other fields */
 };
 
@@ -631,7 +627,7 @@ GADGET_PARAM(collect_ustack);
 	if (!event)
 		return 0;
 
-	gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 ```
 
 ## Common information

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -48,12 +48,17 @@ datasources:
         annotations:
           description: if the process has the requested capability
           columns.width: 10
-      ustack_raw:
-        annotations:
-          columns.hidden: true
       ustack:
         annotations:
-          description: User stack
+          columns.hidden: true
+      ustack.addresses:
+        annotations:
+          description: User stack's addresses
+          columns.hidden: true
+          columns.width: 20
+      ustack.symbols:
+        annotations:
+          description: User stack's symbols
           columns.hidden: true
           columns.width: 20
 params:

--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -89,7 +89,7 @@ struct cap_event {
 	int insetid;
 	gadget_syscall syscall_raw;
 	gadget_kernel_stack kstack_raw;
-	struct gadget_user_stack ustack_raw;
+	struct gadget_user_stack ustack;
 };
 
 #define MAX_ENTRIES 10240
@@ -268,7 +268,7 @@ int BPF_KRETPROBE(ig_trace_cap_x)
 	event->capable = PT_REGS_RC(ctx) == 0;
 	if (collect_kstack)
 		event->kstack_raw = gadget_get_kernel_stack(ctx);
-	gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
 

--- a/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
 
+type ustack struct {
+	Symbols string `json:"symbols"`
+}
+
 type traceCapabilitiesEvent struct {
 	utils.CommonData
 
@@ -45,7 +49,7 @@ type traceCapabilitiesEvent struct {
 	Insetid       uint32 `json:"insetid"`
 	Syscall       string `json:"syscall"`
 	Kstack        string `json:"kstack"`
-	Ustack        string `json:"ustack"`
+	Ustack        ustack `json:"ustack"`
 	Capable       bool   `json:"capable"`
 }
 
@@ -131,8 +135,8 @@ int main() {
 					Cap:        "CAP_SYS_CHROOT",
 					Syscall:    "SYS_CHROOT",
 					Audit:      1,
-					Capable:    false,    // container runtime dependent. See normalize function.
-					Ustack:     "level2", // normalize() just checks for the presence of this string
+					Capable:    false,            // container runtime dependent. See normalize function.
+					Ustack:     ustack{"level2"}, // normalize() just checks for the presence of this string
 
 					// Check the existence of the following fields
 					Timestamp:     utils.NormalizedStr,
@@ -149,7 +153,7 @@ int main() {
 					Syscall:    "SYS_SETPRIORITY",
 					Audit:      1,
 					Capable:    false,
-					Ustack:     "",
+					Ustack:     ustack{""},
 
 					// Check the existence of the following fields
 					Timestamp:     utils.NormalizedStr,
@@ -169,8 +173,8 @@ int main() {
 				utils.NormalizeString(&e.CapEffective)
 
 				if e.Proc.Comm == "mychroot" {
-					if strings.Contains(e.Ustack, "level2") {
-						e.Ustack = "level2"
+					if strings.Contains(e.Ustack.Symbols, "level2") {
+						e.Ustack.Symbols = "level2"
 					}
 
 					// The default capabilities vary between container runtimes:
@@ -186,7 +190,7 @@ int main() {
 					// able to chroot.
 					e.Capable = false
 				} else {
-					e.Ustack = ""
+					e.Ustack.Symbols = ""
 				}
 
 				// Manually normalize fields that might contain 0

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -21,12 +21,17 @@ datasources:
         annotations:
           description: size of malloc operations
           columns.width: 20
-      ustack_raw:
-        annotations:
-          columns.hidden: true
       ustack:
         annotations:
-          description: User stack
+          columns.hidden: true
+      ustack.addresses:
+        annotations:
+          description: User stack's addresses
+          columns.hidden: true
+          columns.width: 20
+      ustack.symbols:
+        annotations:
+          description: User stack's symbols
           columns.hidden: true
           columns.width: 20
 params:

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -33,7 +33,7 @@ struct event {
 	gadget_timestamp timestamp_raw;
 	struct gadget_process proc;
 
-	struct gadget_user_stack ustack_raw;
+	struct gadget_user_stack ustack;
 
 	enum memop operation_raw;
 	__u64 addr;
@@ -118,7 +118,7 @@ static __always_inline int gen_alloc_exit(struct pt_regs *ctx,
 	event->size = size;
 	event->timestamp_raw = bpf_ktime_get_ns();
 
-	gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 
@@ -143,7 +143,7 @@ static __always_inline int gen_free_enter(struct pt_regs *ctx,
 	event->size = 0;
 	event->timestamp_raw = bpf_ktime_get_ns();
 
-	gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
 

--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -32,12 +32,17 @@ datasources:
         annotations:
           columns.width: 32
           columns.minwidth: 24
-      ustack_raw:
-        annotations:
-          columns.hidden: true
       ustack:
         annotations:
-          description: User stack
+          columns.hidden: true
+      ustack.addresses:
+        annotations:
+          description: User stack's addresses
+          columns.hidden: true
+          columns.width: 20
+      ustack.symbols:
+        annotations:
+          description: User stack's symbols
           columns.hidden: true
           columns.width: 20
 params:

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -30,7 +30,7 @@ struct event {
 	__u32 fd;
 	int flags_raw;
 	__u16 mode_raw;
-	struct gadget_user_stack ustack_raw;
+	struct gadget_user_stack ustack;
 	char fname[NAME_MAX];
 };
 
@@ -117,7 +117,7 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 
 	/* event data */
 	gadget_process_populate(&event->proc);
-	gadget_get_user_stack(ctx, &event->ustack_raw, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 
 	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
 	event->flags_raw = ap->flags;

--- a/pkg/operators/ustack/ustack.go
+++ b/pkg/operators/ustack/ustack.go
@@ -18,6 +18,7 @@ package ustack
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf"
 
@@ -27,7 +28,6 @@ import (
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/symbolizer"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/annotations"
 )
 
 const (
@@ -36,7 +36,8 @@ const (
 )
 
 const (
-	userStackTargetNameAnnotation = "ebpf.formatter.ustack"
+	// Params
+	symbolizersParam = "symbolizers"
 )
 
 type Operator struct{}
@@ -54,18 +55,44 @@ func (o *Operator) GlobalParams() api.Params {
 }
 
 func (o *Operator) InstanceParams() api.Params {
-	return nil
+	return api.Params{&api.Param{
+		Key:          symbolizersParam,
+		Description:  `Symbolizers to use. Possible values are: "none", "auto", or comma-separated list among: "symtab"`,
+		DefaultValue: "auto",
+	}}
 }
 
 func (o *Operator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
-	s, err := symbolizer.NewSymbolizer()
-	if err != nil {
-		return nil, err
+	instance := &OperatorInstance{
+		subscriptions: make(map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error),
 	}
 
-	instance := &OperatorInstance{
-		symbolizer:    s,
-		subscriptions: make(map[datasource.DataSource][]func(ds datasource.DataSource, data datasource.Data) error),
+	opts := symbolizer.SymbolizerOptions{}
+	symbolizers := instanceParamValues[symbolizersParam]
+	switch symbolizers {
+	case "", "none":
+		opts.UseSymtab = false
+	case "auto":
+		opts.UseSymtab = true
+	default:
+		list := strings.Split(symbolizers, ",")
+		for _, s := range list {
+			switch s {
+			case "symtab":
+				opts.UseSymtab = true
+			default:
+				return nil, fmt.Errorf("invalid symbolizer: %s", s)
+			}
+		}
+	}
+
+	var err error
+	// When the Symbolizer implements more options, they can be added here
+	if opts.UseSymtab {
+		instance.symbolizer, err = symbolizer.NewSymbolizer(opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 	err = instance.init(gadgetCtx)
 	if err != nil {
@@ -146,15 +173,15 @@ func (o *OperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 				continue
 			}
 
-			targetName, err := annotations.GetTargetNameFromAnnotation(logger, "ustack", in, userStackTargetNameAnnotation)
-			if err != nil {
-				logger.Warnf("getting target name for ustack field %q: %v", in.Name(), err)
-				continue
-			}
-			out, err := ds.AddField(targetName, api.Kind_String, datasource.WithSameParentAs(in))
+			addressesField, err := in.AddSubField("addresses", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
 			if err != nil {
 				return err
 			}
+			symbolsField, err := in.AddSubField("symbols", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
+			if err != nil {
+				return err
+			}
+
 			converter := func(ds datasource.DataSource, data datasource.Data) error {
 				inode, _ := inodeField[0].Uint64(data)
 				// If user stacks are disabled
@@ -209,32 +236,38 @@ func (o *OperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 					return nil
 				}
 
+				var addressesBuilder strings.Builder
 				addrs := make([]uint64, 0, len(stack))
-				for _, addr := range stack {
+				for i, addr := range stack {
 					if addr == 0 {
 						break
 					}
 					addrs = append(addrs, addr)
+					fmt.Fprintf(&addressesBuilder, "[%d]0x%016x; ", i, addr)
 				}
-				task := symbolizer.Task{
-					Name:         fmt.Sprintf("%s/%s", containerName, comm),
-					PidNumbers:   pidNumbers,
-					ContainerPid: containerPid,
-					Ino:          inode,
-					MtimeSec:     int64(mtimeSec),
-					MtimeNsec:    mtimeNsec,
-				}
-				symbols, err := o.symbolizer.Resolve(task, addrs)
-				if err != nil {
-					logger.Warnf("symbolizer: %s", err)
-					return nil
-				}
+				addressesField.PutString(data, addressesBuilder.String())
 
-				outString := ""
-				for i, symbol := range symbols {
-					outString += fmt.Sprintf("[%d]%s; ", i, symbol)
+				if o.symbolizer != nil {
+					task := symbolizer.Task{
+						Name:         fmt.Sprintf("%s/%s", containerName, comm),
+						PidNumbers:   pidNumbers,
+						ContainerPid: containerPid,
+						Ino:          inode,
+						MtimeSec:     int64(mtimeSec),
+						MtimeNsec:    mtimeNsec,
+					}
+					symbols, err := o.symbolizer.Resolve(task, addrs)
+					if err != nil {
+						logger.Warnf("symbolizer: %s", err)
+						return nil
+					}
+
+					var symbolsBuilder strings.Builder
+					for i, symbol := range symbols {
+						fmt.Fprintf(&symbolsBuilder, "[%d]%s; ", i, symbol)
+					}
+					symbolsField.PutString(data, symbolsBuilder.String())
 				}
-				out.PutString(data, outString)
 				return nil
 			}
 			o.subscriptions[ds] = append(o.subscriptions[ds], converter)
@@ -248,7 +281,9 @@ func (o *OperatorInstance) Name() string {
 }
 
 func (o *OperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
-	o.symbolizer.Close()
+	if o.symbolizer != nil {
+		o.symbolizer.Close()
+	}
 	return nil
 }
 

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -41,7 +41,13 @@ const (
 	pruneTickerTime     = time.Minute
 )
 
+type SymbolizerOptions struct {
+	UseSymtab bool
+}
+
 type Symbolizer struct {
+	options SymbolizerOptions
+
 	lock             sync.RWMutex
 	symbolTables     map[exeKey]*symbolTable
 	symbolCountTotal int
@@ -80,7 +86,7 @@ func (k exeKey) String() string {
 	return fmt.Sprintf("ino=%d mtime=%d.%d", k.ino, k.mtimeSec, k.mtimeNsec)
 }
 
-func NewSymbolizer() (*Symbolizer, error) {
+func NewSymbolizer(opts SymbolizerOptions) (*Symbolizer, error) {
 	pid1PidNsInfo, err := os.Stat(fmt.Sprintf("%s/1/ns/pid", host.HostProcFs))
 	if err != nil {
 		return nil, err
@@ -91,6 +97,7 @@ func NewSymbolizer() (*Symbolizer, error) {
 	}
 
 	s := &Symbolizer{
+		options:         opts,
 		symbolTables:    make(map[exeKey]*symbolTable),
 		hostProcFsPidNs: uint32(pid1PidNsStat.Ino),
 		pruneTickerTime: pruneTickerTime,
@@ -181,6 +188,17 @@ type Task struct {
 }
 
 func (s *Symbolizer) Resolve(task Task, addresses []uint64) ([]string, error) {
+	if s.options.UseSymtab {
+		return s.resolveWithSymtab(task, addresses)
+	}
+	// At the moment, we don't support other symbolization methods than symtab
+	// and NewSymbolizer() is only called with UseSymtab. So this code path is
+	// not taken. When implementing more symbolization methods, this can be
+	// added here.
+	return nil, nil
+}
+
+func (s *Symbolizer) resolveWithSymtab(task Task, addresses []uint64) ([]string, error) {
 	res := make([]string, len(addresses))
 
 	if len(addresses) == 0 {


### PR DESCRIPTION
For now, we have only one symbolizer: symtab. I am planning to add more symbolizers in future PRs for goresym and debuginfod.

The symtab symbolizer fills the new sub-field symbols:
```yaml
ustack:
  addresses: '[0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e;
    [3]0x000000000048250b; [4]0x00000000004829ae; [5]0x0000000000482a7e; [6]0x0000000000482afe;
    [7]0x0000000000482b7e; [8]0x0000000000435a9d; [9]0x00000000004625a1; '
  symbols: '[0]runtime/internal/syscall.Syscall6; [1]syscall.Syscall; [2]syscall.Syscall.abi0;
    [3]golang.org/x/sys/unix.Chroot; [4]main.level3; [5]main.level2; [6]main.level1;
    [7]main.main; [8]runtime.main; [9]runtime.goexit.abi0; '
  ...
```
Using --symbolizers=none means the ustack operator will not run the symbolizer, so the symbols sub-field will be empty:
```yaml
ustack:
  addresses: '[0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e;
    [3]0x000000000048250b; [4]0x00000000004829ae; [5]0x0000000000482a7e; [6]0x0000000000482afe;
    [7]0x0000000000482b7e; [8]0x0000000000435a9d; [9]0x00000000004625a1; '
  symbols: ""
  ...
```
Disabling all symbolizers can be useful because the addresses are still returned and users might want to do the symbolization themselves out of band for performance reasons.

Note that gadget still have a --print-ustack parameter. When not used, the addresses are not returned:
```yaml
ustack:
  addresses: ""
  symbols: ""
```
The column view can be enabled with:
```bash
$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:latest \
		--collect-ustack --comm=gochr-dyn --host \
		--symbolizers=auto --fields=proc.comm,cap,ustack.addresses,ustack.symbols
COMM       CAP               USTACK.ADDRESSES                                                          USTACK.SYMBOLS
gochr-dyn  CAP_SYS_CHROOT    [0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e; [3]… [0]runtime/internal/syscall.Syscall6; [1]syscall.Syscall; [2]syscall.Sys…
```
