### PR TITLE
fsnotify gadget: add support for Linux 5.4

### DIFF
--- a/gadgets/fsnotify/README.mdx
+++ b/gadgets/fsnotify/README.mdx
@@ -10,6 +10,8 @@ import TabItem from '@theme/TabItem';
 
 The fsnotify gadget detects applications using inotify or fanotify and enriches the events with the process-related metadata.
 
+This gadget requires Linux >= 5.4. Additionally, the field `i_ino` is only available in Linux >= 5.11.
+
 ## Getting started
 
 Running the gadget:

--- a/gadgets/fsnotify/gadget.yaml
+++ b/gadgets/fsnotify/gadget.yaml
@@ -49,7 +49,7 @@ datasources:
       i_ino:
         annotations:
           columns.hidden: "true"
-          description: inode of the file accessed by inotify
+          description: inode of the file accessed by inotify (requires Linux >= 5.11)
       i_ino_dir:
         annotations:
           columns.hidden: "true"

--- a/gadgets/fsnotify/go/program.go
+++ b/gadgets/fsnotify/go/program.go
@@ -23,15 +23,32 @@ func gadgetPreStart() int32 {
 	// Linux 5.16 renamed fsnotify_add_event to fsnotify_insert_event
 	// https://github.com/torvalds/linux/commit/1ad03c3a326a86e259389592117252c851873395
 	if api.KallsymsSymbolExists("fsnotify_insert_event") {
+		// Fast path for Linux >= 5.16
+		// No need to check for other symbols
+
+		// inotify_handle_event is only on Linux < 5.11
+		api.SetConfig("programs.inotify_handle_event_e.attach_to", "gadget_program_disabled")
+		api.SetConfig("programs.inotify_handle_event_x.attach_to", "gadget_program_disabled")
 		return 0
 	}
 
-	if api.KallsymsSymbolExists("fsnotify_add_event") {
-		api.SetConfig("programs.fsnotify_insert_event_e.attach_to", "fsnotify_add_event")
+	if !api.KallsymsSymbolExists("fsnotify_add_event") {
+		api.Errorf("kernel symbol not found: fsnotify_add_event or fsnotify_insert_event")
 		return 0
 	}
+	api.SetConfig("programs.fsnotify_insert_event_e.attach_to", "fsnotify_add_event")
 
-	api.Errorf("kernel symbol not found: fsnotify_add_event or fsnotify_insert_event")
+	// Linux 5.11 introduced inotify_handle_inode_event (replacing inotify_handle_event)
+	// https://github.com/torvalds/linux/commit/1a2620a99803ad660edc5d22fd9c66cce91ceb1c
+	if !api.KallsymsSymbolExists("inotify_handle_inode_event") {
+		if api.KallsymsSymbolExists("inotify_handle_event") {
+			api.SetConfig("programs.inotify_handle_inode_event_e.attach_to", "gadget_program_disabled")
+			api.SetConfig("programs.inotify_handle_inode_event_x.attach_to", "gadget_program_disabled")
+			api.Warnf("inotify_handle_inode_event not found, falling back to inotify_handle_event")
+			return 0
+		}
+		api.Errorf("kernel symbol not found: inotify_handle_inode_event or inotify_handle_event")
+	}
 	return 0
 }
 

--- a/gadgets/fsnotify/program.bpf.c
+++ b/gadgets/fsnotify/program.bpf.c
@@ -272,6 +272,32 @@ static __always_inline __u32 get_priority(struct fsnotify_group *group)
 	return 0;
 }
 
+static __always_inline int get_fanotify_type(struct fanotify_event *fae)
+{
+	// fanotify types were introduced by Linux v5.6
+	// https://github.com/torvalds/linux/commit/7088f35720a55b99624ea36091538baec7ec611f
+	if (bpf_core_field_exists(fae->type))
+		return BPF_CORE_READ_BITFIELD_PROBED(fae, type);
+
+	return -1;
+}
+
+static __always_inline struct path *
+fanotify_get_path(struct fanotify_event *fae)
+{
+	struct path *p = NULL;
+	int type = get_fanotify_type(fae);
+	if (type == -1)
+		return NULL;
+
+	if (type == FANOTIFY_EVENT_TYPE_PATH)
+		p = &container_of(fae, struct fanotify_path_event, fae)->path;
+	else if (type == FANOTIFY_EVENT_TYPE_PATH_PERM)
+		p = &container_of(fae, struct fanotify_perm_event, fae)->path;
+
+	return p;
+}
+
 // Probes for the tracees
 
 SEC("kprobe/inotify_handle_inode_event")
