### PR TITLE
RUST WASM: Rust bindings for inspektor gadget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ cross-kubectl-gadget-container:
 generate-testdata:
 	$(MAKE) -C ./pkg/operators/ebpf/testdata
 	$(MAKE) -C ./pkg/operators/wasm/testdata
+	$(MAKE) -C ./pkg/operators/wasm/rusttestdata
 
 .PHONY: test
 test: generate-testdata

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -6,6 +6,7 @@ TEST_ARTIFACTS = \
 	dataarray \
 	fields \
 	params \
+	config \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -13,6 +13,7 @@ TEST_ARTIFACTS = \
 	syscall \
 	kallsyms \
 	filtering \
+	baderrptr \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -5,6 +5,7 @@ TEST_ARTIFACTS = \
 	dataemit \
 	dataarray \
 	fields \
+	params \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -14,6 +14,7 @@ TEST_ARTIFACTS = \
 	kallsyms \
 	filtering \
 	baderrptr \
+	badguest \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -10,6 +10,7 @@ TEST_ARTIFACTS = \
 	map \
 	mapofmap \
 	perf \
+	syscall \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -9,6 +9,7 @@ TEST_ARTIFACTS = \
 	config \
 	map \
 	mapofmap \
+	perf \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -11,6 +11,7 @@ TEST_ARTIFACTS = \
 	mapofmap \
 	perf \
 	syscall \
+	kallsyms \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -1,0 +1,25 @@
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+IG ?= ig
+
+TEST_ARTIFACTS = \
+	dataemit \
+	dataarray \
+
+all: $(TEST_ARTIFACTS)
+
+# Mark all test artifact targets as phony
+.PHONY: all clean $(TEST_ARTIFACTS)
+
+$(TEST_ARTIFACTS):
+	@echo "Building $@"
+	@sudo IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/../../../..) $(IG) image build -t $@:latest $@
+	@sudo $(IG) image export $@:latest $@.tar
+	# TODO: This fails with "Error: removing gadget image: unable to reload index:"
+	# @sudo $(IG) image remove $@:latest
+
+clean:
+	for ARTIFACT in $(TEST_ARTIFACTS); do \
+		sudo rm -f $$ARTIFACT.tar; \
+		sudo rm -rf $$ARTIFACT/target; \
+		sudo rm -f $$ARTIFACT/Cargo.lock; \
+	done

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -12,6 +12,7 @@ TEST_ARTIFACTS = \
 	perf \
 	syscall \
 	kallsyms \
+	filtering \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -7,6 +7,8 @@ TEST_ARTIFACTS = \
 	fields \
 	params \
 	config \
+	map \
+	mapofmap \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/Makefile
+++ b/pkg/operators/wasm/rusttestdata/Makefile
@@ -4,6 +4,7 @@ IG ?= ig
 TEST_ARTIFACTS = \
 	dataemit \
 	dataarray \
+	fields \
 
 all: $(TEST_ARTIFACTS)
 

--- a/pkg/operators/wasm/rusttestdata/baderrptr/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/baderrptr/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "baderrptr"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/baderrptr/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/baderrptr/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/baderrptr/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/baderrptr/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::datasources::FieldKind;
+const INVALID_PTR: u32 = 17 * 1024 * 1024;
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    fn fieldGetScalar(acc: u32, data: u32, kind: u32, err_ptr: u32) -> u64;
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    unsafe {
+        fieldGetScalar(55, 55, FieldKind::Uint32 as u32, INVALID_PTR);
+    }
+    panic!("This should never be reached");
+}

--- a/pkg/operators/wasm/rusttestdata/badguest/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/badguest/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "badguest"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/badguest/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/badguest/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/badguest/go.mod
+++ b/pkg/operators/wasm/rusttestdata/badguest/go.mod
@@ -1,0 +1,8 @@
+module main
+
+go 1.24.0
+
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// use this to be able to compile it locally
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../../../

--- a/pkg/operators/wasm/rusttestdata/badguest/program.bpf.c
+++ b/pkg/operators/wasm/rusttestdata/badguest/program.bpf.c
@@ -1,0 +1,15 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+struct map_test_struct {
+	__u32 a;
+	__u32 b;
+	__u8 c;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, struct map_test_struct);
+	__type(value, __u32);
+} test_map SEC(".maps");

