### PR TITLE
gadget params: rename print-*stack to collect-*stack

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -622,8 +622,8 @@ struct event {
 	/* other fields */
 };
 
-const volatile bool print_ustack = false;
-GADGET_PARAM(print_ustack);
+const volatile bool collect_ustack = false;
+GADGET_PARAM(collect_ustack);
 
 ...
 	struct event *event;
@@ -631,7 +631,7 @@ GADGET_PARAM(print_ustack);
 	if (!event)
 		return 0;
 
-	if (print_ustack)
+	if (collect_ustack)
 		gadget_get_user_stack(ctx, &event->ustack_raw);
 ```
 

--- a/gadgets/trace_capabilities/README.mdx
+++ b/gadgets/trace_capabilities/README.mdx
@@ -46,15 +46,15 @@ Only show audit checks
 
 Default value: "false"
 
-### `--print-kstack`
+### `--collect-kstack`
 
-Show kernel stack traces
+Collect kernel stack traces
 
 Default value: "true"
 
-### `--print-ustack`
+### `--collect-ustack`
 
-Show user stack traces
+Collect user stack traces
 
 Default value: "false"
 

--- a/gadgets/trace_capabilities/gadget.yaml
+++ b/gadgets/trace_capabilities/gadget.yaml
@@ -62,14 +62,14 @@ params:
       key: audit-only
       defaultValue: "false"
       description: Only show audit checks
-    print_kstack:
-      key: print-kstack
+    collect_kstack:
+      key: collect-kstack
       defaultValue: "true"
-      description: Show kernel stack traces
-    print_ustack:
-      key: print-ustack
+      description: Collect kernel stack traces
+    collect_ustack:
+      key: collect-ustack
       defaultValue: "false"
-      description: Show user stack traces
+      description: Collect user stack traces
     unique:
       key: unique
       defaultValue: "false"

--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -164,11 +164,11 @@ struct {
 GADGET_TRACER_MAP(events, 1024 * 256);
 GADGET_TRACER(capabilities, events, cap_event);
 
-const volatile bool print_kstack = true;
-GADGET_PARAM(print_kstack);
+const volatile bool collect_kstack = true;
+GADGET_PARAM(collect_kstack);
 
-const volatile bool print_ustack = false;
-GADGET_PARAM(print_ustack);
+const volatile bool collect_ustack = false;
+GADGET_PARAM(collect_ustack);
 
 SEC("kprobe/cap_capable")
 int BPF_KPROBE(ig_trace_cap_e, const struct cred *cred,
@@ -266,8 +266,9 @@ int BPF_KRETPROBE(ig_trace_cap_x)
 	event->cap_raw = ap->cap;
 	// ret=0 means the process has the requested capability, otherwise ret=-EPERM
 	event->capable = PT_REGS_RC(ctx) == 0;
-	event->kstack_raw = gadget_get_kernel_stack(ctx);
-	if (print_ustack)
+	if (collect_kstack)
+		event->kstack_raw = gadget_get_kernel_stack(ctx);
+	if (collect_ustack)
 		gadget_get_user_stack(ctx, &event->ustack_raw);
 
 	event->timestamp_raw = bpf_ktime_get_boot_ns();

--- a/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
@@ -112,7 +112,7 @@ int main() {
 	var testingOpts []igtesting.Option
 	commonDataOpts := []utils.CommonDataOption{utils.WithContainerImageName(containerImage), utils.WithContainerID(testContainer.ID())}
 
-	ustackFlag := "--print-ustack=true"
+	ustackFlag := "--collect-ustack=true"
 	switch utils.CurrentTestComponent {
 	case utils.IgLocalTestComponent:
 		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), ustackFlag))

--- a/gadgets/trace_malloc/README.mdx
+++ b/gadgets/trace_malloc/README.mdx
@@ -30,7 +30,7 @@ Running the gadget:
 
 ## Flags
 
-### `--print-ustack`
+### `--collect-ustack`
 
 Show user stack traces
 

--- a/gadgets/trace_malloc/gadget.yaml
+++ b/gadgets/trace_malloc/gadget.yaml
@@ -31,7 +31,7 @@ datasources:
           columns.width: 20
 params:
   ebpf:
-    print_ustack:
-      key: print-ustack
+    collect_ustack:
+      key: collect-ustack
       defaultValue: "false"
-      description: Show user stack traces
+      description: Collect user stack traces

--- a/gadgets/trace_malloc/program.bpf.c
+++ b/gadgets/trace_malloc/program.bpf.c
@@ -75,8 +75,8 @@ int trace_sched_process_exit(void *ctx)
 GADGET_TRACER_MAP(events, 1024 * 256);
 GADGET_TRACER(malloc, events, event);
 
-const volatile bool print_ustack = false;
-GADGET_PARAM(print_ustack);
+const volatile bool collect_ustack = false;
+GADGET_PARAM(collect_ustack);
 
 static __always_inline int gen_alloc_enter(size_t size)
 {
@@ -118,7 +118,7 @@ static __always_inline int gen_alloc_exit(struct pt_regs *ctx,
 	event->size = size;
 	event->timestamp_raw = bpf_ktime_get_ns();
 
-	if (print_ustack)
+	if (collect_ustack)
 		gadget_get_user_stack(ctx, &event->ustack_raw);
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));
@@ -144,7 +144,7 @@ static __always_inline int gen_free_enter(struct pt_regs *ctx,
 	event->size = 0;
 	event->timestamp_raw = bpf_ktime_get_ns();
 
-	if (print_ustack)
+	if (collect_ustack)
 		gadget_get_user_stack(ctx, &event->ustack_raw);
 
 	gadget_submit_buf(ctx, &events, event, sizeof(*event));


### PR DESCRIPTION
The --print-ustack and --print-kstack flags didn't control whether the stacks are printed but whether they are collected (in ebpf code and in the ustack operator). Hence it makes sense to rename them.

To print the stacks, users must either include the stack fields in the column output with --fields, or use json/yaml output.
