### PR TITLE
tree-wide: Update ebpf-builder missing refs

### DIFF
--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=v0.0.0
 ENV VERSION=${VERSION}
-ARG EBPF_BUILDER=ghcr.io/inspektor-gadget/ebpf-builder:latest
+ARG EBPF_BUILDER=ghcr.io/inspektor-gadget/ebpf-builder:main
 ENV EBPF_BUILDER=${EBPF_BUILDER}
 ARG GOPROXY
 ENV GOPROXY=${GOPROXY}

--- a/docs/gadget-devel/building.md
+++ b/docs/gadget-devel/building.md
@@ -16,7 +16,7 @@ Usage:
 Flags:
       --btfgen                  Enable btfgen
       --btfhub-archive string   Path to the location of the btfhub-archive files
-      --builder-image string    Builder image to use (default "ghcr.io/inspektor-gadget/ebpf-builder:latest")
+      --builder-image string    Builder image to use (default "ghcr.io/inspektor-gadget/ebpf-builder:%IG_TAG%")
   -f, --file string             Path to build.yaml (default "build.yaml")
   -h, --help                    help for build
   -l, --local                   Build using local tools
@@ -122,9 +122,9 @@ $ export IG_SOURCE_PATH=/home/ig/inspektor-gadget
 
 # Build an in-tree gadget that uses Wasm
 $ sudo -E ig image build $IG_SOURCE_PATH/gadgets/trace_open -t trace_open
-Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:latest
+Pulling builder image ghcr.io/inspektor-gadget/ebpf-builder:%IG_TAG%
 latest: Pulling from inspektor-gadget/ebpf-builder
 Digest: sha256:5deec444ea81b866f135430f62b2a580374b7bbcfa5961298cb292546395e3b4
-Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:latest
+Status: Image is up to date for ghcr.io/inspektor-gadget/ebpf-builder:%IG_TAG%
 Successfully built ghcr.io/inspektor-gadget/gadget/trace_open:latest@sha256:d3c0fa005cfc16ae1f9184919b517aa784730ed5bbfb54edc50a3befacbe3383
 ```

--- a/docs/reference/verify-assets.mdx
+++ b/docs/reference/verify-assets.mdx
@@ -286,7 +286,7 @@ We also sign the `ebpf-builder` image which is used to build gadgets.
 You can verify it using the following command:
 
 ```bash
-$ cosign verify --key inspektor-gadget.pub ghcr.io/inspektor-gadget/ebpf-builder:latest
+$ cosign verify --key inspektor-gadget.pub ghcr.io/inspektor-gadget/ebpf-builder:%IG_TAG%
 ```
 
 We highly recommend you to verify by digest and specify the digest when building.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -4,7 +4,7 @@ ROOT_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
-BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:latest
+BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/ebpf-builder:main
 KERNEL_REPOSITORY ?= ghcr.io/inspektor-gadget/ci-kernels
 IG ?= ig
 KUBECTL_GADGET ?= kubectl-gadget


### PR DESCRIPTION
Fixes: c192e6c241ac ("ci: Use main instead of latest for container tags")

Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/4179#issuecomment-2704350522

cc @alban 
