### PR TITLE
container-collection: reduce mem allocs for each event

### DIFF
--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -67,7 +67,7 @@ func enrichContainerWithContainerData(containerData *runtimeclient.ContainerData
 	setIfEmptyStr(&container.K8s.PodUID, containerData.K8s.PodUID)
 	setIfEmptyStr(&container.K8s.ContainerName, containerData.K8s.ContainerName)
 	if container.K8s.PodLabels == nil {
-		container.K8s.PodLabels = containerData.K8s.PodLabels
+		container.SetPodLabels(containerData.K8s.PodLabels)
 	}
 }
 
@@ -98,7 +98,7 @@ func containerRuntimeEnricher(
 				// We couldn't get the labels, but don't drop the container.
 				return true
 			}
-			container.K8s.PodLabels = labels
+			container.SetPodLabels(labels)
 		}
 
 		return true
@@ -576,7 +576,7 @@ func WithKubernetesEnrichment(nodeName string, kubeconfig *rest.Config) Containe
 				container.K8s.Namespace = pod.ObjectMeta.Namespace
 				container.K8s.PodName = pod.ObjectMeta.Name
 				container.K8s.PodUID = string(pod.ObjectMeta.UID)
-				container.K8s.PodLabels = pod.ObjectMeta.Labels
+				container.SetPodLabels(pod.ObjectMeta.Labels)
 
 				// drop pause containers
 				if container.K8s.PodName != "" && container.K8s.ContainerName == "" {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -114,6 +114,7 @@ type Container interface {
 	UsesHostNetwork() bool
 	K8sOwnerReference() *K8sOwnerReference
 	ContainerPid() uint32
+	K8sPodLabelsAsString() string
 }
 
 type BasicRuntimeMetadata struct {


### PR DESCRIPTION
When the podLabels and ownerReference fields are requested in each event, it generates lots of allocations, which takes some cpu time directly and more cpu time indirectly with the Go GC.

This patch reduces those allocations by keeping a cache of the serialized podLabels string. Also, don't allocate the ownerReference field twice.
