### PR TITLE
pkg/kallsyms: re-enable test for kernel module symbol

### DIFF
--- a/pkg/kallsyms/kallsyms_test.go
+++ b/pkg/kallsyms/kallsyms_test.go
@@ -187,14 +187,12 @@ func TestRealKAllSymsParsing(t *testing.T) {
 			expectedKmod:   "",
 			expectedExists: true,
 		},
-		// This test is failing a lot, disable it until we understand why.
-		// See https://github.com/inspektor-gadget/inspektor-gadget/issues/4367
-		//{
-		//	name:           "symbol_from_veth_kmod",
-		//	symbol:         "veth_init",
-		//	expectedKmod:   "veth",
-		//	expectedExists: true,
-		//},
+		{
+			name:           "symbol_from_veth_kmod",
+			symbol:         "veth_open",
+			expectedKmod:   "veth",
+			expectedExists: true,
+		},
 		{
 			name:           "symbol_from_netem_kmod",
 			symbol:         "netem_module_init",


### PR DESCRIPTION
Kallsyms test on symbol veth_init failed a lot, so it was disabled.

I believe this is due to using a function declared with "__init" because the memory holding the code can be lazily reclaimed when the kernel needs more memory,

This patch re-enables the test but uses a different symbol that does not use "__init".

Fixes: d25e2295d1e6 ("pkg/kallsyms: disable failing test")

Fixes: #4367

## Testing done

```
$ go test -exec sudo -v ./pkg/kallsyms/...
...
--- PASS: TestRealKAllSymsParsing (3.67s)
    --- PASS: TestRealKAllSymsParsing/simple_symbol1 (0.46s)
    --- PASS: TestRealKAllSymsParsing/simple_symbol2 (0.47s)
    --- PASS: TestRealKAllSymsParsing/symbol_from_veth_kmod (0.49s)
    --- PASS: TestRealKAllSymsParsing/symbol_from_netem_kmod (0.47s)
    --- PASS: TestRealKAllSymsParsing/symbol_from_overlay_kmod (0.47s)
    --- PASS: TestRealKAllSymsParsing/nonexistent_symbol (0.46s)
```