### PR TITLE
introduce internal metrics

### DIFF
--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
@@ -49,6 +51,11 @@ func (s *Service) GetOperatorMap() map[operators.DataOperator]*params.Params {
 }
 
 func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoRequest) (*api.GetGadgetInfoResponse, error) {
+	metricAttribs := attribute.NewSet(
+		attribute.KeyValue{Key: "gadget-image", Value: attribute.StringValue(req.ImageName)},
+	)
+	defer s.ctrGetGadgetInfo.Add(context.Background(), 1, metric.WithAttributeSet(metricAttribs))
+
 	if req.Version != api.VersionGadgetInfo {
 		return nil, fmt.Errorf("expected version to be %d, got %d", api.VersionGadgetInfo, req.Version)
 	}
@@ -114,6 +121,8 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 		if s.instanceMgr == nil {
 			return errors.New("instance manager not initialized")
 		}
+
+		s.ctrAttachGadget.Add(context.Background(), 1)
 		return s.instanceMgr.AttachToGadgetInstance(attachRequest.Id, runGadget)
 	}
 
@@ -121,6 +130,11 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 	if ociRequest == nil {
 		return fmt.Errorf("expected first control message to be gadget run request")
 	}
+
+	metricAttribs := attribute.NewSet(
+		attribute.KeyValue{Key: "gadget-image", Value: attribute.StringValue(ociRequest.ImageName)},
+	)
+	defer s.ctrRunGadget.Add(context.Background(), 1, metric.WithAttributeSet(metricAttribs))
 
 	p, ok := peer.FromContext(runGadget.Context())
 	if ok && p.AuthInfo != nil {
@@ -278,6 +292,9 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 
 	runtimeParams := s.runtime.ParamDescs().ToParams()
 	runtimeParams.CopyFromMap(ociRequest.ParamValues, "runtime.")
+
+	s.udRunningGadgets.Add(context.Background(), 1, metric.WithAttributeSet(metricAttribs))
+	defer s.udRunningGadgets.Add(context.Background(), -1, metric.WithAttributeSet(metricAttribs))
 
 	err = s.runtime.RunGadget(gadgetCtx, runtimeParams, ociRequest.ParamValues)
 	if err != nil {

--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
@@ -40,6 +41,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/store"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/metrics"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime"
@@ -74,6 +76,12 @@ type Service struct {
 
 	// operators stores all global parameters for DataOperators (non-legacy)
 	operators map[operators.DataOperator]*params.Params
+
+	// metrics (only covering image-based gadgets)
+	ctrGetGadgetInfo metric.Int64Counter
+	ctrRunGadget     metric.Int64Counter
+	ctrAttachGadget  metric.Int64Counter
+	udRunningGadgets metric.Int64UpDownCounter
 }
 
 func NewService(defaultLogger logger.Logger) *Service {
@@ -81,11 +89,19 @@ func NewService(defaultLogger logger.Logger) *Service {
 	for _, op := range operators.GetDataOperators() {
 		ops[op] = apihelpers.ToParamDescs(op.GlobalParams()).ToParams()
 	}
-	return &Service{
+
+	svc := &Service{
 		servers:   map[*grpc.Server]struct{}{},
 		logger:    defaultLogger,
 		operators: ops,
 	}
+
+	svc.ctrGetGadgetInfo, _ = metrics.Int64Counter("svc.GetGadgetInfo")
+	svc.ctrRunGadget, _ = metrics.Int64Counter("svc.RunGadget")
+	svc.ctrAttachGadget, _ = metrics.Int64Counter("svc.AttachGadget")
+	svc.udRunningGadgets, _ = metrics.Int64UpDownCounter("svc.RunningGadgets")
+
+	return svc
 }
 
 func (s *Service) SetEventBufferLength(val uint64) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,653 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics provides a singleton metrics provider that can be used
+// throughout the application to register metrics.
+//
+// This package implements a proxy for the OpenTelemetry metric.Meter interface
+// that forwards operations to one or more registered metric.MeterProvider instances.
+// It allows registering and unregistering providers at runtime, and ensures that
+// all metrics are properly registered with new providers and removed when providers
+// are unregistered.
+//
+// The package supports all standard OpenTelemetry metric types:
+// - Int64Counter and Float64Counter
+// - Int64Histogram and Float64Histogram
+// - Int64Gauge and Float64Gauge
+// - Int64UpDownCounter and Float64UpDownCounter
+//
+// Usage:
+//
+//	// Register a provider
+//	provider := sdkmetric.NewMeterProvider(...)
+//	err := metrics.RegisterProvider(provider)
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+//	// Create a counter
+//	counter, err := metrics.Int64Counter("my_counter")
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+//	// Add a value to the counter
+//	counter.Add(ctx, 1)
+//
+//	// Unregister a provider when done
+//	metrics.UnregisterProvider(provider)
+package metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Proxy is a singleton that provides access to metrics and forwards
+// operations to all registered meter providers. It implements the OpenTelemetry
+// metric.Meter interface by proxying operations to the underlying providers.
+//
+// The Proxy maintains a registry of all metrics that have been created, so that
+// when a new provider is registered, all existing metrics can be registered with
+// the new provider. When a provider is unregistered, all metrics associated with
+// that provider are removed.
+//
+// Thread safety is ensured by using a read-write mutex for all operations.
+type Proxy struct {
+	mu sync.RWMutex
+
+	// providers is a map of registered metric.MeterProvider instances to their meters
+	providers map[metric.MeterProvider]metric.Meter
+
+	// registeredMetrics tracks all metrics that have been created, so they can be
+	// registered with new providers
+	registeredMetrics []metricRegistration
+
+	// Track all created metric wrappers so we can remove provider references when
+	// a provider is unregistered
+	int64Counters         []*int64Counter
+	float64Counters       []*float64Counter
+	int64Histograms       []*int64Histogram
+	float64Histograms     []*float64Histogram
+	int64Gauges           []*int64Gauge
+	float64Gauges         []*float64Gauge
+	int64UpDownCounters   []*int64UpDownCounter
+	float64UpDownCounters []*float64UpDownCounter
+}
+
+// metricRegistration represents a metric that has been registered
+type metricRegistration struct {
+	creator func(provider metric.MeterProvider, meter metric.Meter) error
+}
+
+var (
+	// instance is the singleton instance of Proxy
+	instance *Proxy
+	// once is used to ensure the singleton is initialized only once
+	once sync.Once
+)
+
+// global returns the singleton instance of Proxy
+func global() *Proxy {
+	once.Do(func() {
+		instance = &Proxy{
+			providers:             make(map[metric.MeterProvider]metric.Meter),
+			registeredMetrics:     make([]metricRegistration, 0),
+			int64Counters:         make([]*int64Counter, 0),
+			float64Counters:       make([]*float64Counter, 0),
+			int64Histograms:       make([]*int64Histogram, 0),
+			float64Histograms:     make([]*float64Histogram, 0),
+			int64Gauges:           make([]*int64Gauge, 0),
+			float64Gauges:         make([]*float64Gauge, 0),
+			int64UpDownCounters:   make([]*int64UpDownCounter, 0),
+			float64UpDownCounters: make([]*float64UpDownCounter, 0),
+		}
+	})
+	return instance
+}
+
+// RegisterProvider registers a new provider with the global instance
+func RegisterProvider(provider metric.MeterProvider) error {
+	return global().RegisterProvider(provider)
+}
+
+// UnregisterProvider unregisters a provider from the global instance
+func UnregisterProvider(provider metric.MeterProvider) {
+	global().UnregisterProvider(provider)
+}
+
+// Int64Counter registers a new counter on the global instance
+func Int64Counter(name string, options ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	return global().Int64Counter(name, options...)
+}
+
+// Float64Counter registers a new counter on the global instance
+func Float64Counter(name string, options ...metric.Float64CounterOption) (metric.Float64Counter, error) {
+	return global().Float64Counter(name, options...)
+}
+
+// Int64Histogram registers a new histogram on the global instance
+func Int64Histogram(name string, options ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
+	return global().Int64Histogram(name, options...)
+}
+
+// Float64Histogram registers a new histogram on the global instance
+func Float64Histogram(name string, options ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	return global().Float64Histogram(name, options...)
+}
+
+// Int64Gauge registers a new gauge on the global instance
+func Int64Gauge(name string, options ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+	return global().Int64Gauge(name, options...)
+}
+
+// Float64Gauge registers a new gauge on the global instance
+func Float64Gauge(name string, options ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+	return global().Float64Gauge(name, options...)
+}
+
+// Int64UpDownCounter registers a new updown counter on the global instance
+func Int64UpDownCounter(name string, options ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+	return global().Int64UpDownCounter(name, options...)
+}
+
+// Float64UpDownCounter registers a new updown counter on the global instance
+func Float64UpDownCounter(name string, options ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error) {
+	return global().Float64UpDownCounter(name, options...)
+}
+
+// RegisterProvider registers a new metric.MeterProvider with the given name
+func (r *Proxy) RegisterProvider(provider metric.MeterProvider) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.providers[provider]; ok {
+		return fmt.Errorf("metric provider already registered")
+	}
+
+	meter := provider.Meter("inspektor-gadget")
+
+	r.providers[provider] = meter
+
+	// Register all existing metrics with the new provider
+	for _, reg := range r.registeredMetrics {
+		_ = reg.creator(provider, meter)
+	}
+
+	return nil
+}
+
+// UnregisterProvider removes a metric.MeterProvider with the given name
+// and removes all meters/metrics associated with it
+func (r *Proxy) UnregisterProvider(provider metric.MeterProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Remove the provider from the map
+	delete(r.providers, provider)
+
+	// Remove all metrics associated with this provider
+	for _, counter := range r.int64Counters {
+		delete(counter.counters, provider)
+	}
+	for _, counter := range r.float64Counters {
+		delete(counter.counters, provider)
+	}
+	for _, histogram := range r.int64Histograms {
+		delete(histogram.histograms, provider)
+	}
+	for _, histogram := range r.float64Histograms {
+		delete(histogram.histograms, provider)
+	}
+	for _, gauge := range r.int64Gauges {
+		delete(gauge.gauges, provider)
+	}
+	for _, gauge := range r.float64Gauges {
+		delete(gauge.gauges, provider)
+	}
+	for _, counter := range r.int64UpDownCounters {
+		delete(counter.counters, provider)
+	}
+	for _, counter := range r.float64UpDownCounters {
+		delete(counter.counters, provider)
+	}
+}
+
+// Int64Counter creates a new Int64Counter and registers it with all providers
+func (r *Proxy) Int64Counter(name string, options ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a counter that forwards to all providers
+	counter := &int64Counter{
+		p:        r,
+		counters: make(map[metric.MeterProvider]metric.Int64Counter),
+	}
+
+	// Add the counter to the list of counters
+	r.int64Counters = append(r.int64Counters, counter)
+
+	// Create a registration for this counter
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Int64Counter(name, options...)
+			if err != nil {
+				return err
+			}
+			counter.counters[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the counter for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return counter, err
+}
+
+// Float64Counter creates a new float64Counter and registers it with all providers
+func (r *Proxy) Float64Counter(name string, options ...metric.Float64CounterOption) (metric.Float64Counter, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a counter that forwards to all providers
+	counter := &float64Counter{
+		p:        r,
+		counters: make(map[metric.MeterProvider]metric.Float64Counter),
+	}
+
+	// Add the counter to the list of counters
+	r.float64Counters = append(r.float64Counters, counter)
+
+	// Create a registration for this counter
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Float64Counter(name, options...)
+			if err != nil {
+				return err
+			}
+			counter.counters[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the counter for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return counter, err
+}
+
+// Int64Histogram creates a new int64Histogram and registers it with all providers
+func (r *Proxy) Int64Histogram(name string, options ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a histogram that forwards to all providers
+	histogram := &int64Histogram{
+		p:          r,
+		histograms: make(map[metric.MeterProvider]metric.Int64Histogram),
+	}
+
+	// Add the histogram to the list of histograms
+	r.int64Histograms = append(r.int64Histograms, histogram)
+
+	// Create a registration for this histogram
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Int64Histogram(name, options...)
+			if err != nil {
+				return err
+			}
+			histogram.histograms[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the histogram for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return histogram, err
+}
+
+// Float64Histogram creates a new float64Histogram and registers it with all providers
+func (r *Proxy) Float64Histogram(name string, options ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a histogram that forwards to all providers
+	histogram := &float64Histogram{
+		p:          r,
+		histograms: make(map[metric.MeterProvider]metric.Float64Histogram),
+	}
+
+	// Add the histogram to the list of histograms
+	r.float64Histograms = append(r.float64Histograms, histogram)
+
+	// Create a registration for this histogram
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Float64Histogram(name, options...)
+			if err != nil {
+				return err
+			}
+			histogram.histograms[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the histogram for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return histogram, err
+}
+
+// Int64Gauge creates a new Int64Gauge and registers it with all providers
+func (r *Proxy) Int64Gauge(name string, options ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a gauge that forwards to all providers
+	gauge := &int64Gauge{
+		p:      r,
+		gauges: make(map[metric.MeterProvider]metric.Int64Gauge),
+	}
+
+	// Add the gauge to the list of gauges
+	r.int64Gauges = append(r.int64Gauges, gauge)
+
+	// Create a registration for this gauge
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Int64Gauge(name, options...)
+			if err != nil {
+				return err
+			}
+			gauge.gauges[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the gauge for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return gauge, err
+}
+
+// Float64Gauge creates a new Float64Gauge and registers it with all providers
+func (r *Proxy) Float64Gauge(name string, options ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a gauge that forwards to all providers
+	gauge := &float64Gauge{
+		p:      r,
+		gauges: make(map[metric.MeterProvider]metric.Float64Gauge),
+	}
+
+	// Add the gauge to the list of gauges
+	r.float64Gauges = append(r.float64Gauges, gauge)
+
+	// Create a registration for this gauge
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Float64Gauge(name, options...)
+			if err != nil {
+				return err
+			}
+			gauge.gauges[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the gauge for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return gauge, err
+}
+
+// Int64UpDownCounter creates a new Int64UpDownCounter and registers it with all providers
+func (r *Proxy) Int64UpDownCounter(name string, options ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a counter that forwards to all providers
+	counter := &int64UpDownCounter{
+		p:        r,
+		counters: make(map[metric.MeterProvider]metric.Int64UpDownCounter),
+	}
+
+	// Add the counter to the list of counters
+	r.int64UpDownCounters = append(r.int64UpDownCounters, counter)
+
+	// Create a registration for this counter
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Int64UpDownCounter(name, options...)
+			if err != nil {
+				return err
+			}
+			counter.counters[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the counter for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return counter, err
+}
+
+// Float64UpDownCounter creates a new Float64UpDownCounter and registers it with all providers
+func (r *Proxy) Float64UpDownCounter(name string, options ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var err error
+
+	// Create a counter that forwards to all providers
+	counter := &float64UpDownCounter{
+		p:        r,
+		counters: make(map[metric.MeterProvider]metric.Float64UpDownCounter),
+	}
+
+	// Add the counter to the list of counters
+	r.float64UpDownCounters = append(r.float64UpDownCounters, counter)
+
+	// Create a registration for this counter
+	reg := metricRegistration{
+		creator: func(provider metric.MeterProvider, meter metric.Meter) error {
+			m, err := meter.Float64UpDownCounter(name, options...)
+			if err != nil {
+				return err
+			}
+			counter.counters[provider] = m
+			return nil
+		},
+	}
+	r.registeredMetrics = append(r.registeredMetrics, reg)
+
+	// Create the counter for each provider
+	for provider, meter := range r.providers {
+		err = errors.Join(err, reg.creator(provider, meter))
+	}
+
+	return counter, err
+}
+
+// int64Counter forwards Add calls to all underlying counters
+type int64Counter struct {
+	metric.Int64Counter
+	p        *Proxy
+	counters map[metric.MeterProvider]metric.Int64Counter
+}
+
+// Add adds the given value to all underlying counters
+func (c *int64Counter) Add(ctx context.Context, value int64, options ...metric.AddOption) {
+	c.p.mu.RLock()
+	defer c.p.mu.RUnlock()
+	for _, counter := range c.counters {
+		counter.Add(ctx, value, options...)
+	}
+}
+
+// float64Counter forwards Add calls to all underlying counters
+type float64Counter struct {
+	metric.Float64Counter
+	p        *Proxy
+	counters map[metric.MeterProvider]metric.Float64Counter
+}
+
+// Add adds the given value to all underlying counters
+func (c *float64Counter) Add(ctx context.Context, value float64, options ...metric.AddOption) {
+	c.p.mu.RLock()
+	defer c.p.mu.RUnlock()
+	for _, counter := range c.counters {
+		counter.Add(ctx, value, options...)
+	}
+}
+
+// int64Histogram forwards Record calls to all underlying histograms
+type int64Histogram struct {
+	metric.Int64Histogram
+	p          *Proxy
+	histograms map[metric.MeterProvider]metric.Int64Histogram
+}
+
+// Record records the given value to all underlying histograms
+func (h *int64Histogram) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
+	h.p.mu.RLock()
+	defer h.p.mu.RUnlock()
+	for _, histogram := range h.histograms {
+		histogram.Record(ctx, value, options...)
+	}
+}
+
+// float64Histogram forwards Record calls to all underlying histograms
+type float64Histogram struct {
+	metric.Float64Histogram
+	p          *Proxy
+	histograms map[metric.MeterProvider]metric.Float64Histogram
+}
+
+// Record records the given value to all underlying histograms
+func (h *float64Histogram) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
+	h.p.mu.RLock()
+	defer h.p.mu.RUnlock()
+	for _, histogram := range h.histograms {
+		histogram.Record(ctx, value, options...)
+	}
+}
+
+// int64Gauge forwards operations to all underlying gauges
+type int64Gauge struct {
+	metric.Int64Gauge
+	p      *Proxy
+	gauges map[metric.MeterProvider]metric.Int64Gauge
+}
+
+// Add adds the given value to all underlying gauges
+func (g *int64Gauge) Add(ctx context.Context, value int64, options ...metric.RecordOption) {
+	g.p.mu.RLock()
+	defer g.p.mu.RUnlock()
+	for _, gauge := range g.gauges {
+		gauge.Record(ctx, value, options...)
+	}
+}
+
+// float64Gauge forwards operations to all underlying gauges
+type float64Gauge struct {
+	metric.Float64Gauge
+	p      *Proxy
+	gauges map[metric.MeterProvider]metric.Float64Gauge
+}
+
+// Add adds the given value to all underlying gauges
+func (g *float64Gauge) Add(ctx context.Context, value float64, options ...metric.RecordOption) {
+	g.p.mu.RLock()
+	defer g.p.mu.RUnlock()
+	for _, gauge := range g.gauges {
+		gauge.Record(ctx, value, options...)
+	}
+}
+
+// int64UpDownCounter forwards Add calls to all underlying updown counters
+type int64UpDownCounter struct {
+	metric.Int64UpDownCounter
+	p        *Proxy
+	counters map[metric.MeterProvider]metric.Int64UpDownCounter
+}
+
+// Add adds the given value to all underlying updown counters
+func (c *int64UpDownCounter) Add(ctx context.Context, value int64, options ...metric.AddOption) {
+	c.p.mu.RLock()
+	defer c.p.mu.RUnlock()
+	for _, counter := range c.counters {
+		counter.Add(ctx, value, options...)
+	}
+}
+
+// float64UpDownCounter forwards Add calls to all underlying updown counters
+type float64UpDownCounter struct {
+	metric.Float64UpDownCounter
+	p        *Proxy
+	counters map[metric.MeterProvider]metric.Float64UpDownCounter
+}
+
+// Add adds the given value to all underlying updown counters
+func (c *float64UpDownCounter) Add(ctx context.Context, value float64, options ...metric.AddOption) {
+	c.p.mu.RLock()
+	defer c.p.mu.RUnlock()
+	for _, counter := range c.counters {
+		counter.Add(ctx, value, options...)
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,289 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// TestProxy tests the Proxy functionality
+func TestProxy(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a counter
+	counter, err := proxy.Int64Counter("test_counter")
+	require.NoError(t, err)
+	require.NotNil(t, counter)
+
+	// Add a value to the counter (should not panic even with no providers)
+	counter.Add(context.Background(), 1)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err, "Failed to register provider")
+
+	// Create another counter
+	counter2, err := proxy.Int64Counter("test_counter2")
+	require.NoError(t, err)
+	require.NotNil(t, counter2)
+
+	// Add a value to the counter
+	counter2.Add(context.Background(), 2)
+
+	// Check that the counter has metrics for the provider
+	c2 := counter2.(*int64Counter)
+	require.Equal(t, 1, len(c2.counters), "Expected counter2 to have 1 counter")
+
+	// Try to register the same provider again (should fail)
+	err = proxy.RegisterProvider(provider)
+	require.Error(t, err, "Expected error when registering the same provider twice")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the counter no longer has metrics for the provider
+	require.Equal(t, 0, len(c2.counters), "Expected counter2 to have 0 counters after unregistering provider")
+
+	// Add a value to the counter (should not panic)
+	counter2.Add(context.Background(), 3)
+}
+
+// TestHistogram tests the histogram functionality
+func TestHistogram(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a histogram
+	histogram, err := proxy.Int64Histogram("test_histogram")
+	require.NoError(t, err)
+	require.NotNil(t, histogram)
+
+	// Record a value to the histogram (should not panic even with no providers)
+	histogram.Record(context.Background(), 1)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another histogram
+	histogram2, err := proxy.Int64Histogram("test_histogram2")
+	require.NoError(t, err)
+	require.NotNil(t, histogram2)
+
+	// Record a value to the histogram
+	histogram2.Record(context.Background(), 2)
+
+	// Check that the histogram has metrics for the provider
+	h2 := histogram2.(*int64Histogram)
+	require.Equal(t, 1, len(h2.histograms), "Expected histogram2 to have 1 histogram")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the histogram no longer has metrics for the provider
+	require.Equal(t, 0, len(h2.histograms), "Expected histogram2 to have 0 histograms after unregistering provider")
+
+	// Record a value to the histogram (should not panic)
+	histogram2.Record(context.Background(), 3)
+}
+
+// TestInt64Counter tests the Int64Counter functionality
+func TestInt64Counter(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a counter
+	counter, err := proxy.Int64Counter("test_int64_counter")
+	require.NoError(t, err)
+	require.NotNil(t, counter)
+
+	// Add a value to the counter (should not panic even with no providers)
+	counter.Add(context.Background(), 1)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another counter
+	counter2, err := proxy.Int64Counter("test_int64_counter2")
+	require.NoError(t, err)
+	require.NotNil(t, counter2)
+
+	// Add a value to the counter
+	counter2.Add(context.Background(), 2)
+
+	// Check that the counter has metrics for the provider
+	c2 := counter2.(*int64Counter)
+	require.Equal(t, 1, len(c2.counters), "Expected counter2 to have 1 counter")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the counter no longer has metrics for the provider
+	require.Equal(t, 0, len(c2.counters), "Expected counter2 to have 0 counters after unregistering provider")
+
+	// Add a value to the counter (should not panic)
+	counter2.Add(context.Background(), 3)
+}
+
+// TestFloat64Counter tests the Float64Counter functionality
+func TestFloat64Counter(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a counter
+	counter, err := proxy.Float64Counter("test_float64_counter")
+	require.NoError(t, err)
+	require.NotNil(t, counter)
+
+	// Add a value to the counter (should not panic even with no providers)
+	counter.Add(context.Background(), 1.5)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another counter
+	counter2, err := proxy.Float64Counter("test_float64_counter2")
+	require.NoError(t, err)
+	require.NotNil(t, counter2)
+
+	// Add a value to the counter
+	counter2.Add(context.Background(), 2.5)
+
+	// Check that the counter has metrics for the provider
+	c2 := counter2.(*float64Counter)
+	require.Equal(t, 1, len(c2.counters), "Expected counter2 to have 1 counter")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the counter no longer has metrics for the provider
+	require.Equal(t, 0, len(c2.counters), "Expected counter2 to have 0 counters after unregistering provider")
+
+	// Add a value to the counter (should not panic)
+	counter2.Add(context.Background(), 3.5)
+}
+
+// TestInt64Gauge tests the Int64Gauge functionality
+func TestInt64Gauge(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a gauge
+	gauge, err := proxy.Int64Gauge("test_int64_gauge")
+	require.NoError(t, err)
+	require.NotNil(t, gauge)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another gauge
+	gauge2, err := proxy.Int64Gauge("test_int64_gauge2")
+	require.NoError(t, err)
+	require.NotNil(t, gauge2)
+
+	// Check that the gauge has metrics for the provider
+	g2 := gauge2.(*int64Gauge)
+	require.Equal(t, 1, len(g2.gauges), "Expected gauge2 to have 1 gauge")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the gauge no longer has metrics for the provider
+	require.Equal(t, 0, len(g2.gauges), "Expected gauge2 to have 0 gauges after unregistering provider")
+}
+
+// TestFloat64Gauge tests the Float64Gauge functionality
+func TestFloat64Gauge(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create a gauge
+	gauge, err := proxy.Float64Gauge("test_float64_gauge")
+	require.NoError(t, err)
+	require.NotNil(t, gauge)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another gauge
+	gauge2, err := proxy.Float64Gauge("test_float64_gauge2")
+	require.NoError(t, err)
+	require.NotNil(t, gauge2)
+
+	// Check that the gauge has metrics for the provider
+	g2 := gauge2.(*float64Gauge)
+	require.Equal(t, 1, len(g2.gauges), "Expected gauge2 to have 1 gauge")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the gauge no longer has metrics for the provider
+	require.Equal(t, 0, len(g2.gauges), "Expected gauge2 to have 0 gauges after unregistering provider")
+}
+
+// TestUpDownCounter tests the updown counter functionality
+func TestUpDownCounter(t *testing.T) {
+	// Get the proxy
+	proxy := global()
+
+	// Create an updown counter
+	counter, err := proxy.Int64UpDownCounter("test_updown_counter")
+	require.NoError(t, err)
+	require.NotNil(t, counter)
+
+	// Add a value to the counter (should not panic even with no providers)
+	counter.Add(context.Background(), 1)
+
+	// Register a provider
+	provider := noop.NewMeterProvider()
+	err = proxy.RegisterProvider(provider)
+	require.NoError(t, err)
+
+	// Create another updown counter
+	counter2, err := proxy.Int64UpDownCounter("test_updown_counter2")
+	require.NoError(t, err)
+	require.NotNil(t, counter2)
+
+	// Add a value to the counter
+	counter2.Add(context.Background(), 2)
+
+	// Check that the counter has metrics for the provider
+	c2 := counter2.(*int64UpDownCounter)
+	require.Equal(t, 1, len(c2.counters), "Expected counter2 to have 1 counter")
+
+	// Unregister the provider
+	proxy.UnregisterProvider(provider)
+
+	// Check that the counter no longer has metrics for the provider
+	require.Equal(t, 0, len(c2.counters), "Expected counter2 to have 0 counters after unregistering provider")
+
+	// Add a value to the counter (should not panic)
+	counter2.Add(context.Background(), 3)
+}

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -39,6 +39,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/histogram"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/metrics"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
@@ -47,12 +48,13 @@ import (
 const (
 	name = "otel-metrics"
 
-	Priority                      = 9995 // slightly before CLI so we can reroute output there
-	ParamOtelMetricsListen        = "otel-metrics-listen"
-	ParamOtelMetricsListenAddress = "otel-metrics-listen-address"
-	ParamOtelMetricsName          = "otel-metrics-name"
-	ParamOtelMetricsExporter      = "otel-metrics-exporter"
-	ParamOtelMetricsPrintInterval = "otel-metrics-print-interval"
+	Priority                        = 9995 // slightly before CLI so we can reroute output there
+	ParamOtelMetricsListen          = "otel-metrics-listen"
+	ParamOtelMetricsListenAddress   = "otel-metrics-listen-address"
+	ParamOtelMetricsExportInternals = "otel-metrics-export-internals"
+	ParamOtelMetricsName            = "otel-metrics-name"
+	ParamOtelMetricsExporter        = "otel-metrics-exporter"
+	ParamOtelMetricsPrintInterval   = "otel-metrics-print-interval"
 
 	MetricTypeKey       = "key"
 	MetricTypeCounter   = "counter"
@@ -126,6 +128,12 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 	// Initialize provider map
 	m.providers = map[string]metric.MeterProvider{}
 
+	exportInternals := false
+	if globalParams.Get(ParamOtelMetricsExportInternals).AsBool() {
+		log.Debug("enabled exporting internal metrics")
+		exportInternals = true
+	}
+
 	// Initialize named metric providers
 	mc := make(map[string]*metricsConfig, 0)
 	if config.Config != nil {
@@ -168,6 +176,13 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 						sdkmetric.NewPeriodicReader(otlpcollector, periodicReaderOptions...),
 					),
 				)
+
+				if exportInternals {
+					err := metrics.RegisterProvider(m.providers[k])
+					if err != nil {
+						log.Warnf("failed to register internal metrics for provider %q: %v", k, err)
+					}
+				}
 				log.Debugf("initialized metric provider %q", k)
 			}
 		}
@@ -184,6 +199,13 @@ func (m *otelMetricsOperator) Init(globalParams *params.Params) error {
 	}
 	m.exporter = exporter
 	m.meterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+
+	if exportInternals {
+		err = metrics.RegisterProvider(m.meterProvider)
+		if err != nil {
+			log.Warnf("failed to register internal metrics for global provider: %v", err)
+		}
+	}
 
 	// Start HTTP listener for the global exporter
 	if !m.skipListen {
@@ -213,6 +235,12 @@ func (m *otelMetricsOperator) GlobalParams() api.Params {
 			DefaultValue: "0.0.0.0:2224",
 			TypeHint:     api.TypeString,
 			Description:  "address and port to create the OpenTelemetry metrics listener (Prometheus compatible) on",
+		},
+		{
+			Key:          ParamOtelMetricsExportInternals,
+			DefaultValue: "false",
+			TypeHint:     api.TypeBool,
+			Description:  "export Inspektor Gadget internal metrics",
 		},
 	}
 }


### PR DESCRIPTION
This PR adds a new `metrics` package that allows creating counters/gauges/histograms where
necessary. It works similar to the logger package, which offers a default singleton instance that
other packages can just use.

The package itself works like a proxy for OpenTelemetry: it allows multiple providers to be registered
to export to different targets at once. So this works with both the Prometheus listener, but also
with otel-gRPC exporters.

To enable internal metrics export, specify `--otel-metrics-export-internals` as parameter to the
daemon. If the Prometheus listener is enabled (`--otel-metrics-listen`), you can retrieve the metrics
from http://127.0.0.1:2224

```
...
# HELP svc_RunGadget_total 
# TYPE svc_RunGadget_total counter
svc_RunGadget_total{gadget_image="top_process:mine",otel_scope_name="inspektor-gadget",otel_scope_version=""} 1
# HELP svc_RunningGadgets 
# TYPE svc_RunningGadgets gauge
svc_RunningGadgets{gadget_image="top_process:mine",otel_scope_name="inspektor-gadget",otel_scope_version=""} 0
...
```

I included only basic metrics for now to the `gadget-service` package, but this should be a good
enough example for other operators as well.