### PR TITLE
Adding the path for gadget to find the runc of k0s in finder.go

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -43,6 +43,7 @@ var RuntimePaths = []string{
 	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
 	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2
 	"/usr/libexec/crio/runc",                     // Used in kubeadm on Debian, upstream crio
+	"/var/lib/k0s/bin/runc",                      // Used in k0s
 }
 
 // Notify marks the runtime path given as argument if it exists.


### PR DESCRIPTION
# Adding the path for gadget to find the runc of k0s

Added single line to point gadget to where runc is located

## How to use

no change. But if you previously overwrote the RUNTIME_PATH variable for making k0s work, it should now work out fo the box

## Testing done

CI was run on my fork : please see https://github.com/entlein/inspektor-gadget/actions/runs/14821358374
