### PR TITLE
Dockerfiles: Use --mount-type=cache

### DIFF
--- a/Dockerfiles/gadget.Dockerfile
+++ b/Dockerfiles/gadget.Dockerfile
@@ -20,7 +20,10 @@ RUN cd /gadget && go mod download
 
 # This COPY is limited by .dockerignore
 COPY ./ /gadget
-RUN cd /gadget/gadget-container && \
+RUN \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    cd /gadget/gadget-container && \
 	make -j$(nproc) TARGET_ARCH=${TARGETARCH} gadget-container-deps
 
 # Main gadget image

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -14,7 +14,11 @@ RUN cd /cache && \
 	go mod download
 ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget
 WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget/integration/k8s
-RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go test -c -o ig-integration-${TARGETARCH}.test ./...
+RUN \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOARCH=${TARGETARCH} go test \
+      -c -o ig-integration-${TARGETARCH}.test ./...
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -18,13 +18,16 @@ ADD . /go/src/github.com/inspektor-gadget/inspektor-gadget
 
 WORKDIR /go/src/github.com/inspektor-gadget/inspektor-gadget
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-		-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/internal/version.version=${VERSION} \
-                  -X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${EBPF_BUILDER} \
-                  -extldflags '-static'" \
-		-tags "netgo" \
-		-o ig-${TARGETOS}-${TARGETARCH} \
-		github.com/inspektor-gadget/inspektor-gadget/cmd/ig
+RUN \
+      --mount=type=cache,target=/root/.cache/go-build \
+      --mount=type=cache,target=/go/pkg \
+      CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+        -ldflags "-X github.com/inspektor-gadget/inspektor-gadget/internal/version.version=${VERSION} \
+        -X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${EBPF_BUILDER} \
+        -extldflags '-static'" \
+        -tags "netgo" \
+        -o ig-${TARGETOS}-${TARGETARCH} \
+        github.com/inspektor-gadget/inspektor-gadget/cmd/ig
 
 FROM ${BASE_IMAGE}
 

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -30,7 +30,10 @@ ENV IMAGE_TAG=${IMAGE_TAG}
 
 # This COPY is limited by .dockerignore
 COPY ./ /gadget
-RUN cd /gadget && GOHOSTOS=$TARGETOS GOHOSTARCH=$TARGETARCH make kubectl-gadget
+RUN \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    cd /gadget && GOHOSTOS=$TARGETOS GOHOSTARCH=$TARGETARCH make kubectl-gadget
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
As per this [blog](https://www.docker.com/blog/containerize-your-go-developer-environment-part-2/), we can use incremental builds to improve building things locally. Currently if we make a single change entire build layer is invalidated but this change allows making use of Go’s compiler cache to ensuring we don't compile everything from scratch. Other projects using this:
- https://github.com/kedacore/keda/blob/main/Dockerfile#L29
- https://github.com/docker/buildx/blob/master/Dockerfile#L81
- https://github.com/containerd/containerd/blob/main/.github/workflows/release/Dockerfile#L50

## Testing Done

Before testing clean everything using ` docker system prune -fa && docker builder prune -f`:

### main

```
# clean everything
$ docker system prune -fa && docker builder prune -f
# run the first time
$ make ig
# make a change
$  sed -i 's/gadgets for/awesome gadgets for/g' cmd/ig/main.go
$ time make ig
echo Building ig-linux-amd64
Building ig-linux-amd64
if false == "true" ; then \
        ./tools/getbtfhub.sh && \
        make -f Makefile.btfgen \
                ARCH=amd64 BTFHUB_ARCHIVE=/home/qasim/btfhub-archive/ -j; \
...
real    1m33,419s
user    0m0,761s
sys     0m0,859s
# verify we have new version
$ ./ig -h | grep awesome
```

### PR

```
# clean everything
$ docker system prune -fa && docker builder prune -f
# run the first time
$ make ig
# make a change
$  sed -i 's/gadgets for/awesome gadgets for/g' cmd/ig/main.go
$ time make ig
echo Building ig-linux-amd64
Building ig-linux-amd64
if false == "true" ; then \
        ./tools/getbtfhub.sh && \
        make -f Makefile.btfgen \
                ARCH=amd64 BTFHUB_ARCHIVE=/home/qasim/btfhub-archive/ -j; \
...
real    0m25,301s
user    0m0,584s
sys     0m0,644s
# verify we have new version
$ ./ig -h | grep awesome
```
