### PR TITLE
GadgetContext: Close local operators after remote operators are all closed

### DIFF
--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -69,6 +69,7 @@ type GadgetContext struct {
 	lock             sync.Mutex
 	dataSources      map[string]datasource.DataSource
 	dataOperators    []operators.DataOperator
+	localOperators   []operators.DataOperatorInstance
 	vars             map[string]any
 	params           []*api.Param
 	prepareCallbacks []func()
@@ -374,25 +375,18 @@ func (c *GadgetContext) LoadGadgetInfo(info *api.GadgetInfo, paramValues api.Par
 		c.SetVar("config", v)
 	}
 
-	// After loading gadget info, start local operators as well
-	localOperators, err := c.initAndPrepareOperators(paramValues)
+	var err error
+	// After loading gadget info, get local operators params as well
+	c.localOperators, err = c.initAndPrepareOperators(paramValues)
 	if err != nil {
 		return fmt.Errorf("initializing local operators: %w", err)
 	}
 
 	if run {
-		if err := c.start(localOperators); err != nil {
+		if err := c.start(c.localOperators); err != nil {
 			return fmt.Errorf("starting local operators: %w", err)
 		}
-
 		c.Logger().Debugf("running...")
-
-		go func() {
-			// TODO: Client shouldn't need to wait for the timeout. It should be
-			// managed only on the server side.
-			WaitForTimeoutOrDone(c)
-			c.stop(localOperators)
-		}()
 	}
 
 	if c.ExtraInfo() && extraInfo != nil {
@@ -410,6 +404,14 @@ func (c *GadgetContext) LoadGadgetInfo(info *api.GadgetInfo, paramValues api.Par
 		}
 	}
 	return nil
+}
+
+func (c *GadgetContext) StopLocalOperators() {
+	if c.localOperators == nil {
+		return
+	}
+	c.stop(c.localOperators)
+	c.localOperators = nil
 }
 
 func (c *GadgetContext) OrasTarget() oras.ReadOnlyTarget {

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -123,6 +123,9 @@ func (r *Runtime) runGadgetOnTargets(
 	}
 
 	wg.Wait()
+	// Stop local operators after all remote targets
+	// have stopped their operators and "returned"
+	gadgetCtx.StopLocalOperators()
 	return results, results.Err()
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -59,6 +59,7 @@ type GadgetContext interface {
 	GetVar(string) (any, bool)
 	SerializeGadgetInfo(requestExtraInfo bool) (*api.GadgetInfo, error)
 	LoadGadgetInfo(info *api.GadgetInfo, paramValues api.ParamValues, run bool, extraInfo *api.ExtraInfo) error
+	StopLocalOperators()
 	Params() []*api.Param
 	SetMetadata([]byte)
 	SetParams([]*api.Param)


### PR DESCRIPTION
Before this PR both code paths listened on the same channel. So when a Ctrl+C comes in we do the two things in parallel:
1. Close all operators on the client side
2. Notify server side to close all operators

As an example problems always occur when one is using the `ebpf.map.flush-on-stop` annotation:
1. We are closing all operators on the client side. This is almost guaranteed to execute first and faster (no grpc communication, etc..)
2. We are notifying the server side that the gadget should stop
3. `ebpf.map.flush-on-stop` is seen and the map and events are flushed now to the client
4. Events are received by the client, but all operators are already stopped -> No further processing is done
5. The local CLI operator is still printing these though, since it doesn't do anything in its `.Stop()`

For the use case of `advise networkpolicy` I rely on the local operator `Combiner` and if that is Stopped, it doesn't process any events anymore (unlike the local CLI operator)

This PR changes the behavior to be the following way:
1. Notify server side to close all operators
2. Wait till all servers seized their operations
3. Close the local operators