### PR TITLE
combiner: Disable timeout if interval and count is zero

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -393,6 +393,7 @@ func (i *ebpfInstance) register(gadgetCtx operators.GadgetContext) error {
 		// combiner operator handle the data correctly
 		// TODO: Make this configurable
 		m.ds.AddAnnotation(api.FetchIntervalAnnotation, "0")
+		m.ds.AddAnnotation(api.FetchCountAnnotation, "1")
 	}
 	for name, m := range i.mapIters {
 		fields := make([]*Field, 0)


### PR DESCRIPTION
This combination only happens for the advise_networkpolicy gadget. There we have an array datasource and only want to get a packet at the end of the gadget, when it gets cancled/stopped.

This is done through setting count and interval to 0, while having flush-on-stop set to true