### PR TITLE
Adding runc path of Bottlerocket OS

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -40,10 +40,12 @@ var RuntimePaths = []string{
 	"/usr/lib/cri-o-runc/sbin/runc",
 	"/run/torcx/unpack/docker/bin/runc", // Used in Flatcar Container Linux
 	"/usr/bin/crun",
-	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
-	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2
-	"/usr/libexec/crio/runc",                     // Used in kubeadm on Debian, upstream crio
-	"/var/lib/k0s/bin/runc",                      // Used in k0s
+	"/var/lib/rancher/k3s/data/current/bin/runc",            // Used in k3s
+	"/var/lib/rancher/rke2/bin/runc",                        // Used in RKE2
+	"/usr/libexec/crio/runc",                                // Used in kubeadm on Debian, upstream crio
+	"/var/lib/k0s/bin/runc",                                 // Used in k0s
+	"/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/runc", // Used in Bottlerocket OS
+	"/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/runc",  // Used in Bottlerocket OS
 }
 
 // Notify marks the runtime path given as argument if it exists.


### PR DESCRIPTION
Adding the runtime paths of Bottlerocket OS (for both architectures)
https://bottlerocket.dev/

## How to use

N/A

## Testing done

I have tested my fork with AWS nodes (AMD64 + Graviton ARM) running Bottlerocket OS 1.38.0.



