### PR TITLE
wasmapi/go: define constants for "containers" datasource

### DIFF
--- a/gadgets/traceloop/go/program.go
+++ b/gadgets/traceloop/go/program.go
@@ -691,7 +691,6 @@ func gadgetInit() int32 {
 
 //go:wasmexport gadgetStart
 func gadgetStart() int32 {
-
 	rawString, err := api.GetParamValue("syscall-filters", 256)
 	if err != nil {
 		api.Errorf("failed to get param: %v", err)
@@ -730,7 +729,7 @@ func gadgetStart() int32 {
 			return 1
 		}
 	}
-	
+
 	if len(syscallFilters) > 0 {
 		syscallsEnableFilterMapName := "syscall_enable_filters"
 		syscallsEnableFilterMap, err := api.GetMap(syscallsEnableFilterMapName)
@@ -776,7 +775,7 @@ func gadgetStart() int32 {
 		}
 	}
 
-	ds, err := api.GetDataSource("containers")
+	ds, err := api.GetDataSource(api.DataSourceContainers)
 	if err != nil {
 		api.Errorf("Failed to get data source: %v", err)
 		return 1
@@ -801,9 +800,7 @@ func gadgetStart() int32 {
 	}
 
 	ds.Subscribe(func(ds api.DataSource, data api.Data) {
-		// Event type is CREATED or DELETED, 7 is the length of longest string, i.e.
-		// DELETED.
-		eventType, err := eventTypeField.String(data, 7)
+		eventType, err := eventTypeField.String(data, api.DataSourceContainersEventTypeMaxSize)
 		if err != nil {
 			api.Errorf("getting event_type from corresponding field: %v", err)
 			return
@@ -837,7 +834,7 @@ func gadgetStart() int32 {
 				return
 			}
 		default:
-			api.Errorf("unknown event type for container %v: got %v, expected CREATED or DELETED", name, eventType)
+			// Nothing to do, we don't care about other events.
 		}
 	}, 0)
 

--- a/wasmapi/go/datasource.go
+++ b/wasmapi/go/datasource.go
@@ -129,6 +129,17 @@ var (
 	dsSubcriptions    = map[uint64]subscription{}
 )
 
+const (
+	// Well known data sources
+	DataSourceContainers = "containers"
+
+	// Data source "containers" has a field EventType with the following possible values:
+	// - CREATED
+	// - DELETED
+	// The maximum length is 7. Keeping more for future compatibility.
+	DataSourceContainersEventTypeMaxSize = 16
+)
+
 //go:wasmexport dataSourceCallback
 func dataSourceCallback(cbID uint64, ds uint32, data uint32) {
 	sub, ok := dsSubcriptions[cbID]


### PR DESCRIPTION
Data source "containers" has a field EventType with the following possible values:
- CREATED
- DELETED

The maximum length is 7 characters. However, I am planning do add a new value, so the maximum length will increase.

This patch defines a constant for the maximum length with some spare room to ease future compatibility.

See also: https://github.com/inspektor-gadget/inspektor-gadget/pull/4458#discussion_r2086612875

Fixes: 3690cd4a066c ("gadgets: Convert traceloop to image-based gadgets.")

cc @eiffel-fl 