### PR TITLE
operators/ebpf: Fix missing parameter default value map-fetch-interval

### DIFF
--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -34,6 +34,8 @@ import (
 const (
 	ParamMapIterInterval = "map-fetch-interval"
 	ParamMapIterCount    = "map-fetch-count"
+
+	mapIterIntervalDefault = "1000ms"
 )
 
 type mapIter struct {
@@ -77,7 +79,7 @@ func (i *ebpfInstance) mapParams() api.Params {
 		{
 			Key:          ParamMapIterInterval,
 			Description:  "interval in which to iterate over maps",
-			DefaultValue: "1000ms",
+			DefaultValue: mapIterIntervalDefault,
 			TypeHint:     api.TypeString,
 			Title:        "Map fetch interval",
 		},
@@ -99,7 +101,14 @@ func (i *ebpfInstance) evaluateMapParams(paramValues api.ParamValues) error {
 	globalDuration := time.Duration(0)
 	globalCount := 0
 
-	durations, err := apihelpers.GetDurationValuesPerDataSource(paramValues[ParamMapIterInterval])
+	mapIterInterval := paramValues[ParamMapIterInterval]
+	// It's possible that in the param is empty in some cases, like running the
+	// gadget from a gadget spec file. In this case we need to set the param to
+	// the default value.
+	if mapIterInterval == "" {
+		mapIterInterval = mapIterIntervalDefault
+	}
+	durations, err := apihelpers.GetDurationValuesPerDataSource(mapIterInterval)
 	if err != nil {
 		return fmt.Errorf("evaluating map fetch interval: %w", err)
 	}


### PR DESCRIPTION
The current logic relies on the client to set the value for the parameters. This is done by kubectl-gadget, gadgetctl or ig by performing a call to GetGadgetInfo() to get the list of parameters and their default values. The issue here arises when using the headless mode, as in this case, the call to GetGadgetInfo() is not done, so the value for those parameters is missing if not explicitely set by the user in the gadget manifest file. This behavior causes all gadgets that depend on the "map-fetch-interval" param as it's set to 0.

The ideal solution for it should be something like 3c7f729e83ef ("pkg/gadget-service/api-helpers: Set default value for unset params"), but it doesn't work in this case these parameters are returned by the ExtraParams() method, hence they are not available when InstantiateImageOperator() is called in pkg/operators/oci-handler/oci.go.

Fixes #4408

### Testing

Run a gadget through a gadget manifest file as indicated in #4408, it should fail before this PR and work with this one.


