### PR TITLE
params: Avoid overwritting params in CopyToMap()

### DIFF
--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -279,6 +279,10 @@ func b64DecodeAndDecompress(s string) ([]byte, error) {
 
 func (p *Params) CopyToMap(target map[string]string, prefix string) {
 	for _, param := range *p {
+		if target[prefix+param.Key] != "" {
+			continue
+		}
+
 		if param.TypeHint == TypeBytes {
 			target[prefix+param.Key] = compressAndB64Encode(param.String())
 		} else {


### PR DESCRIPTION
Do not overwrite a param if it's already set on the destination map. This avoid issues when using gadget instance specs, as they params were being overwritten by the default values of the CLI, empty in many cases.

Fixes #3676 

### Testing 

Use the following manifest:

```yaml
# manifest.yaml
apiVersion: 1
kind: instance-spec
image: trace_exec:main
paramValues:
  operator.oci.annotate: wrong_annontation_should_break_the_gadget
```

#### Before this PR

```bash 
$ sudo ig run -f manifest.yaml
RUNTIME.CONTAINERNAME                             COMM                    PID        TID ARGS                         ERRO
```

Gadget runs fine, the annotation is not considered.

#### After this PR 

```bash
$ sudo ig run -f manifest.yaml
Error: initializing and preparing operators: instantiating operator "oci": annotation "wrong_annontation_should_break_the_gadget" must be in subject:assignment format
```

Annotation is taken intro consideration