--- a/pkg/operators/wasm/rusttestdata/badguest/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/badguest/src/lib.rs
@@ -1,0 +1,406 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api;
+
+// We need to copy some declarations from the API to have access to the low
+// level details.
+
+#[repr(u32)] // Specifies the enums to be casted as u32, similar to C enums.
+#[derive(Clone, Copy)]
+enum SubscriptionType {
+    _Invalid = 0,
+    Data = 1,
+    Array = 2,
+    Packet = 3,
+}
+
+// Invalid string: Too big (17 MB, we only provide 16MB to WASM programs)
+const INVALID_STR_PTR: u64 = 1024 * 1024 * 17 << 32;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct SyscallParamRaw {
+    name: [u8; 32],
+    flags: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct SyscallDeclarationRaw {
+    name: [u8; 32],
+    nr_params: u8,
+    _padding: [u8; 3],
+    params: [SyscallParamRaw; 6],
+}
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "gadgetLog"]
+    fn _log(level: u32, msg: u64);
+
+    #[link_name = "newDataSource"]
+    fn _new_datasource(name: u64, typ: u32) -> u32;
+
+    #[link_name = "getDataSource"]
+    fn _get_datasource(name: u64) -> u32;
+
+    #[link_name = "dataSourceSubscribe"]
+    fn _datasource_subscribe(ds: u32, typ: u32, prio: u32, cb: u64) -> u32;
+
+    #[link_name = "dataSourceGetField"]
+    fn _datasource_get_field(ds: u32, name: u64) -> u32;
+
+    #[link_name = "dataSourceAddField"]
+    fn _datasource_add_field(ds: u32, name: u64, kind: u32) -> u32;
+
+    #[link_name = "dataSourceNewPacketSingle"]
+    fn _datasource_new_packet_single(ds: u32) -> u32;
+
+    #[link_name = "dataSourceNewPacketArray"]
+    fn _datasource_new_packet_array(ds: u32) -> u32;
+
+    #[link_name = "dataSourceEmitAndRelease"]
+    fn _datasource_emit_and_release(ds: u32, packet: u32) -> u32;
+
+    #[link_name = "dataSourceRelease"]
+    fn _datasource_release(ds: u32, packet: u32) -> u32;
+
+    #[link_name = "dataSourceUnreference"]
+    fn _datasource_unreference(ds: u32) -> u32;
+
+    #[link_name = "dataSourceIsReferenced"]
+    fn _datasource_is_referenced(ds: u32) -> u32;
+
+    #[link_name = "dataArrayNew"]
+    fn _dataarray_new(d: u32) -> u32;
+
+    #[link_name = "dataArrayAppend"]
+    fn _dataarray_append(d: u32, data: u32) -> u32;
+
+    #[link_name = "dataArrayRelease"]
+    fn _dataarray_release(d: u32, data: u32) -> u32;
+
+    #[link_name = "dataArrayLen"]
+    fn _dataarray_len(d: u32) -> u32;
+
+    #[link_name = "dataArrayGet"]
+    fn _dataarray_get(d: u32, index: u32) -> u32;
+
+    #[link_name = "fieldGetScalar"]
+    fn _field_get_scalar(field: u32, data: u32, kind: u32, err_ptr: u32) -> u64;
+
+    #[link_name = "fieldGetBuffer"]
+    fn _field_get_buffer(field: u32, data: u32, kind: u32, dst: u64) -> i32;
+
+    #[link_name = "fieldSet"]
+    fn _field_set(field: u32, data: u32, kind: u32, value: u64) -> u32;
+
+    #[link_name = "fieldAddTag"]
+    fn _field_add_tag(field: u32, tag: u64) -> u32;
+
+    #[link_name = "getParamValue"]
+    fn _get_param_value(key: u64, dst: u64) -> u32;
+
+    #[link_name = "setConfig"]
+    fn _set_config(key: u64, val: u64, kind: u32) -> u32;
+
+    #[link_name = "newMap"]
+    fn _map_new(name: u64, typ: u32, key_size: u32, value_size: u32, max_entries: u32) -> u32;
+
+    #[link_name = "getMap"]
+    fn _map_get(name: u64) -> u32;
+
+    #[link_name = "mapLookup"]
+    fn _map_lookup(map: u32, key_ptr: u64, value_ptr: u64) -> u32;
+
+    #[link_name = "mapUpdate"]
+    fn _map_update(map: u32, key_ptr: u64, value_ptr: u64, flags: u64) -> u32;
+
+    #[link_name = "mapDelete"]
+    fn _map_delete(map: u32, key_ptr: u64) -> u32;
+
+    #[link_name = "mapRelease"]
+    fn _map_release(map: u32) -> u32;
+
+    #[link_name = "getSyscallDeclaration"]
+    fn _declaration(name: u64, pointer: u64) -> u32;
+
+    #[link_name = "kallsymsSymbolExists"]
+    fn _kallsyms_symbol_exists(symbol: u64) -> u32;
+}
+
+fn string_to_buf_ptr(s: &str) -> u64 {
+    if s.is_empty() {
+        return 0;
+    }
+    let ptr = s.as_ptr() as u32;
+
+    let len = s.len() as u32;
+
+    (u64::from(len) << 32) | u64::from(ptr)
+}
+
+pub fn any_to_buf_ptr<T>(val: &T) -> Result<u64, String> {
+    let size = std::mem::size_of_val(val);
+    if size == 0 {
+        return Err(String::from("zero-sized types not supported"));
+    }
+    let ptr = val as *const T as *const u8;
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, size) };
+
+    let buf_ptr = bytes_to_buf_ptr(bytes);
+
+    Ok(buf_ptr)
+}
+
+fn bytes_to_buf_ptr(b: &[u8]) -> u64 {
+    let len = b.len() as u64;
+    let ptr = b.as_ptr() as u64;
+    (len << 32) | ptr
+}
+
+fn log_and_panic(msg: String) {
+    unsafe {
+        _log(api::log::LogLevel::Error as u32, string_to_buf_ptr(&msg));
+    };
+    panic!("{}", msg)
+}
+
+fn assert_zero<T: std::cmp::PartialEq<u32> + std::fmt::Display>(v: T, msg: &str)
+{
+    if v != 0 {
+        log_and_panic(format!("{} is not zero: {}", v, msg));
+    }
+}
+
+fn assert_non_zero<T: std::cmp::PartialEq<u32> + std::fmt::Display>(v: T, msg: &str)
+{
+    if v == 0 {
+        log_and_panic(format!("{} is not zero: {}", v, msg));
+    }
+}
+
+fn assert_equal<T: std::cmp::PartialEq + std::fmt::Display>(v0: T, v1: T, msg: &str)
+{
+    if v0 != v1 {
+        log_and_panic(format!("{} != {}: {}", v0, v1, msg));
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let ds_single_name = "mysingleds";
+    let ds_array_name = "myarrayds";
+    let field_name = "myfield";
+
+    // Create some resources for testing at the very beginning
+    let ds_single_handle = unsafe { _new_datasource(string_to_buf_ptr(ds_single_name), api::datasources::DataSourceType::Single as u32 as u32) };
+    assert_non_zero(ds_single_handle, "_new_datasource: creating new single");
+
+    let ds_array_handle = unsafe { _new_datasource(string_to_buf_ptr(ds_array_name), api::datasources::DataSourceType::Array as u32 as u32) };
+    assert_non_zero(ds_single_handle, "_new_datasource: creating new array");
+
+    let field_handle = unsafe { _datasource_add_field(ds_single_handle, string_to_buf_ptr(field_name), api::datasources::FieldKind::Uint32 as u32) };
+    assert_non_zero(field_handle, "_datasource_add_field: creating new");
+
+    /********** Log **********/
+    unsafe {
+        _log(api::log::LogLevel::Error as u32, INVALID_STR_PTR);
+        _log(42, string_to_buf_ptr("hello-world")); // invalid log level
+        _log(api::log::LogLevel::Error as u32, string_to_buf_ptr("")); // empty string
+    };
+
+    /********** DataSource **********/
+    assert_zero(unsafe { _new_datasource(INVALID_STR_PTR, api::datasources::DataSourceType::Single as u32) }, "newDataSource: invalid name ptr");
+    assert_zero(unsafe { _new_datasource(string_to_buf_ptr("foo"), 42) }, "newDataSource: invalid type");
+
+    assert_non_zero(unsafe { _get_datasource(string_to_buf_ptr(ds_single_name)) }, "_get_datasource: existing");
+    assert_zero(unsafe { _get_datasource(string_to_buf_ptr("foo")) }, "_get_datasource: non existing");
+    assert_zero(unsafe { _get_datasource(INVALID_STR_PTR) }, "_get_datasource: invalid name ptr");
+
+    assert_zero(unsafe { _datasource_subscribe(ds_single_handle, SubscriptionType::Data as u32, 0, 0) }, "_datasource_subscribe: single");
+    assert_zero(unsafe { _datasource_subscribe(ds_single_handle, SubscriptionType::Packet as u32, 0, 0) }, "_datasource_subscribe: single + packet");
+    assert_zero(unsafe { _datasource_subscribe(ds_array_handle, SubscriptionType::Array as u32, 0, 0) }, "_datasource_subscribe: array");
+    assert_zero(unsafe { _datasource_subscribe(ds_array_handle, SubscriptionType::Packet as u32, 0, 0) }, "_datasource_subscribe: array + packet");
+    assert_zero(unsafe { _datasource_subscribe(ds_array_handle, SubscriptionType::Data as u32, 0, 0) }, "_datasource_subscribe: array + single");
+    assert_non_zero(unsafe { _datasource_subscribe(42, SubscriptionType::Data as u32, 0, 0) }, "_datasource_subscribe: bad handle");
+    assert_non_zero(unsafe { _datasource_subscribe(field_handle, SubscriptionType::Data as u32, 0, 0) }, "_datasource_subscribe: bad handle type");
+    assert_non_zero(unsafe { _datasource_subscribe(ds_single_handle, SubscriptionType::Array as u32, 0, 0) }, "_datasource_subscribe: bad handle type (single)");
+    assert_non_zero(unsafe { _datasource_subscribe(ds_single_handle, 1005, 0, 0) }, "_datasource_subscribe: bad subscription type");
+
+    assert_zero(unsafe { _datasource_add_field(ds_single_handle, string_to_buf_ptr(field_name), api::datasources::FieldKind::Uint32 as u32) }, "_datasource_add_field: duplicated");
+    assert_zero(unsafe { _datasource_add_field(42, string_to_buf_ptr("foo"), api::datasources::FieldKind::Uint32 as u32) }, "_datasource_add_field: bad handle");
+    assert_zero(unsafe { _datasource_add_field(field_handle, string_to_buf_ptr("foo"), api::datasources::FieldKind::Uint32 as u32) }, "_datasource_add_field: bad handle type");
+    assert_zero(unsafe { _datasource_add_field(ds_single_handle, string_to_buf_ptr("foo"), 1005) }, "_datasource_add_field: bad kind");
+
+    assert_non_zero(unsafe { _datasource_get_field(ds_single_handle, string_to_buf_ptr(field_name)) }, "_datasource_get_field: existing");
+    assert_zero(unsafe { _datasource_get_field(42, string_to_buf_ptr("foo")) }, "_datasource_get_field: non existing");
+    assert_zero(unsafe { _datasource_get_field(ds_single_handle, INVALID_STR_PTR) }, "_datasource_get_field: invalid name ptr");
+
+    let packet_single_handle = unsafe { _datasource_new_packet_single(ds_single_handle) };
+    assert_non_zero(packet_single_handle, "_datasource_new_packet_single: creating new");
+    assert_zero(unsafe { _datasource_new_packet_single(42) }, "_datasource_new_packet_single: bad handle");
+    assert_zero(unsafe { _datasource_new_packet_single(field_handle) }, "_datasource_new_packet_single: bad handle type");
+    assert_zero(unsafe { _datasource_new_packet_single(ds_array_handle) }, "_datasource_new_packet_single: bad datasource type");
+
+    let packet_array_handle = unsafe { _datasource_new_packet_array(ds_array_handle) };
+    assert_non_zero(packet_array_handle, "_datasource_new_packet_array: creating new");
+    assert_zero(unsafe { _datasource_new_packet_array(42) }, "_datasource_new_packet_array: bad handle");
+    assert_zero(unsafe { _datasource_new_packet_array(field_handle) }, "_datasource_new_packet_array: bad handle type");
+    assert_zero(unsafe { _datasource_new_packet_array(ds_single_handle) }, "_datasource_new_packet_array: bad datasource type");
+
+    assert_non_zero(unsafe { _datasource_emit_and_release(42, packet_single_handle) }, "_datasource_emit_and_release: bad handle");
+    assert_non_zero(unsafe { _datasource_emit_and_release(field_handle, packet_single_handle) }, "_datasource_emit_and_release: bad datasource handle type");
+    assert_non_zero(unsafe { _datasource_emit_and_release(ds_single_handle, 42) }, "_datasource_emit_and_release: bad packet handle");
+    assert_non_zero(unsafe { _datasource_emit_and_release(ds_single_handle, field_handle) }, "_datasource_emit_and_release: bad packet handle type ");
+
+    assert_zero(unsafe { _datasource_release(ds_single_handle, packet_single_handle) }, "_datasource_release: ok");
+    assert_non_zero(unsafe { _datasource_release(ds_single_handle, packet_single_handle) }, "_datasource_release: double release");
+    assert_non_zero(unsafe { _datasource_release(42, packet_single_handle) }, "_datasource_release: bad handle");
+    assert_non_zero(unsafe { _datasource_release(field_handle, packet_single_handle) }, "_datasource_release: bad handle type");
+    assert_non_zero(unsafe { _datasource_release(ds_single_handle, 42) }, "_datasource_release: bad packet handle");
+    assert_non_zero(unsafe { _datasource_release(ds_single_handle, field_handle) }, "_datasource_release: bad packet handle type");
+
+    let data_elem_handle = unsafe { _dataarray_new(packet_array_handle) };
+    assert_non_zero(data_elem_handle, "_dataarray_new: creating new");
+    assert_zero(unsafe { _dataarray_new(42) }, "_dataarray_new: bad handle");
+    assert_zero(unsafe { _dataarray_new(field_handle) }, "_dataarray_new: bad handle type");
+
+    assert_zero(unsafe { _dataarray_append(packet_array_handle, data_elem_handle) }, "_dataarray_append: ok");
+    assert_non_zero(unsafe { _dataarray_release(packet_array_handle, data_elem_handle) }, "_dataarray_release: bad data handle after append");
+    assert_non_zero(unsafe { _dataarray_append(packet_array_handle, 42) }, "_dataarray_append: bad data handle");
+    assert_non_zero(unsafe { _dataarray_append(packet_array_handle, field_handle) }, "_dataarray_append: bad data handle type");
+    assert_non_zero(unsafe { _dataarray_append(42, data_elem_handle) }, "_dataarray_append: bad handle");
+    assert_non_zero(unsafe { _dataarray_append(field_handle, data_elem_handle) }, "_dataarray_append: bad array handle type");
+
+    assert_equal(unsafe { _dataarray_len(packet_array_handle) }, 1, "_dataarray_len");
+    assert_zero(unsafe { _dataarray_len(42) }, "_dataarray_len: bad handle");
+    assert_zero(unsafe { _dataarray_len(packet_single_handle) }, "_dataarray_len: bad handle type");
+
+    let data_elem_handle2 = unsafe { _dataarray_new(packet_array_handle) };
+    assert_zero(unsafe { _dataarray_release(packet_array_handle, data_elem_handle2) }, "_dataarray_release: ok");
+    assert_non_zero(unsafe { _dataarray_release(packet_array_handle, data_elem_handle2) }, "_dataarray_release: double release");
+    assert_non_zero(unsafe { _dataarray_release(packet_array_handle, 42) }, "_dataarray_release: bad data handle");
+    assert_non_zero(unsafe { _dataarray_release(packet_array_handle, field_handle) }, "_dataarray_release: bad data handle type");
+    assert_non_zero(unsafe { _dataarray_release(42, data_elem_handle2) }, "_dataarray_release: bad array handle");
+    assert_non_zero(unsafe { _dataarray_release(field_handle, data_elem_handle2) }, "_dataarray_release: bad array handle type");
+
+    assert_non_zero(unsafe { _dataarray_get(packet_array_handle, 0) }, "_dataarray_get: index 0");
+    assert_zero(unsafe { _dataarray_get(packet_array_handle, 1) }, "_dataarray_get: index 1");
+    assert_zero(unsafe { _dataarray_get(42, 0) }, "_dataarray_get: bad handle");
+    assert_zero(unsafe { _dataarray_get(packet_single_handle, 0) }, "_dataarray_get: bad handle type");
+
+    /* Fields */
+    let data_handle = unsafe { _datasource_new_packet_single(ds_single_handle) };
+    assert_non_zero(data_handle, "dataSourceNewPacketSingle: creating new");
+
+    assert_zero(unsafe { _field_set(field_handle, data_handle, api::datasources::FieldKind::Uint32 as u32, 1234) }, "_field_set: ok");
+    assert_non_zero(unsafe { _field_set(field_handle, data_handle, api::datasources::FieldKind::Uint64 as u32, 1234) }, "_field_set: bad kind");
+    assert_non_zero(unsafe { _field_set(field_handle, data_handle, 1005, 1234) }, "_field_set: bad kind");
+    assert_non_zero(unsafe { _field_set(field_handle, field_handle, api::datasources::FieldKind::Uint32 as u32, 1234) }, "_field_set: bad data handle");
+    assert_non_zero(unsafe { _field_set(data_handle, data_handle, api::datasources::FieldKind::Uint32 as u32, 1234) }, "_field_set: bad field handle");
+
+    let mut err: u32 = 0;
+    let err_ptr = &mut err as *mut u32 as u32;
+    let ret = unsafe {_field_get_scalar(field_handle, data_handle, api::datasources::FieldKind::Uint32 as u32, err_ptr) };
+    assert_equal(ret, 1234, "_field_get_scalar: ok");
+    assert_zero(err, "_field_get_scalar: ok");
+
+    unsafe { _field_get_scalar(field_handle, data_handle, 1005, err_ptr) };
+    assert_equal(err, 1, "_field_get_scalar: bad kind");
+
+    unsafe {_field_get_scalar(field_handle, field_handle, api::datasources::FieldKind::Uint32 as u32, err_ptr) };
+    assert_equal(err, 1, "_field_get_scalar: bad data handle");
+
+    unsafe { _field_get_scalar(data_handle, data_handle, api::datasources::FieldKind::Uint32 as u32, err_ptr) };
+    assert_equal(err, 1, "_field_get_scalar: bad field handle");
+
+    // a zero err ptr shouldn't cause any crash
+    unsafe { _field_get_scalar(field_handle, data_handle, 1005, 0) };
+
+    /* Params */
+    let param_buf = bytes_to_buf_ptr(&vec![0u8; 512]);
+    assert_non_zero(unsafe { _get_param_value(string_to_buf_ptr("non-existing-param"), param_buf) }, "_get_param_value: not-found");
+    assert_non_zero(unsafe { _get_param_value(INVALID_STR_PTR, param_buf) }, "_get_param_value: invalid key ptr");
+
+    /* Config */
+    assert_zero(unsafe { _set_config(string_to_buf_ptr("key"), string_to_buf_ptr("value"), api::datasources::FieldKind::String as u32) }, "_set_config: ok");
+    assert_non_zero(unsafe { _set_config(string_to_buf_ptr("key"), string_to_buf_ptr("value"), 1005) }, "_set_config: bad kind");
+    assert_non_zero(unsafe { _set_config(INVALID_STR_PTR, string_to_buf_ptr("value"), api::datasources::FieldKind::String as u32) }, "_set_config: bad key ptr");
+    assert_non_zero(unsafe { _set_config(string_to_buf_ptr("key"), INVALID_STR_PTR, api::datasources::FieldKind::String as u32) }, "_set_config: bad value ptr");
+
+    /* Map */
+    assert_zero(unsafe { _map_get(INVALID_STR_PTR) }, "_map_get: bad map pointer");
+    assert_non_zero(unsafe { _map_update(0, INVALID_STR_PTR, INVALID_STR_PTR, 0) }, "_map_update: bad handle");
+    assert_non_zero(unsafe { _map_lookup(0, INVALID_STR_PTR, INVALID_STR_PTR) }, "_map_lookup: bad handle");
+    assert_non_zero(unsafe { _map_delete(0, INVALID_STR_PTR) }, "_map_delete: bad handle");
+
+    /* SyscallDeclaration */
+    let syscall_declaration_size = std::mem::size_of::<SyscallDeclarationRaw>();
+    let syscall_declaration_ptr = bytes_to_buf_ptr(&vec![0u8; syscall_declaration_size]);
+    let invalid_syscall_declaration_ptr = bytes_to_buf_ptr(&vec![0u8; syscall_declaration_size / 2]);
+    assert_zero(unsafe { _declaration(string_to_buf_ptr("execve"), syscall_declaration_ptr) }, "_declaration: good");
+    assert_non_zero(unsafe { _declaration(INVALID_STR_PTR, syscall_declaration_ptr) }, "_declaration: bad syscall name pointer");
+    assert_non_zero(unsafe { _declaration(string_to_buf_ptr("execve"), invalid_syscall_declaration_ptr) }, "_declaration: bad syscall decl pointer");
+
+    /* Kallsyms */
+    assert_equal(unsafe { _kallsyms_symbol_exists(INVALID_STR_PTR) }, 0, "_kallsyms_symbol_exists: bad symbol pointer");
+    assert_equal(unsafe { _kallsyms_symbol_exists(string_to_buf_ptr("abcde_bad_name")) }, 0, "_kallsyms_symbol_exists: nonexistent symbol name");
+    assert_equal(unsafe { _kallsyms_symbol_exists(string_to_buf_ptr("socket_file_ops")) }, 1, "_kallsyms_symbol_exists: good symbol name");
+
+    0
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetStart() -> i32 {
+    #[repr(C)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    struct MapTestStruct {
+        a: i32,
+        b: i32,
+        c: i8,
+        _pad: [i8; 3],
+    }
+
+    let key = MapTestStruct {
+        a: 42,
+        b: 42,
+        c: 43,
+        _pad: [0; 3],
+    };
+    let key_ptr = any_to_buf_ptr(&key).expect("Invalid key pointer");
+
+    let handle = unsafe { _map_get(string_to_buf_ptr("test_map")) };
+    assert_non_zero(handle, "_map_get: test_map should exist");
+
+    assert_non_zero(unsafe { _map_update(handle, INVALID_STR_PTR, INVALID_STR_PTR, 1<<3) }, "_map_update: bad flag value");
+    assert_non_zero(unsafe { _map_update(handle, INVALID_STR_PTR, INVALID_STR_PTR, 0) }, "_map_update: bad key pointer");
+    assert_non_zero(unsafe { _map_update(handle, key_ptr, INVALID_STR_PTR, 0) }, "_map_update: bad value pointer");
+
+    assert_non_zero(unsafe { _map_lookup(handle, INVALID_STR_PTR, 0) }, "_map_lookup: bad key pointer");
+    assert_non_zero(unsafe { _map_lookup(handle, INVALID_STR_PTR, INVALID_STR_PTR) }, "_map_lookup: bad value pointer");
+
+    assert_non_zero(unsafe { _map_delete(handle, INVALID_STR_PTR) }, "_map_delete: bad key pointer");
+
+    let bad_map = unsafe { _map_new(string_to_buf_ptr("bad_map"), api::map::MapType::Hash as u32, 4, 4, 1) };
+    assert_non_zero(bad_map, "newMap: creating map");
+    assert_zero(unsafe { _map_release(bad_map) }, "_map_release: closing map");
+    assert_non_zero(unsafe { _map_lookup(bad_map, INVALID_STR_PTR, INVALID_STR_PTR) }, "_map_lookup: bad handle");
+    assert_non_zero(unsafe { _map_release(bad_map) }, "_map_release: bad handle");
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/config/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "config"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/config/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/config/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/config/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/config/src/lib.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+use api::{
+    errorf,
+    {config::set_config, log::LogLevel},
+};
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
-
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod helpers;
-pub mod log;
-pub mod params;
-pub mod version;
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    if let Err(err) = set_config("foo.bar.zas".to_string(), "myvalue".to_string()) {
+        errorf!("SetConfig failed: {:?}", err);
+        return 1;
+    }
+    // set_config only allows string to be passed as a parameter, so due to check enforced during
+    // compile time, we do not write test for other datatypes.
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/dataarray/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/dataarray/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dataarray"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/dataarray/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/dataarray/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/dataarray/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/dataarray/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::{
+    datasources::{DataArray, DataSource, FieldKind},
+    fields::FieldData,
+    log::LogLevel,
+    warnf,
+};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let Ok(ds) = DataSource::get_datasource("myds".to_string()) else {
+        warnf!("failed to get datasource");
+        return 1;
+    };
+
+    let Ok(foo_field) = ds.get_field("foo") else {
+        warnf!("failed to get host field");
+        return 1;
+    };
+
+    let Err(err) = ds.subscribe_array(
+        move |_source: DataSource, mut array: DataArray| {
+            let len = array.len();
+            if len != 10 {
+                warnf!("bad length: got: {}, expected: 10", len);
+                panic!("bad length");
+            }
+
+            // Update value of first 10 elements
+            for i in 0..10 {
+                let data = array.get(i);
+                let Ok(FieldData::Uint32(val)) = foo_field.get_data(data, FieldKind::Uint32) else {
+                    warnf!("failed to get field at index {}", i);
+                    panic!("failed to get field");
+                };
+
+                if let Err(e) = foo_field.set_data(data, &(val * i as u32)) {
+                    warnf!("failed to set field: {:?}", e);
+                }
+            }
+
+            // Add 5 additional elements
+            for i in 10..15 {
+                let data = array.new();
+                if let Err(e) = foo_field.set_data(data, &(424143 * i as u32)) {
+                    warnf!("failed to set field: {:?}", e);
+                }
+                array.append(data).expect("failed to append data");
+            }
+
+            Ok(())
+        },
+        0,
+    ) else {
+        return 0;
+    };
+
+    warnf!("failed to subscribe {:?}", err);
+    1
+}

