### PR TITLE
docs/kubectl-debug: Fix running with `--enrich-with-k8s-apiserver`

### DIFF
--- a/docs/reference/ig.md
+++ b/docs/reference/ig.md
@@ -193,13 +193,14 @@ In order to use `--enrich-with-k8s-apiserver`, the spawned debug pod has to have
 This can be done with giving it the `cluster-admin` role:
 
 ```bash
-$ kubectl create serviceaccount -n kube-system ig
+$ kubectl create namespace ig
 
 $ kubectl create clusterrolebinding ig \
   --clusterrole=cluster-admin \
-  --serviceaccount=kube-system:ig
+  --serviceaccount=ig:default
 
-$ kubectl debug -n kube-system --as system:serviceaccount:kube-system:ig --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig trace exec --enrich-with-k8s-apiserver -o columns=k8s.owner.kind,k8s.owner.name,pid,comm,args
+$ NODE_NAME=minikube-docker
+$ kubectl debug -n ig --profile=sysadmin node/$NODE_NAME --env NODE_NAME=$NODE_NAME  -ti --image=ghcr.io/inspektor-gadget/ig -- ig run trace_exec --enrich-with-k8s-apiserver --fields k8s.owner.kind,k8s.owner.name,pid,comm,args
 ```
 
 ### Using ig as a daemon


### PR DESCRIPTION
Currently we were using `--as` in the docs to allow `ig` have more permission to list k8s resources but `--as` is only for the client operations, meaning the current steps will fail if the default service account doesn't have enough permissions. This change moves the step to independent namespace `ig` and uses the higher permission for default service account to allow ig run fine using `kubectl debug`.

Also, the old steps worked fine on minikube because of the custom clusterrolebinding [`minikube-rbac`](https://github.com/kubernetes/minikube/blob/97cc0cab231cdafdc35aee41aa655891f5d43f11/pkg/minikube/bootstrapper/kubeadm/kubeadm.go#L1112). 

### Before the change

```
$ NODE_NAME=aks-agentpool-70213919-vmss000000
$  kubectl debug --as=system:serviceaccount:kube-system:ig -n kube-system --profile=sysadmin node/$NODE_NAME --env NODE_NAME=$NODE_NAME -ti --image=ghcr.io/inspektor-gadget/ig -- ig trace exec --enrich-with-k8s-apiserver -o columns=k8s.owner.kind,k8s.owner.name,pid,comm,args  
Creating debugging pod node-debugger-aks-agentpool-70213919-vmss000000-zw9n5 with container debugger on node aks-agentpool-70213919-vmss000000.

If you don't see a command prompt, try pressing enter.
ERRO[0001] kubernetes enricher (from ns/podname): cannot find pod kube-system/csi-azurefile-node-58756: pods "csi-azurefile-node-58756" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 

ERRO[0001] kubernetes enricher (from ns/podname): cannot find pod kube-system/azure-policy-webhook-6cdcfb977f-lsvdt: pods "azure-policy-webhook-6cdcfb977f-lsvdt" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 
ERRO[0002] kubernetes enricher (from ns/podname): cannot find pod kube-system/eraser-controller-manager-8694d54d99-8xgbh: pods "eraser-controller-manager-8694d54d99-8xgbh" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 
ERRO[0002] kubernetes enricher (from ns/podname): cannot find pod kube-system/metrics-server-6d968d6d47-xhb7f: pods "metrics-server-6d968d6d47-xhb7f" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 
ERRO[0002] kubernetes enricher (from ns/podname): cannot find pod kube-system/azure-cns-h5rw4: pods "azure-cns-h5rw4" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 
ERRO[0002] kubernetes enricher (from ns/podname): cannot find pod kube-system/csi-azurefile-node-58756: pods "csi-azurefile-node-58756" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "kube-system" 
^CERRO[0002] kubernetes enricher (from ns/podname): cannot find pod gadget/gadget-t2zxn: pods "gadget-t2zxn" is forbidden: User "system:serviceaccount:kube-system:default" cannot get resource "pods" in API group "" in the namespace "gadget" 
```

### After the change

```
$ kubectl debug -n ig --profile=sysadmin node/aks-agentpool-70213919-vmss000000 --env NODE_NAME=aks-agentpool-70213919-vmss000000 -ti --image=ghcr.io/mqasimsarfraz/ig:main -- ig run trace_exec --enrich-with-k8s-apiserver --fields k8s.owner.kind,k8s.owner.name,pid,comm,args
Creating debugging pod node-debugger-aks-agentpool-70213919-vmss000000-fvfzc with container debugger on node aks-agentpool-70213919-vmss000000.
If you don't see a command prompt, try pressing enter.
WARN[0005] This gadget was built with ig v0.40.0 and it's being run with v0.0.0. Gadget could be incompatible 
WARN[0006] This gadget was built with ig v0.40.0 and it's being run with v0.0.0. Gadget could be incompatible 
K8S.OWNER.KIND                                           K8S.OWNER.NAME                                                  PID COMM             ARGS                                                    
DaemonSet                                                gadget                                                      1340228 runc             /bin/gadgettracermanager -liveness                      
DaemonSet                                                gadget                                                      1340229 runc             /bin/gadgettracermanager -liveness             
```

cc: @alban 