### PR TITLE
Add Limiter Operator Unit Tests

### DIFF
--- a/pkg/operators/limiter/limiter.go
+++ b/pkg/operators/limiter/limiter.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/operators/limiter/limiter.go
+++ b/pkg/operators/limiter/limiter.go
@@ -139,14 +139,18 @@ func (l *limiterOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) er
 		gadgetCtx.Logger().Debugf("limiter: data source %q max-entries %d", ds.Name(), maxEntries)
 
 		ds.SubscribeArray(func(ds datasource.DataSource, data datasource.DataArray) error {
-			if data.Len() <= maxEntries {
-				return nil
-			}
-			if err := data.Resize(maxEntries); err != nil {
-				return fmt.Errorf("limiting data source %q to %d entries: %w", ds.Name(), maxEntries, err)
-			}
-			return nil
+			return limiterFn(ds, data, maxEntries)
 		}, Priority)
+	}
+	return nil
+}
+
+func limiterFn(ds datasource.DataSource, data datasource.DataArray, maxEntries int) error {
+	if data.Len() <= maxEntries {
+		return nil
+	}
+	if err := data.Resize(maxEntries); err != nil {
+		return fmt.Errorf("limiting data source %q to %d entries: %w", ds.Name(), maxEntries, err)
 	}
 	return nil
 }

--- a/pkg/operators/limiter/limiter_test.go
+++ b/pkg/operators/limiter/limiter_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package limiter is a data operator that limits the number of entries in each
+// batch of data. This operator is only enabled for data sources of type array.
+// A great scenario for this operator is when you are already sorting data
+// within an array of data and you want to filter out the top `X` entries.
+package limiter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+)
+
+func TestLimiter(t *testing.T) {
+	type testCase struct {
+		originalSize int
+		limit        int
+		ok           bool
+	}
+
+	testCases := []testCase{
+		{
+			originalSize: 10,
+			limit:        5,
+			ok:           true,
+		},
+		{
+			originalSize: 10,
+			limit:        10,
+			ok:           true,
+		},
+		{
+			originalSize: 10,
+			limit:        15,
+			ok:           true,
+		},
+		{
+			originalSize: 10,
+			limit:        -10,
+			ok:           false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			fmt.Sprintf("originalSize=%d, limit=%d", tc.originalSize, tc.limit),
+			func(t *testing.T) {
+				ds, err := datasource.New(datasource.TypeArray, "limiter")
+				require.NoError(t, err)
+
+				data, err := ds.NewPacketArray()
+				require.NoError(t, err)
+
+				for i := 0; i < tc.originalSize; i++ {
+					data.Append(data.New())
+				}
+
+				err = limiterFn(ds, data, tc.limit)
+
+				if !tc.ok {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				require.Equal(t, min(tc.limit, data.Len()), data.Len()) // limiting to a greater size should not change the size
+			},
+		)
+	}
+}


### PR DESCRIPTION
# Add Unit test cases for the limiter operator

This PR introduces a set of unit test cases for the `limiter` operator, ensuring its correct behavior when applied to data sources of type array. The `limiter` operator restricts the number of entries in each batch of data, which is useful when sorting and filtering the top `X` entries.

The test cases cover various scenarios, including:
- Limiting a dataset to a smaller size.
- Applying a limit equal to the original dataset size.
- Using a limit greater than the dataset size.
- Handling negative limit values to ensure proper error handling.

## How to use

Reviewers can validate this PR by running the test cases included in `limiter_test.go`. The tests ensure that the `limiter` function correctly modifies the dataset size or returns errors when given invalid input.

To run the tests, use:

```sh
go test -v ./pkg/operators/limiter/
```

## Testing done

The following test cases were added in `limiter_test.go`:

- A dataset of size 10 limited to 5 entries.
- A dataset of size 10 limited to 10 entries (should remain unchanged).
- A dataset of size 10 limited to 15 entries (should remain unchanged).
- A dataset of size 10 limited to -10 entries (should return an error).

The tests were executed using:

```sh
go test -v ./pkg/operators/limiter/
```

Output:

```
$ go test -v ./pkg/operators/limiter/
=== RUN   TestLimiter
=== RUN   TestLimiter/originalSize=10,_limit=5
=== RUN   TestLimiter/originalSize=10,_limit=10
=== RUN   TestLimiter/originalSize=10,_limit=15
=== RUN   TestLimiter/originalSize=10,_limit=-10
--- PASS: TestLimiter (0.00s)
    --- PASS: TestLimiter/originalSize=10,_limit=5 (0.00s)
    --- PASS: TestLimiter/originalSize=10,_limit=10 (0.00s)
    --- PASS: TestLimiter/originalSize=10,_limit=15 (0.00s)
    --- PASS: TestLimiter/originalSize=10,_limit=-10 (0.00s)
PASS
ok  	github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter	0.048s

```

The results confirm that the `limiter` operator functions as expected.