### PR TITLE
container-collection: fix SetPodLabels

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -248,6 +248,14 @@ func (c *Container) K8sPodLabelsAsString() string {
 }
 
 func (c *Container) SetPodLabels(podLabels map[string]string) {
+	if len(podLabels) == 0 {
+		// IsEnriched relies on c.K8s.PodLabels == nil to know if it
+		// has been initialized.
+		c.K8s.PodLabels = nil
+		c.podLabelsAsString = ""
+		return
+	}
+
 	kvPairs := make([]string, 0, len(podLabels))
 	c.K8s.PodLabels = make(map[string]string, len(podLabels))
 	for k, v := range podLabels {


### PR DESCRIPTION
Distinguish `c.K8s.PodLabels == nil` from an empty map. [IsEnriched](https://github.com/inspektor-gadget/inspektor-gadget/blob/48296c35caee65c8304ab13d7692c71e9f28c538/pkg/types/types.go#L171-L173) uses `if b.PodLabels != nil` to check if the PodLabels are already set.

Fixes: 8647f0e04eb5 ("container-collection: reduce mem allocs for each event")

See: https://github.com/inspektor-gadget/inspektor-gadget/pull/4237#discussion_r2021233164

## How to use

Use `--enrich-with-k8s-apiserver`.

## Testing done

Test on Minikube. Prepare the permissions for `ig` to run:
```
kubectl create serviceaccount -n kube-system ig
kubectl create clusterrolebinding ig \
  --clusterrole=cluster-admin \
  --serviceaccount=kube-system:ig
```

Test on `main` branch:
```
kubectl debug -n kube-system \
    --as system:serviceaccount:kube-system:ig \
    --profile=sysadmin node/minikube-docker \
    -ti --image=albantest.azurecr.io/ig:main -- \
    ig --pprof-addr=:6060 run trace_open:main \
    --enrich-with-k8s-apiserver --comm=cat -o json
```

Events have `"podLabels":""`

Test on `alban_SetPodLabels_fix` branch:
```
kubectl debug -n kube-system \
    --as system:serviceaccount:kube-system:ig \
    --profile=sysadmin node/minikube-docker \
    -ti --image=albantest.azurecr.io/ig:alban_SetPodLabels_fix -- \
    ig --pprof-addr=:6060 run trace_open:main \
    --enrich-with-k8s-apiserver --comm=cat -o json
```

Events have `"podLabels":"mylabel8=mylabel8"`.

cc @burak-ok @Sefi4