### PR TITLE
docs/reference/export-metrics: Fix typo

### DIFF
--- a/docs/reference/export-metrics.mdx
+++ b/docs/reference/export-metrics.mdx
@@ -220,7 +220,7 @@ operator:
 ```
 
 This will add a new exporter named "myexporter" that can be selected by using the flag
-`--otel-metric-exporter myexporter` when running a gadget. `exporter` needs to be set to `otlp-grpc` and you at least
+`--otel-metrics-exporter myexporter` when running a gadget. `exporter` needs to be set to `otlp-grpc` and you at least
 need to configure an `endpoint`.
 
 #### Insecure


### PR DESCRIPTION
Fix typo in docs/reference/export-metrics