### PR TITLE
daemonset: add startup probe

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -66,6 +66,13 @@ spec:
                 - -liveness
             periodSeconds: 5
             timeoutSeconds: 2
+          startupProbe:
+            exec:
+              command:
+                - /bin/gadgettracermanager
+                - -liveness
+            failureThreshold: 12
+            periodSeconds: 5
           env:
             - name: NODE_NAME
               valueFrom:

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -178,6 +178,13 @@ spec:
                 - -liveness
             periodSeconds: 5
             timeoutSeconds: 2
+          startupProbe:
+            exec:
+              command:
+                - /bin/gadgettracermanager
+                - -liveness
+            failureThreshold: 12
+            periodSeconds: 5
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
The daemon set currently has:
- an optional liveness probe controlled by the flag --liveness-probe
- a mandatory readiness probe, see commit 1af4130f59bc ("cmd/kubect-gadget: Add readiness probe")

When ig is slow to start, it can easily crash loop. It can be slow on large clusters with slow kube-apiservers to reply to the initial requests.

This patch adds a startup probe to wait up to 1 minute to initialize. Kubernetes will mark the pod as ready sooner if the initialization happens faster.

## How to use

Both options are supported:
- kubectl-gadget deploy
- Helm charts

## Testing done

