### PR TITLE
gadget-builder: Switch to debian:bookworm-slim

### DIFF
--- a/Dockerfiles/gadget-builder.Dockerfile
+++ b/Dockerfiles/gadget-builder.Dockerfile
@@ -1,13 +1,17 @@
 ARG CLANG_LLVM_VERSION=18
 ARG BPFTOOL_VERSION=v7.3.0
 ARG LIBBPF_VERSION=v1.3.0
+ARG GOLANG_VERSION=1.24.2
 
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 
-FROM golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e AS builder
+FROM debian:bookworm-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d AS builder
 ARG BPFTOOL_VERSION
 ARG LIBBPF_VERSION
+
+RUN apt-get update \
+	&& apt-get install -y git make tar wget
 
 # Let's install libbpf headers
 RUN git clone --branch ${LIBBPF_VERSION} --depth 1 https://github.com/libbpf/libbpf.git \
@@ -22,30 +26,54 @@ RUN \
 	tar -C /usr/local/bin -xzf bpftool-${BPFTOOL_VERSION}-${ARCH}.tar.gz && \
 	chmod +x /usr/local/bin/bpftool
 
-# We use Go version >1.24 here for the WASM layers, because it is the first version to support exporting functions
-FROM golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
+FROM debian:bookworm-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d
 ARG CLANG_LLVM_VERSION
+ARG GOLANG_VERSION
 # libc-dev is needed for various headers, among others
 # /usr/include/arch-linux-gnu/asm/types.h.
 # We make clang aware of these files through CFLAGS in Makefile.
-# lsb-release wget software-properties-common gnupg are needed by llvm.sh script
+# wget is needed to download the LLVM key and Golang tarball
+# lsb-release software-properties-common is needed to add the LLVM repository
 # xz-utils is needed by btfgen makefile
+# make and git is needed for make ebpf-objects and make clang-format
+# clang-format is needed for make clang-format
 RUN apt-get update \
-	&& apt-get install -y libc-dev lsb-release wget gnupg xz-utils software-properties-common
+	&& apt-get install -y --no-install-recommends libc-dev lsb-release wget xz-utils software-properties-common make git
 
-# Install clang 15
-RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_LLVM_VERSION all \
+# Install clang
+# Add the keys and repository for the LLVM packages
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && codename=$(lsb_release -cs) \
+	# We need to call add-apt-repository twice in debian-bookworm because of a bug: https://github.com/llvm/llvm-project/issues/62475#issuecomment-1579252282
+    && add-apt-repository -y "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_LLVM_VERSION} main" \
+	&& add-apt-repository -y "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_LLVM_VERSION} main" \
+    && apt-get update \
+	&& apt-get install -y --no-install-recommends clang-$CLANG_LLVM_VERSION llvm-$CLANG_LLVM_VERSION clang-format-$CLANG_LLVM_VERSION \
 	&& update-alternatives --install /usr/local/bin/llvm-strip llvm-strip $(which llvm-strip-$CLANG_LLVM_VERSION) 100 \
 	&& update-alternatives --install /usr/local/bin/clang clang $(which clang-$CLANG_LLVM_VERSION) 100 \
 	&& update-alternatives --install /usr/local/bin/clang-format clang-format $(which clang-format-$CLANG_LLVM_VERSION) 100
 
+# Install golang
+RUN ARCH=$(dpkg --print-architecture) \
+	&& wget --quiet https://go.dev/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz && \
+	tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-${ARCH}.tar.gz && \
+	rm go${GOLANG_VERSION}.linux-${ARCH}.tar.gz && \
+	ln -s /usr/local/go/bin/go /usr/local/bin/go && \
+	chmod +x /usr/local/go/bin/go
+
 COPY --from=builder /usr/include/bpf /usr/include/bpf
 COPY --from=builder /usr/local/bin/bpftool /usr/local/bin/bpftool
 
-# To avoid hitting this:
-# failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
+# To avoid hitting
+# 1. failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
+# 2. could not create module cache: mkdir /go: permission denied
 # when run as non root.
-ENV GOCACHE=/tmp/
+ENV GOCACHE=/tmp/gocache
+ENV GOMODCACHE=/tmp/gomodcache
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
 # Create a directory which can be read, written and executed by everyone, this
 # avoid trouble when running as non root.
 RUN mkdir -m 777 /work


### PR DESCRIPTION
This reduces the gadget-builder image by `1.3 GB`.

```bash
$ docker images -f reference=test
REPOSITORY   TAG                  IMAGE ID       CREATED                SIZE
test         bookworm-slim        bd8cc75cb312   51 seconds ago         1.1GB
test         base                 9776844636a0   About an 2 hours ago   2.43GB
```

Roughly were the sizes come from:
- `75MB`: `debian:bookworm-slim`
- `260MB`: `libc-dev lsb-release wget gnupg xz-utils software-properties-common make git`
- `470MB`: `clang-18 llvm-18 clang-format-18`
- `253MB`: Golang 1.24 tarball installation

This is a good base image IMO. And it can be taken to optimize the size even further if its needed by looking at specific files or more specific packages

ref https://github.com/inspektor-gadget/inspektor-gadget/issues/4345