### PR TITLE
charts: Allow specifying extra config for operators

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,5 +1,5 @@
 HELM ?= helm
-HELM_DOCS_IMAGE ?= jnorwood/helm-docs:v1.11.0
+HELM_DOCS_IMAGE ?= jnorwood/helm-docs:v1.14.2
 BUILD_DIR ?= bin
 OUTPUT_DIR ?= $(BUILD_DIR)
 CHART_DIR := $(BUILD_DIR)/gadget

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -30,3 +30,8 @@ data:
             otel-metrics-listen: {{ .Values.config.otelMetricsListen }}
             otel-metrics-listen-address: {{ .Values.config.otelMetricsAddress }}
       {{- end }}
+      {{- if .Values.config.extraOperatorConfig }}
+      {{- range $operatorName, $operatorConfig := .Values.config.extraOperatorConfig }}
+        {{ $operatorName }}:{{ toYaml $operatorConfig | nindent 10 }}
+      {{- end }}
+      {{- end }}

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -44,6 +44,54 @@
         },
         "eventsBufferLength": {
           "type": "string"
+        },
+        "daemonLogLevel": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warning",
+            "error",
+            "fatal",
+            "panic"
+          ]
+        },
+        "verifyGadgets": {
+          "type": "boolean"
+        },
+        "gadgetsPublicKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedGadgets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disallowGadgetsPulling": {
+          "type": "boolean"
+        },
+        "mountPullSecret": {
+          "type": "boolean"
+        },
+        "appArmorProfile": {
+            "type": "string"
+        },
+        "otelMetricsListen" : {
+          "type": "boolean"
+        },
+        "otelMetricsAddress" : {
+          "type": "string"
+        },
+        "extraOperatorConfig": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
         }
       }
     },

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -59,6 +59,26 @@ config:
   # -- Enable eBPF stats
   enableBpfStats: false
 
+  # Allow specifying extra operator config for the operator as:
+  #config:
+  #  extraOperatorConfig:
+  #    otel-logs:
+  #      exporters:
+  #        grpc:
+  #          exporter: otlp-grpc
+  #          compression: gzip
+  #          endpoint: "127.0.0.1:4317"
+  #          insecure: true
+  #    otel-metrics:
+  #      exporters:
+  #        grpc:
+  #          exporter: otlp-grpc
+  #          endpoint: "127.0.0.1:4317"
+  #          insecure: true
+  #          temporality: delta
+  #          interval: 30s
+  # -- Allow specifying extra operator configuration
+  extraOperatorConfig: {}
 image:
   # -- Container repository for the container image
   repository: ghcr.io/inspektor-gadget/inspektor-gadget


### PR DESCRIPTION
Currently we have to define some kind of mapping for each operator in the helm, which makes sense but there should be way to specify additional config. This is also useful once we are trying to add more operators for testing purposes. 

### Todo:

- [ ] Should we move all the operator config in same structure with some defaults?
- [ ] See how it behaves under duplicate keys.

### Testing Done

```
→ cat bin/values.yaml 
config:
  extraOperatorConfig:
    otel-logs:
      exporters:
        grpc:
          exporter: otlp-grpc
          compression: gzip
          endpoint: "127.0.0.1:4317"
          insecure: true
    otel-metrics:
      exporters:
        grpc:
          exporter: otlp-grpc
          endpoint: "127.0.0.1:4317"
          insecure: true
          temporality: delta
          interval: 30s
→ helm upgrade --install gadget charts/bin/gadget --namespace gadget --create-namespace -f bin/values.yaml 
Release "gadget" has been upgraded. Happy Helming!
NAME: gadget
LAST DEPLOYED: Fri May  9 11:54:30 2025
NAMESPACE: gadget
STATUS: deployed
REVISION: 3
TEST SUITE: None
NOTES:
Inspektor Gadget "main" installed successfully!

For usage details, visit https://www.inspektor-gadget.io
→ kubectl get cm -n gadget  -o yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    config.yaml: |-
      hook-mode: auto
      fallback-pod-informer: true
      events-buffer-length: 16384
      containerd-socketpath: /run/containerd/containerd.sock
      crio-socketpath: /run/crio/crio.sock
      docker-socketpath: /run/docker.sock
      podman-socketpath: /run/podman/podman.sock
      operator:
        ebpf:
          enable-bpfstats: false
        oci:
          verify-image: true
          public-keys:
            - |
              -----BEGIN PUBLIC KEY-----
              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
              Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
              -----END PUBLIC KEY-----
          allowed-gadgets:
            []
          disallow-pulling: false
        otel-logs:
          exporters:
            grpc:
              compression: gzip
              endpoint: 127.0.0.1:4317
              exporter: otlp-grpc
              insecure: true
        otel-metrics:
          exporters:
            grpc:
              endpoint: 127.0.0.1:4317
              exporter: otlp-grpc
              insecure: true
              interval: 30s
              temporality: delta

```

 
