### PR TITLE
user_stack_map.h: fix compilation warnings

### DIFF
--- a/include/gadget/user_stack_map.h
+++ b/include/gadget/user_stack_map.h
@@ -145,7 +145,10 @@ gadget_get_user_stack(void *ctx, struct gadget_user_stack *ustack)
 
 	struct pid *thread_pid = BPF_CORE_READ(task, thread_pid);
 	unsigned int level = BPF_CORE_READ(thread_pid, level);
-	struct upid *numbers = &thread_pid->numbers;
+	// Cast pointer to "struct upid *" to avoid compilation warning in a way
+	// that works both on Linux < v6.5 and >= v6.5. See:
+	// https://github.com/torvalds/linux/commit/b69f0aeb068980af983d399deafc7477cec8bc04
+	struct upid *numbers = (struct upid *)&thread_pid->numbers;
 
 	ustack->pid_level0 = BPF_CORE_READ(numbers, nr);
 	ustack->pidns_level0 = BPF_CORE_READ(numbers, ns, ns.inum);


### PR DESCRIPTION
We have the following code pattern:
```c
	// vmlinux.h
	struct pid {
	        struct upid numbers[1];
	};
	// include/gadget/user_stack_map.h
	struct upid *numbers = &thread_pid->numbers;
```
It generates the following compilation warning:

> /work/include/gadget/user_stack_map.h:148:15: warning: incompatible
> pointer types initializing 'struct upid *' with an expression of type
> 'struct upid (*)[1]' [-Wincompatible-pointer-types]

We cannot solve it with the following code:
```c
	struct upid *numbers = &thread_pid->numbers[0];
```
because Linux v6.5 commit [b69f0aeb0689](https://github.com/torvalds/linux/commit/b69f0aeb068980af983d399deafc7477cec8bc04) made the following change:
```diff
-       struct upid numbers[1];
+       struct upid numbers[];
```
And it would generate a CORE relocation with an accessor for the first entry of the array. The relocation would fail at load time because flex-array are zero-sized in BTF.

So we unfortunately have to cast the pointer to make it work without warnings both on Linux >= v6.5 and < v6.5.

