### PR TITLE
ci: Move the website build check higher

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -53,13 +53,6 @@ jobs:
       run: |
         make manifests generate generate-documentation
         git diff --exit-code HEAD --
-    - name: Check that there are not broken links
-      uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
-      with:
-        config-file: .github/workflows/mlc_config.json
-        use-quiet-mode: 'yes'
-        check-modified-files-only: 'yes'
-        base-branch: 'main'
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       id: filter
       with:
@@ -78,6 +71,13 @@ jobs:
         git clone https://github.com/inspektor-gadget/website/
         cd website
         IG_DOCS=$GITHUB_WORKSPACE/inspektor-gadget/docs make docs && npm install && npm run build
+    - name: Check that there are not broken links
+      uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+      with:
+        config-file: .github/workflows/mlc_config.json
+        use-quiet-mode: 'yes'
+        check-modified-files-only: 'yes'
+        base-branch: 'main'
 
   actionlint:
     name: Lint GitHub Actions workflows


### PR DESCRIPTION
Currently if we introduce a new documentation page we don't check if it will break the webiste build because the link check step fails with 404 for that page. This change reorders the checks to ensure we always check if a page will break website build to avoid issues like: https://github.com/inspektor-gadget/inspektor-gadget/pull/4325

Ref: https://github.com/inspektor-gadget/inspektor-gadget/pull/4325#issuecomment-2797328660