### PR TITLE
gadgets/bpfstats: Do not require --enable-bpfstats

### DIFF
--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -18,8 +18,6 @@ data:
       docker-socketpath: {{ .Values.config.dockerSocketPath }}
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
       operator:
-        ebpf:
-          enable-bpfstats: {{ .Values.config.enableBpfStats }}
         oci:
           verify-image: {{ .Values.config.verifyGadgets }}
           public-keys:{{ toYaml $.Values.config.gadgetsPublicKeys | nindent 12 }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -56,9 +56,6 @@ config:
   # -- Address to listen for OpenTelemetry metrics
   otelMetricsAddress: "0.0.0.0:2224"
 
-  # -- Enable eBPF stats
-  enableBpfStats: false
-
 image:
   # -- Container repository for the container image
   repository: ghcr.io/inspektor-gadget/inspektor-gadget

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -111,7 +111,6 @@ var (
 	disallowGadgetsPull   bool
 	otelMetricsListen     bool
 	otelMetricsListenAddr string
-	enableBpfStats        bool
 )
 
 var supportedHooks = []string{"auto", "crio", "podinformer", "nri", "fanotify+ebpf"}
@@ -260,9 +259,6 @@ func init() {
 	deployCmd.PersistentFlags().StringVar(
 		&otelMetricsListenAddr,
 		"otel-metrics-listen-address", "0.0.0.0:2224", "Address and port to create the OpenTelemetry metrics listener (Prometheus compatible) on")
-	deployCmd.PersistentFlags().BoolVar(
-		&enableBpfStats,
-		"enable-bpfstats", false, "Enable capturing eBPF stats")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -819,11 +815,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				}
 				opCfg[gadgettracermanagerconfig.OtelMetrics] = otelMetricsConfig
 			}
-
-			opEbpfCfg := map[string]interface{}{
-				gadgettracermanagerconfig.EnableBPFStats: enableBpfStats,
-			}
-			opCfg[gadgettracermanagerconfig.EBPFOperator] = opEbpfCfg
 
 			data, err := yaml.Marshal(cfg)
 			if err != nil {

--- a/gadgets/bpfstats/README.mdx
+++ b/gadgets/bpfstats/README.mdx
@@ -38,20 +38,18 @@ Default value: "false"
 
 ## Guide
 
-In order for this gadget to work, the server needs to be running with the
-`--enable-bpfstats` flag:
-
+Start the server part of IG:
 
 <Tabs groupId="env">
   <TabItem value="kubectl-gadget" label="kubectl gadget">
 ```bash
-$ kubectl gadget deploy --enable-bpfstats
+$ kubectl gadget deploy
 ```
   </TabItem>
 
   <TabItem value="ig-daemon" label="ig-daemon">
 ```bash
-$ sudo ig daemon --enable-bpfstats
+$ sudo ig daemon
 ```
   </TabItem>
 </Tabs>
@@ -304,14 +302,3 @@ Also note:
   but only their file descriptors (i.e. sizeof(int) = 4 bytes)
 * `BPF_MAP_TYPE_{HASH,ARRAY}_OF_MAPS`: value_size is not counting the inner maps,
   but only their file descriptors (i.e. sizeof(int) = 4 bytes)
-
-#### bpfstats not disabled for Kernels < 5.8
-
-The bpfstats Gadgets enables collection of eBPF program stats by trying to use
-`BPF_ENABLE_STATS` first (which requires Linux >= 5.8). If that fails, it will
-fall back to trying to enable via sysctl (/proc/sys/kernel/bpf_stats_enabled),
-on this case, the collection of stats will remain active even after stopping
-Inspektor Gadget.
-
-It is a temporary limitation that we're working to fix, in the meanwhile you can
-use `sysctl kernel.bpf_stats_enabled=0` to disable it.

--- a/gadgets/bpfstats/test/unit/bpfstats_test.go
+++ b/gadgets/bpfstats/test/unit/bpfstats_test.go
@@ -92,9 +92,6 @@ func TestBpfstatsGadget(t *testing.T) {
 			t.Parallel()
 
 			runner := utilstest.NewRunnerWithTest(t, testCase.runnerConfig)
-			globalParams := map[string]string{
-				"operator.ebpf.enable-bpfstats": "true",
-			}
 
 			normalizeEvent := func(event *ExpectedBpfstatsEvent) {
 				utils.NormalizeInt(&event.MapCount)
@@ -117,12 +114,11 @@ func TestBpfstatsGadget(t *testing.T) {
 			}
 
 			opts := gadgetrunner.GadgetRunnerOpts[ExpectedBpfstatsEvent]{
-				Image:              "bpfstats",
-				Timeout:            5 * time.Second,
-				ParamValues:        paramValues,
-				GlobalParamsValues: globalParams,
-				OnGadgetRun:        onGadgetRun,
-				NormalizeEvent:     normalizeEvent,
+				Image:          "bpfstats",
+				Timeout:        5 * time.Second,
+				ParamValues:    paramValues,
+				OnGadgetRun:    onGadgetRun,
+				NormalizeEvent: normalizeEvent,
 			}
 
 			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -34,6 +34,5 @@ const (
 	OtelMetrics              = "otel-metrics"
 	OtelMetricsListen        = "otel-metrics-listen"
 	OtelMetricsListenAddress = "otel-metrics-listen-address"
-	EnableBPFStats           = "enable-bpfstats"
 	EBPFOperator             = "ebpf"
 )

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -28,8 +28,6 @@ data:
       docker-socketpath: /run/docker.sock
       podman-socketpath: /run/podman/podman.sock
       operator:
-        ebpf:
-          enable-bpfstats: false
         oci:
           verify-image: true
           public-keys:


### PR DESCRIPTION
The current implementation of the bpfstats gadget requires the daemon to be deployed with the --enable-bpfstats parameter to enable eBPF stats collection in the kernel. This UX is bad as users will need to enable it from the beginning, having a performance issue for all gadgets that are run, and by not being able to use this functionality on an existing IG deployment without having to restart it.

This PR changes the approach to enable the stats only when the bpfstats gadget is run, which is more practical as users don't need to change any configuration at deploy time and the stats collection is only enabled while the bpfstats gadget runs.

By changing this, we also fix an issue where stats collection wasn't disabled after running Inspektor Gadget.

Ref #4402
