### PR TITLE
Remove panic when sort used incorrectly

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -164,7 +164,11 @@ func removeSplitSortArgs(args []string) []string {
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--sort" {
 			// Remove also the next element as it is the arg of --sort
-			return append(args[:i], args[i+2:]...)
+			if i == len(args)-1 {
+				return args[:len(args)-1]
+			} else {
+				return append(args[:i], args[i+2:]...)
+			}
 		}
 	}
 	return args


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1e29eb44-ac81-4985-a6fc-d2cc8027a348)



Refer #4204 
The logic is currently working for in-built gadgets and I think the same will work for image based too but I am facing issues with running image based gadgets..I think there is  some version compatibility issue.