### PR TITLE
Documentation: Correct function for getting mntns id of containers

### DIFF
--- a/docs/gadget-devel/hello-world-gadget.md
+++ b/docs/gadget-devel/hello-world-gadget.md
@@ -386,6 +386,8 @@ struct event {
 and set this field
 
 ```c
+u64 mntns_id;
+mntns_id = gadget_get_current_mntns_id();
 event->mntns_id = mntns_id;
 ```
 


### PR DESCRIPTION
Using correct exported function from 'gadget/mntns.h' library.