### PR TITLE
ci: Fix key calculation for gadget-builder-image cache

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -989,7 +989,10 @@ jobs:
             context: "/home/runner/work/inspektor-gadget/inspektor-gadget"
             dockerfile: "Dockerfiles/gadget-builder.Dockerfile"
             platform: "linux/amd64,linux/arm64"
-            key-files: "'include/**','Dockerfiles/gadget-builder.Dockerfile','cmd/common/image/Makefile.build'"
+            key-files: |
+              include/**
+              Dockerfiles/gadget-builder.Dockerfile
+              cmd/common/image/Makefile.build
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Docker Buildx


### PR DESCRIPTION
Previous logic was always using the same key for the cache:

```
Run actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
  with:
    path: /tmp/.buildx-cache
    key: Linux-docker-gadget-builder-
    restore-keys: Linux-docker-gadget-builder-
```

Fixes: f438ace21f5c ("ci: Enable cache for building helper images")


