### PR TITLE
Add tty field

### DIFF
--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -87,6 +87,11 @@ datasources:
           description: Whether the executable file of the process (script in case of script) is in the upper layer of the overlay filesystem. Initialized when the execution succeeded or failed with the -ENOEXEC error ("Exec format error"). Notice that to get failed executions, you need to set ignore_failed to false.
           columns.width: 5
           columns.hidden: true
+      tty:
+        annotations:
+          description: The controlling terminal of the process. 0 for processes without a terminal.
+          columns.width: 5
+          columns.hidden: false
 params:
   ebpf:
     ignore_failed:

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -40,6 +40,7 @@ struct event {
 	__u32 sessionid;
 	gadget_errno error_raw;
 	int args_count;
+	int tty;
 	bool upper_layer;
 	bool fupper_layer;
 	bool pupper_layer;
@@ -133,6 +134,8 @@ static __always_inline int enter_execve(const char *pathname, const char **args)
 
 	event->args_count = 0;
 	event->args_size = 0;
+
+	event->tty = BPF_CORE_READ(task, signal, tty, index);
 
 	if (paths) {
 		struct fs_struct *fs = BPF_CORE_READ(task, fs);


### PR DESCRIPTION
Fixes #4495


```
RUNTIME.CONTAINERNAME                                                                     COMM                    PID        TID TTY_INDEX   ARGS                                                      ERROR
happy_jackson                                                                             utempter              27564      27564 0                                                                          
happy_jackson                                                                             groups                27565      27565 1           /usr/bin/groups                                                
happy_jackson                                                                             locale-check          27566      27566 1           /usr/bin/locale-check C.UTF-8                                  
happy_jackson                                                                             dircolors             27567      27567 1           /usr/bin/dircolors -b                                          
happy_jackson                                                                             mesg                  27568      27568 1           /usr/bin/mesg n                                                
happy_jackson                                                                             bash                  28146      28146 2           /bin/bash                                                      
happy_jackson                                                                             utempter              28147      28147 0                                                                          
happy_jackson                                                                             groups                28148      28148 2           /usr/bin/groups                                                
happy_jackson                                                                             locale-check          28149      28149 2           /usr/bin/locale-check C.UTF-8                                  
happy_jackson                                                                             dircolors             28150      28150 2           /usr/bin/dircolors -b                                          
happy_jackson                                                                             mesg                  28151      28151 2           /usr/bin/mesg n                                                
happy_jackson                                                                             bash                  28441      28441 3           /bin/bash                                                      
happy_jackson                                                                             utempter              28442      28442 0                                                                          
happy_jackson                                                                             groups                28443      28443 3           /usr/bin/groups                                                
happy_jackson                                                                             locale-check          28444      28444 3           /usr/bin/locale-check C.UTF-8                                  
happy_jackson                                                                             dircolors             28445      28445 3           /usr/bin/dircolors -b                                          
happy_jackson                                                                             mesg                  28446      28446 3           /usr/bin/mesg 

```


Tested by creating multiple terminal sessions within a container using tmux
