### PR TITLE
trace_dns: Add nameserver field

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -102,6 +102,9 @@ datasources:
         annotations:
           columns.hidden: "true"
           description: Recursion Desired Flag
+      nameserver:
+        annotations:
+          description: Nameserver for the DNS request
 
 params:
   ebpf:

--- a/gadgets/trace_dns/test/integration/trace_dns_test.go
+++ b/gadgets/trace_dns/test/integration/trace_dns_test.go
@@ -38,8 +38,9 @@ type traceDNSEvent struct {
 	NetNsID   uint64        `json:"netns_id"`
 	Proc      utils.Process `json:"proc"`
 
-	Src utils.L4Endpoint `json:"src"`
-	Dst utils.L4Endpoint `json:"dst"`
+	Src        utils.L4Endpoint `json:"src"`
+	Dst        utils.L4Endpoint `json:"dst"`
+	Nameserver utils.L3Endpoint `json:"nameserver"`
 
 	// Raw fields are coming from wasm, test them too
 	ID                 string `json:"id"`
@@ -163,6 +164,10 @@ func newTraceDNSStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting
 						Proto:   strings.ToUpper(tc.protocol),
 						K8s:     k8sDataServer,
 					},
+					Nameserver: utils.L3Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+					},
 					QrRaw:    false,
 					Qr:       "Q",
 					Name:     "fake.test.com.",
@@ -197,6 +202,10 @@ func newTraceDNSStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting
 						Port:    utils.NormalizedInt,
 						Proto:   strings.ToUpper(tc.protocol),
 						K8s:     k8sDataClient,
+					},
+					Nameserver: utils.L3Endpoint{
+						Addr:    serverIP,
+						Version: 4,
 					},
 					QrRaw:     true,
 					Qr:        "R",
@@ -234,6 +243,10 @@ func newTraceDNSStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting
 						Proto:   strings.ToUpper(tc.protocol),
 						K8s:     k8sDataServer,
 					},
+					Nameserver: utils.L3Endpoint{
+						Addr:    serverIP,
+						Version: 4,
+					},
 					QrRaw:    false,
 					Qr:       "Q",
 					Name:     "fake.test.com.",
@@ -268,6 +281,10 @@ func newTraceDNSStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting
 						Port:    utils.NormalizedInt,
 						Proto:   strings.ToUpper(tc.protocol),
 						K8s:     k8sDataClient,
+					},
+					Nameserver: utils.L3Endpoint{
+						Addr:    serverIP,
+						Version: 4,
 					},
 					QrRaw:     true,
 					Qr:        "R",


### PR DESCRIPTION
As pointed out in the comment https://github.com/inspektor-gadget/inspektor-gadget/issues/3804#issuecomment-2551617018, we are missing `namesever` field. Also, in certain [troubleshooting steps](https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/connectivity/troubleshoot-dns-failures-across-an-aks-cluster-in-real-time#step-3-verify-the-health-of-the-upstream-dns-servers) in makes sense to be able to filter query/responses based on nameserver.

## Testing Done

### generate events
```
$ docker run --rm -it busybox sh
/ # nslookup google.com.
Server:         192.168.0.1
Address:        192.168.0.1:53

Non-authoritative answer:
Name:   google.com
Address: 142.250.181.206

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:4005:802::200e

/ # exit
→ docker run --rm -it busybox sh
/ # nslookup google.com. 
Server:         192.168.0.1
Address:        192.168.0.1:53

Non-authoritative answer:
Name:   google.com
Address: 142.250.181.206

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:4005:802::200e

/ # nslookup google.com. 1.1.1.1
Server:         1.1.1.1
Address:        1.1.1.1:53

Non-authoritative answer:
Name:   google.com
Address: 142.250.180.110

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:401b:805::200e

/ # nslookup google.com. 8.8.8.8
Server:         8.8.8.8
Address:        8.8.8.8:53

Non-authoritative answer:
Name:   google.com
Address: 142.250.181.206

Non-authoritative answer:
Name:   google.com
Address: 2a00:1450:4005:802::200e
```

### verify gadget output:

```
→ sudo ./ig run trace_dns:qasim-dns-nameserver --verify-image=false --fields +nameserver
WARN[0000] image signature verification is disabled due to using corresponding option 
WARN[0000] image signature verification is disabled due to using corresponding option 
SRC                                                  DST                                                  NAMESERVER                     COMM                    PID        TID QR   QTYPE                          NAME                                                     RCODE           ADDRESSES                      RUNTIME.CONTAINERNAME                                                              LATENCY_NS
172.17.0.2:38032                                     192.168.0.1:53                                       192.168.0.1                    nslookup             155690     155690 Q    A                              google.com.                                                                                             awesome_grothendieck                                                                      0ns
172.17.0.2:38032                                     192.168.0.1:53                                       192.168.0.1                    nslookup             155690     155690 Q    AAAA                           google.com.                                                                                             awesome_grothendieck                                                                      0ns
192.168.0.1:53                                       172.17.0.2:38032                                     192.168.0.1                    nslookup             155690     155690 R    A                              google.com.                                              Success         142.250.181.206                awesome_grothendieck                                                                  15.13ms
192.168.0.1:53                                       172.17.0.2:38032                                     192.168.0.1                    nslookup             155690     155690 R    AAAA                           google.com.                                              Success         2a00:1450:4005:802::200e       awesome_grothendieck                                                                  15.08ms
172.17.0.2:43770                                     1.1.1.1:53                                           1.1.1.1                        nslookup             155691     155691 Q    A                              google.com.                                                                                             awesome_grothendieck                                                                      0ns
172.17.0.2:43770                                     1.1.1.1:53                                           1.1.1.1                        nslookup             155691     155691 Q    AAAA                           google.com.                                                                                             awesome_grothendieck                                                                      0ns
1.1.1.1:53                                           172.17.0.2:43770                                     1.1.1.1                        nslookup             155691     155691 R    A                              google.com.                                              Success         142.250.180.110                awesome_grothendieck                                                                  18.89ms
1.1.1.1:53                                           172.17.0.2:43770                                     1.1.1.1                        nslookup             155691     155691 R    AAAA                           google.com.                                              Success         2a00:1450:401b:805::200e       awesome_grothendieck                                                                  28.03ms
172.17.0.2:43121                                     8.8.8.8:53                                           8.8.8.8                        nslookup             155693     155693 Q    A                              google.com.                                                                                             awesome_grothendieck                                                                      0ns
172.17.0.2:43121                                     8.8.8.8:53                                           8.8.8.8                        nslookup             155693     155693 Q    AAAA                           google.com.                                                                                             awesome_grothendieck                                                                      0ns
8.8.8.8:53                                           172.17.0.2:43121                                     8.8.8.8                        nslookup             155693     155693 R    A                              google.com.                                              Success         142.250.181.206                awesome_grothendieck                                                                  15.02ms
8.8.8.8:53                                           172.17.0.2:43121                                     8.8.8.8                        nslookup             155693     155693 R    AAAA                           google.com.                                              Success         2a00:1450:4005:802::200e       awesome_grothendieck                                                                  19.77ms
```

