### PR TITLE
ig, ig-k8s: ensure that $NODE_NAME is set

### DIFF
--- a/pkg/gadget-service/store/k8s-configmap-store/configmapstore.go
+++ b/pkg/gadget-service/store/k8s-configmap-store/configmapstore.go
@@ -16,6 +16,7 @@ package k8sconfigmapstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -61,9 +62,13 @@ type Store struct {
 }
 
 func New(mgr *instancemanager.Manager, namespace string) (*Store, error) {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		return nil, errors.New("NODE_NAME environment variable is not set, cannot use config map store")
+	}
 	s := &Store{
 		instanceMgr:     mgr,
-		nodeName:        os.Getenv("NODE_NAME"),
+		nodeName:        nodeName,
 		gadgetNamespace: namespace,
 	}
 	err := s.init()

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -267,7 +267,11 @@ func (l *localManager) Init(operatorParams *params.Params) error {
 
 	additionalOpts := []containercollection.ContainerCollectionOption{}
 	if operatorParams.Get(EnrichWithK8sApiserver).AsBool() {
-		additionalOpts = append(additionalOpts, containercollection.WithKubernetesEnrichment("", nil))
+		nodeName := os.Getenv("NODE_NAME")
+		if nodeName == "" {
+			return errors.New("NODE_NAME environment variable is not set, cannot enrich with K8s API server")
+		}
+		additionalOpts = append(additionalOpts, containercollection.WithKubernetesEnrichment(nodeName, nil))
 	}
 
 	igManager, err := igmanager.NewManager(l.rc, additionalOpts)


### PR DESCRIPTION
"ig run --enrich-with-k8s-apiserver" requires that $NODE_NAME is set. This patch ensures that nodeName is initialized correctly.

Without this patch, the function getPodByCgroups (which allows to distinguish different containers in a single pod) will not be able to fetch only the pods for the current node. The kube-apiserver will receive requests with this URL:

    /api/v1/pods?fieldSelector=spec.nodeName%3D

On clusters with many nodes, this was a waste of resources.

