### PR TITLE
ci: Use main instead of latest for container tags

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
   dnstester_image:
     description: 'The image used for the dnstester.'
-    default: 'ghcr.io/inspektor-gadget/dnstester:latest'
+    default: 'ghcr.io/inspektor-gadget/dnstester:main'
   gadget_repository:
     description: 'Repository where gadget images are stored.'
     required: true

--- a/.github/actions/set-container-repo-and-determine-image-tag/action.yml
+++ b/.github/actions/set-container-repo-and-determine-image-tag/action.yml
@@ -1,6 +1,6 @@
 name: "Output the container repository and image tag to be used"
 description: "Container repository is inputs.registry/inputs.container-image.
-  Image tag is latest if branch is main, otherwise it is the tag or branch name with slashes replaced by hyphens."
+  Image tag is the tag or branch name with slashes replaced by hyphens."
 
 inputs:
   registry:
@@ -52,10 +52,6 @@ runs:
         # If GITHUB_REF_NAME is 'foo/bar', image_tag will be 'foo-bar', we need
         # this because it is not possible to have slash in image tag.
         image_tag=${GITHUB_REF_NAME//\//-}
-        if [ "$image_tag" = "main" ]; then
-            image_tag="latest"
-        fi
-
         echo "image-tag=${image_tag}" >> $GITHUB_OUTPUT
     - name: Output gadgets repository
       id: gadget-repository
@@ -79,8 +75,4 @@ runs:
         # If GITHUB_REF_NAME is 'foo/bar', image_tag will be 'foo-bar', we need
         # this because it is not possible to have slash in image tag.
         gadget_tag=${GITHUB_REF_NAME//\//-}
-        if [ "$gadget_tag" = "main" ]; then
-            gadget_tag="latest"
-        fi
-
         echo "gadget-tag=${gadget_tag}" >> $GITHUB_OUTPUT

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -6,8 +6,8 @@ env:
   # controller-gen with go >1.21 panics, but we can't update controller-gen itself
   GO_VERSION_DOC_CHECK: 1.21.3
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-
-  DEFAULT_DNSTESTER_IMAGE: ghcr.io/inspektor-gadget/dnstester:latest
-  DEFAULT_EBPF_BUILDER_IMAGE: ghcr.io/inspektor-gadget/ebpf-builder:latest
+  DEFAULT_DNSTESTER_IMAGE: ghcr.io/inspektor-gadget/dnstester:main
+  DEFAULT_EBPF_BUILDER_IMAGE: ghcr.io/inspektor-gadget/ebpf-builder:main
   # With the recent update of docker/build-push-action to v6, this action
   # started creating docker build summary files (i.e. .dockerbuild).
   # Sadly, these files create troubles when trying to download artifact in the
@@ -768,7 +768,7 @@ jobs:
       - name: Unpack ig-linux-amd64.tar.gz & Analyze memory
         run: |
           tar zxvf /home/runner/work/inspektor-gadget/ig-linux-amd64.tar.gz
-          sudo ./ig run trace_dns:latest --pprof-addr=localhost:6060 &
+          sudo ./ig run trace_dns:main --pprof-addr=localhost:6060 &
           sleep 10
           curl http://localhost:6060/debug/pprof/heap | tee heap.out
           go tool pprof -top -inuse_space ./ig heap.out | tee inuse_space.txt

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's
 # This version number must be kept in sync with CI workflow lint one.
 LINTER_IMAGE ?= golangci/golangci-lint:v1.63.4@sha256:7f4c8ee8a63d56caa41c099cf658f68b192b615e0f30e94b8864e81a3ceafb53
 
-EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
+EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder:main
 
-DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:main"
 
 PLATFORMS ?= "linux/amd64,linux/arm64"
 
@@ -245,7 +245,7 @@ cross-kubectl-gadget-container:
 
 # tests
 .PHONY: generate-testdata
-generate-testdata: 
+generate-testdata:
 	$(MAKE) -C ./pkg/operators/ebpf/testdata
 	$(MAKE) -C ./pkg/operators/wasm/testdata
 

--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -46,7 +46,7 @@ import (
 var helpersFS embed.FS
 
 // It can be overridden at build time
-var builderImage = "ghcr.io/inspektor-gadget/ebpf-builder:latest"
+var builderImage = "ghcr.io/inspektor-gadget/ebpf-builder:main"
 
 const (
 	DEFAULT_EBPF_SOURCE = "program.bpf.c"
@@ -305,8 +305,8 @@ func ensureBuilderImage(ctx context.Context, cli *client.Client, builderImage st
 	f := filters.NewArgs()
 	f.Add("reference", builderImage)
 
-	// For :latest we always want to have the newest image that is available upstream
-	if !strings.HasSuffix(builderImage, ":latest") {
+	// For :main we always want to have the newest image that is available upstream
+	if !strings.HasSuffix(builderImage, ":main") {
 		images, err := cli.ImageList(ctx, image.ListOptions{Filters: f})
 		if err != nil {
 			return fmt.Errorf("listing images: %w", err)

--- a/docs/api/_golang/datasource/main.go
+++ b/docs/api/_golang/datasource/main.go
@@ -53,7 +53,7 @@ func do() error {
 
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
 	)
 

--- a/docs/api/_golang/from_file/main.go
+++ b/docs/api/_golang/from_file/main.go
@@ -58,7 +58,7 @@ func do() error {
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
 		// The name of the gadget to run is needed as a tarball can contain multiple images.
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
 		gadgetcontext.WithOrasReadonlyTarget(ociStore),
 	)

--- a/docs/api/_golang/from_memory/main.go
+++ b/docs/api/_golang/from_memory/main.go
@@ -70,7 +70,7 @@ func do() error {
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
 		// The name of the gadget to run is needed as a tarball can contain multiple images.
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator),
 		gadgetcontext.WithOrasReadonlyTarget(target),
 	)

--- a/docs/api/_golang/grpc/main.go
+++ b/docs/api/_golang/grpc/main.go
@@ -50,7 +50,7 @@ func do() error {
 
 	gadgetCtx := gadgetcontext.New(
 		ctx,
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(myOperator),
 	)
 

--- a/docs/api/_golang/operators/main.go
+++ b/docs/api/_golang/operators/main.go
@@ -58,7 +58,7 @@ func do() error {
 
 	gadgetCtx := gadgetcontext.New(
 		ctx,
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(
 			ocihandler.OciHandler,
 			localManagerOp,

--- a/docs/api/_golang/trace_open/main.go
+++ b/docs/api/_golang/trace_open/main.go
@@ -72,7 +72,7 @@ func do() error {
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
 		// This is the image that contains the gadget we want to run.
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		// List of operators that will be run with the gadget
 		gadgetcontext.WithDataOperators(
 			ocihandler.OciHandler, // pass singleton instance of the oci-handler

--- a/docs/api/golang.mdx
+++ b/docs/api/golang.mdx
@@ -125,10 +125,10 @@ image.
 
 ```bash
 # pull the image if not already present on the system
-$ sudo ig image pull trace_open:latest
+$ sudo ig image pull trace_open:main
 
 # export the image to a tarball
-$ sudo ig image export trace_open:latest trace_open.tar
+$ sudo ig image export trace_open:main trace_open.tar
 ```
 
 import FromFile from '!!raw-loader!./_golang/from_file/main.go';

--- a/examples/gadgets/other/mutate/main.go
+++ b/examples/gadgets/other/mutate/main.go
@@ -65,7 +65,7 @@ func do() error {
 
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
-		"ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_open:main",
 		gadgetcontext.WithDataOperators(ocihandler.OciHandler, myOperator, clioperator.CLIOperator),
 	)
 

--- a/examples/gadgets/trace_dns/main.go
+++ b/examples/gadgets/trace_dns/main.go
@@ -75,7 +75,7 @@ func do() error {
 
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
-		"ghcr.io/inspektor-gadget/gadget/trace_dns:latest",
+		"ghcr.io/inspektor-gadget/gadget/trace_dns:main",
 		gadgetcontext.WithDataOperators(
 			ocihandler.OciHandler,
 			localManagerOp,

--- a/gadgets/trace_dns/test/integration/trace_dns_test.go
+++ b/gadgets/trace_dns/test/integration/trace_dns_test.go
@@ -59,7 +59,7 @@ type traceDNSEvent struct {
 }
 
 const (
-	DefaultServerImage = "ghcr.io/inspektor-gadget/dnstester:latest"
+	DefaultServerImage = "ghcr.io/inspektor-gadget/dnstester:main"
 	DefaultClientImage = gadgettesting.BusyBoxImage
 )
 

--- a/integration/components/image/integration_test.go
+++ b/integration/components/image/integration_test.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	integration      = flag.Bool("integration", false, "run integration tests")
-	testBuilderImage = flag.String("builder-image", "ghcr.io/inspektor-gadget/ebpf-builder:latest", "ebpf builder image")
+	testBuilderImage = flag.String("builder-image", "ghcr.io/inspektor-gadget/ebpf-builder:main", "ebpf builder image")
 )
 
 func TestMain(m *testing.M) {

--- a/integration/ig/non-k8s/Makefile
+++ b/integration/ig/non-k8s/Makefile
@@ -1,4 +1,4 @@
-DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:main"
 CONTAINER_RUNTIME ?= docker
 
 # build

--- a/integration/ig/non-k8s/integration_test.go
+++ b/integration/ig/non-k8s/integration_test.go
@@ -28,7 +28,7 @@ var (
 	containerFactory containers.ContainerFactory
 	// flags
 	integration    = flag.Bool("integration", false, "run integration tests")
-	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
+	dnsTesterImage = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:main", "dnstester container image")
 	runtime        = flag.String("runtime", "docker", "which runtime to use (docker, containerd)")
 )
 

--- a/integration/k8s/Makefile
+++ b/integration/k8s/Makefile
@@ -1,9 +1,9 @@
-# Test commands in this Makefile only covers ig. 
+# Test commands in this Makefile only covers ig.
 # Kubectl-gadget test commands are covered in ../../Makefile.
 
 include $(shell pwd)/../../minikube.mk
 
-DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:latest"
+DNSTESTER_IMAGE ?= "ghcr.io/inspektor-gadget/dnstester:main"
 GOPROXY ?= $(shell go env GOPROXY)
 
 # make does not allow implicit rules (with '%') to be phony so let's use

--- a/integration/k8s/integration_test.go
+++ b/integration/k8s/integration_test.go
@@ -51,7 +51,7 @@ var (
 
 var (
 	integrationTest = flag.Bool("integration", false, "run integration tests")
-	dnsTesterImage  = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:latest", "dnstester container image")
+	dnsTesterImage  = flag.String("dnstester-image", "ghcr.io/inspektor-gadget/dnstester:main", "dnstester container image")
 	testComponent   = flag.String("test-component", "", "run tests for specific component")
 	k8sArch         = flag.String("k8s-arch", "amd64", "allows to skip tests that are not supported on a given CPU architecture")
 )

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -14,9 +14,6 @@ fi
 
 BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
 if [ "$1" = "branch" ] ; then
-  if [ "$BRANCH_PREFIX" = "main" ] ; then
-    BRANCH_PREFIX="latest"
-  fi
   echo "${BRANCH_PREFIX//\//-}"
 else
   echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
We're using latest on the wrong way, use main to indicate this is about the development version.

Part of #4049
