### PR TITLE
Document filter quoting

### DIFF
--- a/docs/reference/manifests.mdx
+++ b/docs/reference/manifests.mdx
@@ -83,6 +83,7 @@ image: trace_exec
 name: my-gadget-1
 paramValues:
   operator.LocalManager.host: true
+  operator.filter.filter: 'proc.comm~^ba.*$'
 tags:
   - mytag1
   - mytag2

--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -142,6 +142,16 @@ The filter syntax supports the following operations:
 - `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 ```
 
+:::info
+
+It's recommended to wrap the **entire** filter expression with single quotes when using filters containing special characters to avoid unexpected behavior:
+
+```bash
+--filter 'proc.comm~^ba.*$'
+```
+
+:::
+
 #### Examples
 
 **Equal filter**: To filter events where the `comm` field equals `cat`, use:

--- a/docs/spec/operators/filter.md
+++ b/docs/spec/operators/filter.md
@@ -30,6 +30,24 @@ The filter syntax supports the following operations:
 - `field<value`: Matches if the content of `field` is less than `value`.
 - `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 
+:::info
+
+It's recommended to wrap the **entire** filter expression with single quotes when using filters containing special characters to avoid unexpected behavior.
+
+[CLI](../../reference/run.mdx) example:
+
+```bash
+--filter 'proc.comm~^ba.*$'
+```
+
+[Gadget instance manifest](../../reference/manifests.mdx) example:
+
+```yaml
+operator.filter.filter: 'proc.comm~^ba.*$'
+```
+
+:::
+
 Fully qualified name: `operator.filter.filter`
 
 ### multiple filters


### PR DESCRIPTION
# Document filter quoting

When specifying filters which contain special characters either on a shell or in a YAML document, it's easy to run into quoting issues. For example, specifying proc.comm~'^bash$' in a YAML document results in the single quotes being passed down to IG which in turn causes unexpected filtering behavior in user space.

## How to use

Ensure the content makes sense and the docs are rendered correctly.

## Testing done

I ran

```
make docs
npm install docusaurus
npm run dev
```

under https://github.com/inspektor-gadget/website and ensured the documents render fine.