### PR TITLE
ci: Improve gadget building time 

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -375,6 +375,11 @@ func isImageLocallyAvailable(ctx context.Context, cli *client.Client, imageRefer
 				return true, nil
 			}
 		}
+		for _, digest := range img.RepoDigests {
+			if digest == imageReference {
+				return true, nil
+			}
+		}
 	}
 	return false, nil
 }

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -15,6 +15,7 @@ COSIGN ?= cosign
 CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
+DOCKER ?= docker
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -64,18 +65,26 @@ GADGETS_README_DEV = $(filter-out ci/%, $(addsuffix /dev.md, $(GADGETS)))
 .PHONY: all
 all: build
 
+.PHONY: build
 build: $(GADGETS)
+
+# Pull the gadget builder in an independent step to avoid doing the same for
+# each gadget, which introduces some overhead and increases the build time.
+.PHONY: pull-builder-image
+pull-builder-image:
+	$(DOCKER) pull $(BUILDER_IMAGE)
 
 # GADGET_BUILD_PARAMS can be used to pass additional parameters e.g
 # GADGET_BUILD_PARAMS="--update-metadata" make build
 .PHONY: $(GADGETS)
-$(GADGETS):
+$(GADGETS): pull-builder-image
 	@echo "Building $@"
 	@sudo -E \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
 		-t $(GADGET_REPOSITORY)/$@:$(GADGET_TAG) \
+		--builder-image-pull=never \
 		$$GADGET_BUILD_PARAMS \
 		$@
 


### PR DESCRIPTION
- Move the pulling logic to a different step on the makefile to avoid pulling the gadget builder for each gadget.
- Fix a bug found while trying the above 

### Testing 

0. Be sure you have the latest gadget-builder image available:

```bash 
$ docker pull ghcr.io/inspektor-gadget/gadget-builder:main
main: Pulling from inspektor-gadget/gadget-builder
Digest: sha256:dac71c0de0d83ecc8e7785688548fc795a1e8c374e4dfa2827fe982dd99f8584
Status: Image is up to date for ghcr.io/inspektor-gadget/gadget-builder:main
ghcr.io/inspektor-gadget/gadget-builder:main
```

### Before this PR 

Building with a single core on my machine takes around 2 minutes 

```bash
$ time make -C gadgets
...

real    1m52,879s
user    0m0,411s
sys     0m0,458s
```

### After this PR 

Building with a single core only takes around 1m20s.

```bash 
$ time make -C gadgets

real    1m18,537s
user    0m0,648s
sys     0m0,521s
```

EDIT: I initially opened this hoping the time used in the CI will be lower, but it seems to be the same, probably because the latency between github runners and ghcr is very small, hence trying to pull the image multiple times doesn't have a big impact as when running it locally. Please check it on your systems and let me know if you see any improvement.