### PR TITLE
Unit Tests for Trace Capabilities Gadget

### DIFF
--- a/gadgets/trace_capabilities/test/unit/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/unit/trace_capabilities_test.go
@@ -1,0 +1,189 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type ExpectedTraceCapabilitiesEvent struct {
+	Proc          utils.Process
+	Cap           string `json:"cap"`
+	Audit         uint32 `json:"audit"`
+	Syscall       string `json:"syscall"`
+	CurrentUserNs uint64 `json:"current_userns"`
+	TargetUserNs  uint64 `json:"target_userns"`
+	Insetid       uint32 `json:"insetid"`
+}
+
+type testDef struct {
+	name                string
+	generateEvent       func()
+	requestedPermission string
+	syscall             string
+	insetId             uint32
+}
+
+func TestTraceCapabilitiesGadget(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+	testCases := []testDef{
+		{
+			name: "raw_socket",
+			generateEvent: func() {
+				fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_ICMP)
+				if err != nil {
+					syscall.Close(fd)
+				}
+			},
+			syscall:             "SYS_SOCKET",
+			requestedPermission: "CAP_NET_RAW",
+		},
+		{
+			name: "device_access",
+			generateEvent: func() {
+				fd, _ := syscall.Open("/dev/mem", syscall.O_RDONLY, 0)
+				if fd >= 0 {
+					syscall.Close(fd)
+				}
+			},
+			requestedPermission: "CAP_SYS_RAWIO",
+			syscall:             "SYS_OPENAT",
+		},
+		{
+			name: "perf_event_open",
+			generateEvent: func() {
+				// Open perf event with dummy args; usually fails unless properly configured.
+				attr := &unix.PerfEventAttr{Type: unix.PERF_TYPE_HARDWARE, Size: uint32(unsafe.Sizeof(unix.PerfEventAttr{}))}
+				fd, _ := unix.PerfEventOpen(attr, -1, 0, -1, 0)
+				if fd >= 0 {
+					syscall.Close(fd)
+				}
+			},
+			requestedPermission: func() string {
+				kernelVersion := gadgettesting.GetKernelVersion(t)
+				if kernelVersion.Kernel < 5 || (kernelVersion.Kernel == 5 && kernelVersion.Major < 8) {
+					// CAP_SYS_ADMIN is requested for kernel < 5.8
+					return "CAP_SYS_ADMIN"
+				}
+				return "CAP_PERFMON"
+			}(),
+			syscall: "SYS_PERF_EVENT_OPEN",
+		},
+		{
+			name: "nice",
+			generateEvent: func() {
+				currPriority, _ := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+				err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, -1)
+				if err != nil {
+					syscall.Setpriority(syscall.PRIO_PROCESS, 0, currPriority)
+				}
+			},
+			requestedPermission: "CAP_SYS_NICE",
+			syscall:             "SYS_SETPRIORITY",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			runner := utilstest.NewRunnerWithTest(t, &utilstest.RunnerConfig{})
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, func() error {
+					testCase.generateEvent()
+					return nil
+				})
+				return nil
+			}
+			opts := gadgetrunner.GadgetRunnerOpts[ExpectedTraceCapabilitiesEvent]{
+				Image:          "trace_capabilities",
+				Timeout:        5 * time.Second,
+				MntnsFilterMap: utilstest.CreateMntNsFilterMap(t, runner.Info.MountNsID),
+				OnGadgetRun:    onGadgetRun,
+			}
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+			gadgetRunner.RunGadget()
+			utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, fd int) *ExpectedTraceCapabilitiesEvent {
+				return &ExpectedTraceCapabilitiesEvent{
+					Proc:          info.Proc,
+					Cap:           testCase.requestedPermission,
+					Audit:         1,
+					Insetid:       testCase.insetId,
+					CurrentUserNs: info.UserNsID,
+					TargetUserNs:  info.UserNsID,
+					Syscall:       testCase.syscall,
+				}
+			})(t, runner.Info, 0, gadgetRunner.CapturedEvents)
+		})
+	}
+}
+
+func TestNonAuditCapabilities(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+	runner := utilstest.NewRunnerWithTest(t, &utilstest.RunnerConfig{})
+	var cmd *exec.Cmd
+	onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+		utilstest.RunWithRunner(t, runner, func() error {
+			cmd = exec.Command("/bin/cat", "/proc/kallsyms")
+			err := cmd.Run()
+			require.NoError(t, err)
+			return nil
+		})
+		return nil
+	}
+	opts := gadgetrunner.GadgetRunnerOpts[ExpectedTraceCapabilitiesEvent]{
+		Image:          "trace_capabilities",
+		Timeout:        5 * time.Second,
+		MntnsFilterMap: utilstest.CreateMntNsFilterMap(t, runner.Info.MountNsID),
+		OnGadgetRun:    onGadgetRun,
+	}
+	gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+	gadgetRunner.RunGadget()
+
+	utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, fd int) *ExpectedTraceCapabilitiesEvent {
+		return &ExpectedTraceCapabilitiesEvent{
+			Proc: utils.Process{
+				Pid:     uint32(cmd.Process.Pid),
+				Tid:     uint32(cmd.Process.Pid),
+				Comm:    "cat",
+				MntNsID: info.MountNsID,
+				Parent: utils.Parent{
+					Comm: "unit.test",
+					Pid:  uint32(os.Getpid()),
+				},
+			},
+			Cap:           "CAP_SYSLOG",
+			Audit:         0,
+			Insetid:       0,
+			CurrentUserNs: info.UserNsID,
+			TargetUserNs:  info.UserNsID,
+			Syscall:       "SYS_OPENAT",
+		}
+	})(t, runner.Info, 0, gadgetRunner.CapturedEvents)
+}


### PR DESCRIPTION
# Add unit tests for trace_capabilities gadget

This PR introduces a new set of unit tests for the `trace_capabilities` gadget to validate its ability to detect capability-related syscalls. These tests simulate various syscalls (`unshare`, `socket`, `chroot`, `nice`) that require specific Linux capabilities (`CAP_SYS_ADMIN`, `CAP_NET_RAW`, `CAP_SYS_CHROOT`, `CAP_SYS_NICE`) and assert that the gadget captures the corresponding events with the correct capability.

Each test case uses a minimal syscall invocation to trigger the gadget and then checks that exactly one event is captured, with the expected `Cap` field value. The tests are written using the standard Go `testing` package, along with helper utilities from `inspektor-gadget` for setting up the test environment and gadget runner.

an effort towards #3835 

## How to use

To validate this PR, reviewers can run the following command to execute the unit tests:

```bash
GADGET_TAG=trace_cap_unit_tests IG_VERIFY_IMAGE=false go test -v -exec 'sudo -E' ./gadgets/trace_capabilities/test/unit/...
```

Ensure that the tests pass and that each one captures a single event with the correct capability name.

## Testing done

I manually ran the following command to execute the unit tests:

```bash
GADGET_TAG=trace_cap_unit_tests IG_VERIFY_IMAGE=false go test -v -exec 'sudo -E' ./gadgets/trace_capabilities/test/unit/...
```

All test cases passed successfully, and the gadget accurately captured the capability events for each syscall. The output confirmed that the expected capabilities matched the captured `Cap` values in each case.