### PR TITLE
k8s.io/client-go: add user agent

### DIFF
--- a/Dockerfiles/ig-tests.Dockerfile.dockerignore
+++ b/Dockerfiles/ig-tests.Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 !go.mod
 !go.sum
 !pkg
+!internal
 !integration
 !Makefile*
 !*.mk

--- a/cmd/common/version.go
+++ b/cmd/common/version.go
@@ -17,6 +17,7 @@ package common
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
@@ -28,6 +29,7 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Show version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("v%s\n", version.Version().String())
+			log.Debugf("Inspektor Gadget User Agent: %s\n", version.UserAgent())
 		},
 	}
 }

--- a/examples/container-hook/Dockerfile.dockerignore
+++ b/examples/container-hook/Dockerfile.dockerignore
@@ -3,3 +3,4 @@
 !go.sum
 !examples
 !pkg
+!internal

--- a/examples/container-hook/main.go
+++ b/examples/container-hook/main.go
@@ -222,7 +222,7 @@ func main() {
 		if *kubeconfig == "" && os.Getenv("KUBECONFIG") != "" {
 			*kubeconfig = os.Getenv("KUBECONFIG")
 		}
-		client, err = k8sutil.NewClientset(*kubeconfig)
+		client, err = k8sutil.NewClientset(*kubeconfig, "container-hook-publish-event")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to get Kubernetes client set: %s\n", err)
 			os.Exit(1)

--- a/examples/kube-container-collection/Dockerfile.dockerignore
+++ b/examples/kube-container-collection/Dockerfile.dockerignore
@@ -3,4 +3,4 @@
 !go.sum
 !examples
 !pkg
-!internal/thirdparty
+!internal

--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -109,7 +109,7 @@ func main() {
 		*node = os.Getenv("NODE_NAME")
 	}
 
-	config, err := k8sutil.NewKubeConfig(*kubeconfig)
+	config, err := k8sutil.NewKubeConfig(*kubeconfig, "kube-container-collection")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get kubeconfig: %s\n", err)
 		os.Exit(1)

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -287,6 +287,7 @@ func main() {
 
 	if serve {
 		log.Infof("Inspektor Gadget version: %s", version.Version().String())
+		log.Infof("Inspektor Gadget User Agent: %s", version.UserAgent())
 
 		if experimental.Enabled() {
 			log.Info("Experimental features enabled")

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package version_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
+)
+
+func TestVersion(t *testing.T) {
+	// Example of version when running unit tests:
+	// v0.0.0
+	v := version.VersionString()
+	assert.NotEqual(t, v, "")
+	assert.NotContains(t, v, "unknown")
+	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+`), v)
+}
+
+func TestUserAgent(t *testing.T) {
+	// Example of user agent when running unit tests:
+	// version.test/v0.0.0 (linux/amd64) kubernetes/unknown
+	ua := version.UserAgent()
+	assert.NotEqual(t, ua, "")
+	assert.Regexp(t, regexp.MustCompile(`[\w.-]+/v\d+\.\d+\.\d+[\w-]* \(\w+/\w+\) kubernetes/[\w.-]+`), ua)
+}

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
@@ -129,7 +130,7 @@ func (c *Container) GetOwnerReference() (*metav1.OwnerReference, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes config: %w", err)
 	}
-
+	kubeconfig.UserAgent = version.UserAgent() + " (container-collection/GetOwnerReference)"
 	dynamicClient, err := dynamic.NewForConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("getting get dynamic Kubernetes client: %w", err)

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config/gadgettracermanagerconfig"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
@@ -55,6 +56,7 @@ func NewK8sClient(nodeName string) (*K8sClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.UserAgent = version.UserAgent() + " (container-collection/NewK8sClient)"
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	containerhook "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cgroups"
@@ -520,6 +521,7 @@ func WithKubernetesEnrichment(nodeName string, kubeconfig *rest.Config) Containe
 			if err != nil {
 				return fmt.Errorf("getting Kubernetes config: %w", err)
 			}
+			kubeconfig.UserAgent = version.UserAgent() + " (container-collection/WithKubernetesEnrichment)"
 		}
 		clientset, err := kubernetes.NewForConfig(kubeconfig)
 		if err != nil {

--- a/pkg/container-collection/podinformer.go
+++ b/pkg/container-collection/podinformer.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 )
 
 type PodInformer struct {
@@ -54,6 +56,7 @@ func NewPodInformer(node string) (*PodInformer, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.UserAgent = version.UserAgent() + " (container-collection/NewPodInformer)"
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/pkg/gadget-service/store/k8s-configmap-store/configmapstore.go
+++ b/pkg/gadget-service/store/k8s-configmap-store/configmapstore.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	instancemanager "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/instance-manager"
 )
@@ -78,6 +79,7 @@ func (s *Store) init() error {
 	if err != nil {
 		return err
 	}
+	config.UserAgent = version.UserAgent() + " (k8s-configmap-store/init)"
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -24,9 +24,11 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+
+	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 )
 
-func NewKubeConfig(kubeconfigPath string) (*rest.Config, error) {
+func NewKubeConfig(kubeconfigPath, userAgentComment string) (*rest.Config, error) {
 	var config *rest.Config
 	var err error
 	if kubeconfigPath != "" {
@@ -42,11 +44,16 @@ func NewKubeConfig(kubeconfigPath string) (*rest.Config, error) {
 			}
 		}
 	}
+	config.UserAgent = version.UserAgent()
+	if userAgentComment != "" {
+		config.UserAgent += " (" + userAgentComment + ")"
+	}
+
 	return config, err
 }
 
-func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
-	config, err := NewKubeConfig(kubeconfigPath)
+func NewClientset(kubeconfigPath, userAgentComment string) (*kubernetes.Clientset, error) {
+	config, err := NewKubeConfig(kubeconfigPath, userAgentComment)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +68,8 @@ func NewClientset(kubeconfigPath string) (*kubernetes.Clientset, error) {
 
 // NewClientsetWithProtobuf creates a client to talk to the Kubernetes API
 // server using protobuf encoding.
-func NewClientsetWithProtobuf(kubeconfigPath string) (*kubernetes.Clientset, error) {
-	config, err := NewKubeConfig(kubeconfigPath)
+func NewClientsetWithProtobuf(kubeconfigPath, userAgentComment string) (*kubernetes.Clientset, error) {
+	config, err := NewKubeConfig(kubeconfigPath, userAgentComment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operators/common/kubeinventorycache.go
+++ b/pkg/operators/common/kubeinventorycache.go
@@ -199,7 +199,7 @@ func transformObject(obj any) (any, error) {
 }
 
 func newCache() (*inventoryCache, error) {
-	clientset, err := k8sutil.NewClientsetWithProtobuf("")
+	clientset, err := k8sutil.NewClientsetWithProtobuf("", "kube-inventory-cache")
 	if err != nil {
 		return nil, fmt.Errorf("creating new k8s clientset: %w", err)
 	}

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -315,7 +315,7 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 
 		if pullSecretString != "" {
 			var err error
-			k8sClient, err := k8sutil.NewClientset("")
+			k8sClient, err := k8sutil.NewClientset("", "pull-secret")
 			if err != nil {
 				return fmt.Errorf("creating new k8s clientset: %w", err)
 			}


### PR DESCRIPTION
# k8s.io/client-go: add user agent

When investigating high network traffic to the Kubernetes API server, it is useful to have the user agent set with relevent information to find out where the requests are coming from.

## How to use

No changes in the configuration or installation.

Users of Kubernetes can use the [Audit Logs](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/) to see the user agent in the requests to the API server.

## Testing done

With internal executables:

```
$ sudo ./ig version 
v0.40.0-61-g68cce8aa6-dirty
$ sudo ./ig version -v
v0.40.0-61-g68cce8aa6-dirty
DEBU[0000] Inspektor Gadget User Agent: ig/v0.40.0-61-g68cce8aa6-dirty (linux/amd64) kubernetes/v0.33.0 
```

```
$ kubectl logs -n gadget gadget-9jsh2|head -2
time="2025-05-15T12:26:46Z" level=info msg="Inspektor Gadget version: 0.40.0-61-g5eb92cb1a-dirty"
time="2025-05-15T12:26:46Z" level=info msg="Inspektor Gadget User Agent: gadgettracermanager/v0.40.0-61-g5eb92cb1a-dirty (linux/amd64) kubernetes/v0.33.0"
```

Tested with [additional](https://gist.github.com/alban/1ab9cc0f1997ecf664b3ff6550bb961f) `fmt.Printf` debugs:
```
$ kubectl logs -n gadget gadget-tcdt5|grep '^UserAgent:'|uniq
UserAgent: gadgettracermanager/v0.40.0-61-g2b5c8b489-dirty (linux/amd64) kubernetes/v0.33.0 (container-collection/WithKubernetesEnrichment)
UserAgent: gadgettracermanager/v0.40.0-61-g2b5c8b489-dirty (linux/amd64) kubernetes/v0.33.0 (container-collection/NewK8sClient)
UserAgent: gadgettracermanager/v0.40.0-61-g2b5c8b489-dirty (linux/amd64) kubernetes/v0.33.0 (container-collection/NewPodInformer)
UserAgent: gadgettracermanager/v0.40.0-61-g2b5c8b489-dirty (linux/amd64) kubernetes/v0.33.0 (container-collection/GetOwnerReference)
UserAgent: gadgettracermanager/v0.40.0-61-g2b5c8b489-dirty (linux/amd64) kubernetes/v0.33.0 (k8s-configmap-store/init)
```

With third-party software using Inspektor Gadget as a library (tested with [igver3](https://github.com/alban/igexamples/tree/main/cmd/igver3)):

```
$ ./igver3 |grep UserAgent
version.UserAgent: igver3/v0.0.0-20250515123755-150ef58ada95+dirty (linux/amd64) ig/v0.40.1-0.20250515123231-d6b81d20dfa8 kubernetes/v0.33.0
```