@@ -279,6 +305,8 @@ int BPF_KPROBE(inotify_handle_inode_event_e, struct fsnotify_mark *inode_mark,
 	       u32 mask, struct inode *inode, struct inode *dir,
 	       const struct qstr *name, u32 cookie)
 {
+	// inotify_handle_inode_event is introduced in Linux v5.11:
+	// https://github.com/torvalds/linux/commit/1a2620a99803ad660edc5d22fd9c66cce91ceb1c
 	if (!fanotify_only) {
 		u64 pid_tgid = bpf_get_current_pid_tgid();
 		struct fsnotify_insert_event_value value = {
@@ -404,24 +432,18 @@ int BPF_KPROBE(fsnotify_insert_event_e, struct fsnotify_group *group,
 		case fanotify:
 			fae = container_of(event, struct fanotify_event, fse);
 			ee->fa_mask = BPF_CORE_READ(fae, mask);
-			ee->fa_type = BPF_CORE_READ_BITFIELD_PROBED(fae, type);
+			// fanotify types were introduced by Linux v5.6
+			// https://github.com/torvalds/linux/commit/7088f35720a55b99624ea36091538baec7ec611f
+			if (bpf_core_field_exists(fae->type))
+				ee->fa_type = BPF_CORE_READ_BITFIELD_PROBED(
+					fae, type);
 			ee->fa_pid = BPF_CORE_READ(fae, pid, numbers[0].nr);
 			ee->fa_flags =
 				BPF_CORE_READ(group, fanotify_data.flags);
 			ee->fa_f_flags =
 				BPF_CORE_READ(group, fanotify_data.f_flags);
 
-			if (ee->fa_type == FANOTIFY_EVENT_TYPE_PATH)
-				p = &container_of(fae,
-						  struct fanotify_path_event,
-						  fae)
-					     ->path;
-			else if (ee->fa_type == FANOTIFY_EVENT_TYPE_PATH_PERM)
-				p = &container_of(fae,
-						  struct fanotify_perm_event,
-						  fae)
-					     ->path;
-
+			p = fanotify_get_path(fae);
 			if (p)
 				bpf_probe_read_kernel_str(ee->name,
 							  GADGET_PATH_MAX,
@@ -467,7 +489,9 @@ int BPF_KPROBE(fsnotify_destroy_event, struct fsnotify_group *group,
 		goto out;
 
 	fae = container_of(event, struct fanotify_event, fse);
-	fa_type = BPF_CORE_READ_BITFIELD_PROBED(fae, type);
+	fa_type = get_fanotify_type(fae);
+	if (fa_type == -1)
+		goto out;
 	if (fa_type != FANOTIFY_EVENT_TYPE_PATH_PERM)
 		goto out;
 
@@ -560,7 +584,9 @@ prepare_ee_for_fa_perm(struct enriched_event *ee, struct fsnotify_event *event,
 		return;
 
 	fae = container_of(event, struct fanotify_event, fse);
-	fa_type = BPF_CORE_READ_BITFIELD_PROBED(fae, type);
+	fa_type = get_fanotify_type(fae);
+	if (fa_type == -1)
+		return;
 	if (fa_type != FANOTIFY_EVENT_TYPE_PATH_PERM)
 		return;
 


### PR DESCRIPTION
# fsnotify gadget: add support for Linux 5.4

Linux had the following changes:
* The fanotify_event type changed in Linux 5.6 (https://github.com/torvalds/linux/commit/7088f35720a55b99624ea36091538baec7ec611f), so we need to use CORE functions to access it.
* Function `inotify_handle_inode_event` replaced `inotify_handle_event` in Linux 5.10 (https://github.com/torvalds/linux/commit/1a2620a99803ad660edc5d22fd9c66cce91ceb1c), so we need to enable/disable attachments appropriately in the WASM module.

## How to use

No changes

## Testing done

```
make -C gadgets VIMTO=/home/alban/go/bin/vimto IG_DEBUG_LOGS=true IG_VERIFY_IMAGE=false GADGET_TAG=alban_fsnotify_linux5.4 KERNEL_VERSION=5.4 fsnotify/test-unit
make -C gadgets VIMTO=/home/alban/go/bin/vimto IG_DEBUG_LOGS=true IG_VERIFY_IMAGE=false GADGET_TAG=alban_fsnotify_linux5.4 KERNEL_VERSION=5.10 fsnotify/test-unit
make -C gadgets VIMTO=/home/alban/go/bin/vimto IG_DEBUG_LOGS=true IG_VERIFY_IMAGE=false GADGET_TAG=alban_fsnotify_linux5.4 KERNEL_VERSION=5.15 fsnotify/test-unit
```

It works except the inode field which is not supported in the older version of Linux. The test is updated accordingly.

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/4166