### PR TITLE
ci: Fix storing test reports

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2209,7 +2209,7 @@ jobs:
     - name: Get all reports
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        patterns: "test-reports-*-*"
+        pattern: "test-reports-*-*"
     - name: Store test report
       shell: bash {0}
       run: ./tools/store-test-reports.sh

--- a/tools/store-test-reports.sh
+++ b/tools/store-test-reports.sh
@@ -41,6 +41,11 @@ function store-reports {
       --arg job_key ${job_key} \
       '.[$job_key] = (.[$job_key][-99:] + $obj)' \
       data/workflows.json > workflows.json.tmp
+      if [ ! -s workflows.json.tmp ]; then
+        echo "Skipping empty file: $i" >&2
+        rm workflows.json.tmp
+        continue
+      fi
       mv workflows.json.tmp data/workflows.json
   done
 


### PR DESCRIPTION
It seems storing test reports was broken as part of https://github.com/inspektor-gadget/inspektor-gadget/pull/4157. It seems we were missing some error handling which resulted in broken file being committed. Also, this can be confirmed by https://github.com/inspektor-gadget/ig-test-reports since no new reports have been published. 

Fixes: bd82e6199bafa2d8faebd86e145a7e647f0d42d0

## Testing Done

- Reports are now pushed fine: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/14996739819/job/42134141907#step:4:18
- https://github.com/inspektor-gadget/ig-test-reports/commits/main/
