### PR TITLE
gadgets: Add dummy unit tests for all gadgets

### DIFF
--- a/gadgets/audit_seccomp/test/unit/audit_seccomp_test.go
+++ b/gadgets/audit_seccomp/test/unit/audit_seccomp_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestAuditSeccomp(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "audit_seccomp")
+}

--- a/gadgets/deadlock/test/unit/deadlock_test.go
+++ b/gadgets/deadlock/test/unit/deadlock_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestDeadlock(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "deadlock")
+}

--- a/gadgets/profile_blockio/test/unit/profile_blockio_test.go
+++ b/gadgets/profile_blockio/test/unit/profile_blockio_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestProfileBlockio(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+
+	// TODO: This is the minimum kernel version the gadget works on among the
+	// ones we test. We need to check if it works with other versions that we
+	// don't test, like 5.9
+	gadgettesting.MinimumKernelVersion(t, "5.10")
+
+	gadgettesting.DummyGadgetTest(t, "profile_blockio")
+}

--- a/gadgets/profile_cpu/test/unit/profile_cpu_test.go
+++ b/gadgets/profile_cpu/test/unit/profile_cpu_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestProfileCpu(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "profile_cpu")
+}

--- a/gadgets/profile_qdisc_latency/test/unit/profile_qdisc_latency_test.go
+++ b/gadgets/profile_qdisc_latency/test/unit/profile_qdisc_latency_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestProfileQdiscLatency(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+
+	// TODO: This is the minimum kernel version the gadget works on among the
+	// ones we test. We need to check if it works with other versions that we
+	// don't test, like 5.14
+	gadgettesting.MinimumKernelVersion(t, "5.15")
+
+	gadgettesting.DummyGadgetTest(t, "profile_qdisc_latency")
+}

--- a/gadgets/profile_tcprtt/test/unit/profile_tcprtt_test.go
+++ b/gadgets/profile_tcprtt/test/unit/profile_tcprtt_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestProfileTcprtt(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "profile_tcprtt")
+}

--- a/gadgets/snapshot_socket/test/unit/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/unit/snapshot_socket_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestSnapshotSocket(t *testing.T) {
+	gadgettesting.MinimumKernelVersion(t, "5.8")
+
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "snapshot_socket")
+}

--- a/gadgets/top_blockio/test/unit/top_blockio_test.go
+++ b/gadgets/top_blockio/test/unit/top_blockio_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTopBlockio(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+
+	// TODO: This is the minimum kernel version the gadget works on among the
+	// ones we test. We need to check if it works with other versions that we
+	// don't test, like 6.5
+	gadgettesting.MinimumKernelVersion(t, "6.6")
+
+	gadgettesting.DummyGadgetTest(t, "top_blockio")
+}

--- a/gadgets/top_process/test/unit/top_process_test.go
+++ b/gadgets/top_process/test/unit/top_process_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTopProcess(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "top_process")
+}

--- a/gadgets/top_tcp/test/unit/top_tcp_test.go
+++ b/gadgets/top_tcp/test/unit/top_tcp_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTopTcp(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "top_tcp")
+}

--- a/gadgets/trace_dns/test/unit/trace_dns_test.go
+++ b/gadgets/trace_dns/test/unit/trace_dns_test.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceDns(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces the right events.
+	paramValues := map[string]string{
+		"operator.oci.ebpf.paths": "true",
+	}
+	gadgettesting.DummyGadgetTest(t, "trace_dns", gadgettesting.WithParamValues(paramValues))
+}

--- a/gadgets/trace_fsslower/test/unit/trace_fsslower_test.go
+++ b/gadgets/trace_fsslower/test/unit/trace_fsslower_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceFsslower(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+
+	if os.Getenv("KERNEL_VERSION") != "" {
+		t.Skipf("Skipping test on ci-kernels images don't provide any filesystem")
+	}
+
+	paramValues := map[string]string{
+		"operator.oci.wasm.filesystem": "ext4",
+	}
+	gadgettesting.DummyGadgetTest(t, "trace_fsslower", gadgettesting.WithParamValues(paramValues))
+}

--- a/gadgets/trace_lsm/test/unit/trace_lsm_test.go
+++ b/gadgets/trace_lsm/test/unit/trace_lsm_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceLsm(t *testing.T) {
+	t.Skip("Unit tests for this gadget doesn't work yet")
+
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_lsm")
+}

--- a/gadgets/trace_malloc/test/unit/trace_malloc_test.go
+++ b/gadgets/trace_malloc/test/unit/trace_malloc_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceMalloc(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_malloc")
+}

--- a/gadgets/trace_mount/test/unit/trace_mount_test.go
+++ b/gadgets/trace_mount/test/unit/trace_mount_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceMount(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_mount")
+}

--- a/gadgets/trace_oomkill/test/unit/trace_oomkill_test.go
+++ b/gadgets/trace_oomkill/test/unit/trace_oomkill_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceOomkill(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_oomkill")
+}

--- a/gadgets/trace_sni/test/unit/trace_sni_test.go
+++ b/gadgets/trace_sni/test/unit/trace_sni_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceSni(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_sni")
+}

--- a/gadgets/trace_tcpdrop/test/unit/trace_tcpdrop_test.go
+++ b/gadgets/trace_tcpdrop/test/unit/trace_tcpdrop_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceTcpdrop(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+
+	// TODO: This is the minimum kernel version the gadget works on among the
+	// ones we test. We need to check if it works with other versions that we
+	// don't test, like 6.0
+	gadgettesting.MinimumKernelVersion(t, "6.1")
+
+	gadgettesting.DummyGadgetTest(t, "trace_tcpdrop")
+}

--- a/gadgets/trace_tcpretrans/test/unit/trace_tcpretrans_test.go
+++ b/gadgets/trace_tcpretrans/test/unit/trace_tcpretrans_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceTcpretrans(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "trace_tcpretrans")
+}

--- a/gadgets/traceloop/test/unit/traceloop_test.go
+++ b/gadgets/traceloop/test/unit/traceloop_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+)
+
+func TestTraceloop(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.InitUnitTest(t)
+
+	// TODO: This is the minimum kernel version the gadget works on among the
+	// ones we test. We need to check if it works with other versions that we
+	// don't test, like 5.9
+	gadgettesting.MinimumKernelVersion(t, "5.10")
+
+	// This gadget requires the containers datasource, create a dummy operator to register it
+	myOp := simple.New("myop",
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			ds, err := gadgetCtx.RegisterDataSource(datasource.TypeSingle, "containers")
+			require.NoError(t, err)
+
+			_, err = ds.AddField("event_type", api.Kind_String)
+			require.NoError(t, err)
+
+			_, err = ds.AddField("mntns_id", api.Kind_Uint64)
+			require.NoError(t, err)
+
+			_, err = ds.AddField("name", api.Kind_String)
+			require.NoError(t, err)
+
+			return nil
+		}),
+	)
+
+	opts := gadgetrunner.GadgetRunnerOpts[any]{
+		Image:   "traceloop",
+		Timeout: 5 * time.Second,
+		ParamValues: map[string]string{
+			"operator.oci.wasm.syscall-filters": "",
+		},
+	}
+
+	gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+	gadgetRunner.DataOperator = append(gadgetRunner.DataOperator, myOp)
+	gadgetRunner.RunGadget()
+}


### PR DESCRIPTION
Add dummy unit tests to verify that at least those gadgets are running fine on different kernel versions. For sure, we need to extend them later on to verify the data provided by the gadget.

