### PR TITLE
ig(UX): add aliases for image list (ls) and remove (rm)

### DIFF
--- a/cmd/common/image/list.go
+++ b/cmd/common/image/list.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ func NewListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:          "list",
+		Aliases:      []string{"ls"},
 		Short:        "List gadget images on the host",
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,

--- a/cmd/common/image/remove.go
+++ b/cmd/common/image/remove.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 func NewRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "remove IMAGE",
+		Aliases:      []string{"rm"},
 		Short:        "Remove local gadget image",
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),


### PR DESCRIPTION
I'm used to calling the shorter aliases on Docker, this makes them also available on ig.

Before:
```bash
$ sudo ./ig image ls
Manage gadget images

Usage:
  ig image [command]

Available Commands:
  build       Build a gadget image
  export      Export the SRC_IMAGE images to DST_FILE
  import      Import images from SRC_FILE
  inspect     Inspect a gadget image
  list        List gadget images on the host
  pull        Pull the specified image from a remote registry
  push        Push the specified image to a remote registry
  remove      Remove local gadget image
  tag         Tag the local SRC_IMAGE image with the DST_IMAGE
...
```

After:
```bash
$ sudo ./ig image ls
REPOSITORY                                                                   TAG                                                                         DIGEST       CREATED
albantest.azurecr.io/trace_udns                                              t1                                                                          4f62df72aa95 11 months ago
docker.io/library/mygadget                                                   latest                                                                      5ff7f30b278a
docker.io/library/trace_open                                                 latest                                                                      04996d3e0a37
docker.io/library/trace_open                                                 latest2                                                                     04996d3e0a37
ghcr.io/alban/asg2024/gotls                                                  latest                                                                      f08eebe2d2c3 6 months ago
...
```