### PR TITLE
inspect: improves utility and command ux

### DIFF
--- a/cmd/common/utils/flags.go
+++ b/cmd/common/utils/flags.go
@@ -34,7 +34,6 @@ const (
 	OutputModeJSON       = "json"
 	OutputModeJSONPretty = "jsonpretty"
 	OutputModeYAML       = "yaml"
-	OutputModeCustom     = "custom"
 )
 
 var SupportedOutputModes = []string{OutputModeJSON, OutputModeColumns}

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,8 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,11 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
 github.com/Microsoft/hcsshim v0.12.9/go.mod h1:fJ0gkFAna6ukt0bLdKB8djt4XIJhF/vEPuoIWYVvZ8Y=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
## Changes

Currently, the output of `image inspect` command is very large and difficult to directly comprehend.
This PR adds improved formatting options to the command and improves the UX.

## How to use

```bash
$ sudo ./ig image inspect trace_dns:latest --extra-info="ebpf.programs" --jsonpath="[0].Section" 
[
  "socket1"
]

$ sudo ./ig image inspect trace_dns:latest --extra-info="ebpf.sections" --jsonpath="[2]" 
[
  ".text"
]

$ sudo ./ig image inspect trace_dns:latest --extra-info="ebpf.flowchart" --jsonpath="[1]"
Error: extra info "ebpf.flowchart" is not JSON
```

Part of #3387 