### PR TITLE
container-hook: introduce PreCreateContainer events

### DIFF
--- a/gadgets/ci/datasource-containers/go/program.go
+++ b/gadgets/ci/datasource-containers/go/program.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,7 +50,7 @@ func gadgetPreStart() int {
 	}
 
 	ds.Subscribe(func(ds api.DataSource, data api.Data) {
-		_, err := eventTypeField.String(data, 7)
+		_, err := eventTypeField.String(data, api.DataSourceContainersEventTypeMaxSize)
 		if err != nil {
 			api.Errorf("getting event_type from corresponding field: %v", err)
 			return

--- a/pkg/container-collection/container-collection.go
+++ b/pkg/container-collection/container-collection.go
@@ -490,7 +490,8 @@ func (cc *ContainerCollection) Subscribe(key interface{}, selector ContainerSele
 	}
 	ret := []*Container{}
 	cc.pubsub.Subscribe(key, func(event PubSubEvent) {
-		if ContainerSelectorMatches(&selector, event.Container) {
+		// PRECREATE events cannot be filtered since they are not enriched yet.
+		if event.Type == EventTypePreCreateContainer || ContainerSelectorMatches(&selector, event.Container) {
 			f(event)
 		}
 	}, func() {

--- a/pkg/container-collection/options.go
+++ b/pkg/container-collection/options.go
@@ -630,6 +630,20 @@ func WithContainerFanotifyEbpf() ContainerCollectionOption {
 				cc.AddContainer(container)
 			case containerhook.EventTypeRemoveContainer:
 				cc.RemoveContainer(notif.ContainerID)
+			case containerhook.EventTypePreCreateContainer:
+				if cc.pubsub != nil {
+					container := &Container{
+						Runtime: RuntimeMetadata{
+							types.BasicRuntimeMetadata{
+								ContainerID:   notif.ContainerID,
+								ContainerName: notif.ContainerName,
+							},
+						},
+						OciConfig: notif.ContainerConfig,
+						Bundle:    notif.Bundle,
+					}
+					cc.pubsub.Publish(EventTypePreCreateContainer, container)
+				}
 			}
 		})
 		if err != nil {

--- a/pkg/container-collection/pubsub.go
+++ b/pkg/container-collection/pubsub.go
@@ -26,12 +26,15 @@ type FuncNotify func(event PubSubEvent)
 const (
 	EventTypeAddContainer EventType = iota
 	EventTypeRemoveContainer
+	EventTypePreCreateContainer
 )
 
 func (e *EventType) String() string {
 	switch *e {
 	case EventTypeRemoveContainer:
 		return "DELETED"
+	case EventTypePreCreateContainer:
+		return "PRECREATE"
 	case EventTypeAddContainer:
 		fallthrough
 	default:
@@ -43,6 +46,8 @@ func EventTypeFromString(s string) EventType {
 	switch s {
 	case "DELETED":
 		return EventTypeRemoveContainer
+	case "PRECREATE":
+		return EventTypePreCreateContainer
 	case "CREATED":
 		fallthrough
 	default:

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -324,6 +324,14 @@ func (m *KubeManagerInstance) handleGadgetInstance(log logger.Logger) error {
 					attachContainerFunc(event.Container)
 				case containercollection.EventTypeRemoveContainer:
 					detachContainerFunc(event.Container)
+				case containercollection.EventTypePreCreateContainer:
+					// nothing to do
+				default:
+					log.Errorf("unknown event type, expected either %s, %s or %s, got %s",
+						containercollection.EventTypePreCreateContainer,
+						containercollection.EventTypeAddContainer,
+						containercollection.EventTypeRemoveContainer,
+						event.Type)
 				}
 			},
 		)

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -448,9 +448,14 @@ func (l *localManagerTrace) handleGadgetInstance(log logger.Logger) error {
 						attachContainerFunc(event.Container)
 					case containercollection.EventTypeRemoveContainer:
 						detachContainerFunc(event.Container)
+					case containercollection.EventTypePreCreateContainer:
+						// nothing to do
 					default:
-						log.Errorf("unknown event type, expected either %s or %s, got %s", containercollection.EventTypeAddContainer, containercollection.EventTypeRemoveContainer, event.Type)
-						return
+						log.Errorf("unknown event type, expected either %s, %s or %s, got %s",
+							containercollection.EventTypePreCreateContainer,
+							containercollection.EventTypeAddContainer,
+							containercollection.EventTypeRemoveContainer,
+							event.Type)
 					}
 				},
 			)

--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -129,9 +129,10 @@ const (
 	DataSourceContainers = "containers"
 
 	// Data source "containers" has a field EventType with the following possible values:
+	// - PRECREATE
 	// - CREATED
 	// - DELETED
-	// The maximum length is 7. Keeping more for future compatibility.
+	// The maximum length is 9. Keeping more for future compatibility.
 	DataSourceContainersEventTypeMaxSize = 16
 )
 


### PR DESCRIPTION
PreCreateContainer events happen before the container is created and include the OCI config. The event is included in the "containers" datasource, so gadgets have an opportunity to inspect the container id and container config.

The pid, namespaces and other fields are not available since they will be known only after the container is created.

---

This is part of #4458.

This patch does not allow gadgets to modify the container config yet. I intend to introduce that in a future PR.

## How to use

```
$ sudo ig list-containers -w
...
2025-05-27T17:30:22… PRECREATE                      3888fa4ac0652b4…                                       0                                               1970-01-01T01:00:00.000000000+01:00
2025-05-27T17:30:22… CREATED    docker              3888fa4ac0652b4… keen_cartwright                       3357032 busybox                                 2025-05-27T17:30:22.432075058+02:00
2025-05-27T17:30:27… DELETED    docker              3888fa4ac0652b4… keen_cartwright                       3357032 busybox                                 2025-05-27T17:30:22.432075058+02:00
```

## Testing done

```
$ sudo ig list-containers -w
$ sudo ig list-containers -w -o json
```

## TODO

- [x] #4531
- [x] add test in gadgets/ci/datasource-containers/test/integration/datasource_test.go (done after #4520)
