### PR TITLE
ci: Enable cache for building helper images

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -988,42 +988,30 @@ jobs:
             context: "tools/dnstester"
             dockerfile: "tools/dnstester/Dockerfile"
             platform: "linux/amd64,linux/arm64"
-            filter-patterns:
-              - "tools/dnstester/*"
+            key-files: "tools/dnstester/*"
           - name: "gadget-builder"
             context: "/home/runner/work/inspektor-gadget/inspektor-gadget"
             dockerfile: "Dockerfiles/gadget-builder.Dockerfile"
             platform: "linux/amd64,linux/arm64"
-            filter-patterns:
-              - "include/**"
-              - "Dockerfiles/gadget-builder.Dockerfile"
-              - "cmd/common/image/Makefile.build"
+            key-files: "'include/**','Dockerfiles/gadget-builder.Dockerfile','cmd/common/image/Makefile.build'"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-      id: filter
-      with:
-        # https://github.com/rhysd/actionlint/blob/main/docs/checks.md#check-type-check-expression
-        filters: |
-          pattern: ${{ toJson(matrix.image.filter-patterns) }}
-    - name: Check if we should build helpers
-      id: check-build-helpers
-      # always build the images on release, merge to main or to a release branch
-      if: steps.filter.outputs.pattern == 'true' || startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release-') || github.ref_name == 'main'
-      run: |
-          echo "build=true" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
-      if: steps.check-build-helpers.outputs.build == 'true'
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+    - name: Cache Docker layers
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-docker-${{ matrix.image.name }}-${{ hashFiles(matrix.image.key-files) }}
+        restore-keys: |
+          ${{ runner.os }}-docker-${{ matrix.image.name}}-
     - name: Login to Container Registry
-      if: steps.check-build-helpers.outputs.build == 'true'
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Set container repository and determine image tag
-      if: steps.check-build-helpers.outputs.build == 'true'
       id: set-repo-determine-image-tag
       uses: ./.github/actions/set-container-repo-and-determine-image-tag
       with:
@@ -1031,7 +1019,6 @@ jobs:
         container-image: ${{ github.repository_owner }}/${{ matrix.image.name }}
     - name: Build ${{ matrix.image.name }} image
       id: build-image
-      if: steps.check-build-helpers.outputs.build == 'true'
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
       with:
         context: ${{ matrix.image.context }}
@@ -1041,6 +1028,8 @@ jobs:
         # https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository
         push: ${{ vars.PUSH_HELPERS == 'ENABLE_PUSH_HELPERS' }}
         tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
         platforms: ${{ matrix.image.platform }}
     - name: Save ${{ matrix.image.name }} image tag output
       id: image-tag
@@ -1063,12 +1052,19 @@ jobs:
 
         echo "${{ matrix.image.name }}=${image}" >> $GITHUB_OUTPUT
     - name: Sign ${{ matrix.image.name }} image
-      if: steps.check-build-helpers.outputs.build == 'true' && needs.check-secrets.outputs.cosign == 'true' && vars.PUSH_HELPERS == 'ENABLE_PUSH_HELPERS'
+      if:  needs.check-secrets.outputs.cosign == 'true' && vars.PUSH_HELPERS == 'ENABLE_PUSH_HELPERS'
       uses: ./.github/actions/sign-container-image
       with:
         password: '${{ secrets.COSIGN_PASSWORD }}'
         private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         image: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.build-image.outputs.digest }}"
+    # old cache entries aren’t deleted, so the cache size keeps growing
+    # remove old cache and move new cache to cache path to workaround the issue
+    # https://github.com/docker/build-push-action/issues/252
+    - name: Move ig container image cache to correct location
+      run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   build-examples:
     name: example


### PR DESCRIPTION
We aren't caching the Docker layers for helper images like the gadget-builder. It causes the following:
1. The building takes very long (~5mins)
2. A new built image has a totally different set of digest for its layers compared to one generated in a previous builder as our images don't have "reproducible builds" support.

The second point affects users compiling gadgets, as each time the image was changed upstream, they have to pull all the layers (hundreds of MBs).

This commit enables the cache fixing the issues described above. Now, also the logic to avoid building the image based on some file patterns is removed as we can always try to build it with a very minimum overhead.

--- 

The issue with #4345 was not only having a big image (which has been improved a lot in #4407), but producing one with different hash each time even if there were not any changes

---

### Testing 

I pushed this commit to the main branch of my fork, the image was built and pushed and the cache was created:
(run log https://github.com/mauriciovasquezbernal/inspektor-gadget/actions/runs/14938958457/job/41972649853)

![image](https://github.com/user-attachments/assets/774bd5dc-0a91-4042-9a67-02d2572ddde1)

Then I pulled it from my machine:

```bash
$ docker pull ghcr.io/mauriciovasquezbernal/gadget-builder:main
main: Pulling from mauriciovasquezbernal/gadget-builder
254e724d7786: Already exists
54a73374204c: Pull complete
6b6fa017d695: Pull complete
305b1a7efd5b: Pull complete
51f865fbab7f: Pull complete
c30234827b1e: Pull complete
3491132245d9: Pull complete
4f4fb700ef54: Pull complete
d5f27c6711b6: Pull complete
Digest: sha256:1b0644f6ec703871b4567123a0f95d23eb58116eed1e21dca9cdba3d38f2aed9
Status: Downloaded newer image for ghcr.io/mauriciovasquezbernal/gadget-builder:main
ghcr.io/mauriciovasquezbernal/gadget-builder:main
```

As expected, it pulled a lot of layers

Then I pushed a commit simulating a small change to a header file, now the compilation only took 30 seconds:
(run https://github.com/mauriciovasquezbernal/inspektor-gadget/actions/runs/14938958457/job/41972649852)

![image](https://github.com/user-attachments/assets/abe109f8-bc44-49d1-9c68-5c67b917b672)

When trying to pull it, only a small layer was pulled:

```bash
$ docker pull ghcr.io/mauriciovasquezbernal/gadget-builder:main
main: Pulling from mauriciovasquezbernal/gadget-builder
254e724d7786: Already exists
54a73374204c: Already exists
6b6fa017d695: Already exists
305b1a7efd5b: Already exists
51f865fbab7f: Already exists
c30234827b1e: Already exists
3491132245d9: Already exists
4f4fb700ef54: Already exists
33adc89c2121: Pull complete
Digest: sha256:e1ea1634fb927b303c04bec25d0994674b996a0466e9917a61e44c75783ca81a
Status: Downloaded newer image for ghcr.io/mauriciovasquezbernal/gadget-builder:main
ghcr.io/mauriciovasquezbernal/gadget-builder:main
```

Fixes #4345

cc @mqasimsarfraz @rata

