### PR TITLE
Makefile: Update missing reference of EBPF_BUILDER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ig-all: $(IG_TARGETS) ig
 ig:
 	CGO_ENABLED=0 go build \
         -ldflags "-X github.com/inspektor-gadget/inspektor-gadget/internal/version.version=${VERSION} \
-        -X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${EBPF_BUILDER} \
+        -X github.com/inspektor-gadget/inspektor-gadget/cmd/common/image.builderImage=${GADGET_BUILDER} \
         -extldflags '-static'" \
         -tags "netgo" \
         ./cmd/ig


### PR DESCRIPTION
Commit 9bd1f3e0aa08 ("Rename ebpf-builder to gadget-builder") renamed EBPF_BUILDER to GADGET_BUILDER, but commit a0ad5aab6b3d ("Makefile: Build ig for host architecture with go build instead of docker.") missed it and used the old EBPF_BUILDER.

This caused the builder image to be empty when ig was compiled with `make ig` producing an error when building a Gadget:

```bash
$ ig image build -h | grep builder
      --builder-image string        Builder image to use

$ sudo ig image build .
Pulling builder image
Error: pulling builder image: invalid reference format
```
Fixes: a0ad5aab6b3d ("Makefile: Build ig for host architecture with go build instead of docker.") 
Link: https://kubernetes.slack.com/archives/CSYL75LF6/p1745944201173279

