### PR TITLE
gadget audit_seccomp: add user stacks

### DIFF
--- a/gadgets/audit_seccomp/README.mdx
+++ b/gadgets/audit_seccomp/README.mdx
@@ -164,6 +164,43 @@ test-audit-seccomp    unshare            485888      485888         …_KILL_THR
 </TabItem>
 </Tabs>
 
+In the previous examples, it is straightforward why the application is
+performing the syscall. The unshare program executes the unshare syscall and
+the mkdir program executes the mkdir syscall. For bigger applications, it can
+be useful to show the user stack trace.
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+
+```bash
+$ kubectl gadget run audit_seccomp:%IG_TAG% --collect-ustack -o jsonpretty
+...
+  "ustack": {
+    "addresses": "[0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e; [3]0x000000000048250b; [4]0x00000000004829ae; [5]0x0000000000482a7e; [6]0x0000000000482afe; [7]0x0000000000482b7e; [8]0x0000000000435a9d; [9]0x00000000004625a1; ",
+    ...
+    "symbols": "[0]runtime/internal/syscall.Syscall6; [1]syscall.Syscall; [2]syscall.Syscall.abi0; [3]golang.org/x/sys/unix.Chroot; [4]main.level3; [5]main.level2; [6]main.level1; [7]main.main; [8]runtime.main; [9]runtime.goexit.abi0; "
+  }
+^C
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+
+```bash
+$ sudo -E ig run audit_seccomp:%IG_TAG% --collect-ustack -o jsonpretty
+...
+  "ustack": {
+    "addresses": "[0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e; [3]0x000000000048250b; [4]0x00000000004829ae; [5]0x0000000000482a7e; [6]0x0000000000482afe; [7]0x0000000000482b7e; [8]0x0000000000435a9d; [9]0x00000000004625a1; ",
+    ...
+    "symbols": "[0]runtime/internal/syscall.Syscall6; [1]syscall.Syscall; [2]syscall.Syscall.abi0; [3]golang.org/x/sys/unix.Chroot; [4]main.level3; [5]main.level2; [6]main.level1; [7]main.main; [8]runtime.main; [9]runtime.goexit.abi0; "
+  }
+^C
+```
+
+</TabItem>
+</Tabs>
+
 Finally, clean the system:
 
 <Tabs groupId="env">

--- a/gadgets/audit_seccomp/gadget.yaml
+++ b/gadgets/audit_seccomp/gadget.yaml
@@ -17,3 +17,22 @@ datasources:
           description: Seccomp return code
           columns.width: 20
           columns.ellipsis: start
+      ustack:
+        annotations:
+          columns.hidden: true
+      ustack.addresses:
+        annotations:
+          description: User stack's addresses
+          columns.hidden: true
+          columns.width: 20
+      ustack.symbols:
+        annotations:
+          description: User stack's symbols
+          columns.hidden: true
+          columns.width: 20
+params:
+  ebpf:
+    collect_ustack:
+      key: collect-ustack
+      defaultValue: "false"
+      description: Collect user stack traces


### PR DESCRIPTION
# gadget audit_seccomp: add user stacks

This is done in the same way as other gadgets:
- trace_capabilities
- trace_malloc
- trace_open

## How to use

Documentation added in the PR.

## Testing done

I used the following `profile.json`:
```json
{
   "defaultAction" : "SCMP_ACT_ALLOW",
   "syscalls" : [
      {
         "action" : "SCMP_ACT_KILL",
         "names" : [
            "unshare",
            "chroot"
         ]
      }
   ]
}
```
And the following Go program:
```go
package main

import (
        "fmt"
        "time"
        "unsafe"

        "golang.org/x/sys/unix"
)

func level3() {
        fmt.Printf("level3: %v\n", level3)
        err := unix.Chroot("/")
        fmt.Printf("chroot: err=%v\n", err)
}

func level2() {
        fmt.Printf("level2: %v\n", level2)
        level3()
}

func level1() {
        fmt.Printf("level1: %v\n", level1)
        level2()
}

func main() {
        fmt.Printf("main: %v\n", main)
        level1()
        time.Sleep(time.Second)
}
```
With the following command:
```
docker run --name test-audit-seccomp -v $PWD:/host -ti --rm --security-opt seccomp=/tmp/profile.json   busybox /bin/sh -c 'while true ; do /host/gochr-dyn & sleep 2 ; done'
```
And the following IG command:
```
sudo -E ./ig run audit_seccomp:alban_audit_seccomp_with_stack --verify-image=false --collect-ustack -o jsonpretty
```