--- a/pkg/operators/wasm/rusttestdata/dataemit/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/dataemit/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dataemit"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/dataemit/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/dataemit/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/dataemit/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/dataemit/src/lib.rs
@@ -1,0 +1,85 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::{
+    datasources::{Data, DataSource, DataSourceType, FieldKind, Packet},
+    fields::FieldData,
+    log::LogLevel,
+    warnf,
+};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let Ok(old_ds) = DataSource::get_datasource("old_ds".to_string()) else {
+        warnf!("failed to get datasource");
+        return 1;
+    };
+
+    let foo_field = match old_ds.get_field("foo") {
+        Ok(field) => field,
+        Err(e) => {
+            warnf!("failed to get host field: {:?}", e);
+            return 1;
+        }
+    };
+
+    let Ok(new_ds) = DataSource::new_datasource("new_ds".to_string(), DataSourceType::Single)
+    else {
+        warnf!("failed to create datasource");
+        return 1;
+    };
+
+    let bar_field = match new_ds.add_field("bar", FieldKind::Uint32) {
+        Ok(field) => field,
+        Err(e) => {
+            warnf!("failed to add field: {:?}", e);
+            return 1;
+        }
+    };
+
+    let Err(e) = old_ds.subscribe(
+        move |_source: DataSource, data: Data| {
+            let val = match foo_field.get_data(data, FieldKind::Uint32) {
+                Ok(FieldData::Uint32(v)) => v,
+                Err(e) => {
+                    warnf!("failed to get field: {:?}", e);
+                    panic!("failed to get field");
+                }
+                _ => {
+                    warnf!("unexpected field data type");
+                    panic!("unexpected field data type");
+                }
+            };
+
+            if val % 2 == 0 {
+                let packet = match new_ds.new_packet_single() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        warnf!("failed to create new packet: {:?}", e);
+                        panic!("failed to create packet");
+                    }
+                };
+                _ = bar_field.set_data(Data(packet.0), &(val * 5));
+                _ = new_ds.emit_and_release(Packet(packet.0));
+            }
+        },
+        0,
+    ) else {
+        return 0;
+    };
+
+    warnf!("failed to subscribe: {:?}", e);
+    1
+}

