### PR TITLE
[Backport v0.38] oci: call `saveIndexWithLock` after importing gadget images

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -399,6 +399,10 @@ func ImportGadgetImages(ctx context.Context, srcFile string) ([]string, error) {
 		}
 		return nil
 	})
+
+	if err := ociStore.saveIndexWithLock(); err != nil {
+		return nil, err
+	}
 
 	return ret, err
 }


### PR DESCRIPTION
The updated OCI store didn't get written to disk after importing a gadget image, so that importing had no effect.

Fixes: 12453a012de6 ("pkg/oci: Use a file lock to avoid concurrency issues")
Fixes: #4208

cc @flyth 