### PR TITLE
wasmapi: improve error messages

### DIFF
--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ func (ds DataSource) NewPacketArray() (PacketArray, error) {
 func (ds DataSource) EmitAndRelease(packet Packet) error {
 	ret := dataSourceEmitAndRelease(uint32(ds), uint32(packet))
 	if ret != 0 {
-		return fmt.Errorf("emitting data")
+		return errors.New("emitting data")
 	}
 	return nil
 }

--- a/wasmapi/go/fields.go
+++ b/wasmapi/go/fields.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"runtime"
 	"unsafe"
@@ -198,7 +199,7 @@ func (f Field) AddTag(tag string) error {
 	ret := fieldAddTag(uint32(f), uint64(stringToBufPtr(tag)))
 	runtime.KeepAlive(tag)
 	if ret != 0 {
-		return errors.New("error adding tag")
+		return fmt.Errorf("error adding tag %q in field handle %d", tag, f)
 	}
 	return nil
 }

--- a/wasmapi/go/handle.go
+++ b/wasmapi/go/handle.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"errors"
+	"fmt"
 	_ "unsafe"
 )
 
@@ -26,7 +26,7 @@ func releaseHandle(handle uint32) uint32
 func ReleaseHandle[T ~uint32](handle T) error {
 	ret := releaseHandle(uint32(handle))
 	if ret != 0 {
-		return errors.New("error releasing handle")
+		return errors.New("error releasing handle %d", uint32(handle))
 	}
 	return nil
 }

--- a/wasmapi/go/map.go
+++ b/wasmapi/go/map.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -145,7 +144,7 @@ func (m Map) Lookup(key any, value any) error {
 	runtime.KeepAlive(key)
 	runtime.KeepAlive(value)
 	if ret != 0 {
-		return errors.New("looking up map")
+		return fmt.Errorf("looking up key %v in map handle %d", key, m)
 	}
 
 	v := reflect.ValueOf(value)
@@ -173,7 +172,7 @@ func (m Map) Update(key any, value any, flags MapUpdateFlags) error {
 	runtime.KeepAlive(key)
 	runtime.KeepAlive(value)
 	if ret != 0 {
-		return errors.New("updating value in map")
+		return fmt.Errorf("updating value in map handle %d", m)
 	}
 	return nil
 }
@@ -187,7 +186,7 @@ func (m Map) Delete(key any) error {
 	ret := mapDelete(uint32(m), uint64(keyPtr))
 	runtime.KeepAlive(key)
 	if ret != 0 {
-		return errors.New("deleting value in map")
+		return fmt.Errorf("deleting value in map handle %d", m)
 	}
 	return nil
 }
@@ -195,7 +194,7 @@ func (m Map) Delete(key any) error {
 func (m Map) Close() error {
 	ret := mapRelease(uint32(m))
 	if ret != 0 {
-		return errors.New("closing map")
+		return fmt.Errorf("closing map handle %d", m)
 	}
 	return nil
 }

--- a/wasmapi/go/params.go
+++ b/wasmapi/go/params.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"errors"
+	"fmt"
 	_ "unsafe"
 )
 
@@ -29,7 +29,7 @@ func GetParamValue(key string, maxSize uint64) (string, error) {
 	k := uint64(stringToBufPtr(key))
 	ret := getParamValue(k, uint64(bytesToBufPtr(dst)))
 	if ret == 1 {
-		return "", errors.New("error getting param value")
+		return "", fmt.Errorf("getting param value %q", key)
 	}
 
 	return fromCString(dst), nil

--- a/wasmapi/go/perf.go
+++ b/wasmapi/go/perf.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	_ "unsafe"
@@ -51,7 +50,7 @@ func NewPerfReader(m Map, size uint32, isOverwritable bool) (PerfReader, error) 
 
 	ret := newPerfReader(uint32(m), size, isOverwritableUint32)
 	if ret == 0 {
-		return 0, errors.New("creating perf reader")
+		return 0, fmt.Errorf("creating perf reader for map handle %d", m)
 	}
 
 	return PerfReader(ret), nil
@@ -60,7 +59,7 @@ func NewPerfReader(m Map, size uint32, isOverwritable bool) (PerfReader, error) 
 func (p PerfReader) Pause() error {
 	ret := perfReaderPause(uint32(p))
 	if ret != 0 {
-		return errors.New("pausing perf reader")
+		return fmt.Errorf("pausing perf reader handle %d", p)
 	}
 
 	return nil
@@ -69,7 +68,7 @@ func (p PerfReader) Pause() error {
 func (p PerfReader) Resume() error {
 	ret := perfReaderResume(uint32(p))
 	if ret != 0 {
-		return errors.New("resuming perf reader")
+		return fmt.Errorf("resuming perf reader handle %d", p)
 	}
 
 	return nil
@@ -81,18 +80,18 @@ func (p PerfReader) Read(dst []byte) error {
 	case 0:
 		return nil
 	case 1:
-		return errors.New("reading perf reader record")
+		return fmt.Printf("reading perf reader record from perf reader handle %d", p)
 	case 2:
 		return os.ErrDeadlineExceeded
 	default:
-		return fmt.Errorf("bad return value: expected 0, 1 or 2, got %d", ret)
+		return fmt.Errorf("bad return value from perfReaderRead: expected 0, 1 or 2, got %d", ret)
 	}
 }
 
 func (p PerfReader) Close() error {
 	ret := perfReaderClose(uint32(p))
 	if ret != 0 {
-		return errors.New("closing perf reader")
+		return fmt.Errorf("closing perf reader handle %d", p)
 	}
 
 	return nil


### PR DESCRIPTION
Before this patch, a gadget could fail with this error:
```
ERRO[0003] failed to get param value: error getting param value
Error running application: running gadget: starting operators: starting operator "oci": pre-starting operator "wasm": gadgetPreStart failed
```

The wasmapi has a lot of error messages that don't give much context. This patch adds a bit more context in the error messages.