--- a/pkg/operators/wasm/rusttestdata/fields/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/fields/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fields"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/fields/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/fields/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/fields/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/fields/src/lib.rs
@@ -1,0 +1,168 @@
+use api::{
+    datasources::{DataSource, Field, FieldKind},
+    errorf,
+    log::LogLevel,
+};
+use std::{any::Any, sync::Arc};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let Ok(ds) = DataSource::get_datasource("myds".to_string()) else {
+        errorf!("failed to get datasource");
+        return 1;
+    };
+    #[derive(Debug, Clone)]
+    struct MyField {
+        name: &'static str,
+        typ: FieldKind,
+        acc: Field,
+        val: Arc<dyn Any + Send + Sync>,
+        tag: &'static str,
+    }
+
+    let mut fields = vec![
+        MyField {
+            name: "field_bool",
+            typ: FieldKind::Bool,
+            val: Arc::new(true),
+            tag: "tag_bool",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_int8",
+            typ: FieldKind::Int8,
+            val: Arc::new(-123i8),
+            tag: "tag_int8",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_int16",
+            typ: FieldKind::Int16,
+            val: Arc::new(-25647i16),
+            tag: "tag_int16",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_int32",
+            typ: FieldKind::Int32,
+            val: Arc::new(-535245564i32),
+            tag: "tag_int32",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_int64",
+            typ: FieldKind::Int64,
+            val: Arc::new(-1234567890i64),
+            tag: "tag_int64",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_uint8",
+            typ: FieldKind::Uint8,
+            val: Arc::new(56u8),
+            tag: "tag_uint8",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_uint16",
+            typ: FieldKind::Uint16,
+            val: Arc::new(12345u16),
+            tag: "tag_uint16",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_uint32",
+            typ: FieldKind::Uint32,
+            val: Arc::new(1234567890u32),
+            tag: "tag_uint32",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_uint64",
+            typ: FieldKind::Uint64,
+            val: Arc::new(1234567890123456u64),
+            tag: "tag_uint64",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_float32",
+            typ: FieldKind::Float32,
+            val: Arc::new(3.14159f32),
+            tag: "tag_float32",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_float64",
+            typ: FieldKind::Float64,
+            val: Arc::new(3.14159265359f64),
+            tag: "tag_float64",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_string",
+            typ: FieldKind::String,
+            val: Arc::new("Hello, World!".to_string()),
+            tag: "tag_string",
+            acc: Field(0),
+        },
+        MyField {
+            name: "field_bytes",
+            typ: FieldKind::Bytes,
+            val: Arc::new(vec![0x1u8, 0x2u8, 0x3u8, 0x4u8, 0x5u8]),
+            tag: "tag_bytes",
+            acc: Field(0),
+        },
+    ];
+
+    for f in fields.iter_mut() {
+        let Ok(field) = ds.add_field(f.name, f.typ) else {
+            let name = f.name;
+            errorf!("failed to add field: {}", name);
+            return 1;
+        };
+        if let Err(e) = field.add_tag(f.tag) {
+            let tag = f.tag;
+            errorf!("failed to add tag: {} -> {:?}", tag, e);
+            return 1;
+        }
+        f.acc = field;
+    }
+
+    let Ok(host_field) = ds.get_field("host_field") else {
+        errorf!("failed to get host field");
+        return 1;
+    };
+
+    fields.push(MyField {
+        name: "host_field",
+        typ: FieldKind::String,
+        val: Arc::new("LOCALHOST".to_string()),
+        tag: "host_tag",
+        acc: host_field,
+    });
+
+    let result = ds.subscribe(
+        {
+            move |_source, data| {
+                for f in fields.iter() {
+                    let field = f.acc;
+
+                    if let Err(e) = field.set_data(data, &*f.val) {
+                        let name = f.name;
+                        errorf!("failed to set field {}: {:?}", name, e);
+                        panic!("failed to set field");
+                    }
+                }
+            }
+        },
+        0,
+    );
+
+    if result.is_err() {
+        errorf!("failed to subscribe");
+        return 1;
+    }
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/filtering/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/filtering/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "filtering"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/filtering/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/filtering/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/filtering/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/filtering/src/lib.rs
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+use api::{
+    errorf,
+    {filter::should_discard_mntns_id, log::LogLevel},
+};
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
+const MNTNS_DISCARDED: u64 = 555;
+const MNTNS_NOT_DISCARDED: u64 = 777;
 
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod filter;
-pub mod handle;
-pub mod helpers;
-pub mod kallsyms;
-pub mod log;
-pub mod map;
-pub mod params;
-pub mod perf;
-pub mod syscall;
-pub mod version;
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetStart() -> i32 {
+    if !should_discard_mntns_id(MNTNS_DISCARDED) {
+        errorf!("mntns should be discarded");
+        return 1;
+    }
+    if should_discard_mntns_id(MNTNS_NOT_DISCARDED) {
+        errorf!("mntns should not be discarded");
+        return 1;
+    }
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kallsyms"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/kallsyms/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/kallsyms/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/src/lib.rs
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+use api::errorf;
+use api::{kallsyms, log::LogLevel};
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let mut exists = kallsyms::kallsyms_symbol_exists("abcde_this_symbol_does_not_exist");
+    if exists {
+        errorf!("kallsyms_symbol_exists wrongly found symbol");
+        return 1;
+    }
 
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod handle;
-pub mod helpers;
-pub mod kallsyms;
-pub mod log;
-pub mod map;
-pub mod params;
-pub mod perf;
-pub mod syscall;
-pub mod version;
+    exists = kallsyms::kallsyms_symbol_exists("socket_file_ops");
+    if !exists {
+        errorf!("kallsyms_symbol_exists did not find symbol");
+        return 1;
+    }
+
+    return 0;
+}

--- a/pkg/operators/wasm/rusttestdata/map/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/map/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/map/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/map/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/map/program.bpf.c
+++ b/pkg/operators/wasm/rusttestdata/map/program.bpf.c
@@ -1,0 +1,15 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+struct map_test_struct {
+	__u32 a;
+	__u32 b;
+	__u8 c;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, struct map_test_struct);
+	__type(value, __u32);
+} test_map SEC(".maps");

--- a/pkg/operators/wasm/rusttestdata/map/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/map/src/lib.rs
@@ -1,0 +1,188 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::{
+    errorf,
+    {
+        log::LogLevel,
+        map::{Map, MapSpec, MapType, MapUpdateFlags},
+    },
+};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let map_name = "test_map";
+    if let Ok(_) = Map::get(map_name) {
+        api::errorf!("{} map does not exist", map_name);
+        return 1;
+    }
+    0
+}
+
+// #[repr(C)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct MapTestStruct {
+    a: i32,
+    b: i32,
+    c: i8,
+    _pad: [i8; 3],
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetStart() -> i32 {
+    let map_name = "test_map";
+    let mut expected_val: i32 = 42;
+    let new_val: i32 = 43;
+    let key = MapTestStruct {
+        a: 42,
+        b: 42,
+        c: 43,
+        _pad: [0; 3],
+    };
+    let mut val: i32 = 0;
+    //Defining m inside a block to test Map drop trait.
+    {
+        let Ok(m) = Map::get(map_name) else {
+            errorf!("map doesn't exists: {}", map_name);
+            return 1;
+        };
+
+        if let Err(err) = m.put(&key, &expected_val) {
+            api::errorf!(
+                "setting {} value for {:?} key in {}: {}",
+                expected_val,
+                key,
+                map_name,
+                err
+            );
+            return 1;
+        }
+
+        if let Err(_) = m.lookup(&key, &mut val) {
+            api::errorf!("no value found for key {:?} in {}", key, map_name);
+            return 1;
+        }
+
+        if val != expected_val {
+            api::errorf!("expected value {}, got {}", expected_val, val);
+            return 1;
+        }
+
+        //     Code is not required as parameter's type are checked at compile time
+        //     match m.lookup(&key, val) {
+        //     Ok(_) => {api::error!("lookup only accepts pointer for value argument");
+        //             return 1;},
+        //     Err(_) => {
+        //     }
+        // }
+
+        if let Err(_) = m.update(&key, &new_val, MapUpdateFlags::UpdateExist) {
+            api::errorf!("updating value for key {:?} in {}", key, map_name);
+            return 1;
+        }
+
+        if let Err(_) = m.lookup(&key, &mut val) {
+            api::errorf!("no value found for key {:?} in {}", key, map_name);
+            return 1;
+        }
+        if val != new_val {
+            api::errorf!("expected value {}, got {}", new_val, val);
+            return 1;
+        }
+
+        if let Err(_) = m.delete(&key) {
+            api::errorf!("deleting value for key {:?} in {}", key, map_name);
+            return 1;
+        }
+
+        if let Err(_) = m.put(&key, &val) {
+            api::errorf!("setting {} value for key {:?} in {:?}", val, key, map_name);
+            return 1;
+        }
+
+        if let Ok(_) = m.update(&key, &new_val, MapUpdateFlags::UpdateNoExist) {
+            api::errorf!(
+                "cannot update value for key {:?} in {} as it is not already present",
+                key,
+                map_name
+            );
+            return 1;
+        }
+
+        if let Err(_) = m.update(&key, &new_val, MapUpdateFlags::UpdateExist) {
+            api::errorf!(
+                "cannot update value for key {:?} in {} as it is already present",
+                key,
+                map_name
+            );
+            return 1;
+        }
+        if let Err(_) = m.delete(&key) {
+            api::errorf!("deleting value for key {:?} in {}", key, map_name);
+            return 1;
+        }
+
+        if let Ok(_) = m.delete(&key) {
+            api::errorf!("there is value for key {:?} in {}", key, map_name);
+            return 1;
+        }
+    }
+    // As the block ends, the map tries to be dropped, but cannot close map got with get()
+
+    let map_spec = MapSpec {
+        name: "map_test".to_string(),
+        typ: MapType::Hash,
+        key_size: 4,
+        value_size: 4,
+        max_entries: 1,
+    };
+
+    let Ok(new_map) = Map::new(map_spec.clone()) else {
+        let name = map_spec.name.clone();
+        api::errorf!("creating map {:?}", name);
+        return 1;
+    };
+
+    let k: i32 = 42;
+    val = 43;
+    if let Err(_) = new_map.put(&k, &val) {
+        let name = map_spec.name.clone();
+        api::errorf!("setting {} value for key {} in {:?}", val, k, name);
+        return 1;
+    }
+
+    if let Err(_) = new_map.lookup(&k, &mut val) {
+        let name = map_spec.name.clone();
+        api::errorf!("no value found for key {} in {:?}", k, name);
+        return 1;
+    }
+
+    expected_val = 43;
+    if val != expected_val {
+        api::errorf!("expected value {}, got {}", expected_val, val);
+        return 1;
+    }
+
+    let k2 = 0xdead;
+    val = 0xcafe;
+    if let Ok(_) = new_map.put(&k2, &val) {
+        let name = map_spec.name.clone();
+        api::errorf!("map {:?} has one max entry, trying to put two", name);
+        return 1;
+    }
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mapofmap"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/mapofmap/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/mapofmap/program.bpf.c
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/program.bpf.c
@@ -1,0 +1,22 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+struct map_test_struct {
+	__u32 a;
+	__u32 b;
+	__u8 c;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+	__uint(key_size, sizeof(struct map_test_struct));
+	__uint(value_size, sizeof(u32));
+	__uint(max_entries, 1024);
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(key_size, sizeof(u32));
+			__uint(value_size, sizeof(u32));
+			__uint(max_entries, 1);
+		});
+} map_of_map SEC(".maps");

