### PR TITLE
wasm: Change module name from env to ig

### DIFF
--- a/docs/gadget-devel/gadget-wasm-api-raw.md
+++ b/docs/gadget-devel/gadget-wasm-api-raw.md
@@ -20,7 +20,7 @@ contains the length and the lower 32 the memory address.
 
 ## Wasm Module Exported Functions
 
-The Wasm module implemented by the gadget also needs to export some functions to
+The Wasm program implemented by the gadget also needs to export some functions to
 be invoked by the host.
 
 ### `gadgetAPIVersion`
@@ -58,6 +58,8 @@ This function is called after the the gadget is stopped. This function is option
 See description in dataSourceSubscribe below.
 
 ## API
+
+The Wasm API provided to the gadget resides in the `ig` module.
 
 ### Log
 

--- a/pkg/operators/wasm/testdata/baderrptr/program.go
+++ b/pkg/operators/wasm/testdata/baderrptr/program.go
@@ -21,7 +21,7 @@ import (
 // Invalid ptr: out of bound 17 MB (max memory of the module is 16MB)
 const invalidPtr uint32 = uint32(17 * 1024 * 1024)
 
-//go:wasmimport env fieldGetScalar
+//go:wasmimport ig fieldGetScalar
 func fieldGetScalar(acc uint32, data uint32, kind uint32, errPtr uint32) uint64
 
 //go:wasmexport gadgetInit

--- a/pkg/operators/wasm/testdata/badguest/program.go
+++ b/pkg/operators/wasm/testdata/badguest/program.go
@@ -57,85 +57,85 @@ type syscallDeclaration struct {
 	params   [6]syscallParam
 }
 
-//go:wasmimport env gadgetLog
+//go:wasmimport ig gadgetLog
 func gadgetLog(level uint32, str uint64)
 
-//go:wasmimport env newDataSource
+//go:wasmimport ig newDataSource
 func newDataSource(name uint64, typ uint32) uint32
 
-//go:wasmimport env getDataSource
+//go:wasmimport ig getDataSource
 func getDataSource(name uint64) uint32
 
-//go:wasmimport env dataSourceSubscribe
+//go:wasmimport ig dataSourceSubscribe
 func dataSourceSubscribe(ds uint32, typ uint32, prio uint32, cb uint64) uint32
 
-//go:wasmimport env dataSourceGetField
+//go:wasmimport ig dataSourceGetField
 func dataSourceGetField(ds uint32, name uint64) uint32
 
-//go:wasmimport env dataSourceAddField
+//go:wasmimport ig dataSourceAddField
 func dataSourceAddField(ds uint32, name uint64, kind uint32) uint32
 
-//go:wasmimport env dataSourceNewPacketSingle
+//go:wasmimport ig dataSourceNewPacketSingle
 func dataSourceNewPacketSingle(ds uint32) uint32
 
-//go:wasmimport env dataSourceNewPacketArray
+//go:wasmimport ig dataSourceNewPacketArray
 func dataSourceNewPacketArray(ds uint32) uint32
 
-//go:wasmimport env dataSourceEmitAndRelease
+//go:wasmimport ig dataSourceEmitAndRelease
 func dataSourceEmitAndRelease(ds uint32, packet uint32) uint32
 
-//go:wasmimport env dataSourceRelease
+//go:wasmimport ig dataSourceRelease
 func dataSourceRelease(ds uint32, packet uint32) uint32
 
-//go:wasmimport env dataArrayNew
+//go:wasmimport ig dataArrayNew
 func dataArrayNew(d uint32) uint32
 
-//go:wasmimport env dataArrayAppend
+//go:wasmimport ig dataArrayAppend
 func dataArrayAppend(d uint32, data uint32) uint32
 
-//go:wasmimport env dataArrayRelease
+//go:wasmimport ig dataArrayRelease
 func dataArrayRelease(d uint32, data uint32) uint32
 
-//go:wasmimport env dataArrayLen
+//go:wasmimport ig dataArrayLen
 func dataArrayLen(d uint32) uint32
 
-//go:wasmimport env dataArrayGet
+//go:wasmimport ig dataArrayGet
 func dataArrayGet(d uint32, index uint32) uint32
 
-//go:wasmimport env fieldGetScalar
+//go:wasmimport ig fieldGetScalar
 func fieldGetScalar(acc uint32, data uint32, kind uint32, errPtr uint32) uint64
 
-//go:wasmimport env fieldSet
+//go:wasmimport ig fieldSet
 func fieldSet(acc uint32, data uint32, kind uint32, value uint64) uint32
 
-//go:wasmimport env getParamValue
+//go:wasmimport ig getParamValue
 func getParamValue(key uint64, dst uint64) uint32
 
-//go:wasmimport env setConfig
+//go:wasmimport ig setConfig
 func setConfig(key uint64, val uint64, kind uint32) uint32
 
-//go:wasmimport env newMap
+//go:wasmimport ig newMap
 func newMap(name uint64, typ uint32, keySize uint32, valueSize uint32, maxEntries uint32) uint32
 
-//go:wasmimport env getMap
+//go:wasmimport ig getMap
 func getMap(name uint64) uint32
 
-//go:wasmimport env mapLookup
+//go:wasmimport ig mapLookup
 func mapLookup(m uint32, keyptr uint64, valueptr uint64) uint32
 
-//go:wasmimport env mapUpdate
+//go:wasmimport ig mapUpdate
 func mapUpdate(m uint32, keyptr uint64, valueptr uint64, flags uint64) uint32
 
-//go:wasmimport env mapDelete
+//go:wasmimport ig mapDelete
 func mapDelete(m uint32, keyptr uint64) uint32
 
-//go:wasmimport env mapRelease
+//go:wasmimport ig mapRelease
 func mapRelease(m uint32) uint32
 
-//go:wasmimport env getSyscallDeclaration
+//go:wasmimport ig getSyscallDeclaration
 func getSyscallDeclaration(name uint64, pointer uint64) uint32
 
-//go:wasmimport env kallsymsSymbolExists
+//go:wasmimport ig kallsymsSymbolExists
 func kallsymsSymbolExists(symbol uint64) uint32
 
 func stringToBufPtr(s string) uint64 {

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -219,20 +219,20 @@ func (i *wasmOperatorInstance) init(
 		WithMemoryLimitPages(256) // 16MB (64KB per page)
 	i.rt = wazero.NewRuntimeWithConfig(ctx, rtConfig)
 
-	env := i.rt.NewHostModuleBuilder("env")
+	igModuleBuilder := i.rt.NewHostModuleBuilder("ig")
 
-	i.addLogFuncs(env)
-	i.addDataSourceFuncs(env)
-	i.addFieldFuncs(env)
-	i.addParamsFuncs(env)
-	i.addConfigFuncs(env)
-	i.addMapFuncs(env)
-	i.addHandleFuncs(env)
-	i.addSyscallsDeclarationsFuncs(env)
-	i.addPerfFuncs(env)
-	i.addKallsymsFuncs(env)
+	i.addLogFuncs(igModuleBuilder)
+	i.addDataSourceFuncs(igModuleBuilder)
+	i.addFieldFuncs(igModuleBuilder)
+	i.addParamsFuncs(igModuleBuilder)
+	i.addConfigFuncs(igModuleBuilder)
+	i.addMapFuncs(igModuleBuilder)
+	i.addHandleFuncs(igModuleBuilder)
+	i.addSyscallsDeclarationsFuncs(igModuleBuilder)
+	i.addPerfFuncs(igModuleBuilder)
+	i.addKallsymsFuncs(igModuleBuilder)
 
-	if _, err := env.Instantiate(ctx); err != nil {
+	if _, err := igModuleBuilder.Instantiate(ctx); err != nil {
 		return fmt.Errorf("instantiating host module: %w", err)
 	}
 

--- a/wasmapi/go/config.go
+++ b/wasmapi/go/config.go
@@ -20,7 +20,7 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env setConfig
+//go:wasmimport ig setConfig
 //go:linkname setConfig setConfig
 func setConfig(key uint64, val uint64, kind uint32) uint32
 

--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -21,67 +21,67 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env newDataSource
+//go:wasmimport ig newDataSource
 //go:linkname newDataSource newDataSource
 func newDataSource(name uint64, typ uint32) uint32
 
-//go:wasmimport env getDataSource
+//go:wasmimport ig getDataSource
 //go:linkname getDataSource getDataSource
 func getDataSource(name uint64) uint32
 
-//go:wasmimport env dataSourceSubscribe
+//go:wasmimport ig dataSourceSubscribe
 //go:linkname dataSourceSubscribe dataSourceSubscribe
 func dataSourceSubscribe(ds uint32, typ uint32, prio uint32, cb uint64) uint32
 
-//go:wasmimport env dataSourceGetField
+//go:wasmimport ig dataSourceGetField
 //go:linkname dataSourceGetField dataSourceGetField
 func dataSourceGetField(ds uint32, name uint64) uint32
 
-//go:wasmimport env dataSourceAddField
+//go:wasmimport ig dataSourceAddField
 //go:linkname dataSourceAddField dataSourceAddField
 func dataSourceAddField(ds uint32, name uint64, kind uint32) uint32
 
-//go:wasmimport env dataSourceNewPacketSingle
+//go:wasmimport ig dataSourceNewPacketSingle
 //go:linkname dataSourceNewPacketSingle dataSourceNewPacketSingle
 func dataSourceNewPacketSingle(ds uint32) uint32
 
-//go:wasmimport env dataSourceNewPacketArray
+//go:wasmimport ig dataSourceNewPacketArray
 //go:linkname dataSourceNewPacketArray dataSourceNewPacketArray
 func dataSourceNewPacketArray(ds uint32) uint32
 
-//go:wasmimport env dataSourceEmitAndRelease
+//go:wasmimport ig dataSourceEmitAndRelease
 //go:linkname dataSourceEmitAndRelease dataSourceEmitAndRelease
 func dataSourceEmitAndRelease(ds uint32, packet uint32) uint32
 
-//go:wasmimport env dataSourceRelease
+//go:wasmimport ig dataSourceRelease
 //go:linkname dataSourceRelease dataSourceRelease
 func dataSourceRelease(ds uint32, packet uint32) uint32
 
-//go:wasmimport env dataSourceUnreference
+//go:wasmimport ig dataSourceUnreference
 //go:linkname dataSourceUnreference dataSourceUnreference
 func dataSourceUnreference(ds uint32) uint32
 
-//go:wasmimport env dataSourceIsReferenced
+//go:wasmimport ig dataSourceIsReferenced
 //go:linkname dataSourceIsReferenced dataSourceIsReferenced
 func dataSourceIsReferenced(ds uint32) uint32
 
-//go:wasmimport env dataArrayNew
+//go:wasmimport ig dataArrayNew
 //go:linkname dataArrayNew dataArrayNew
 func dataArrayNew(d uint32) uint32
 
-//go:wasmimport env dataArrayAppend
+//go:wasmimport ig dataArrayAppend
 //go:linkname dataArrayAppend dataArrayAppend
 func dataArrayAppend(d uint32, data uint32) uint32
 
-//go:wasmimport env dataArrayRelease
+//go:wasmimport ig dataArrayRelease
 //go:linkname dataArrayRelease dataArrayRelease
 func dataArrayRelease(d uint32, data uint32) uint32
 
-//go:wasmimport env dataArrayLen
+//go:wasmimport ig dataArrayLen
 //go:linkname dataArrayLen dataArrayLen
 func dataArrayLen(d uint32) uint32
 
-//go:wasmimport env dataArrayGet
+//go:wasmimport ig dataArrayGet
 //go:linkname dataArrayGet dataArrayGet
 func dataArrayGet(d uint32, index uint32) uint32
 

--- a/wasmapi/go/fields.go
+++ b/wasmapi/go/fields.go
@@ -21,19 +21,19 @@ import (
 	"unsafe"
 )
 
-//go:wasmimport env fieldGetScalar
+//go:wasmimport ig fieldGetScalar
 //go:linkname fieldGetScalar fieldGetScalar
 func fieldGetScalar(field uint32, data uint32, kind uint32, errPtr uint32) uint64
 
-//go:wasmimport env fieldGetBuffer
+//go:wasmimport ig fieldGetBuffer
 //go:linkname fieldGetBuffer fieldGetBuffer
 func fieldGetBuffer(field uint32, data uint32, kind uint32, dst uint64) int32
 
-//go:wasmimport env fieldSet
+//go:wasmimport ig fieldSet
 //go:linkname fieldSet fieldSet
 func fieldSet(field uint32, data uint32, kind uint32, value uint64) uint32
 
-//go:wasmimport env fieldAddTag
+//go:wasmimport ig fieldAddTag
 //go:linkname fieldAddTag fieldAddTag
 func fieldAddTag(field uint32, tag uint64) uint32
 

--- a/wasmapi/go/handle.go
+++ b/wasmapi/go/handle.go
@@ -19,7 +19,7 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env releaseHandle
+//go:wasmimport ig releaseHandle
 //go:linkname releaseHandle releaseHandle
 func releaseHandle(handle uint32) uint32
 

--- a/wasmapi/go/kallsyms.go
+++ b/wasmapi/go/kallsyms.go
@@ -19,7 +19,7 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env kallsymsSymbolExists
+//go:wasmimport ig kallsymsSymbolExists
 //go:linkname kallsymsSymbolExists kallsymsSymbolExists
 func kallsymsSymbolExists(symbol uint64) uint32
 

--- a/wasmapi/go/log.go
+++ b/wasmapi/go/log.go
@@ -20,7 +20,7 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env gadgetLog
+//go:wasmimport ig gadgetLog
 //go:linkname gadgetLog gadgetLog
 func gadgetLog(level uint32, str uint64)
 

--- a/wasmapi/go/map.go
+++ b/wasmapi/go/map.go
@@ -22,27 +22,27 @@ import (
 	"unsafe"
 )
 
-//go:wasmimport env newMap
+//go:wasmimport ig newMap
 //go:linkname newMap newMap
 func newMap(name uint64, typ uint32, keySize uint32, valueSize uint32, maxEntries uint32) uint32
 
-//go:wasmimport env getMap
+//go:wasmimport ig getMap
 //go:linkname getMap getMap
 func getMap(name uint64) uint32
 
-//go:wasmimport env mapLookup
+//go:wasmimport ig mapLookup
 //go:linkname mapLookup mapLookup
 func mapLookup(m uint32, keyptr uint64, valueptr uint64) uint32
 
-//go:wasmimport env mapUpdate
+//go:wasmimport ig mapUpdate
 //go:linkname mapUpdate mapUpdate
 func mapUpdate(m uint32, keyptr uint64, valueptr uint64, flags uint64) uint32
 
-//go:wasmimport env mapDelete
+//go:wasmimport ig mapDelete
 //go:linkname mapDelete mapDelete
 func mapDelete(m uint32, keyptr uint64) uint32
 
-//go:wasmimport env mapRelease
+//go:wasmimport ig mapRelease
 //go:linkname mapRelease mapRelease
 func mapRelease(m uint32) uint32
 

--- a/wasmapi/go/params.go
+++ b/wasmapi/go/params.go
@@ -19,7 +19,7 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env getParamValue
+//go:wasmimport ig getParamValue
 //go:linkname getParamValue getParamValue
 func getParamValue(key uint64, dst uint64) uint32
 

--- a/wasmapi/go/perf.go
+++ b/wasmapi/go/perf.go
@@ -21,23 +21,23 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env newPerfReader
+//go:wasmimport ig newPerfReader
 //go:linkname newPerfReader newPerfReader
 func newPerfReader(mapHandle uint32, size uint32, isOverwritable uint32) uint32
 
-//go:wasmimport env perfReaderPause
+//go:wasmimport ig perfReaderPause
 //go:linkname perfReaderPause perfReaderPause
 func perfReaderPause(perfMapHandle uint32) uint32
 
-//go:wasmimport env perfReaderResume
+//go:wasmimport ig perfReaderResume
 //go:linkname perfReaderResume perfReaderResume
 func perfReaderResume(perfMapHandle uint32) uint32
 
-//go:wasmimport env perfReaderRead
+//go:wasmimport ig perfReaderRead
 //go:linkname perfReaderRead perfReaderRead
 func perfReaderRead(perfMapHandle uint32, dst uint64) uint32
 
-//go:wasmimport env perfReaderClose
+//go:wasmimport ig perfReaderClose
 //go:linkname perfReaderClose perfReaderClose
 func perfReaderClose(perfMapHandle uint32) uint32
 

--- a/wasmapi/go/syscall.go
+++ b/wasmapi/go/syscall.go
@@ -21,15 +21,15 @@ import (
 	_ "unsafe"
 )
 
-//go:wasmimport env getSyscallName
+//go:wasmimport ig getSyscallName
 //go:linkname getSyscallName getSyscallName
 func getSyscallName(id uint32, dst uint64) uint32
 
-//go:wasmimport env getSyscallID
+//go:wasmimport ig getSyscallID
 //go:linkname getSyscallID getSyscallID
 func getSyscallID(name uint64) int32
 
-//go:wasmimport env getSyscallDeclaration
+//go:wasmimport ig getSyscallDeclaration
 //go:linkname getSyscallDeclaration getSyscallDeclaration
 func getSyscallDeclaration(name uint64, pointer uint64) uint32
 


### PR DESCRIPTION
We should name our module `ig` instead of `env`