### PR TITLE
docs: Fix softlink for advise_networkpolicy

### DIFF
--- a/docs/gadgets/advise_networkpolicy.mdx
+++ b/docs/gadgets/advise_networkpolicy.mdx
@@ -1,1 +1,1 @@
-gadgets/advise_networkpolicy/README.mdx
+../../gadgets/advise_networkpolicy/README.mdx


### PR DESCRIPTION
Fix link to ensure website builds fine.

Fixes: e9904075d92d ("Gadgets: Add advise_networkpolicy as ibg")

