### PR TITLE
image-build: fix update-metadata with targ_comm

### DIFF
--- a/pkg/gadgets/run/types/metadata.go
+++ b/pkg/gadgets/run/types/metadata.go
@@ -479,7 +479,13 @@ func checkParamVar(spec *ebpf.CollectionSpec, name string) error {
 	if btfVar.Linkage != btf.GlobalVar {
 		return fmt.Errorf("%q is not a global variable", name)
 	}
-	btfConst, ok := btfVar.Type.(*btf.Const)
+	typ := btfVar.Type
+	if btfArr, ok := typ.(*btf.Array); ok {
+		// Example of valid array of constants:
+		// const volatile gadget_comm targ_comm[TASK_COMM_LEN] = {};
+		typ = btfArr.Type
+	}
+	btfConst, ok := typ.(*btf.Const)
 	if !ok {
 		return fmt.Errorf("%q is not const", name)
 	}


### PR DESCRIPTION
`gadgets/Makefile` suggests to use `GADGET_BUILD_PARAMS="--update-metadata"`

But that build parameter does not work anymore:
```
Error: updating metadata file: populating metadata: handling params: "targ_comm" is not const
```
This is because the `targ_comm` is not a constant but an array of constants:
```
const volatile gadget_comm targ_comm[TASK_COMM_LEN] = {};
```
This patch updates the code to accept arrays of constants.

## How to use

```
GADGET_BUILD_PARAMS="--update-metadata" make -C gadgets/ trace_exec
```

## Testing done

```
$ GADGET_BUILD_PARAMS="--update-metadata" make -C gadgets/ trace_exec
make: Entering directory '/home/alban/go/src/github.com/inspektor-gadget/inspektor-gadget/gadgets'
Building trace_exec
Pulling builder image ghcr.io/inspektor-gadget/gadget-builder:main
main: Pulling from inspektor-gadget/gadget-builder
Digest: sha256:9b95d9d64fcbff2fbc123bb0bafcfc4c132d3132e63d12ee79e368f585e46f67
Status: Image is up to date for ghcr.io/inspektor-gadget/gadget-builder:main
Successfully built ghcr.io/inspektor-gadget/gadget/trace_exec:alban_params@sha256:6b0280a415aff28259c2407a82b48238dec0962c342408d6118834071dda691b
make: Leaving directory '/home/alban/go/src/github.com/inspektor-gadget/inspektor-gadget/gadgets'
```