### PR TITLE
gadget-service: improve logging of headless gadget instances

### DIFF
--- a/pkg/gadget-service/instance-manager/log.go
+++ b/pkg/gadget-service/instance-manager/log.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instancemanager
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+type logWrapper struct {
+	*log.Entry
+	logLevel logger.Level
+}
+
+func (w *logWrapper) SetLevel(level logger.Level) {
+	w.logLevel = level
+}
+
+func (w *logWrapper) GetLevel() logger.Level {
+	return w.logLevel
+}

--- a/pkg/gadget-service/instance-manager/manager.go
+++ b/pkg/gadget-service/instance-manager/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,7 +119,15 @@ func (m *Manager) RunGadget(instance *api.GadgetInstance) {
 	m.mu.Unlock()
 	go func() {
 		defer cancel()
-		err := gi.Run(ctx, m.runtime, logger.DefaultLogger())
+		l := log.StandardLogger()
+		l.SetFormatter(&log.JSONFormatter{})
+		lwr := &logWrapper{Entry: l.WithFields(log.Fields{
+			"type":         "gadget-log",
+			"instanceID":   instance.Id,
+			"instanceName": instance.Name,
+			"gadget":       instance.GadgetConfig.ImageName,
+		}), logLevel: logger.Level(instance.GadgetConfig.LogLevel)}
+		err := gi.Run(ctx, m.runtime, lwr)
 		if err != nil {
 			log.Errorf("running gadget: %v", err)
 			gi.mu.Lock()


### PR DESCRIPTION
This changes the output format of gadget logs to JSON and adds the fields "instanceID", "instanceName" and "gadget" to make them easier to digest for existing postprocessing pipelines. This doesn't change the way the non-gadget logging is handled, so that will still be in plain-text and should probably be adjusted later on as well.

Example output:

```json
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"found image op \"ebpf\"","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"populating map \"gadget_mntns_filter_map\"","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"variable \"gadget_filter_by_mntns\" bool Var:\"gadget_filter_by_mntns\":4006870ac0[global]","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"adding param \"targ_pid\" (uint32)","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"adding param \"targ_tid\" (uint32)","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"adding param \"targ_uid\" (uint32)","time":"2025-04-10T12:31:55+02:00"}
{"gadget":"trace_exec:main","instanceID":"3c27a1c3f8c20d0d3684ada14e06624c","instanceName":"zealous_khorana","level":"debug","msg":"adding param \"targ_gid\" (uint32)","time":"2025-04-10T12:31:55+02:00"}
```

Fixes #4240