### PR TITLE
operators: wasm: testdata: Fix wrong name for datasource.

### DIFF
--- a/pkg/operators/wasm/testdata/badguest/program.go
+++ b/pkg/operators/wasm/testdata/badguest/program.go
@@ -188,7 +188,7 @@ func gadgetInit() int32 {
 	debug.SetGCPercent(-1)
 
 	const (
-		dsSingleName = "myarrayds"
+		dsSingleName = "mysingleds"
 		dsArrayName  = "myarrayds"
 		fieldName    = "myfield"
 	)


### PR DESCRIPTION
Found while writing the following:
https://github.com/inspektor-gadget/inspektor-gadget/commit/ad6130736a63305f038c9e451491478dbf40b177#diff-c0d7f9a4592f240dcb072b359a9472a528939f9c4e803f8ddc523e8d83a52121