--- a/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
@@ -1,0 +1,99 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::errorf;
+use api::{
+    log::LogLevel,
+    map::{Map, MapSpec, MapType},
+};
+
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct MapTestStruct {
+    a: i32,
+    b: i32,
+    c: i8,
+    _pad: [i8; 3],
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetStart() -> i32 {
+    let map_of_map_name = "map_of_map";
+    let mut inner_map: Map = Map(0);
+    let key = MapTestStruct {
+        a: 42,
+        b: 42,
+        c: 43,
+        _pad: [0; 3],
+    };
+
+    let Ok(map_of_map) = Map::get(map_of_map_name) else {
+        errorf!("{} map must exist", map_of_map_name);
+        return 1;
+    };
+    let hash_map_name = "test_hash".to_string();
+
+    let inner_map_spec = MapSpec {
+        name: hash_map_name.clone(),
+        typ: MapType::Hash,
+        key_size: 4,
+        value_size: 4,
+        max_entries: 1,
+    };
+
+    let Ok(hash_map) = Map::new(inner_map_spec.clone()) else {
+        errorf!("creating map {}", hash_map_name);
+        return 1;
+    };
+
+    if let Err(e) = map_of_map.put(&key, &hash_map) {
+        errorf!(
+            "setting {} inner map value for key {:?} in {}: {}",
+            hash_map_name,
+            key,
+            map_of_map_name,
+            e
+        );
+        return 1;
+    }
+    if let Err(_) = map_of_map.lookup(&key, &mut inner_map) {
+        errorf!("no value found for key {:?} in {}", key, map_of_map_name);
+        return 1;
+    }
+
+    if inner_map.0 == 0 {
+        errorf!("expected handle to be different than 0");
+        return 1;
+    }
+
+    if inner_map.0 == hash_map.0 {
+        errorf!("expected handle to be different than hashMap");
+        return 1;
+    }
+
+    let k: u32 = 42;
+    let v: u32 = 43;
+    if let Err(e) = inner_map.put(&k, &v) {
+        errorf!("putting value in inner map {}: {}", hash_map_name, e);
+        return 1;
+    }
+
+    if let Err(_) = map_of_map.delete(&key) {
+        errorf!("deleting map {:?}", hash_map);
+        return 1;
+    }
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/params/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/params/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "params"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/params/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/params/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/params/gadget.yaml
+++ b/pkg/operators/wasm/rusttestdata/params/gadget.yaml
@@ -1,0 +1,11 @@
+name: params_test
+params:
+  wasm:
+    param-key:
+      key: param-key
+      description: param-description
+      defaultValue: param-default-value
+      typeHint: param-type-hint
+      title: param-title
+      alias: param-alias
+      isMandatory: true

--- a/pkg/operators/wasm/rusttestdata/params/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/params/src/lib.rs
@@ -1,0 +1,26 @@
+use api::{
+    errorf,
+    {log::LogLevel, params::get_param_value},
+};
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub fn gadgetStart() -> i32 {
+    let Ok(val) = get_param_value("param-key".to_string(), 32) else {
+        errorf!("failed to get param");
+        return 1;
+    };
+
+    let expected = "param-value".to_string();
+    if val != expected {
+        errorf!("param value should be {:?}, got: {:?}", expected, val);
+        return 1;
+    }
+
+    if let Ok(_) = get_param_value("non-existing-param".to_string(), 32) {
+        errorf!("looking for non-existing-param succeeded");
+        return 1;
+    }
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/perf/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/perf/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "perf"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/perf/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/perf/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/perf/program.bpf.c
+++ b/pkg/operators/wasm/rusttestdata/perf/program.bpf.c
@@ -1,0 +1,28 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+struct event {
+	__u32 a;
+	__u32 b;
+	__u8 c;
+	__u8 unused[247];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32));
+} events SEC(".maps");
+
+SEC("tracepoint/syscalls/sys_enter_write")
+int test_write_e(struct syscall_trace_enter *ctx)
+{
+	struct event event = { .a = 42, .b = 42, .c = 43 };
+
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+			      sizeof(event));
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::{
+    errorf, info,
+    {log::LogLevel, map::Map, perf::PerfReader},
+};
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct Event {
+    a: u32,
+    b: u32,
+    c: u8,
+    _unused: [u8; 247],
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetStart() -> i32 {
+    let map_name = "events";
+    let sample = [0u8; 4096];
+    let Ok(perf_array) = Map::get(map_name) else {
+        errorf!("{} map exists", map_name);
+        return 1;
+    };
+
+    let Ok(perf_reader) = PerfReader::new(perf_array, 4096, true) else {
+        errorf!("creating perf reader");
+        return 1;
+    };
+
+    if let Ok(_) = perf_reader.read(&sample) {
+        errorf!("perf over writable reader must be paused before reading");
+        return 1;
+    }
+
+    for _ in 0..10 {
+        // Let's generate some events by calling indirectly the write() syscall.
+        info!("testing perf array");
+    }
+
+    if let Err(_) = perf_reader.pause() {
+        errorf!("pausing perf reader");
+        return 1;
+    }
+
+    if let Err(_) = perf_reader.read(&sample) {
+        errorf!("reading perf record");
+        return 1;
+    }
+
+    let ev = sample.as_ptr() as *const Event;
+    let evv = unsafe { *ev };
+    let expected_event = Event {
+        a: 42,
+        b: 42,
+        c: 43,
+        _unused: [0; 247],
+    };
+    if evv != expected_event {
+        errorf!(
+            "record read mismatch: expected {:?}, got {:?}",
+            expected_event,
+            evv
+        );
+        return 1;
+    }
+
+    if let Err(_) = perf_reader.resume() {
+        errorf!("resuming perf reader");
+        return 1;
+    }
+
+    0
+}

--- a/pkg/operators/wasm/rusttestdata/syscall/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/syscall/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "syscall"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+once_cell="1.18"
+api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/syscall/build.yaml
+++ b/pkg/operators/wasm/rusttestdata/syscall/build.yaml
@@ -1,0 +1,1 @@
+wasm: src/lib.rs

--- a/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::{
+    errorf,
+    {
+        log::LogLevel,
+        syscall::{get_syscall_declaration, get_syscall_id, get_syscall_name},
+    },
+};
+
+const UNKNOWN_SYSCALL_ID: u16 = 1337;
+const OPEN_TREE_SYSCALL_ID: u16 = 428;
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn gadgetInit() -> i32 {
+    let mut syscall_id: u16 = UNKNOWN_SYSCALL_ID;
+    let Ok(mut syscall_name) = get_syscall_name(syscall_id) else {
+        errorf!("failed to get name for syscall ID {}", syscall_id);
+        return 1;
+    };
+
+    // Check behavior is conform with strace
+    let expected_syscall_name = format!("syscall_{:x}", syscall_id);
+
+    if syscall_name != expected_syscall_name {
+        errorf!(
+            "mismatch for syscall {}: expected {}, got {}",
+            syscall_id,
+            expected_syscall_name,
+            syscall_name
+        );
+        return 1;
+    }
+
+    syscall_id = OPEN_TREE_SYSCALL_ID;
+    let Ok(name) = get_syscall_name(syscall_id) else {
+        errorf!("failed to get name for syscall ID {}", syscall_id);
+        return 1;
+    };
+    syscall_name = name;
+
+    let expected_syscall_name = "open_tree".to_string();
+
+    if syscall_name != expected_syscall_name {
+        errorf!(
+            "mismatch for syscall {}: expected {}, got {}",
+            syscall_id,
+            expected_syscall_name,
+            syscall_name
+        );
+        return 1;
+    }
+
+    // open_tree has the same ID for both amd64 and arm64.
+    syscall_name = "open_tree".to_string();
+    let Ok(id) = get_syscall_id(syscall_name.clone()) else {
+        errorf!("failed to get ID for syscall {}", syscall_name);
+        return 1;
+    };
+
+    if id as u16 != OPEN_TREE_SYSCALL_ID {
+        errorf!(
+            "mismatch for syscall {}: expected {}, got {}",
+            syscall_name,
+            OPEN_TREE_SYSCALL_ID,
+            id
+        );
+        return 1;
+    }
+
+    // Test invalid syscall name
+    let syscall_name = "foobar".to_string();
+    if let Ok(val) = get_syscall_id(syscall_name.clone()) {
+        errorf!(
+            "expected no syscall ID for syscall {}, got {}",
+            syscall_name,
+            val
+        );
+        return 1;
+    }
+
+    if let Ok(val) = get_syscall_declaration(&syscall_name) {
+        errorf!(
+            "expected no declaration for syscall {}, but got {:?}",
+            syscall_name,
+            val
+        );
+        return 1;
+    }
+
+    let syscall_name = "execve".to_string();
+    let Ok(declaration) = get_syscall_declaration(&syscall_name) else {
+        errorf!("failed to get declaration for syscall {}", syscall_name);
+        return 1;
+    };
+
+    let param_count = declaration.params.len();
+    let expected_param_count = 3;
+
+    if param_count != expected_param_count {
+        errorf!(
+            "syscall {} has {} parameters, got {}",
+            syscall_name,
+            expected_param_count,
+            param_count
+        );
+        return 1;
+    }
+
+    let param_name: String = declaration.params[0].name.clone();
+    let expected_param_name = "filename".to_string();
+    if param_name != expected_param_name {
+        errorf!(
+            "syscall {}, first parameter is named {}, got {}",
+            syscall_name,
+            expected_param_name,
+            param_name
+        );
+        return 1;
+    }
+
+    if !declaration.params[0].is_pointer {
+        errorf!(
+            "in {}, parameter {} is expected to be a pointer",
+            syscall_name,
+            param_name
+        );
+        return 1;
+    }
+
+    0
+}

--- a/wasmapi/rust/Cargo.toml
+++ b/wasmapi/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1.18"

--- a/wasmapi/rust/src/config.rs
+++ b/wasmapi/rust/src/config.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{datasources::FieldKind, helpers::string_to_buf_ptr};
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "setConfig"]
+    fn _set_config(key: u64, val: u64, kind: u32) -> u32;
+}
+pub trait Allowed {
+    fn to_buf_ptr(&self) -> u64;
+}
+
+impl Allowed for String {
+    fn to_buf_ptr(&self) -> u64 {
+        string_to_buf_ptr(self).0
+    }
+}
+
+pub fn set_config<T: Allowed>(key: String, val: T) -> Result<(), String> {
+    let key_ptr = string_to_buf_ptr(&key);
+    let val_ptr = val.to_buf_ptr();
+
+    let ret = unsafe { _set_config(key_ptr.0, val_ptr, FieldKind::String as u32) };
+    if ret != 0 {
+        Err("setting config".to_string())
+    } else {
+        Ok(())
+    }
+}

