### PR TITLE
operators: ebpf: Use Info() for --trace-pipe.

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -548,7 +548,7 @@ func (i *ebpfInstance) tracePipe(gadgetCtx operators.GadgetContext) error {
 		defer tracePipe.Close()
 		scanner := bufio.NewScanner(tracePipe)
 		for scanner.Scan() {
-			log.Debug(scanner.Text())
+			log.Info(scanner.Text())
 		}
 	}()
 	return nil


### PR DESCRIPTION
This way, using --trace-pipe actually prints the data without needing -v.

Fixes: d28c76d0ef85 ("pkg/operators/ebpf: ebpf layer operator")
