### PR TITLE
inspect: adds command to kubectl-gadget

### DIFF
--- a/cmd/common/image/image.go
+++ b/cmd/common/image/image.go
@@ -20,12 +20,21 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
 )
 
-func NewImageCmd(r runtime.Runtime) *cobra.Command {
+func NewImageCmd(r runtime.Runtime, addCommands []*cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Manage gadget images",
 	}
 
+	// add only specific subcommands (only grpc-supported commands in case of gadgetctl/kubectl-gadget)
+	if addCommands != nil {
+		for _, c := range addCommands {
+			cmd.AddCommand(c)
+		}
+		return cmd
+	}
+
+	// add all subcommands if not specified (in case of ig)
 	cmd.AddCommand(NewBuildCmd())
 	cmd.AddCommand(NewExportCmd())
 	cmd.AddCommand(NewImportCmd())

--- a/cmd/gadgetctl/main.go
+++ b/cmd/gadgetctl/main.go
@@ -97,6 +97,11 @@ func main() {
 		log.Fatalf("setting runtime flags from config: %v", err)
 	}
 
+	// add image subcommands to be added, for now only inspect is supported
+	imgCommands := []*cobra.Command{
+		image.NewInspectCmd(runtime),
+	}
+
 	hiddenColumnTags := []string{"kubernetes"}
 	common.AddCommandsFromRegistry(rootCmd, runtime, hiddenColumnTags)
 
@@ -105,7 +110,7 @@ func main() {
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags, common.CommandModeRun))
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags, common.CommandModeAttach))
 	rootCmd.AddCommand(common.NewConfigCmd(runtime, rootFlags))
-	rootCmd.AddCommand(image.NewImageCmd(runtime))
+	rootCmd.AddCommand(image.NewImageCmd(runtime, imgCommands))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	rootCmd.AddCommand(newDaemonCommand(runtime))
 	rootCmd.AddCommand(common.NewLoginCmd())
-	rootCmd.AddCommand(image.NewImageCmd(runtime))
+	rootCmd.AddCommand(image.NewImageCmd(runtime, nil))
 	rootCmd.AddCommand(common.NewLogoutCmd())
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags, common.CommandModeRun))
 	rootCmd.AddCommand(common.NewConfigCmd(runtime, rootFlags))

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -26,6 +26,7 @@ import (
 	paramsPkg "github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	img "github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/advise"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
@@ -153,6 +154,11 @@ func main() {
 		log.Warnf(err.Error())
 	}
 
+	// add image subcommands to be added, for now only inspect is supported
+	imgCommands := []*cobra.Command{
+		img.NewInspectCmd(grpcRuntime),
+	}
+
 	gadgetNamespace := runtimeGlobalParams.Get(grpcruntime.ParamGadgetNamespace).AsString()
 
 	hiddenColumnTags := []string{"runtime"}
@@ -167,6 +173,7 @@ func main() {
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, grpcRuntime, hiddenColumnTags, common.CommandModeRun))
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, grpcRuntime, hiddenColumnTags, common.CommandModeAttach))
 	rootCmd.AddCommand(common.NewConfigCmd(grpcRuntime, rootFlags))
+	rootCmd.AddCommand(img.NewImageCmd(grpcRuntime, imgCommands))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## Changes
- extends the `NewImageCmd` to receive the new 'addCommands' param which can be used to add image commands optionally in `gadgetctl/kubectl-gadget` (only commands that are grpc-supported)
- adds inspect command in `kubectl-gadget`


Part of #3387 