### PR TITLE
New Gadget: Snapshot File

### DIFF
--- a/docs/gadgets/snapshot_file.mdx
+++ b/docs/gadgets/snapshot_file.mdx
@@ -1,0 +1,1 @@
+../../gadgets/snapshot_file/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -64,6 +64,7 @@ GADGETS ?= \
 	ci/sched_cls_drop \
 	ci/image_inspect \
 	ci/container_filtering \
+	snapshot_file \
 	#
 
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/gadgets/snapshot_file/README.md
+++ b/gadgets/snapshot_file/README.md
@@ -1,0 +1,5 @@
+# snapshot_file
+
+The snapshot file gadget gathers information about all the open files (regular and directories by default).
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/snapshot_file.

--- a/gadgets/snapshot_file/README.mdx
+++ b/gadgets/snapshot_file/README.mdx
@@ -1,0 +1,112 @@
+---
+title: snapshot_file
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The `snapshot_file` gadget shows open files for running processes.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/snapshot_file:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_file:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+### `--paths`
+
+Show full file paths (by default, only dentry names are shown).
+
+Default value: `"false"`
+
+### `--file-type-mask`
+
+Filter which file types to display using a bitmask.
+By default, only **regular files** and **directories** are shown (bitmask value 17).
+
+Supported file types:
+
+- REGULAR
+- SOCKET
+- PIPE
+- BPF_MAP
+- DIRECTORY
+- CHAR_DEV
+- BLOCK_DEV
+- SYMLINK
+- OTHER
+
+The bitmask order, from left to right, corresponds to the file types listed above.
+
+## Guide
+
+Run a pod / container:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl run --restart=Never --image=busybox test-snapshot-file -- sh -c 'echo hello > /tmp/demo.txt && tail -f /tmp/demo.txt'
+pod/test-snapshot-file created
+```
+
+</TabItem>
+
+<TabItem value="ig" label="ig">
+```bash
+$ docker run --name test-snapshot-file -d busybox /bin/sh -c 'echo hello > /tmp/demo.txt && tail -f /tmp/demo.txt'
+...
+```
+
+Now, run the gadget and see how it shows the open file:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl gadget run snapshot_file:%IG_TAG%
+K8S.NODE         K8S.NAMESPACE   K8S.PODNAME         K8S.CONTAINERNAME   COMM   PID   TID   FD   PATH      TYPE       FLAGS    
+minikube-docker  default         test-snapshot-file  test-snapshot-file  tail   5432  5432  3    demo.txt  REGULAR    O_RDONLY  
+^C
+```
+</TabItem>
+
+<TabItem value="ig" label="ig">
+```bash
+$ sudo ig run snapshot_file:%IG_TAG% -c test-snapshot-file
+RUNTIME.CONTAINERNAME             COMM               PID        TID   FD         PATH            TYPE            FLAGS              
+test-snapshot-file                tail               5321       5321  3          demo.txt        REGULAR         O_RDONLY
+^C
+```
+</TabItem>
+</Tabs>
+
+Finally, clean the system:
+
+<Tabs groupId="env">
+<TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+$ kubectl delete pod test-snapshot-file
+```
+</TabItem>
+
+<TabItem value="ig" label="ig">
+```bash
+$ docker rm -f test-snapshot-file
+```
+</TabItem>
+</Tabs>
+

--- a/gadgets/snapshot_file/artifacthub-pkg.yml
+++ b/gadgets/snapshot_file/artifacthub-pkg.yml
@@ -1,0 +1,31 @@
+# Artifact Hub package metadata file
+version: 0.46.0
+name: "snapshot file"
+category: monitoring-logging
+displayName: "snapshot file"
+createdAt: "2025-11-14T02:10:08Z"
+digest: "2025-11-14T02:10:08Z"
+description: "Show open files for running processes"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/snapshot_file"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/snapshot_file:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+    - files
+    - snapshot
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/snapshot_file"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/snapshot_file:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/snapshot_file/gadget.yaml
+++ b/gadgets/snapshot_file/gadget.yaml
@@ -1,0 +1,30 @@
+name: snapshot file
+description: Show open files
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/snapshot_file
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/snapshot_file
+datasources:
+  files:
+    fields:
+      mntns_id:
+        annotations:
+          columns.hidden: true
+      inode:
+        annotations:
+          columns.hidden: true
+      flags_raw:
+        annotations:
+          columns.hidden: true
+      flags:
+        annotations:
+          columns.hidden: false
+params:
+  ebpf:
+    paths:
+      key: paths
+      defaultValue: "false"
+      description: Enable to get the complete file paths in the output. If disabled, only the file names will be shown.
+    file_type_mask:
+      key: type-mask
+      defaultValue: "17"
+      description: File type mask to filter files by type (default includes regular files and directories => 2^0 + 2^4 = 17)

--- a/gadgets/snapshot_file/program.bpf.c
+++ b/gadgets/snapshot_file/program.bpf.c
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Shaheer Ahmad */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+#include <gadget/macros.h>
+#include <gadget/filter.h>
+#include <gadget/types.h>
+#include <gadget/filesystem.h>
+
+const volatile bool paths = false;
+
+#define MAX_PATH_LEN 256
+
+enum file_type {
+	REGULAR = 0,
+	SOCKET,
+	PIPE,
+	BPF_MAP,
+	DIRECTORY,
+	CHAR_DEV,
+	BLOCK_DEV,
+	SYMLINK,
+	OTHER
+};
+
+// Regular and Directory by default
+const volatile u32 file_type_mask = (1U << REGULAR) | (1U << DIRECTORY);
+
+struct gadget_file {
+	gadget_mntns_id mntns_id;
+	char comm[TASK_COMM_LEN];
+	gadget_pid pid;
+	gadget_tid tid;
+	__u32 fd;
+	enum file_type type_raw;
+	char path[MAX_PATH_LEN];
+	__u64 inode;
+	gadget_file_flags flags_raw;
+};
+
+#define S_IFMT 00170000 /* bitmask for the file type bitfields */
+#define S_IFSOCK 0140000 /* socket */
+#define S_IFLNK 0120000 /* symbolic link */
+#define S_IFREG 0100000 /* regular file */
+#define S_IFBLK 0060000 /* block device */
+#define S_IFDIR 0040000 /* directory */
+#define S_IFCHR 0020000 /* character device */
+#define S_IFIFO 0010000 /* FIFO */
+
+GADGET_PARAM(file_type_mask);
+GADGET_PARAM(paths);
+
+GADGET_SNAPSHOTTER(files, gadget_file, ig_snap_file);
+
+static __always_inline u32 classify_file_type(struct file *file)
+{
+	u32 mode = BPF_CORE_READ(file, f_inode, i_mode) & S_IFMT;
+
+	switch (mode) {
+	case S_IFREG:
+		return REGULAR;
+	case S_IFDIR:
+		return DIRECTORY;
+	case S_IFIFO:
+		return PIPE;
+	case S_IFSOCK:
+		return SOCKET;
+	case S_IFCHR:
+		return CHAR_DEV;
+	case S_IFBLK:
+		return BLOCK_DEV;
+	case S_IFLNK:
+		return SYMLINK;
+	default:
+		return OTHER;
+	}
+}
+
+static __always_inline int copy_dentry_name(struct path *path, char *buf,
+					    int buf_len)
+{
+	// barebones implementation to get the first part of the dentry name
+	struct dentry *dentry;
+	const unsigned char *name;
+	u32 name_len;
+
+	if (!path || !buf)
+		return -1;
+
+	dentry = BPF_CORE_READ(path, dentry);
+	name = BPF_CORE_READ(dentry, d_name.name);
+	name_len = BPF_CORE_READ(dentry, d_name.len);
+
+	if (name_len >= buf_len)
+		name_len = buf_len - 1;
+
+	if (bpf_probe_read_kernel_str(buf, name_len + 1, name) < 0)
+		return -1;
+
+	return 0;
+}
+
+/*  
+   * BPF iterator program: one invocation per (task, file)  
+   */
+SEC("iter/task_file")
+int ig_snap_file(struct bpf_iter__task_file *ctx)
+{
+	struct seq_file *seq = ctx->meta->seq;
+	struct task_struct *task = ctx->task;
+	struct file *file = ctx->file;
+	struct gadget_file info;
+
+	if (!task || !file)
+		return 0;
+
+	if (gadget_should_discard_data(
+		    task->nsproxy->mnt_ns->ns.inum, task->tgid, task->pid,
+		    task->comm, task->cred->uid.val, task->cred->gid.val))
+		return 0;
+
+	info.mntns_id = task->nsproxy->mnt_ns->ns.inum;
+	__builtin_memcpy(info.comm, task->comm, TASK_COMM_LEN);
+	info.pid = task->tgid;
+	info.tid = task->pid;
+	info.fd = ctx->fd;
+	info.inode = BPF_CORE_READ(file, f_inode, i_ino);
+	info.flags_raw = BPF_CORE_READ(file, f_flags);
+
+	info.type_raw = classify_file_type(file);
+
+	if (!((1U << info.type_raw) & file_type_mask))
+		return 0; // skip this file
+	if (paths) {
+		char *file_path;
+		file_path = get_path_str(&file->f_path);
+		bpf_probe_read_kernel_str(info.path, sizeof(info.path),
+					  file_path);
+	} else {
+		copy_dentry_name(&file->f_path, info.path, MAX_PATH_LEN);
+	}
+	bpf_seq_write(seq, &info, sizeof(info));
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/gadgets/snapshot_file/test/unit/snapshot_file_test.go
+++ b/gadgets/snapshot_file/test/unit/snapshot_file_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type ExpectedSnapshotFileEvent struct {
+	MntNsID uint64 `json:"mntns_id"`
+	Comm    string `json:"comm"`
+	Pid     uint32 `json:"pid"`
+	Tid     uint32 `json:"tid"`
+	Type    string `json:"type"`
+	Path    string `json:"path"`
+}
+
+type testDef struct {
+	runnerConfig   *utils.RunnerConfig
+	generateEvent  func(t *testing.T) (string, int, error)
+	validateEvent  func(t *testing.T, info *utils.RunnerInfo, pid int, filePath string, events []ExpectedSnapshotFileEvent)
+	mntnsFilterMap func(info *utils.RunnerInfo) *ebpf.Map
+}
+
+func TestSnapshotFileGadget(t *testing.T) {
+	// task iterator was introduced in 5.8
+	gadgettesting.MinimumKernelVersion(t, "5.8")
+	gadgettesting.InitUnitTest(t)
+	runnerConfig := &utils.RunnerConfig{HostNetwork: true}
+	testCases := map[string]testDef{
+		"captures_events_with_no_filter": {
+			runnerConfig:  runnerConfig,
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utils.RunnerInfo, pid int, filePath string, events []ExpectedSnapshotFileEvent) {
+				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedSnapshotFileEvent {
+					return &ExpectedSnapshotFileEvent{
+						Comm:    "tail",
+						Type:    "REGULAR",
+						Path:    filePath,
+						Pid:     uint32(pid),
+						Tid:     uint32(pid),
+						MntNsID: info.MountNsID,
+					}
+				})(t, info, pid, events)
+			},
+		},
+		"captures_events_with_matching_filter": {
+			runnerConfig: runnerConfig,
+			mntnsFilterMap: func(info *utils.RunnerInfo) *ebpf.Map {
+				return utils.CreateMntNsFilterMap(t, info.MountNsID)
+			},
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utils.RunnerInfo, pid int, filePath string, events []ExpectedSnapshotFileEvent) {
+				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedSnapshotFileEvent {
+					return &ExpectedSnapshotFileEvent{
+						Comm:    "tail",
+						Type:    "REGULAR",
+						Path:    filePath,
+						Pid:     uint32(pid),
+						Tid:     uint32(pid),
+						MntNsID: info.MountNsID,
+					}
+				})(t, info, pid, events)
+			},
+		},
+		"captures_no_events_with_no_matching_filter": {
+			runnerConfig: runnerConfig,
+			mntnsFilterMap: func(info *utils.RunnerInfo) *ebpf.Map {
+				mnts, _ := containerutils.GetNetNs(os.Getpid())
+				return utils.CreateMntNsFilterMap(t, mnts)
+			},
+			generateEvent: generateEvent,
+			validateEvent: func(t *testing.T, info *utils.RunnerInfo, pid int, filePath string, events []ExpectedSnapshotFileEvent) {
+				for _, event := range events {
+					if event.Comm == "tail" && event.Type == "REGULAR" && event.Path == filePath && event.Pid == uint32(pid) {
+						t.Errorf("Did not expect any matching event, but found one: %+v", event)
+					}
+				}
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var processId int
+			var filePath string
+
+			runner := utils.NewRunnerWithTest(t, testCase.runnerConfig)
+			var mntnsFilterMap *ebpf.Map
+			if testCase.mntnsFilterMap != nil {
+				mntnsFilterMap = testCase.mntnsFilterMap(runner.Info)
+			}
+			beforeGadgetRun := func() error {
+				utils.RunWithRunner(t, runner, func() error {
+					uniqueFilePath, pid, err := testCase.generateEvent(t)
+					if err != nil {
+						return err
+					}
+					processId = pid
+					filePath = uniqueFilePath
+					return nil
+				})
+				return nil
+			}
+			opts := gadgetrunner.GadgetRunnerOpts[ExpectedSnapshotFileEvent]{
+				Image:           "snapshot_file",
+				Timeout:         5 * time.Second,
+				MntnsFilterMap:  mntnsFilterMap,
+				BeforeGadgetRun: beforeGadgetRun,
+				ParamValues: api.ParamValues{
+					"operator.oci.ebpf.paths": "true", // unique full paths ensure non interference between parallel tests
+				},
+			}
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+			gadgetRunner.RunGadget()
+			testCase.validateEvent(t, runner.Info, processId, filePath, gadgetRunner.CapturedEvents)
+		})
+	}
+}
+
+func generateEvent(t *testing.T) (string, int, error) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "demo.txt")
+
+	createCmd := exec.Command("sh", "-c", "echo hello > "+filePath)
+	if err := createCmd.Run(); err != nil {
+		return "", 0, err
+	}
+
+	tailCmd := exec.Command("tail", "-f", filePath)
+	if err := tailCmd.Start(); err != nil {
+		return "", 0, err
+	}
+
+	pid := tailCmd.Process.Pid
+
+	t.Cleanup(func() {
+		if tailCmd.Process != nil {
+			_ = tailCmd.Process.Kill()
+		}
+	})
+	return filePath, pid, nil
+}


### PR DESCRIPTION
From the root directory, run this to build the gadget
`./ig image build -t snapshot_file:latest ./gadgets/snapshot_file`
then run the gadget using
`sudo ./ig run snapshot_file:latest --verify-image=false`
you may pass optional  `--type-mask` parameter for filtering

an effort towards #1774 

sample output:
<img width="772" height="412" alt="image" src="https://github.com/user-attachments/assets/47265cb7-f115-4f98-87f7-68ab497f236c" />
