### PR TITLE
container-collection/k8s: Set PodLabels with the method

### DIFF
--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -212,10 +212,12 @@ func (k *K8sClient) GetRunningContainers(pod *v1.Pod) []Container {
 					Namespace:     pod.GetNamespace(),
 					PodName:       pod.GetName(),
 					ContainerName: s.Name,
-					PodLabels:     labels,
 				},
 			},
 		}
+
+		// PodLabels must be set through the SetPodLabels method
+		containerDef.SetPodLabels(pod.Labels)
 		containers = append(containers, containerDef)
 	}
 


### PR DESCRIPTION
Initial K8s containers set the PodLabels directly. This changed in https://github.com/inspektor-gadget/inspektor-gadget/pull/4237 where the PodLabels ***has to be set*** through the Method `SetPodLabels`, so it updates the `podLabelsAsString` which actually gets written to the events

Fixes: 8647f0e04eb51d15673325791de22f8324a436d9