### PR TITLE
container-collection: publish oci config as a string

### DIFF
--- a/examples/kube-container-collection/main.go
+++ b/examples/kube-container-collection/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -81,13 +80,8 @@ func callback(notif containercollection.PubSubEvent) {
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
 		fmt.Printf("Container added: %v pid %d\n", notif.Container.Runtime.ContainerID, notif.Container.ContainerPid())
-		if notif.Container.OciConfig != nil {
-			config, err := json.Marshal(notif.Container.OciConfig)
-			if err != nil {
-				publishEvent(notif.Container, "CannotMarshalContainerConfig", err.Error())
-			} else {
-				publishEvent(notif.Container, "NewContainerConfig", string(config))
-			}
+		if notif.Container.OciConfig != "" {
+			publishEvent(notif.Container, "NewContainerConfig", notif.Container.OciConfig)
 		} else {
 			publishEvent(notif.Container, "ContainerConfigNotFound", "")
 		}

--- a/gadgets/ci/datasource-containers/test/integration/datasource_test.go
+++ b/gadgets/ci/datasource-containers/test/integration/datasource_test.go
@@ -30,10 +30,12 @@ import (
 )
 
 type DatasourceContainersEvent struct {
-	CgroupID  uint64 `json:"cgroup_id"`
-	EventType string `json:"event_type"`
-	MntnsID   uint64 `json:"mntns_id"`
-	Name      string `json:"name"`
+	ContainerID     string `json:"container_id"`
+	ContainerConfig string `json:"container_config"`
+	CgroupID        uint64 `json:"cgroup_id"`
+	EventType       string `json:"event_type"`
+	MntnsID         uint64 `json:"mntns_id"`
+	Name            string `json:"name"`
 }
 
 func TestDatasourceContainers(t *testing.T) {
@@ -80,15 +82,21 @@ func TestDatasourceContainers(t *testing.T) {
 	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
 		func(t *testing.T, output string) {
 			expectedEntry := &DatasourceContainersEvent{
-				EventType: "CREATED",
-				Name:      containerName,
-				MntnsID:   utils.NormalizedInt,
-				CgroupID:  utils.NormalizedInt,
+				EventType:       "CREATED",
+				Name:            containerName,
+				MntnsID:         utils.NormalizedInt,
+				CgroupID:        utils.NormalizedInt,
+				ContainerID:     utils.NormalizedStr,
+				ContainerConfig: "", // See issue 3884
 			}
 
 			normalize := func(e *DatasourceContainersEvent) {
 				utils.NormalizeInt(&e.CgroupID)
 				utils.NormalizeInt(&e.MntnsID)
+				utils.NormalizeString(&e.ContainerID)
+				// ContainerConfig is sometimes empty:
+				// https://github.com/inspektor-gadget/inspektor-gadget/issues/3884
+				e.ContainerConfig = ""
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)

--- a/integration/ig/non-k8s/list_containers_test.go
+++ b/integration/ig/non-k8s/list_containers_test.go
@@ -43,7 +43,7 @@ func TestFilterByContainerName(t *testing.T) {
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.OciConfig = nil
+				c.OciConfig = ""
 				c.Bundle = ""
 				c.Mntns = 0
 				c.Netns = 0
@@ -110,7 +110,7 @@ func TestWatchContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.OciConfig = nil
+				e.Container.OciConfig = ""
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
 				e.Container.Netns = 0

--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -90,7 +90,7 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.OciConfig = nil
+				c.OciConfig = ""
 				c.Bundle = ""
 				c.Mntns = 0
 				c.Netns = 0
@@ -163,7 +163,7 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.OciConfig = nil
+				e.Container.OciConfig = ""
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
 				e.Container.Netns = 0

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -66,7 +66,7 @@ func newListContainerTestStep(
 			}
 
 			normalize := func(c *containercollection.Container) {
-				c.OciConfig = nil
+				c.OciConfig = ""
 				c.Bundle = ""
 				c.Mntns = 0
 				c.Netns = 0
@@ -199,7 +199,7 @@ func TestWatchCreatedContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.OciConfig = nil
+				e.Container.OciConfig = ""
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
 				e.Container.Netns = 0
@@ -295,7 +295,7 @@ func TestWatchDeletedContainers(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.OciConfig = nil
+				e.Container.OciConfig = ""
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
 				e.Container.Netns = 0
@@ -394,7 +394,7 @@ func TestPodWithSecurityContext(t *testing.T) {
 			}
 
 			normalize := func(e *containercollection.PubSubEvent) {
-				e.Container.OciConfig = nil
+				e.Container.OciConfig = ""
 				e.Container.Bundle = ""
 				e.Container.Mntns = 0
 				e.Container.Netns = 0

--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/moby/moby/pkg/stringid"
-	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -41,7 +40,7 @@ type Container struct {
 
 	// Container's configuration is the config.json from the OCI runtime
 	// spec
-	OciConfig *ocispec.Spec `json:"ociConfig,omitempty"`
+	OciConfig string `json:"ociConfig,omitempty"`
 
 	// Bundle is the directory containing the config.json from the OCI
 	// runtime spec

--- a/pkg/container-collection/ocispec.go
+++ b/pkg/container-collection/ocispec.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file provides lightweight functions to parse the OCI config
+// The oci config is expected to be in the format of
+// https://github.com/opencontainers/runtime-spec/blob/v1.2.1/specs-go/config.go#L18
+
+package containercollection
+
+import (
+	"encoding/json"
+)
+
+// ociConfigGetSourceMounts returns the source mounts from the oci config
+func ociConfigGetSourceMounts(ociConfig string) (out []string, err error) {
+	var config struct {
+		Mounts []struct {
+			Source string `json:"source,omitempty"`
+		} `json:"mounts,omitempty"`
+	}
+	err = json.Unmarshal([]byte(ociConfig), &config)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range config.Mounts {
+		out = append(out, m.Source)
+	}
+	return out, nil
+}
+
+// ociConfigGetAnnotations returns the annotations from the oci config
+func ociConfigGetAnnotations(ociConfig string) (map[string]string, error) {
+	var config struct {
+		Annotations map[string]string `json:"annotations,omitempty"`
+	}
+	err := json.Unmarshal([]byte(ociConfig), &config)
+	if err != nil {
+		return nil, err
+	}
+	return config.Annotations, nil
+}

--- a/pkg/container-hook/tracer_test.go
+++ b/pkg/container-hook/tracer_test.go
@@ -78,7 +78,7 @@ func TestContainerHookEvent(t *testing.T) {
 				// normalize
 				event.ContainerName = ""
 				event.ContainerPID = 0
-				event.ContainerConfig = nil
+				event.ContainerConfig = ""
 				event.Bundle = ""
 
 				events = append(events, event)

--- a/pkg/gadgettracermanager/gadgettracermanager.go
+++ b/pkg/gadgettracermanager/gadgettracermanager.go
@@ -26,8 +26,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 	log "github.com/sirupsen/logrus"
 
-	ocispec "github.com/opencontainers/runtime-spec/specs-go"
-
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerhook "github.com/inspektor-gadget/inspektor-gadget/pkg/container-hook"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -175,20 +173,13 @@ func (g *GadgetTracerManager) AddContainer(_ context.Context, containerDefinitio
 				ContainerName: containerDefinition.Name,
 			},
 		},
+		OciConfig: containerDefinition.OciConfig,
 	}
 	if containerDefinition.LabelsSet {
 		container.K8s.PodLabels = make(map[string]string)
 		for _, l := range containerDefinition.Labels {
 			container.K8s.PodLabels[l.Key] = l.Value
 		}
-	}
-	if containerDefinition.OciConfig != "" {
-		containerConfig := &ocispec.Spec{}
-		err := json.Unmarshal([]byte(containerDefinition.OciConfig), containerConfig)
-		if err != nil {
-			return nil, fmt.Errorf("unmarshaling container config: %w", err)
-		}
-		container.OciConfig = containerConfig
 	}
 
 	g.ContainerCollection.AddContainer(&container)


### PR DESCRIPTION
This PR is a first step for #4458.

The container-collection package detects when the container runtime starts a new container and reads the oci config (config.json from the container runtime spec). This config is used internally in the container-collection package for two purposes:
1. Look up the mount for the Kubernetes ServiceAccount token volume to distinguish several containers from the same pod.
2. Look up the annotations for Kubernetes enrichment (pod name, etc.)

This patch makes the config available in the containers data source as a string. It is now unmarshalled partially only when needed.

Before this patch, the config was completely unmarshalled using the opencontainers/runtime-spec package v1.2.1 (version specified in go.mod):
https://github.com/opencontainers/runtime-spec/blob/v1.2.1/specs-go/config.go#L6

```
$ sudo ig list-containers -o json -w
{
  "timestamp": "2025-05-20T11:04:34+02:00",
  "event": "CREATED",
  "container": {
    "runtime": {
      "runtimeName": "docker",
      "containerId": "a5c7f2341346455531e3b5c4ca9fa96ed598d2c8d157ff617bfce1f5a948be57",
      "containerName": "ecstatic_tesla",
      "containerPid": 49978,
      "containerImageName": "busybox",
      "containerStartedAt": 1747731874644255522
    },
    "k8s": {},
    "ociConfig": {
      "ociVersion": "1.2.0",
      "process": {
        "terminal": true,
```

This means that if users run runc/crun with a newer version of runtime-spec with new fields, they will be lost.

After this patch, the config is displayed as a string without changes:
```
$ sudo ig list-containers -o json -w
{
  "timestamp": "2025-05-20T11:02:36+02:00",
  "event": "CREATED",
  "container": {
    "runtime": {
      "runtimeName": "docker",
      "containerId": "e63be34d020f4b3f44cd7cba885511f751dc901ab605324551d7e18ede482ca1",
      "containerName": "ecstatic_solomon",
      "containerPid": 48248,
      "containerImageName": "busybox",
      "containerStartedAt": 1747731756812735022
    },
    "k8s": {},
    "ociConfig": "{\"ociVersion\":\"1.2.0\",\"process\":{\"terminal\":true
```

This will be useful in the next patches when implementing the possibility to modify the config from the "containers" data source:
- We will avoid unnecessary unmarshalling/re-marshalling
- This will help with compatibility when additional fields are added in the container-runtime spec.

## How to use



## Testing done

- [x] Listing containers
  - [x] Manual test: `sudo ig list-containers -o json -w`
  - [x] Automatic tests: `integration/**/list_containers_test.go`
- [x] OCI config in the "containers" data source: `gadgets/ci/datasource-containers/test/integration/datasource_test.go`
