### PR TITLE
container-collection: improve error messages

### DIFF
--- a/pkg/container-collection/ocispec.go
+++ b/pkg/container-collection/ocispec.go
@@ -20,10 +20,15 @@ package containercollection
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 // ociConfigGetSourceMounts returns the source mounts from the oci config
 func ociConfigGetSourceMounts(ociConfig string) (out []string, err error) {
+	if ociConfig == "" {
+		return nil, errors.New("ociConfig is empty")
+	}
+
 	var config struct {
 		Mounts []struct {
 			Source string `json:"source,omitempty"`
@@ -41,6 +46,10 @@ func ociConfigGetSourceMounts(ociConfig string) (out []string, err error) {
 
 // ociConfigGetAnnotations returns the annotations from the oci config
 func ociConfigGetAnnotations(ociConfig string) (map[string]string, error) {
+	if ociConfig == "" {
+		return nil, errors.New("ociConfig is empty")
+	}
+
 	var config struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 	}

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -539,11 +539,6 @@ func WithKubernetesEnrichment(nodeName string) ContainerCollectionOption {
 						return false
 					}
 				}
-				srcs, err := ociConfigGetSourceMounts(container.OciConfig)
-				if err != nil {
-					log.Warnf("kubernetes enricher: failed to get source mounts for container %s: %s", container.Runtime.ContainerID, err)
-					// We won't get ContainerName but keep going
-				}
 
 				if container.K8s.ContainerName == "" {
 					var containerName string
@@ -558,6 +553,13 @@ func WithKubernetesEnrichment(nodeName string) ContainerCollectionOption {
 					for _, c := range pod.Spec.EphemeralContainers {
 						containerNames = append(containerNames, c.Name)
 					}
+
+					srcs, err := ociConfigGetSourceMounts(container.OciConfig)
+					if err != nil {
+						log.Warnf("kubernetes enricher: failed to get source mounts for container %s: %s", container.Runtime.ContainerID, err)
+						// We won't get ContainerName but keep going
+					}
+
 				outerLoop:
 					for _, name := range containerNames {
 						for _, src := range srcs {


### PR DESCRIPTION
When ig fails to get the OCI config, the error messages were confusing:
```
WARN[0001] kubernetes enricher: failed to get source mounts for container 0cae3a07a7f140e770c415d421d7ff641b46ca2bff898e2226d8069e6e086e5d: unexpected end of JSON input
WARN[0001] kubernetes enricher: failed to get source mounts for container 6a01354d1e6a0d7902b8cda9f3b15ab982d4915c62172a6ebecc197aa0131445: unexpected end of JSON input
WARN[0001] kubernetes enricher: failed to get source mounts for container 9b30e0412a63f36fbd959ffe913d8618b1bfec555cc9d322904991e723e20cae: unexpected end of JSON input
```
To reproduce:
```
$ minikube cp ig /bin/ig
$ minikube ssh sudo chmod +x /bin/ig
$ minikube ssh "sudo NODE_NAME=minikube-docker ig run trace_exec:main --enrich-with-k8s-apiserver --kubeconfig=/etc/kubernetes/admin.conf"
```
This patch:
- improves the warning message
- removes the warning message if the OCI config is not actually needed

Fixes: b1f24a0bcb7f ("container-collection: publish oci config as a string")

Related PRs:
- #4518
- #4482 
- #4520

cc @mqasimsarfraz 