### PR TITLE
inspect: adds oci extra info

### DIFF
--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -316,9 +316,17 @@ $ sudo ig image inspect fsnotify:main |jq keys
 WARN[0001] image signature verification is disabled due to using corresponding option 
 [
   "ebpf.maps",
+  "ebpf.mermaid.flowchart",
+  "ebpf.mermaid.sequence",
   "ebpf.programs",
   "ebpf.sections",
   "ebpf.variables",
+  "oci.created",
+  "oci.digest",
+  "oci.manifest",
+  "oci.metadata",
+  "oci.repository",
+  "oci.tag",
   "wasm.gadgetAPIVersion",
   "wasm.upcalls"
 ]
@@ -351,4 +359,57 @@ ig_fa_pick_e:
 ...
 	25: MovImm dst: r0 imm: 0
 	26: Exit
+
+# Printing the gadget annotations
+$ sudo ig image inspect audit_seccomp:main --extra-info=oci.manifest -o custom|jq '.annotations'
+{
+  "io.inspektor-gadget.builder.version": "fb7bfcd",
+  "org.opencontainers.image.created": "2025-04-10T08:49:17Z",
+  "org.opencontainers.image.description": "Audit syscalls according to the seccomp profile",
+  "org.opencontainers.image.documentation": "https://www.inspektor-gadget.io/docs/latest/gadgets/audit_seccomp",
+  "org.opencontainers.image.source": "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/audit_seccomp",
+  "org.opencontainers.image.title": "audit seccomp",
+  "org.opencontainers.image.url": "https://inspektor-gadget.io/"
+}
+
+# Printing the gadget metadata
+$ sudo ig image inspect audit_seccomp:main --extra-info=oci.metadata -o custom
+name: audit seccomp
+description: Audit syscalls according to the seccomp profile
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/audit_seccomp
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/audit_seccomp
+datasources:
+  seccomp:
+    fields:
+      syscall_raw:
+        annotations:
+          columns.hidden: true
+      syscall:
+        annotations:
+          columns.width: 20
+      code:
+        annotations:
+          description: Seccomp return code
+          columns.width: 20
+          columns.ellipsis: start
+      ustack:
+        annotations:
+          columns.hidden: true
+      ustack.addresses:
+        annotations:
+          description: User stack's addresses
+          columns.hidden: true
+          columns.width: 20
+      ustack.symbols:
+        annotations:
+          description: User stack's symbols
+          columns.hidden: true
+          columns.width: 20
+params:
+  ebpf:
+    collect_ustack:
+      key: collect-ustack
+      defaultValue: "false"
+      description: Collect user stack traces
 ```

--- a/pkg/operators/oci-handler/extrainfo.go
+++ b/pkg/operators/oci-handler/extrainfo.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocihandler
+
+import (
+	"encoding/json"
+
+	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+)
+
+func addExtraInfo(gadgetCtx operators.GadgetContext, metadata []byte, manifest *ocispec.Manifest) error {
+	parsed, err := reference.Parse(gadgetCtx.ImageName())
+	if err != nil {
+		return err
+	}
+
+	var repository string
+	if named, ok := parsed.(reference.Named); ok {
+		repository = named.Name()
+	}
+
+	tag := "latest"
+	if tagged, ok := parsed.(reference.Tagged); ok {
+		tag = tagged.Tag()
+	}
+
+	digest := manifest.Config.Digest.String()
+
+	created := manifest.Annotations[ocispec.AnnotationCreated]
+
+	ociInfo := &api.ExtraInfo{
+		Data: make(map[string]*api.GadgetInspectAddendum),
+	}
+	manifestJson, _ := json.Marshal(manifest)
+	ociInfo.Data["oci.manifest"] = &api.GadgetInspectAddendum{
+		ContentType: "application/json",
+		Content:     manifestJson,
+	}
+	ociInfo.Data["oci.metadata"] = &api.GadgetInspectAddendum{
+		ContentType: "text/yaml",
+		Content:     metadata,
+	}
+	ociInfo.Data["oci.repository"] = &api.GadgetInspectAddendum{
+		ContentType: "text/plain",
+		Content:     []byte(repository),
+	}
+	ociInfo.Data["oci.tag"] = &api.GadgetInspectAddendum{
+		ContentType: "text/plain",
+		Content:     []byte(tag),
+	}
+	ociInfo.Data["oci.digest"] = &api.GadgetInspectAddendum{
+		ContentType: "text/plain",
+		Content:     []byte(digest),
+	}
+	ociInfo.Data["oci.created"] = &api.GadgetInspectAddendum{
+		ContentType: "text/plain",
+		Content:     []byte(created),
+	}
+
+	gadgetCtx.SetVar("extraInfo.oci", ociInfo)
+
+	return nil
+}

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -400,6 +400,14 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		return nil
 	}
 
+	// add extra info if requested
+	if gadgetCtx.ExtraInfo() {
+		err := addExtraInfo(gadgetCtx, metadata, manifest)
+		if err != nil {
+			return fmt.Errorf("adding extra info: %w", err)
+		}
+	}
+
 	extraParams := make([]*api.Param, 0)
 	for _, opInst := range o.imageOperatorInstances {
 		err := opInst.Prepare(o.gadgetCtx)


### PR DESCRIPTION
## Changes
This PR adds extra oci information in the inspect command

## How to use

```
$ sudo ./ig image inspect trace_dns:main | jq 'with_entries(select(.key | startswith("oci")))'


  "oci.created": {
    "content": "2025-04-01T16:19:23Z",
    "contentType": "text/plain"
  },
  "oci.digest": {
    "content": "sha256:87de05648f4a380edc3b3187d875b47dd094f71e40dc76400918615705e3eb34",
    "contentType": "text/plain"
  },
  "oci.manifest": {
    "content": "{\"schemaVersion\":2,\"...,
    "contentType": "application/vnd.oci.image.manifest.v1+json"
  },
  "oci.metadata": {
    "content": "name: trace dns\ndescription: ...",
    "contentType": "text/yaml"
  },
  "oci.repository": {
    "content": "ghcr.io/inspektor-gadget/gadget/trace_dns",
    "contentType": "text/plain"
  },
  "oci.tag": {
    "content": "main",
    "contentType": "text/plain"
  }
}

```

Part of #3387 