### PR TITLE
localmanager: Fix crash when container collection isn't available

### DIFF
--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -544,6 +544,10 @@ func (l *localManager) InstantiateDataOperator(gadgetCtx operators.GadgetContext
 
 	var containersPublisher *common.ContainersPublisher
 	if enableContainersDs {
+		if l.igManager == nil {
+			return nil, fmt.Errorf("container-collection isn't available, but containers datasource is enabled")
+		}
+
 		containersPublisher, err = common.NewContainersPublisher(gadgetCtx, &l.igManager.ContainerCollection)
 		if err != nil {
 			return nil, fmt.Errorf("creating containers publisher: %w", err)


### PR DESCRIPTION
If the container collection is not available and the containerDS is requested, the code crashes as l.igManager is nil. Add an explicit check for it.

Fixes: 0a60b97d4a15 ("pkg/containers-publisher: Add new containerspublisher package.")

Found while implementing a dummy test for traceloop on #4544

https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/15422969966/attempts/1

```bash
--- FAIL: TestTraceloop (2.04s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3490e9f]

goroutine 18 [running]:
testing.tRunner.func1.2({0x38736e0, 0x592fbf0})
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1737 +0x35e
panic({0x38736e0?, 0x592fbf0?})
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/panic.go:787 +0x132
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManager).InstantiateDataOperator(0xc0001bb3b0, {0x417aad0, 0xc0003cba40}, 0xc0020e6060)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager/localmanager.go:547 +0x2ff
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).initAndPrepareOperators(0xc0003cba40, 0xc0001bb500)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/gadget-context/run.go:70 +0x536
github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context.(*GadgetContext).Run(0xc0003cba40, 0xc0001bb500)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/gadget-context/run.go:177 +0x346
github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local.(*Runtime).RunGadget(0x4131418?, {0x418dbd0?, 0xc0003cba40?}, 0x0?, 0xc00209fe10?)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/runtime/local/oci.go:34 +0x27
github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner.(*GadgetRunner[...]).RunGadget(0x4124ac0)
	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner/gadgetrunner.go:214 +0xac5
github.com/inspektor-gadget/inspektor-gadget/gadgets/testing.DummyGadgetTest(0xc0003cb880, {0x3d42e2f, 0x9}, {0xc000085758, 0x1, 0x0?})
	/home/runner/work/inspektor-gadget/inspektor-gadget/gadgets/testing/testing.go:161 +0x105
github.com/inspektor-gadget/inspektor-gadget/gadgets/traceloop/test/unit.TestTraceloop(0xc0003cb880)
	/home/runner/work/inspektor-gadget/inspektor-gadget/gadgets/traceloop/test/unit/traceloop_test.go:31 +0xa5
testing.tRunner(0xc0003cb880, 0x3e94b60)
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x413
```