### PR TITLE
trace_capabilities: fix use of uninitialized variable

### DIFF
--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -171,7 +171,6 @@ SEC("kprobe/cap_capable")
 int BPF_KPROBE(ig_trace_cap_e, const struct cred *cred,
 	       struct user_namespace *targ_ns, int cap, int cap_opt)
 {
-	u64 mntns_id;
 	__u64 pid_tgid;
 	struct task_struct *task;
 
@@ -203,7 +202,7 @@ int BPF_KPROBE(ig_trace_cap_e, const struct cred *cred,
 	if (unique) {
 		struct unique_key key = {
 			.cap = cap,
-			.mntns_id = mntns_id,
+			.mntns_id = gadget_get_current_mntns_id(),
 		};
 
 		if (bpf_map_lookup_elem(&seen, &key) != NULL) {


### PR DESCRIPTION
The variable mntns_id is used without initialization. The bug was introduced after refactoring filters.

Compiler warnings:
```
/work/gadgets/trace_capabilities/program.bpf.c:206:16: warning: variable 'mntns_id' is uninitialized when used here [-Wuninitialized]
  206 |                         .mntns_id = mntns_id,
      |                                     ^~~~~~~~
/work/gadgets/trace_capabilities/program.bpf.c:174:14: note: initialize the variable 'mntns_id' to silence this warning
  174 |         u64 mntns_id;
      |                     ^
      |                      = 0
```

Compiler warnings were not printed because of #4343.

Fixes 728b2eb59aa8 ("gadgets: Use filter helpers from last commit")

## How to use

No changes.

## Testing done

Test workload:
```
for i in `seq 20` ; do docker run -d --env i=$i --privileged ubuntu sh -c "sleep 5 ; cp /usr/sbin/chroot /usr/sbin/chroot$i ; chroot$i / sleep 20" ; done
```
The 20 containers run concurrently, so mount namespace ids are not reused.

IG command:
```
sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_cap_unique --verify-image=false --unique --filter runtime.containerImageName=ubuntu
```
Checking the content of the "seen" map:
```
sudo bpftool map dump name seen
```

**Before this patch:**
* The map contains garbage. Example:
```json
    {
        "key": {
            "cap": 2,
            "mntns_id": 5
        },
        "value": 0
    }
```
* The IG output misses some entry. Example:
```
$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:main --verify-image=false --unique --filter runtime.containerImageName=ubuntu
WARN[0001] image signature verification is disabled due to using corresponding option 
WARN[0002] image signature verification is disabled due to using corresponding option 
RUNTIME.CONTAINERNAME                         COMM                    PID        TID CAPA… AUDIT       CAP                      SYSCALL                       
cool_yalow                                    chroot1              548256     548256 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
admiring_kare                                 chroot2              548306     548306 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
vibrant_grothendieck                          chroot3              548367     548367 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
mystifying_saha                               chroot4              548445     548445 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
admiring_ritchie                              chroot5              548564     548564 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
sharp_hypatia                                 chroot6              548636     548636 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
hopeful_grothendieck                          chroot7              548697     548697 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
keen_gagarin                                  chroot10             548708     548708 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
laughing_hofstadter                           chroot11             548720     548720 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
suspicious_lovelace                           chroot13             548753     548753 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
musing_austin                                 chroot14             548756     548756 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
focused_hermann                               chroot16             548760     548760 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
relaxed_jackson                               chroot17             548762     548762 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
hopeful_kapitsa                               chroot18             548815     548815 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
vibrant_robinson                              chroot20             548819     548819 true  1           CAP_SYS_CHROOT           SYS_CHROOT
```

**After this patch:**
* The map contains valid data
* The IG output contains all 20 entries.
```
$ sudo ./ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_cap_unique --verify-image=false --unique --filter runtime.containerImageName=ubuntu
WARN[0001] image signature verification is disabled due to using corresponding option 
WARN[0002] image signature verification is disabled due to using corresponding option 
RUNTIME.CONTAINERNAME                         COMM                    PID        TID CAPA… AUDIT       CAP                      SYSCALL                       
infallible_diffie                             chroot1              551981     551981 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
quizzical_poitras                             chroot2              552053     552053 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
frosty_mayer                                  chroot3              552136     552136 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
kind_bhaskara                                 chroot4              552230     552230 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
elated_swirles                                chroot5              552293     552293 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
funny_shaw                                    chroot6              552361     552361 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
serene_meitner                                chroot7              552439     552439 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
festive_greider                               chroot8              552452     552452 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
youthful_lovelace                             chroot9              552468     552468 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
elastic_ride                                  chroot10             552506     552506 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
pensive_swanson                               chroot11             552509     552509 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
stupefied_knuth                               chroot12             552513     552513 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
dreamy_poitras                                chroot13             552523     552523 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
modest_feistel                                chroot14             552533     552533 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
elegant_hawking                               chroot15             552546     552546 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
condescending_snyder                          chroot16             552548     552548 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
pensive_williamson                            chroot17             552567     552567 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
strange_lalande                               chroot18             552569     552569 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
elegant_bhaskara                              chroot19             552571     552571 true  1           CAP_SYS_CHROOT           SYS_CHROOT                    
compassionate_chebyshev                       chroot20             552573     552573 true  1           CAP_SYS_CHROOT           SYS_CHROOT
```