### PR TITLE
docs: Fix OCI helm chart URL

### DIFF
--- a/docs/reference/install-kubernetes.md
+++ b/docs/reference/install-kubernetes.md
@@ -270,15 +270,15 @@ Inspektor Gadget can also be installed using our [official Helm chart](https://g
 #### From OCI registry
 
 ```bash
-$ CHART_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name | sed 's/^v//')
-$ helm install gadget --namespace=gadget --create-namespace oci://ghcr.io/inspektor-gadget/charts/gadget --version=$CHART_VERSION
+CHART_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name | sed 's/^v//')
+helm install gadget --namespace=gadget --create-namespace oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget --version=$CHART_VERSION
 ```
 
 #### From HTTP(s) repository
 
 ```bash
-$ helm repo add gadget https://inspektor-gadget.github.io/charts
-$ helm install gadget gadget/gadget --namespace=gadget --create-namespace
+helm repo add gadget https://inspektor-gadget.github.io/charts
+helm install gadget gadget/gadget --namespace=gadget --create-namespace
 ```
 
 For more information on the Helm chart, please refer to the [Helm Chart documentation](https://artifacthub.io/packages/helm/gadget/gadget).


### PR DESCRIPTION
It seems the URL for OCI helm chart was incorrect. This PR fixes the URL for the OCI helm chart.

## Testing Done:

```
$ CHART_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name | sed 's/^v//')
$ helm install gadget --namespace=gadget --create-namespace oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget --version=$CHART_VERSION
Pulled: ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget:0.40.0
Digest: sha256:2518a01a989384a013a2b2528276a5c7db0e345a0cd19fdc49c8e8350e3559c4
W0512 17:55:03.989090  411655 warnings.go:70] spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/gadget]: deprecated since v1.30; use the "appArmorProfile" field instead
W0512 17:55:03.989135  411655 warnings.go:70] [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image ghcr.io/inspektor-gadget/inspektor-gadget:v0.40.0 for container gadget has not been allowed.
NAME: gadget
LAST DEPLOYED: Mon May 12 17:55:00 2025
NAMESPACE: gadget
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Inspektor Gadget "v0.40.0" installed successfully!

For usage details, visit https://www.inspektor-gadget.io

```

ref: https://github.com/inspektor-gadget/inspektor-gadget/pkgs/container/inspektor-gadget%2Fcharts%2Fgadget/408590472?tag=0.40.0