--- a/wasmapi/rust/src/datasources.rs
+++ b/wasmapi/rust/src/datasources.rs
@@ -1,0 +1,343 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use once_cell::sync::Lazy;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use crate::helpers::string_to_buf_ptr; //relative paths may hinder in testing.
+
+#[derive(Debug)]
+pub enum DataSourceError {
+    NotFound(String),
+    CreationFailed(String),
+    SubscribingFailed,
+    PacketCreationFailed,
+    EmitFailed,
+    ReleaseFailed,
+    UnreferenceFailed,
+    AddFieldFailed(String),
+    AppendFailed,
+    GeneralError,
+}
+
+pub type Result<T> = std::result::Result<T, DataSourceError>;
+
+#[repr(u32)] // Specifies the enums to be casted as u32, similar to C enums.
+#[derive(Clone, Copy)]
+enum SubscriptionType {
+    _Invalid = 0,
+    Data = 1,
+    Array = 2,
+    Packet = 3,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum DataSourceType {
+    Undefined = 0,
+    Single = 1,
+    Array = 2,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug)]
+pub enum FieldKind {
+    Invalid = 0,
+    Bool = 1,
+    Int8 = 2,
+    Int16 = 3,
+    Int32 = 4,
+    Int64 = 5,
+    Uint8 = 6,
+    Uint16 = 7,
+    Uint32 = 8,
+    Uint64 = 9,
+    Float32 = 10,
+    Float64 = 11,
+    String = 12,
+    CString = 13,
+    Bytes = 14,
+}
+
+pub enum CallBack {
+    Data(DataFunc),
+    Array(DataArrayFunc),
+    Packet(PacketFunc),
+}
+
+type DataFunc = Arc<dyn Fn(DataSource, Data) + Send + Sync + 'static>;
+type DataArrayFunc = Arc<dyn Fn(DataSource, DataArray) -> Result<()> + Send + Sync + 'static>;
+type PacketFunc = Arc<dyn Fn(DataSource, Packet) -> Result<()> + Send + Sync + 'static>;
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "newDataSource"]
+    fn _new_datasource(name: u64, typ: u32) -> u32;
+
+    #[link_name = "getDataSource"]
+    fn _get_datasource(name: u64) -> u32;
+
+    #[link_name = "dataSourceSubscribe"]
+    fn _datasource_subscribe(ds: u32, typ: u32, prio: u32, cb: u64) -> u32;
+
+    #[link_name = "dataSourceGetField"]
+    fn _datasource_get_field(ds: u32, name: u64) -> u32;
+
+    #[link_name = "dataSourceAddField"]
+    fn _datasource_add_field(ds: u32, name: u64, kind: u32) -> u32;
+
+    #[link_name = "dataSourceNewPacketSingle"]
+    fn _datasource_new_packet_single(ds: u32) -> u32;
+
+    #[link_name = "dataSourceNewPacketArray"]
+    fn _datasource_new_packet_array(ds: u32) -> u32;
+
+    #[link_name = "dataSourceEmitAndRelease"]
+    fn _datasource_emit_and_release(ds: u32, packet: u32) -> u32;
+
+    #[link_name = "dataSourceRelease"]
+    fn _datasource_release(ds: u32, packet: u32) -> u32;
+
+    #[link_name = "dataSourceUnreference"]
+    fn _datasource_unreference(ds: u32) -> u32;
+
+    #[link_name = "dataSourceIsReferenced"]
+    fn _datasource_is_referenced(ds: u32) -> u32;
+
+    #[link_name = "dataArrayNew"]
+    fn _dataarray_new(d: u32) -> u32;
+
+    #[link_name = "dataArrayAppend"]
+    fn _dataarray_append(d: u32, data: u32) -> u32;
+
+    #[link_name = "dataArrayRelease"]
+    fn _dataarray_release(d: u32, data: u32) -> u32;
+
+    #[link_name = "dataArrayLen"]
+    fn _dataarray_len(d: u32) -> u32;
+
+    #[link_name = "dataArrayGet"]
+    fn _dataarray_get(d: u32, index: u32) -> u32;
+}
+
+static DS_SUBSCRIPTION_CTR: AtomicU64 = AtomicU64::new(0);
+static DS_SUBCRIPTION: Lazy<Mutex<HashMap<u64, CallBack>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Clone, Copy, Debug)]
+pub struct DataSource(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct Packet(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct Field(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct Data(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct DataArray(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct PacketSingle(pub u32);
+#[derive(Clone, Copy, Debug)]
+pub struct PacketArray(pub u32);
+
+impl DataSource {
+    pub fn new_datasource(name: String, typ: DataSourceType) -> Result<Self> {
+        let ptr = string_to_buf_ptr(name.as_str());
+        let handle = unsafe { _new_datasource(ptr.0, typ as u32) };
+
+        if handle == 0 {
+            Err(DataSourceError::CreationFailed(name))
+        } else {
+            Ok(Self(handle))
+        }
+    }
+
+    pub fn get_datasource(name: String) -> Result<Self> {
+        let ptr = string_to_buf_ptr(name.as_str());
+        let handle = unsafe { _get_datasource(ptr.0) };
+        if handle == 0 {
+            Err(DataSourceError::NotFound(name))
+        } else {
+            Ok(Self(handle))
+        }
+    }
+
+    fn _subscribe(&self, typ: SubscriptionType, prio: u32, cb: CallBack) -> Result<()> {
+        let ctr = DS_SUBSCRIPTION_CTR.fetch_add(1, Ordering::SeqCst);
+        DS_SUBCRIPTION.lock().unwrap().insert(ctr, cb);
+        let ret = unsafe { _datasource_subscribe(self.0, typ as u32, prio, ctr) };
+        if ret != 0 {
+            Err(DataSourceError::SubscribingFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn subscribe<F>(&self, cb: F, prio: u32) -> Result<()>
+    where
+        F: Fn(DataSource, Data) + Send + Sync + 'static,
+    {
+        self._subscribe(SubscriptionType::Data, prio, CallBack::Data(Arc::new(cb)))
+    }
+
+    pub fn subscribe_array<F>(&self, cb: F, prio: u32) -> Result<()>
+    where
+        F: Fn(DataSource, DataArray) -> Result<()> + Send + Sync + 'static,
+    {
+        self._subscribe(SubscriptionType::Array, prio, CallBack::Array(Arc::new(cb)))
+    }
+
+    pub fn subscribe_packet<F>(&self, cb: F, prio: u32) -> Result<()>
+    where
+        F: Fn(DataSource, Packet) -> Result<()> + Send + Sync + 'static,
+    {
+        self._subscribe(
+            SubscriptionType::Packet,
+            prio,
+            CallBack::Packet(Arc::new(cb)),
+        )
+    }
+
+    pub fn get_field(&self, name: &str) -> Result<Field> {
+        let ptr = string_to_buf_ptr(name);
+        let ret = unsafe { _datasource_get_field(self.0, ptr.0) };
+        if ret == 0 {
+            Err(DataSourceError::NotFound(name.to_string()))
+        } else {
+            Ok(Field(ret))
+        }
+    }
+
+    pub fn add_field(&self, name: &str, kind: FieldKind) -> Result<Field> {
+        let ptr = string_to_buf_ptr(name);
+        let ret = unsafe { _datasource_add_field(self.0, ptr.0, kind as u32) };
+        if ret == 0 {
+            Err(DataSourceError::AddFieldFailed(name.to_string()))
+        } else {
+            Ok(Field(ret))
+        }
+    }
+
+    pub fn new_packet_single(&self) -> Result<PacketSingle> {
+        let ret = unsafe { _datasource_new_packet_single(self.0) };
+        if ret == 0 {
+            Err(DataSourceError::PacketCreationFailed)
+        } else {
+            Ok(PacketSingle(ret))
+        }
+    }
+
+    pub fn new_packet_array(&self) -> Result<PacketArray> {
+        let ret = unsafe { _datasource_new_packet_array(self.0) };
+        if ret == 0 {
+            Err(DataSourceError::PacketCreationFailed)
+        } else {
+            Ok(PacketArray(ret))
+        }
+    }
+
+    pub fn emit_and_release(&self, packet: Packet) -> Result<()> {
+        let ret = unsafe { _datasource_emit_and_release(self.0, packet.0) };
+        if ret != 0 {
+            Err(DataSourceError::EmitFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn release(&self, packet: Packet) -> Result<()> {
+        let ret = unsafe { _datasource_release(self.0, packet.0) };
+        if ret != 0 {
+            Err(DataSourceError::ReleaseFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn unreference(&self) -> Result<()> {
+        let ret = unsafe { _datasource_unreference(self.0) };
+        if ret != 0 {
+            Err(DataSourceError::UnreferenceFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn is_referenced(&self) -> bool {
+        unsafe { _datasource_is_referenced(self.0) == 1 }
+    }
+}
+
+impl DataArray {
+    pub fn new(&self) -> Data {
+        let data = unsafe { _dataarray_new(self.0) };
+        Data(data)
+    }
+
+    pub fn append(&mut self, data: Data) -> Result<()> {
+        let ret = unsafe { _dataarray_append(self.0, data.0) };
+        if ret != 0 {
+            Err(DataSourceError::AppendFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn release(&self, data: Data) -> Result<()> {
+        let ret = unsafe { _dataarray_release(self.0, data.0) };
+        if ret != 0 {
+            Err(DataSourceError::ReleaseFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { _dataarray_len(self.0) as usize }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        unsafe { _dataarray_len(self.0) == 0 }
+    }
+
+    pub fn get(&self, index: usize) -> Data {
+        Data(unsafe { _dataarray_get(self.0, index as u32) })
+    }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+fn dataSourceCallback(cb_id: u64, ds: u32, data: u32) {
+    let subscription = DS_SUBCRIPTION.lock().unwrap();
+    let Some(cb) = subscription.get(&cb_id) else {
+        return;
+    };
+
+    match cb {
+        CallBack::Data(cb) => {
+            cb(DataSource(ds), Data(data));
+        }
+        CallBack::Array(cb) => {
+            _ = cb(DataSource(ds), DataArray(data));
+        }
+        CallBack::Packet(cb) => {
+            _ = cb(DataSource(ds), Packet(data));
+        }
+    }
+}

--- a/wasmapi/rust/src/fields.rs
+++ b/wasmapi/rust/src/fields.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::datasources::{Data, Field, FieldKind};
+use crate::helpers::{bytes_to_buf_ptr, from_c_string, string_to_buf_ptr}; //relative paths may hinder in testing.
+use std::any::Any;
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "fieldGetScalar"]
+    fn _field_get_scalar(field: u32, data: u32, kind: u32, err_ptr: u32) -> u64;
+    #[link_name = "fieldGetBuffer"]
+    fn _field_get_buffer(field: u32, data: u32, kind: u32, dst: u64) -> i32;
+    #[link_name = "fieldSet"]
+    fn _field_set(field: u32, data: u32, kind: u32, value: u64) -> u32;
+    #[link_name = "fieldAddTag"]
+    fn _field_add_tag(field: u32, tag: u64) -> u32;
+}
+
+pub type Result<T> = std::result::Result<T, String>;
+
+pub enum FieldData {
+    Bool(bool),
+    Float32(f32),
+    Float64(f64),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Uint8(u8),
+    Uint16(u16),
+    Uint32(u32),
+    Uint64(u64),
+}
+
+impl Field {
+    fn get_scalar(&self, data: Data, kind: FieldKind) -> Result<u64> {
+        let mut err: u32 = 0;
+        let err_ptr = &mut err as *mut u32 as u32;
+        let val = unsafe { _field_get_scalar(self.0, data.0, kind as u32, err_ptr) };
+        if err != 0 {
+            return Err(String::from("Error getting field"));
+        }
+        Ok(val)
+    }
+
+    fn set(&self, data: Data, kind: FieldKind, value: u64) -> Result<()> {
+        let ret = unsafe { _field_set(self.0, data.0, kind as u32, value) };
+        if ret != 0 {
+            return Err(String::from("Error setting field"));
+        }
+        Ok(())
+    }
+
+    pub fn get_data(&self, data: Data, field_kind: FieldKind) -> Result<FieldData> {
+        match field_kind {
+            FieldKind::Bool => {
+                let val = self.get_scalar(data, FieldKind::Bool).map(|v| v == 1)?;
+                Ok(FieldData::Bool(val))
+            }
+            FieldKind::Float32 => {
+                let val = self
+                    .get_scalar(data, FieldKind::Float32)
+                    .map(|v| f32::from_bits(v as u32))?;
+                Ok(FieldData::Float32(val))
+            }
+            FieldKind::Float64 => {
+                let val = self
+                    .get_scalar(data, FieldKind::Float64)
+                    .map(f64::from_bits)?;
+                Ok(FieldData::Float64(val))
+            }
+            FieldKind::Bytes => Err("Use bytes function".to_string()),
+            FieldKind::String => Err("Use string function".to_string()),
+            FieldKind::Int8 => {
+                let val = self.get_scalar(data, FieldKind::Int8).map(|v| v as i8)?;
+                Ok(FieldData::Int8(val))
+            }
+            FieldKind::Int16 => {
+                let val = self.get_scalar(data, FieldKind::Int16).map(|v| v as i16)?;
+                Ok(FieldData::Int16(val))
+            }
+            FieldKind::Int32 => {
+                let val = self.get_scalar(data, FieldKind::Int32).map(|v| v as i32)?;
+                Ok(FieldData::Int32(val))
+            }
+            FieldKind::Int64 => {
+                let val = self.get_scalar(data, FieldKind::Int64).map(|v| v as i64)?;
+                Ok(FieldData::Int64(val))
+            }
+            FieldKind::Uint8 => {
+                let val = self.get_scalar(data, FieldKind::Uint8).map(|v| v as u8)?;
+                Ok(FieldData::Uint8(val))
+            }
+            FieldKind::Uint16 => {
+                let val = self.get_scalar(data, FieldKind::Uint16).map(|v| v as u16)?;
+                Ok(FieldData::Uint16(val))
+            }
+            FieldKind::Uint32 => {
+                let val = self.get_scalar(data, FieldKind::Uint32).map(|v| v as u32)?;
+                Ok(FieldData::Uint32(val))
+            }
+            FieldKind::Uint64 => {
+                let val = self.get_scalar(data, FieldKind::Uint64)?;
+                Ok(FieldData::Uint64(val))
+            }
+            _ => Err("Not a valid FieldKind".to_string()),
+        }
+    }
+
+    pub fn set_data(&self, data: Data, value: &(dyn Any + Send)) -> Result<()> {
+        if let Some(bool_val) = value.downcast_ref::<bool>() {
+            return self.set(data, FieldKind::Bool, if *bool_val { 1 } else { 0 });
+        }
+        if let Some(float_val) = value.downcast_ref::<f32>() {
+            return self.set(data, FieldKind::Float32, float_val.to_bits() as u64);
+        }
+        if let Some(float_val) = value.downcast_ref::<f64>() {
+            return self.set(data, FieldKind::Float64, float_val.to_bits());
+        }
+        if let Some(bytes) = value.downcast_ref::<&[u8]>() {
+            return self.set(data, FieldKind::Bytes, bytes_to_buf_ptr(bytes).0);
+        }
+        if let Some(bytes) = value.downcast_ref::<Vec<u8>>() {
+            return self.set(data, FieldKind::Bytes, bytes_to_buf_ptr(bytes).0);
+        }
+        if let Some(string_val) = value.downcast_ref::<String>() {
+            return self.set(data, FieldKind::String, string_to_buf_ptr(string_val).0);
+        }
+        if let Some(val) = value.downcast_ref::<i8>() {
+            return self.set(data, FieldKind::Int8, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<i16>() {
+            return self.set(data, FieldKind::Int16, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<i32>() {
+            return self.set(data, FieldKind::Int32, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<i64>() {
+            return self.set(data, FieldKind::Int64, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<u8>() {
+            return self.set(data, FieldKind::Uint8, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<u16>() {
+            return self.set(data, FieldKind::Uint16, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<u32>() {
+            return self.set(data, FieldKind::Uint32, *val as u64);
+        }
+        if let Some(val) = value.downcast_ref::<u64>() {
+            return self.set(data, FieldKind::Uint64, *val);
+        }
+
+        Err("Unsupported value type".to_string())
+    }
+
+    pub fn string(&self, data: Data, max_size: u32) -> Result<String> {
+        let buffer = vec![0u8; max_size as usize];
+        let n = self.bytes(data, &buffer);
+        match n {
+            Ok(ret) => Ok(from_c_string(&buffer[0..ret as usize])),
+            Err(field_err) => Err(field_err),
+        }
+    }
+
+    pub fn bytes(&self, data: Data, dst: &[u8]) -> Result<u32> {
+        let ret = unsafe {
+            _field_get_buffer(
+                self.0,
+                data.0,
+                FieldKind::Bytes as u32,
+                bytes_to_buf_ptr(dst).0,
+            )
+        };
+        if ret == -1 {
+            return Err(String::from("Error getting bytes"));
+        }
+        Ok(ret as u32)
+    }
+
+    pub fn add_tag(&self, tag: &str) -> Result<()> {
+        let ret = unsafe { _field_add_tag(self.0, string_to_buf_ptr(tag).0) };
+        if ret != 0 {
+            return Err(String::from("Error adding tag"));
+        }
+        Ok(())
+    }
+}

--- a/wasmapi/rust/src/filter.rs
+++ b/wasmapi/rust/src/filter.rs
@@ -12,24 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "shouldDiscardMntnsID"]
+    fn _should_discard_mntns_id(mntns_id: u64) -> u32;
+}
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
-
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod filter;
-pub mod handle;
-pub mod helpers;
-pub mod kallsyms;
-pub mod log;
-pub mod map;
-pub mod params;
-pub mod perf;
-pub mod syscall;
-pub mod version;
+pub fn should_discard_mntns_id(mntns_id: u64) -> bool {
+    let ret = unsafe { _should_discard_mntns_id(mntns_id) };
+    ret != 0
+}

--- a/wasmapi/rust/src/handle.rs
+++ b/wasmapi/rust/src/handle.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "releaseHandle"]
+    fn _release_handle(handle: u32) -> u32;
+}
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
+pub type Result<T> = std::result::Result<T, String>;
 
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod helpers;
-pub mod log;
-pub mod map;
-pub mod params;
-pub mod version;
-pub mod handle;
+pub fn release_handle<T: Into<u32>>(h: T) -> Result<()> {
+    let ret = unsafe { _release_handle(h.into()) };
+    if ret != 0 {
+        Err("error releasing handle".to_string())
+    } else {
+        Ok(())
+    }
+}

--- a/wasmapi/rust/src/helpers.rs
+++ b/wasmapi/rust/src/helpers.rs
@@ -1,0 +1,94 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{mem, slice};
+
+#[derive(Copy, Clone)]
+pub struct BufPtr(pub u64);
+
+pub fn string_to_buf_ptr(s: &str) -> BufPtr {
+    if s.is_empty() {
+        return BufPtr(0);
+    }
+    let ptr = s.as_ptr() as u32;
+
+    let len = s.len() as u32;
+
+    BufPtr((u64::from(len) << 32) | u64::from(ptr))
+}
+/*
+any_to_buf_ptr returns a bufPtr that encodes the pointer and length of the
+input.
+The input is first encoded to binary buffer, which is then used as the
+returned bufPtr.
+WARNING the binary encoding will only work on fixed size data, *i.e.* with
+int32 but not with int, as this data would be exchanged from 32 bits WASM VM
+to host which can be 64 bits.
+WARNING T has to mimic kernel representation of data structure by
+adding padding if needed.
+*/
+pub fn any_to_buf_ptr<T>(val: &T) -> Result<BufPtr, String> {
+    let size = mem::size_of_val(val);
+    if size == 0 {
+        return Err(String::from("zero-sized types not supported"));
+    }
+    let ptr = val as *const T as *const u8;
+    let bytes = unsafe { slice::from_raw_parts(ptr, size) };
+
+    let buf_ptr = bytes_to_buf_ptr(bytes);
+
+    Ok(buf_ptr)
+}
+
+pub fn any_to_buf_ptr_mut<T>(val: &mut T) -> Result<BufPtr, String> {
+    let size = std::mem::size_of_val(val);
+    if size == 0 {
+        return Err(String::from("zero-sized types not supported"));
+    }
+
+    let ptr = val as *mut T as *mut u8;
+    let bytes = unsafe { std::slice::from_raw_parts_mut(ptr, size) };
+
+    Ok(bytes_to_buf_ptr(bytes))
+}
+
+pub fn bytes_to_buf_ptr(b: &[u8]) -> BufPtr {
+    let len = b.len() as u64;
+    let ptr = b.as_ptr() as u64;
+    BufPtr((len << 32) | ptr)
+}
+
+pub fn from_c_string(input: &[u8]) -> String {
+    let end = input.iter().position(|&b| b == 0).unwrap_or(input.len());
+    String::from_utf8_lossy(&input[..end]).into_owned()
+}
+
+impl BufPtr {
+    pub fn bytes(&self) -> Option<Vec<u8>> {
+        if self.0 == 0 {
+            return None;
+        }
+
+        let ptr = (self.0 & 0xFFFF_FFFF) as usize as *const u8;
+        let len = (self.0 >> 32) as usize;
+
+        if ptr.is_null() || len == 0 {
+            return None;
+        }
+
+        // Create a slice from raw parts and clone it to a Vec
+        let slice = unsafe { slice::from_raw_parts(ptr, len) };
+        Some(slice.to_vec())
+    }
+}

--- a/wasmapi/rust/src/kallsyms.rs
+++ b/wasmapi/rust/src/kallsyms.rs
@@ -12,23 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
+use crate::helpers::string_to_buf_ptr;
 
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "kallsymsSymbolExists"]
+    fn _kallsyms_symbol_exists(symbol: u64) -> u32;
+}
 
-pub mod config;
-pub mod datasources;
-pub mod fields;
-pub mod handle;
-pub mod helpers;
-pub mod kallsyms;
-pub mod log;
-pub mod map;
-pub mod params;
-pub mod perf;
-pub mod syscall;
-pub mod version;
+pub fn kallsyms_symbol_exists(symbol: &str) -> bool {
+    let ret = unsafe { _kallsyms_symbol_exists(string_to_buf_ptr(symbol).0) };
+    ret != 0
+}

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -29,4 +29,5 @@ pub mod log;
 pub mod map;
 pub mod params;
 pub mod perf;
+pub mod syscall;
 pub mod version;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -23,9 +23,10 @@
 pub mod config;
 pub mod datasources;
 pub mod fields;
+pub mod handle;
 pub mod helpers;
 pub mod log;
 pub mod map;
 pub mod params;
+pub mod perf;
 pub mod version;
-pub mod handle;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -25,5 +25,6 @@ pub mod datasources;
 pub mod fields;
 pub mod helpers;
 pub mod log;
+pub mod map;
 pub mod params;
 pub mod version;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -20,6 +20,7 @@
 //! rust due to ownership model as the variable don't go out of scope until
 //! block lifetime.
 
+pub mod datasources;
 pub mod helpers;
 pub mod log;
 pub mod version;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -21,4 +21,5 @@
 //! block lifetime.
 
 pub mod helpers;
+pub mod log;
 pub mod version;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! "api" crate contains the reference implementation of the wasm API for Inspektor
+//! Gadget. It's designed to be used by gadgets and not by any other internal
+//! component of Inspektor Gadget.
+
+//! A similar function to runtime.keepAlive() in 'Golang' is not required in
+//! rust due to ownership model as the variable don't go out of scope until
+//! block lifetime.
+
+pub mod helpers;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -21,6 +21,7 @@
 //! block lifetime.
 
 pub mod datasources;
+pub mod fields;
 pub mod helpers;
 pub mod log;
 pub mod version;

--- a/wasmapi/rust/src/lib.rs
+++ b/wasmapi/rust/src/lib.rs
@@ -24,4 +24,5 @@ pub mod datasources;
 pub mod fields;
 pub mod helpers;
 pub mod log;
+pub mod params;
 pub mod version;

--- a/wasmapi/rust/src/log.rs
+++ b/wasmapi/rust/src/log.rs
@@ -1,0 +1,122 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::helpers::string_to_buf_ptr; //relative paths may hinder in testing.
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "gadgetLog"]
+    fn _log(level: u32, msg: u64);
+}
+
+pub enum LogLevel {
+    Error = 0,
+    Warn = 1,
+    Info = 2,
+    Debug = 3,
+    Trace = 4,
+}
+
+pub fn log(level: LogLevel, message: &str) {
+    unsafe {
+        _log(level as u32, string_to_buf_ptr(message).0);
+    }
+}
+
+// Rust doesn't support default vardiac, but similar functionality are provided by macros allow for multiple arguments
+#[macro_export]
+macro_rules! log {
+    ($level:expr, $($arg:expr),+ $(,)?) => {{
+        let message = [$($arg),+].join(" ");
+        $crate::log::log($level, &message);
+    }};
+}
+
+#[macro_export]
+macro_rules! logf {
+    ($level:expr, $fmt:literal $(, $arg:tt)* ) => {{
+        let message = format!($fmt $(, $arg)*);
+        $crate::log::log($level, &message);
+    }};
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {
+        $crate::log!($crate::log::LogLevel::Error, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! errorf {
+    ($fmt:literal $(, $arg:tt)* ) => {
+        $crate::logf!(LogLevel::Error, $fmt $(, $arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {
+        $crate::log!(LogLevel::Warn, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! warnf {
+    ($fmt:literal $(, $arg:tt)* ) => {
+        $crate::logf!(LogLevel::Warn, $fmt $(, $arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {
+        $crate::log!(LogLevel::Info, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! infof {
+    ($fmt:literal $(, $arg:tt)* ) => {
+        $crate::logf!(LogLevel::Info, $fmt $(, $arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        $crate::log!(LogLevel::Debug, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! debugf {
+    ($fmt:literal $(, $arg:tt)* ) => {
+        $crate::logf!(LogLevel::Debug, $fmt $(, $arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        $crate::log!(LogLevel::Trace, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! tracef {
+    ($fmt:literal $(, $arg:tt)* ) => {
+        $crate::logf!(LogLevel::Trace, $fmt $(, $arg)*);
+    };
+}

--- a/wasmapi/rust/src/map.rs
+++ b/wasmapi/rust/src/map.rs
@@ -1,0 +1,175 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    error,
+    helpers::{any_to_buf_ptr, string_to_buf_ptr},
+};
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "newMap"]
+    fn _map_new(name: u64, typ: u32, key_size: u32, value_size: u32, max_entries: u32) -> u32;
+    #[link_name = "getMap"]
+    fn _map_get(name: u64) -> u32;
+    #[link_name = "mapLookup"]
+    fn _map_lookup(map: u32, key_ptr: u64, value_ptr: u64) -> u32;
+    #[link_name = "mapUpdate"]
+    fn _map_update(map: u32, key_ptr: u64, value_ptr: u64, flags: u64) -> u32;
+    #[link_name = "mapDelete"]
+    fn _map_delete(map: u32, key_ptr: u64) -> u32;
+    #[link_name = "mapRelease"]
+    fn _map_release(map: u32) -> u32;
+}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum MapType {
+    Unspecified = 0,
+    Hash,
+    Array,
+    ProgramArray,
+    PerfEventArray,
+    PerCPUHash,
+    PerCPUArray,
+    StackTrace,
+    CGroupArray,
+    LRUHash,
+    LRUCPUHash,
+    LPMTrie,
+    ArrayOfMaps,
+    HashOfMaps,
+    DevMap,
+    SockMap,
+    CPUMap,
+    XSKMap,
+    SockHash,
+    CGroupStorage,
+    ReusePortSockArray,
+    PerCPUCGroupStorage,
+    Queue,
+    Stack,
+    SkStorage,
+    DevMapHash,
+    StructOpsMap,
+    RingBuf,
+    InodeStorage,
+    TaskStorage,
+    BloomFilter,
+    UserRingbuf,
+    CgroupStorage,
+    Arena,
+}
+
+pub type Result<T> = std::result::Result<T, String>;
+
+#[repr(u64)]
+#[derive(Clone, Copy)]
+pub enum MapUpdateFlags {
+    UpdateAny = 0,
+    UpdateNoExist = 1,
+    UpdateExist = 2,
+    UpdateLock = 4,
+}
+
+#[derive(Debug)]
+pub struct Map(pub u32);
+
+#[derive(Clone)]
+pub struct MapSpec {
+    pub name: String,
+    pub typ: MapType,
+    pub key_size: u32,
+    pub value_size: u32,
+    pub max_entries: u32,
+}
+
+impl Drop for Map {
+    fn drop(&mut self) {
+        let ret = unsafe { _map_release(self.0) };
+        if ret != 0 {
+            error!("Failed to release map");
+        }
+    }
+}
+
+impl Map {
+    pub fn new(spec: MapSpec) -> Result<Self> {
+        let name_ptr = string_to_buf_ptr(&spec.name);
+        let ret = unsafe {
+            _map_new(
+                name_ptr.0,
+                spec.typ as u32,
+                spec.key_size,
+                spec.value_size,
+                spec.max_entries,
+            )
+        };
+        if ret == 0 {
+            Err(format!("Failed to create map {}", spec.name))
+        } else {
+            Ok(Map(ret))
+        }
+    }
+
+    pub fn get(name: &str) -> Result<Self> {
+        let ret = unsafe { _map_get(string_to_buf_ptr(name).0) };
+        if ret == 0 {
+            Err(format!("Map {} not found", name))
+        } else {
+            Ok(Map(ret))
+        }
+    }
+    // Only allows pointers to key and value
+    pub fn lookup<T, U>(&self, key: &T, value: &mut U) -> Result<()> {
+        let key_ptr = any_to_buf_ptr(key)?;
+        let value_ptr = any_to_buf_ptr(value)?;
+
+        let ret = unsafe { _map_lookup(self.0, key_ptr.0, value_ptr.0) };
+        if ret != 0 {
+            return Err(String::from("Error looking up map"));
+        }
+        let val_len = value_ptr.0 >> 32;
+        if let Some(bytes) = value_ptr.bytes() {
+            unsafe {
+                std::ptr::copy(bytes.as_ptr(), value as *mut U as *mut u8, val_len as usize);
+            }
+        };
+        Ok(())
+    }
+
+    pub fn put<T, U>(&self, key: &T, value: &U) -> Result<()> {
+        self.update(key, value, MapUpdateFlags::UpdateAny)
+    }
+
+    pub fn update<T, U>(&self, key: &T, value: &U, flags: MapUpdateFlags) -> Result<()> {
+        let key_ptr = any_to_buf_ptr(key)?;
+        let value_ptr = any_to_buf_ptr(value)?;
+
+        let ret = unsafe { _map_update(self.0, key_ptr.0, value_ptr.0, flags as u64) };
+        if ret != 0 {
+            return Err(String::from("Failed to update map"));
+        }
+        Ok(())
+    }
+
+    pub fn delete<T>(&self, key: &T) -> Result<()> {
+        let key_ptr = any_to_buf_ptr(key)?;
+        let ret = unsafe { _map_delete(self.0, key_ptr.0) };
+        if ret != 0 {
+            return Err(String::from("Failed to delete key"));
+        }
+        Ok(())
+    }
+}

--- a/wasmapi/rust/src/params.rs
+++ b/wasmapi/rust/src/params.rs
@@ -1,0 +1,35 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::helpers::{bytes_to_buf_ptr, from_c_string, string_to_buf_ptr};
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "getParamValue"]
+    fn _get_param_value(key: u64, dst: u64) -> u32;
+}
+
+pub fn get_param_value(key: String, max_size: u64) -> Result<String, String> {
+    let dst = vec![0u8; max_size as usize];
+
+    let key_ptr = string_to_buf_ptr(&key);
+    let dst_ptr = bytes_to_buf_ptr(&dst);
+
+    let result = unsafe { _get_param_value(key_ptr.0, dst_ptr.0) };
+    if result == 1 {
+        return Err("error getting param value".to_string());
+    }
+
+    Ok(from_c_string(&dst))
+}

--- a/wasmapi/rust/src/perf.rs
+++ b/wasmapi/rust/src/perf.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::helpers::bytes_to_buf_ptr;
+use crate::map::Map;
+pub type Result<T> = std::result::Result<T, String>;
+
+#[derive(Debug, Clone)]
+pub struct PerfReader(pub u32);
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "newPerfReader"]
+    fn _perfreader_new(map_handle: u32, size: u32, is_overwritable: u32) -> u32;
+
+    #[link_name = "perfReaderPause"]
+    fn _perfreader_pause(handle: u32) -> u32;
+
+    #[link_name = "perfReaderResume"]
+    fn _perfreader_resume(handle: u32) -> u32;
+
+    #[link_name = "perfReaderRead"]
+    fn _perfreader_read(handle: u32, dst: u64) -> u32;
+
+    #[link_name = "perfReaderClose"]
+    fn _perfreader_close(handle: u32) -> u32;
+}
+
+impl Drop for PerfReader {
+    fn drop(&mut self) {
+        let ret = unsafe { _perfreader_close(self.0) };
+        if ret != 0 {
+            crate::error!("failed to close perf reader");
+        }
+    }
+}
+
+impl PerfReader {
+    pub fn new(map: Map, size: u32, is_overwritable: bool) -> Result<Self> {
+        let flag = if is_overwritable { 1 } else { 0 };
+        let handle = unsafe { _perfreader_new(map.0, size, flag) };
+        if handle == 0 {
+            Err(String::from("failed to create perf reader"))
+        } else {
+            Ok(PerfReader(handle))
+        }
+    }
+
+    pub fn pause(&self) -> Result<()> {
+        let ret = unsafe { _perfreader_pause(self.0) };
+        if ret != 0 {
+            Err(String::from("failed to pause perf reader"))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn resume(&self) -> Result<()> {
+        let ret = unsafe { _perfreader_resume(self.0) };
+        if ret != 0 {
+            Err(String::from("failed to resume perf reader"))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn read(&self, dst: &[u8]) -> Result<()> {
+        let ptr = bytes_to_buf_ptr(dst);
+        let ret = unsafe { _perfreader_read(self.0, ptr.0) };
+        match ret {
+            0 => Ok(()),
+            1 => Err(String::from("reading perf reader record")),
+            2 => Err(String::from("deadline exceeded")),
+            _ => Err(format!("bad return value: expected 0, 1 or 2, got {}", ret)),
+        }
+    }
+}

--- a/wasmapi/rust/src/syscall.rs
+++ b/wasmapi/rust/src/syscall.rs
@@ -1,0 +1,104 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::helpers::{any_to_buf_ptr_mut, bytes_to_buf_ptr, from_c_string, string_to_buf_ptr};
+
+#[link(wasm_import_module = "ig")]
+extern "C" {
+    #[link_name = "getSyscallName"]
+    fn _get_syscall_name(id: u32, dst: u64) -> u32;
+    #[link_name = "getSyscallID"]
+    fn _get_syscall_id(name: u64) -> i32;
+    #[link_name = "getSyscallDeclaration"]
+    fn _get_syscall_declaration(name: u64, pointer: u64) -> u32;
+}
+
+pub const IS_POINTER_FLAG: u32 = 1;
+pub const MAX_SYSCALL_LENGTH: usize = 64;
+
+pub type Result<T> = std::result::Result<T, String>;
+
+// Keep in sync with pkg/operators/wasm/syscalls.go
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct SyscallParamRaw {
+    name: [u8; 32],
+    flags: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct SyscallDeclarationRaw {
+    name: [u8; 32],
+    nr_params: u8,
+    _padding: [u8; 3],
+    params: [SyscallParamRaw; 6],
+}
+
+#[derive(Debug)]
+pub struct SyscallParam {
+    pub name: String,
+    pub is_pointer: bool,
+}
+
+#[derive(Debug)]
+pub struct SyscallDeclaration {
+    pub name: String,
+    pub params: Vec<SyscallParam>,
+}
+
+pub fn get_syscall_name(id: u16) -> Result<String> {
+    let dst = [0u8; MAX_SYSCALL_LENGTH];
+    let result = unsafe { _get_syscall_name(id as u32, bytes_to_buf_ptr(&dst).0 as u64) };
+
+    if result == 1 {
+        Err(format!("getting syscall name for syscall id {}", id))
+    } else {
+        Ok(from_c_string(&dst))
+    }
+}
+
+pub fn get_syscall_id(name: String) -> Result<i32> {
+    let id = unsafe { _get_syscall_id(string_to_buf_ptr(&name).0) };
+
+    if id == -1 {
+        Err(format!("getting syscall ID for syscall {}", name))
+    } else {
+        Ok(id)
+    }
+}
+
+pub fn get_syscall_declaration(name: &str) -> Result<SyscallDeclaration> {
+    let mut raw_decl = SyscallDeclarationRaw::default();
+    let buf_ptr = any_to_buf_ptr_mut(&mut raw_decl).expect("Invalid raw syscall declaration");
+    let ret = unsafe { _get_syscall_declaration(string_to_buf_ptr(name).0 as u64, buf_ptr.0) };
+
+    if ret == 1 {
+        return Err(format!("syscall declaration {} not found", name));
+    }
+
+    let syscall_name = from_c_string(&raw_decl.name);
+    let mut params = Vec::with_capacity(raw_decl.nr_params as usize);
+    for i in 0..raw_decl.nr_params as usize {
+        let raw_param = &raw_decl.params[i];
+        params.push(SyscallParam {
+            name: from_c_string(&raw_param.name),
+            is_pointer: (raw_param.flags & IS_POINTER_FLAG) != 0,
+        });
+    }
+
+    Ok(SyscallDeclaration {
+        name: syscall_name,
+        params,
+    })
+}

--- a/wasmapi/rust/src/version.rs
+++ b/wasmapi/rust/src/version.rs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! "api" crate contains the reference implementation of the wasm API for Inspektor
-//! Gadget. It's designed to be used by gadgets and not by any other internal
-//! component of Inspektor Gadget.
-
-//! A similar function to runtime.keepAlive() in 'Golang' is not required in
-//! rust due to ownership model as the variable don't go out of scope until
-//! block lifetime.
-
-pub mod helpers;
-pub mod version;
+#[no_mangle]
+#[allow(non_snake_case)]
+pub fn gadgetAPIVersion() -> u64 {
+    1
+}


### PR DESCRIPTION
**Allowing users to use rust wasm modules in `ig` using wasm bindings**
A package which have rust wrapped WASM APIs allows users to use different modules to write wasm supported code.

It currently only has log and datasources bindings, as they are manually tested. Other bindings will be added shortly.  

**Testing**
Automatic testing needs to done for that, I am searching codebase for test support.
