### PR TITLE
gadgets/Makefile: Make GADGETS variable configurable

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -20,7 +20,7 @@ DOCKER ?= docker
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
 
-GADGETS = \
+GADGETS ?= \
 	advise_networkpolicy \
 	advise_seccomp \
 	audit_seccomp \


### PR DESCRIPTION
When I want to build, push, run tests, ... a subset of gadgets I currently need to do the following:

```bash
$ make -C gadgets trace_exec
$ make -C gadgets trace_open
$ ...

$ make -C gadgets trace_exec/test_unit
$ make -C gadgets trace_open/test_unit
```

With the commit in this PR I can easily do all the steps in one:
```bash
$ GADGETS="trace_exec trace_open" make -C gadgets
$ GADGETS="trace_exec trace_open" make -C gadgets test-unit
```

This has the additional benefit for `test-unit` and `test-integration`, where it only runs the tests for gadgets that actually have the corresponding tests