### PR TITLE
ci: Automatically update the latest tag on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Inspektor Gadget Release
+env:
+  REGISTRY: ghcr.io
 on:
   release:
     types: [published]
@@ -14,6 +16,7 @@ jobs:
       # https://github.com/peter-evans/create-pull-request#token
       contents: write
       pull-requests: write
+      packages: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Update new version in krew-index
@@ -82,3 +85,15 @@ jobs:
           In case of problems, please check the logs in the [Artifact Hub control panel](https://artifacthub.io/control-panel).
 
           Best regards.
+    - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+    - name: Update latest tag
+      env:
+        IMAGE_TAG: ${{ github.event.release.tag_name }}
+        GADGET_TAG: ${{ github.event.release.tag_name }}
+      run:
+        make update-latest-tag

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -12,6 +12,7 @@ IG_RUNTIME ?= docker
 IG_FLAGS ?=
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
+CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
 
@@ -101,7 +102,7 @@ $(GADGETS_README_DEV):
 		echo "Creating $@"; \
 		touch $@; \
 	fi
-	@# Update dev.md with mermaid diagrams. 
+	@# Update dev.md with mermaid diagrams.
 	echo -e "# Developer Notes\n\nThis file complements the README file with implementation details specific to this gadget. It includes diagrams that illustrate how eBPF programs interact with eBPF maps. These visualizations help clarify the internal data flow and logic, making it easier to understand, maintain, and extend the gadget." > "$@"; \
 	echo -e "\n## Program-Map interactions\n\nThe following diagrams are generated using the \`ig image inspect\` command. Note they are a best-effort representation of the actual interactions, as they do not account for conditionals in the code that may prevent certain program–map interactions from occurring at runtime." >> "$@"
 	echo -e "\n### Flowchart\n\n\`\`\`mermaid" >> "$@"
@@ -212,3 +213,10 @@ test-local: test-integration
 .PHONY:
 test-k8s: IG_PATH=$(KUBECTL_GADGET)
 test-k8s: test-integration
+
+.PHONY:
+%-update-latest-tag:
+	$(CRANE) copy $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(GADGET_REPOSITORY)/$*:latest
+
+.PHONY:
+update-latest-tag: $(addsuffix -update-latest-tag,$(GADGETS))


### PR DESCRIPTION
This commit adds logic to update the latest tag for the container images to point to the latest release.

Fixes #4049

### Testing 

I did a release test on my fork: https://github.com/mauriciovasquezbernal/inspektor-gadget/actions/runs/14651783727/job/41119058541

`latest` and `v0.100.0` point to the same digest:

```bash 
$ docker pull ghcr.io/mauriciovasquezbernal/inspektor-gadget:v0.100.0
v0.100.0: Pulling from mauriciovasquezbernal/inspektor-gadget
Digest: sha256:e072440047636d2588a14b2038c6c632174a30c6135ccc528c5bb4acd8d5fd33
Status: Image is up to date for ghcr.io/mauriciovasquezbernal/inspektor-gadget:v0.100.0
ghcr.io/mauriciovasquezbernal/inspektor-gadget:v0.100.0

$ docker pull ghcr.io/mauriciovasquezbernal/inspektor-gadget:latest
latest: Pulling from mauriciovasquezbernal/inspektor-gadget
Digest: sha256:e072440047636d2588a14b2038c6c632174a30c6135ccc528c5bb4acd8d5fd33
Status: Image is up to date for ghcr.io/mauriciovasquezbernal/inspektor-gadget:latest
ghcr.io/mauriciovasquezbernal/inspektor-gadget:latest
```