### PR TITLE
gadgets/trace_exec: cleaned up test process in unit tests

### DIFF
--- a/gadgets/trace_exec/test/unit/trace_exec_test.go
+++ b/gadgets/trace_exec/test/unit/trace_exec_test.go
@@ -146,7 +146,10 @@ func TestTraceExecGadget(t *testing.T) {
 					if testCase.runFromThread {
 						generateEventFromThread(t, testCase.argv)
 					} else {
-						os.StartProcess(testCase.argv[0], testCase.argv, &os.ProcAttr{})
+						p, err := os.StartProcess(testCase.argv[0], testCase.argv, &os.ProcAttr{})
+						if err == nil {
+							defer p.Wait()
+						}
 					}
 					return nil
 				})


### PR DESCRIPTION
For the trace exec unit tests, this commit cleans up the resources being used by the test process.
