### PR TITLE
trace_dns: Handling warning during build

### DIFF
--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -281,13 +281,13 @@ int ig_trace_dns(struct __sk_buff *skb)
 		return 0;
 
 	// Calculate the DNS offset in the packet
+	struct tcphdr tcph;
 	switch (proto) {
 	case IPPROTO_UDP:
 		dns_off = l4_off + sizeof(struct udphdr);
 		break;
 	case IPPROTO_TCP:
 		// This is best effort, since we don't reassemble TCP segments.
-		struct tcphdr tcph;
 		if (bpf_skb_load_bytes(skb, l4_off, &tcph, sizeof tcph))
 			return 0;
 


### PR DESCRIPTION
Currently when build dns gadget I see following warning

```
$ export GADGET_BUILD_PARAMS=--verbose
$ make -C gadgets IG=$PWD/ig trace_dns
make: Entering directory '/home/qasim/work/cloud/github.com/inspektor-gadget/inspektor-gadget/gadgets'
Building trace_dns
Pulling builder image ghcr.io/inspektor-gadget/gadget-builder:main
main: Pulling from inspektor-gadget/gadget-builder
...
/work/gadgets/trace_dns/program.bpf.c:290:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  290 |                 struct tcphdr tcph;
      |                 ^
/work/gadgets/trace_dns/program.bpf.c:290:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  290 |                 struct tcphdr tcph;
      |                 ^

...
```

After this change we don't see the warning when building dns gadget. 

Fixes: e5ce66a63ee0135d214499d67b4098b10e9679a6

