### PR TITLE
golangci-lint: Update to v1.64.8

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -110,7 +110,7 @@ jobs:
       uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
       with:
         # This version number must be kept in sync with Makefile lint one.
-        version: v1.63.4
+        version: v1.64.8
         working-directory: /home/runner/work/inspektor-gadget/inspektor-gadget
         # Workaround to display the output:
         # https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BPFTOOL ?= bpftool
 ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
 
 # This version number must be kept in sync with CI workflow lint one.
-LINTER_IMAGE ?= golangci/golangci-lint:v1.63.4@sha256:7f4c8ee8a63d56caa41c099cf658f68b192b615e0f30e94b8864e81a3ceafb53
+LINTER_IMAGE ?= golangci/golangci-lint:v1.64.8@sha256:2987913e27f4eca9c8a39129d2c7bc1e74fbcf77f181e01cea607be437aa5cb8
 
 EBPF_BUILDER ?= ghcr.io/inspektor-gadget/ebpf-builder:main
 


### PR DESCRIPTION
The lint step in https://github.com/inspektor-gadget/inspektor-gadget/pull/4214 fails. While running `make lint` locally on that branch, the RAM usage just keeps rising (over 30GB) and then it gets OOM killed.

Updating `golangci-lint` resolves this issue.