### PR TITLE
pkg/params: allow escaping comma characters for string slices

### DIFF
--- a/pkg/gadget-service/api/helpers.go
+++ b/pkg/gadget-service/api/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,26 +97,30 @@ func (pv ParamValues) ExtractPrefixedValues(prefix string) ParamValues {
 
 func SplitStringWithEscape(s string, sep rune) []string {
 	var result []string
-	var part string
+	var b strings.Builder
 	var escape bool
 	for _, c := range s {
 		if escape {
 			escape = false
-			part += string(c)
+			if c != sep && c != '\\' {
+				// Leave escape char alone if not a sep or backslash
+				b.WriteByte('\\')
+			}
+			b.WriteRune(c)
 			continue
 		}
 		switch c {
 		case '\\':
 			escape = true
 		case sep:
-			result = append(result, part)
-			part = ""
+			result = append(result, b.String())
+			b.Reset()
 		default:
-			part += string(c)
+			b.WriteRune(c)
 		}
 	}
-	if part != "" {
-		result = append(result, part)
+	if b.Len() > 0 {
+		result = append(result, b.String())
 	}
 	return result
 }

--- a/pkg/operators/filter/filter_test.go
+++ b/pkg/operators/filter/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -247,7 +247,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name:         "string escaped match positive",
-			filterString: `stringValueEscaped==a\,\\\/`,
+			filterString: `stringValueEscaped==a\,\/`,
 			match:        true,
 		},
 

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Inspektor Gadget authors
+// Copyright 2022-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,6 +134,12 @@ func TestParamAs(t *testing.T) {
 			name:     "StringSlice()_Empty",
 			value:    "",
 			expected: []string{},
+			getter:   func(p *Param) any { return p.AsStringSlice() },
+		},
+		{
+			name:     "StringSlice()_EscapedCommas",
+			value:    "foo,bar,zas\\,foob,olo\\lol,fro\\\\bedeedoo",
+			expected: []string{"foo", "bar", "zas,foob", "olo\\lol", "fro\\bedeedoo"},
 			getter:   func(p *Param) any { return p.AsStringSlice() },
 		},
 		{
@@ -463,8 +469,8 @@ func TestBytesHandling(t *testing.T) {
 }
 
 func TestStringSlice(t *testing.T) {
-	const testStringSlice = "foo,bar,quux"
-	testStringSliceExpected := []string{"foo", "bar", "quux"}
+	const testStringSlice = "foo,bar,quux,abc\\,def"
+	testStringSliceExpected := []string{"foo", "bar", "quux", "abc,def"}
 	params := Params{
 		&Param{
 			ParamDesc: &ParamDesc{


### PR DESCRIPTION
This allows strings to contain escaped commas (e.g. `abc\,def,ghi`) that are not considered delimiters (leading to `["abc,def", "ghi"` instead of `["abc\", "def", ghi"]`). Escape characters are only removed if used with a legal character (comma and backslash), and otherwise kept as is.

I also modified the already existing code in the api package to behave the same way (before it would always remove escape characters). I deliberately chose to duplicate code here to keep both packages fully self-contained.

This was reported as bug on [slack](https://kubernetes.slack.com/archives/CSYL75LF6/p1747680905544569).