### PR TITLE
introduce generic packet filters and new gadget tcpdump

### DIFF
--- a/docs/gadgets/tcpdump.mdx
+++ b/docs/gadgets/tcpdump.mdx
@@ -1,0 +1,1 @@
+../../gadgets/tcpdump/README.mdx

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101 // indirect
+	github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b // indirect
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/containerd/containerd v1.7.28 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gopacket/gopacket v1.4.0 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
@@ -95,6 +97,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
+	github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -29,6 +29,8 @@ github.com/cilium/ebpf v0.8.1/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMt
 github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101 h1:DWbiRLIoIjcHMZ3jXcEYIzMjXPHcSmO6ipjOk+mGDBA=
 github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b h1:EgR1t4Lnq6uP6QxJQ+oIFtENOHUY3/7gMOE76vL0KcA=
+github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b/go.mod h1:X/9cHz8JVzKlvoZyKBgMgrogKZlLf+pWjmm5gSUm5dI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
@@ -167,6 +169,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAx
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
+github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
@@ -281,6 +285,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
+github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7 h1:MfXxQU9tEe3zmyLVVwE8gJwQVtsG2aqzBkFNz0N6eAo=
+github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7/go.mod h1:1jryUz9E2ndKwZBNHzVhLMzS3WHO0fOKydYi9XWWu9w=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -32,6 +32,7 @@ GADGETS ?= \
 	profile_cpu \
 	profile_qdisc_latency \
 	profile_tcprtt \
+	tcpdump \
 	trace_bind \
 	trace_capabilities \
 	trace_dns \

--- a/gadgets/tcpdump/README.md
+++ b/gadgets/tcpdump/README.md
@@ -1,0 +1,6 @@
+# tcpdump
+
+The tcpdump gadget captures packets in container contexts and allows applying pcap-compatible filters. This is usually
+combined with the `pcap-ng` output mode and piped to the `tcpdump` command or to a file - see the guide below.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/tcpdump

--- a/gadgets/tcpdump/README.mdx
+++ b/gadgets/tcpdump/README.mdx
@@ -1,0 +1,80 @@
+---
+title: tcpdump
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# tcpdump
+
+The tcpdump gadget captures packets in container contexts and allows applying pcap-compatible filters. This is usually
+combined with the `pcap-ng` output mode and piped to the `tcpdump` command or to a file - see the guide below.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/tcpdump:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/tcpdump:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+### `--snaplen`
+
+Sets the maximum number of bytes to capture from a packet.
+
+Default value: 0
+
+## Guide
+
+### Piping to tcpdump
+
+If you want to let tcpdump analyze the captured traffic directly, you can use the `pcap-ng` output mode and pipe IG's
+output directly to tcpdump like so:
+
+```bash
+$ ig run tcpdump:%IG_TAG% --host --pf "port 80" -o pcap-ng | tcpdump -nvr -
+14:18:23.386163 IP (tos 0x0, ttl 64, id 59190, offset 0, flags [DF], proto TCP (6), length 60)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [S], cksum 0xb6f0 (incorrect -> 0x68f7), seq 1211089028, win 64240, options [mss 1460,sackOK,TS val 3404957675 ecr 0,nop,wscale 7], length 0
+14:18:23.405108 IP (tos 0x0, ttl 127, id 3783, offset 0, flags [none], proto TCP (6), length 48)
+    13.107.253.67.80 > 172.17.0.2.53618: Flags [S.], cksum 0x988a (correct), seq 2080464456, ack 1211089029, win 32768, options [mss 1460,wscale 1,nop], length 0
+14:18:23.405212 IP (tos 0x0, ttl 64, id 59191, offset 0, flags [DF], proto TCP (6), length 40)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [.], cksum 0xb6dc (incorrect -> 0x425a), ack 1, win 502, length 0
+14:18:23.405869 IP (tos 0x0, ttl 64, id 59192, offset 0, flags [DF], proto TCP (6), length 116)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [P.], cksum 0xb728 (incorrect -> 0x4206), seq 1:77, ack 1, win 502, length 76: HTTP
+14:18:23.406531 IP (tos 0x0, ttl 127, id 3784, offset 0, flags [none], proto TCP (6), length 40)
+    13.107.253.67.80 > 172.17.0.2.53618: Flags [.], cksum 0x0404 (correct), ack 77, win 16384, length 0
+14:18:23.433402 IP (tos 0x0, ttl 127, id 3785, offset 0, flags [none], proto TCP (6), length 319)
+    13.107.253.67.80 > 172.17.0.2.53618: Flags [P.], cksum 0x98ef (correct), seq 1:280, ack 77, win 16384, length 279: HTTP, length: 279
+	HTTP/1.1 307 Temporary Redirect
+	Date: Wed, 30 Jul 2025 12:18:23 GMT
+	Content-Type: text/html
+	Content-Length: 0
+	Connection: keep-alive
+	Location: https://microsoft.com/
+	X-Cache: CONFIG_NOCACHE
+
+14:18:23.433435 IP (tos 0x0, ttl 64, id 59193, offset 0, flags [DF], proto TCP (6), length 40)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [.], cksum 0xb6dc (incorrect -> 0x40f8), ack 280, win 501, length 0
+14:18:23.434372 IP (tos 0x0, ttl 64, id 59194, offset 0, flags [DF], proto TCP (6), length 40)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [F.], cksum 0xb6dc (incorrect -> 0x40f7), seq 77, ack 280, win 501, length 0
+14:18:23.436706 IP (tos 0x0, ttl 127, id 3786, offset 0, flags [none], proto TCP (6), length 40)
+    13.107.253.67.80 > 172.17.0.2.53618: Flags [.], cksum 0x02ec (correct), ack 78, win 16384, length 0
+14:18:23.466609 IP (tos 0x0, ttl 127, id 3787, offset 0, flags [none], proto TCP (6), length 40)
+    13.107.253.67.80 > 172.17.0.2.53618: Flags [F.], cksum 0x02eb (correct), seq 280, ack 78, win 16384, length 0
+14:18:23.466629 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 40)
+    172.17.0.2.53618 > 13.107.253.67.80: Flags [.], cksum 0x40f6 (correct), ack 281, win 501, length 0
+```
+

--- a/gadgets/tcpdump/gadget.yaml
+++ b/gadgets/tcpdump/gadget.yaml
@@ -1,0 +1,44 @@
+name: tcpdump
+description: Capture network packets
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/tcpdump
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/tcpdump
+params:
+  ebpf:
+    snaplen:
+      key: snaplen
+      description: 'Maximum number of bytes to capture from a packet.'
+datasources:
+  packets:
+    annotations:
+      ebpf.rest.len: payload_len
+      ebpf.rest.name: payload
+      cli.supported-output-modes: pcap-ng,columns,json,yaml
+      cli.default-output-mode: columns
+      cli.raw.fields: payload
+      pcap.payload: payload
+      pcap.timestamp: timestamp
+      pcap.packet-length: payload_len
+    fields:
+      ifindex:
+        annotations:
+          pcap.interface-key: true
+      payload:
+        annotations:
+          content-type: application/x-raw-packet
+      k8s.node:
+        annotations:
+          pcap.interface-var: k8s.node
+          pcap.interface-key: true
+      k8s.containerName:
+        annotations:
+          pcap.interface-var: k8s.containerName
+      k8s.podName:
+        annotations:
+          pcap.interface-var: k8s.podName
+      k8s.podLabels:
+        annotations:
+          pcap.interface-var: k8s.podLabels
+      runtime.containerName:
+        annotations:
+          pcap.interface-var: runtime.containerName

--- a/gadgets/tcpdump/program.bpf.c
+++ b/gadgets/tcpdump/program.bpf.c
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 The Inspektor Gadget authors */
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/macros.h>
+#include <gadget/types.h>
+#include <gadget/buffer.h>
+#include <gadget/filter.h>
+#include <gadget/packetfilter.h>
+
+#define GADGET_TYPE_NETWORKING
+#include <gadget/sockets-map.h>
+
+#define MAX_PKT_LEN 1500
+
+#define PACKET_TYPE_EGRESS 0
+#define PACKET_TYPE_INGRESS 1
+
+struct packet_event_t {
+	gadget_timestamp timestamp_raw;
+	u8 packet_type;
+	u32 ifindex;
+	u32 payload_len;
+	u32 packet_size;
+	struct gadget_process proc;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32));
+} packets SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct packet_event_t));
+} tmp_packets SEC(".maps");
+
+GADGET_TRACER(packets, packets, packet_event_t);
+
+const volatile __u16 snaplen = MAX_PKT_LEN;
+GADGET_PARAM(snaplen);
+
+GADGET_PF();
+
+static __always_inline int handle(struct __sk_buff *skb, __u8 packet_type)
+{
+	if (!gadget_pf_matches((void *)skb, (void *)(long)skb->data,
+			       (void *)(long)skb->data_end))
+		return 0;
+
+	struct gadget_socket_value *skb_val = gadget_socket_lookup(skb);
+	if (gadget_should_discard_data_by_skb(skb_val))
+		return 0;
+
+	struct packet_event_t *event;
+
+	int zero = 0;
+	event = bpf_map_lookup_elem(&tmp_packets, &zero);
+	if (!event)
+		return 0; // it never happens
+
+	__builtin_memset(event, 0, sizeof(*event));
+
+	__u64 len = skb->len;
+	event->packet_size = len;
+
+	if (len > snaplen)
+		len = snaplen;
+
+	event->payload_len = len;
+	event->timestamp_raw = bpf_ktime_get_ns();
+	event->ifindex = skb->ifindex;
+	event->packet_type = packet_type;
+
+	// Enrich event with process metadata
+	gadget_process_populate_from_socket(skb_val, &event->proc);
+
+	bpf_perf_event_output(skb, &packets, len << 32 | BPF_F_CURRENT_CPU,
+			      event, sizeof(*event));
+	return 0;
+}
+
+SEC("classifier/ingress/main")
+int ingress_main(struct __sk_buff *skb)
+{
+	bpf_skb_pull_data(skb, 0);
+	return handle(skb, PACKET_TYPE_INGRESS);
+}
+
+SEC("classifier/egress/main")
+int egress_main(struct __sk_buff *skb)
+{
+	bpf_skb_pull_data(skb, 0);
+	return handle(skb, PACKET_TYPE_EGRESS);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/gadgets/tcpdump/test/integration/tcpdump_test.go
+++ b/gadgets/tcpdump/test/integration/tcpdump_test.go
@@ -1,0 +1,154 @@
+// Copyright 2019-2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type tcpdumpEvent struct {
+	utils.CommonData
+
+	Timestamp string `json:"timestamp"`
+}
+
+const (
+	DefaultClientImage = gadgettesting.BusyBoxImage
+)
+
+type testCase struct {
+	name string
+
+	clientImage string
+	clientUID   uint32
+	clientGID   uint32
+	clientCmds  func(string, uint32, uint32) []string
+}
+
+func newTCPDumpStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting.Option) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	if utils.CurrentTestComponent == utils.IgLocalTestComponent && utils.Runtime == "containerd" {
+		t.Skip("Skipping test as containerd test utils can't use the network")
+	}
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+	clientContainerName := fmt.Sprintf("%s-client", tc.name)
+
+	var nsTest string
+	clientContainerOpts := []containers.ContainerOption{containers.WithContainerImage(tc.clientImage)}
+
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		nsTest = utils.GenerateTestNamespaceName(t, tc.name)
+		testutils.CreateK8sNamespace(t, nsTest)
+
+		clientContainerOpts = append(clientContainerOpts, containers.WithContainerNamespace(nsTest))
+		clientContainerOpts = append(clientContainerOpts, containers.WithUseExistingNamespace())
+	}
+
+	nslookupCmds := tc.clientCmds("1.1.1.1", tc.clientUID, tc.clientGID)
+
+	clientContainer := containerFactory.NewContainer(
+		clientContainerName,
+		fmt.Sprintf("while true; do %s; sleep 1; done", strings.Join(nslookupCmds, " ; ")),
+		clientContainerOpts...,
+	)
+	clientContainer.Start(t)
+	t.Cleanup(func() {
+		clientContainer.Stop(t)
+	})
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+	commonDataOpts := []utils.CommonDataOption{utils.WithContainerID(clientContainer.ID())}
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		// TODO: skip validation of ContainerImageName because of https://github.com/inspektor-gadget/inspektor-gadget/issues/4104
+		commonDataOpts = append(commonDataOpts, utils.WithContainerImageName(utils.NormalizedStr))
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime), "--pf=port 53", "--timeout=5"))
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-n=%s", nsTest), "--pf=port 53", "--timeout=5"))
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(nsTest)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(nsTest), utils.WithContainerImageName(tc.clientImage))
+	}
+
+	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
+		func(t *testing.T, output string) {
+			expectedEntries := []*tcpdumpEvent{
+				// A DNS packet
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+
+					Timestamp: utils.NormalizedStr,
+				},
+			}
+
+			normalize := func(e *tcpdumpEvent) {
+				utils.NormalizeCommonData(&e.CommonData)
+				utils.NormalizeString(&e.Timestamp)
+
+				if utils.CurrentTestComponent == utils.IgLocalTestComponent {
+					utils.NormalizeString(&e.Runtime.ContainerImageName)
+				}
+			}
+
+			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntries...)
+		},
+	))
+
+	return igrunner.New("tcpdump", runnerOpts...), testingOpts
+}
+
+func TestTCPDump(t *testing.T) {
+	t.Parallel()
+
+	clientImage := os.Getenv("TEST_DNS_CLIENT_IMAGE")
+	if clientImage == "" {
+		clientImage = DefaultClientImage
+	}
+
+	tc := testCase{
+		name: "test-tcpdump",
+
+		clientImage: clientImage,
+		clientUID:   1000,
+		clientGID:   1111,
+		clientCmds: func(serverIP string, uid, gid uint32) []string {
+			return []string{
+				fmt.Sprintf("setuidgid %d:%d nslookup -type=a fake.test.com. %s", uid, gid, serverIP),
+				fmt.Sprintf("setuidgid %d:%d nslookup -type=aaaa fake.test.com. %s", uid, gid, serverIP),
+			}
+		},
+	}
+
+	tcpDumpCmd, testingOpts := newTCPDumpStep(t, tc)
+	igtesting.RunTestSteps([]igtesting.TestStep{tcpDumpCmd}, t, testingOpts...)
+}

--- a/gadgets/tcpdump/test/unit/tcpdump_test.go
+++ b/gadgets/tcpdump/test/unit/tcpdump_test.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTraceDns(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces the right events.
+	paramValues := map[string]string{}
+	gadgettesting.DummyGadgetTest(t, "tcpdump", gadgettesting.WithParamValues(paramValues))
+}

--- a/go.mod
+++ b/go.mod
@@ -27,13 +27,13 @@ require (
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/gopacket/gopacket v1.4.0
 	github.com/kr/pretty v0.3.1
 	github.com/moby/moby v28.4.0+incompatible
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_golang v1.23.0
 	github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20210917134616-9c00a300bb7a
 	github.com/seccomp/libseccomp-golang v0.11.0 // indirect
 	github.com/sigstore/sigstore v1.9.5

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101
+	github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b
 	github.com/containerd/containerd v1.7.28
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.9.0
@@ -30,7 +31,9 @@ require (
 	github.com/moby/moby v28.4.0+incompatible
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1
+	github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_golang v1.23.0
 	github.com/s3rj1k/go-fanotify/fanotify v0.0.0-20210917134616-9c00a300bb7a
 	github.com/seccomp/libseccomp-golang v0.11.0 // indirect
 	github.com/sigstore/sigstore v1.9.5
@@ -54,7 +57,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.14.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
-	golang.org/x/net v0.44.0 // indirect
+	golang.org/x/net v0.44.0
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0
 	golang.org/x/term v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopacket/gopacket v1.2.0 h1:eXbzFad7f73P1n2EJHQlsKuvIMJjVXK5tXoSca78I3A=
-github.com/gopacket/gopacket v1.2.0/go.mod h1:BrAKEy5EOGQ76LSqh7DMAr7z0NNPdczWm2GxCG7+I8M=
+github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
+github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/cilium/ebpf v0.8.1/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMt
 github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101 h1:DWbiRLIoIjcHMZ3jXcEYIzMjXPHcSmO6ipjOk+mGDBA=
 github.com/cilium/ebpf v0.19.1-0.20250729164112-d994daa25101/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b h1:EgR1t4Lnq6uP6QxJQ+oIFtENOHUY3/7gMOE76vL0KcA=
+github.com/cloudflare/cbpfc v0.0.0-20240920015331-ff978e94500b/go.mod h1:X/9cHz8JVzKlvoZyKBgMgrogKZlLf+pWjmm5gSUm5dI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
@@ -200,6 +202,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopacket/gopacket v1.2.0 h1:eXbzFad7f73P1n2EJHQlsKuvIMJjVXK5tXoSca78I3A=
+github.com/gopacket/gopacket v1.2.0/go.mod h1:BrAKEy5EOGQ76LSqh7DMAr7z0NNPdczWm2GxCG7+I8M=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -328,6 +332,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20250523060157-0ea5ed0382a2 h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20250523060157-0ea5ed0382a2/go.mod h1:MXdPzqAA8pHC58USHqNCSjyLnRQ6D+NjbpP+02Z1U/0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
+github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7 h1:MfXxQU9tEe3zmyLVVwE8gJwQVtsG2aqzBkFNz0N6eAo=
+github.com/packetcap/go-pcap v0.0.0-20250723190045-d00b185f30b7/go.mod h1:1jryUz9E2ndKwZBNHzVhLMzS3WHO0fOKydYi9XWWu9w=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/include/gadget/packetfilter.h
+++ b/include/gadget/packetfilter.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: (GPL-2.0 WITH Linux-syscall-note) OR Apache-2.0 */
+
+// This file defines some helpers to apply packet filters to a skb.
+
+#ifndef PACKETFILTER_H
+#define PACKETFILTER_H
+
+// GADGET_PF is used to define a new packet filter with a given name. The name is optional.
+#define GADGET_PF(name)                                                      \
+	static __noinline bool gadget_pf_##name(void *_skb, void *__skb,     \
+						void *___skb, void *data,    \
+						void *data_end)              \
+	{                                                                    \
+		return data != data_end && _skb == __skb && __skb == ___skb; \
+	}
+
+// Count number of arguments
+#define _ARG_N(_1, _2, _3, _4, N, ...) N
+#define COUNT_ARGS(...) _ARG_N(__VA_ARGS__, 4, 3, 2, 1)
+
+// Dispatch to the correct macro based on argument count
+#define _GADGET_PF_MATCHES_0() \
+	_Static_assert(0, "gadget_pf_matches: wrong number of arguments")
+
+#define _GADGET_PF_MATCHES_1(ARG1) \
+	_Static_assert(0, "gadget_pf_matches: wrong number of arguments")
+
+#define _GADGET_PF_MATCHES_2(ARG1, ARG2) \
+	_Static_assert(0, "gadget_pf_matches: wrong number of arguments")
+
+#define _GADGET_PF_MATCHES_3(skb, data, data_end) \
+	gadget_pf_matches_impl(, skb, data, data_end)
+
+#define _GADGET_PF_MATCHES_4(name, skb, data, data_end) \
+	gadget_pf_matches_impl(name, skb, data, data_end)
+
+// Macro overloading dispatcher
+#define _GADGET_PF_MATCHES_CHOOSER2(count) _GADGET_PF_MATCHES_##count
+#define _GADGET_PF_MATCHES_CHOOSER1(count) _GADGET_PF_MATCHES_CHOOSER2(count)
+#define _GADGET_PF_MATCHES_CHOOSER(...) \
+	_GADGET_PF_MATCHES_CHOOSER1(COUNT_ARGS(__VA_ARGS__))
+
+#define gadget_pf_matches(...) \
+	_GADGET_PF_MATCHES_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+
+// the redundant skb args reserve some registers (R1-R3) for the cbpf2ebpf conversion
+#define gadget_pf_matches_impl(name, skb, data, data_end) \
+	gadget_pf_##name(skb, skb, skb, data, data_end)
+
+#endif

--- a/pkg/libpcap-compiler/cbpf.go
+++ b/pkg/libpcap-compiler/cbpf.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libpcap_compiler
+
+import (
+	"github.com/packetcap/go-pcap/filter"
+	"golang.org/x/net/bpf"
+)
+
+// CompileCbpf compiles a libpcap expression into cbpf instructions
+func CompileCbpf(expr string) ([]bpf.Instruction, error) {
+	if len(expr) == 0 {
+		return nil, nil
+	}
+
+	x := filter.NewExpression(expr)
+	f := x.Compile()
+	return f.Compile()
+}

--- a/pkg/libpcap-compiler/ebpf.go
+++ b/pkg/libpcap-compiler/ebpf.go
@@ -1,0 +1,77 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package libpcap_compiler compiles libpcap filter expressions into eBPF
+// code. This package contains parts and/or was inspired from:
+// https://github.com/jschwinger233/elibpcap/
+// https://github.com/mozillazg/ptcpdump/
+package libpcap_compiler
+
+import (
+	"github.com/cilium/ebpf/asm"
+	"github.com/cloudflare/cbpfc"
+)
+
+const (
+	RejectAllExpr = "__reject_all__"
+)
+
+type StackOffset int
+
+const (
+	BpfReadKernelOffset StackOffset = -8 * (iota + 1)
+	R1Offset
+	R2Offset
+	R3Offset
+	R4Offset
+	R5Offset
+	AvailableOffset
+)
+
+// CompileEbpf compiles a libpcap filter expression to eBPF instructions
+func CompileEbpf(expr string, fname string) (insts asm.Instructions, err error) {
+	if expr == RejectAllExpr {
+		return asm.Instructions{
+			asm.Mov.Reg(asm.R4, asm.R5), // r4 = r5 (data = data_end)
+		}, nil
+	}
+	cbpfInsts, err := CompileCbpf(expr)
+	if err != nil {
+		return
+	}
+
+	ebpfInsts, err := cbpfc.ToEBPF(cbpfInsts, cbpfc.EBPFOpts{
+		// skb->data is at r4, skb->data_end is at r5.
+		PacketStart: asm.R4,
+		PacketEnd:   asm.R5,
+		Result:      asm.R0,
+		ResultLabel: "_result_" + fname,
+		// result is at R0, _skb is at R1, __skb is at R2, ___skb is at R3.
+		// these are reserved and will be used internally
+		Working:     [4]asm.Register{asm.R0, asm.R1, asm.R2, asm.R3},
+		LabelPrefix: "_prefix_" + fname,
+		StackOffset: -int(AvailableOffset),
+	})
+	if err != nil {
+		return
+	}
+
+	return append(ebpfInsts,
+		asm.Mov.Imm(asm.R1, 0).WithSymbol("_result_"+fname), // r1 = 0 (_skb)
+		asm.Mov.Imm(asm.R2, 0),                              // r2 = 0 (__skb)
+		asm.Mov.Imm(asm.R3, 0),                              // r3 = 0 (___skb)
+		asm.Mov.Reg(asm.R4, asm.R0),                         // r4 = $result (data)
+		asm.Mov.Imm(asm.R5, 0),                              // r5 = 0 (data_end)
+	), nil
+}

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -43,6 +44,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	libpcap_compiler "github.com/inspektor-gadget/inspektor-gadget/pkg/libpcap-compiler"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/networktracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
@@ -376,27 +378,59 @@ func (i *ebpfInstance) init(gadgetCtx operators.GadgetContext) error {
 			if len(parts) != 3 {
 				return fmt.Errorf("invalid section name %q", p.SectionName)
 			}
-			if parts[0] != "classifier" {
-				return fmt.Errorf("invalid section name %q", p.SectionName)
+
+			for idx := 0; idx < len(p.Instructions); idx++ {
+				inst := p.Instructions[idx]
+				name, ok := strings.CutPrefix(inst.Symbol(), packetFilterPrefix)
+				if !ok {
+					continue
+				}
+				filter := i.paramValues[packetFilterParam+"-"+name]
+
+				// If the name is empty, we'll use `pf` as the parameter name directly
+				if name == "" {
+					filter = i.paramValues[packetFilterParam]
+				}
+				if filter == "" {
+					i.logger.Debugf("skipping pcap filter %q at %d: no filter set", filter, idx)
+					continue
+				}
+				injectIdx := idx
+				i.logger.Debugf("injecting pcap filter %q at %d", filter, idx)
+				insns := p.Instructions
+				filterInsns, err := libpcap_compiler.CompileEbpf(filter, inst.Symbol())
+				if err != nil {
+					return fmt.Errorf("adding filter: %w", err)
+				}
+				filterInsns[0] = filterInsns[0].WithMetadata(insns[injectIdx].Metadata)
+				insns[injectIdx] = insns[injectIdx].WithMetadata(asm.Metadata{})
+				p.Instructions = append(insns[:injectIdx], append(filterInsns, insns[injectIdx:]...)...)
+
+				idx = injectIdx
 			}
 
-			var direction tchandler.AttachmentDirection
-
-			switch parts[1] {
-			case "ingress":
-				direction = tchandler.AttachmentDirectionIngress
-			case "egress":
-				direction = tchandler.AttachmentDirectionEgress
+			switch parts[0] {
 			default:
-				return fmt.Errorf("unsupported hook type %q", parts[1])
-			}
+				return fmt.Errorf("invalid section name %q (nclass)", p.SectionName)
+			case "classifier":
+				var direction tchandler.AttachmentDirection
 
-			handler, err := tchandler.NewHandler(direction)
-			if err != nil {
-				return fmt.Errorf("creating tc network tracer: %w", err)
-			}
+				switch parts[1] {
+				case "ingress":
+					direction = tchandler.AttachmentDirectionIngress
+				case "egress":
+					direction = tchandler.AttachmentDirectionEgress
+				default:
+					return fmt.Errorf("unsupported hook type %q", parts[1])
+				}
 
-			i.tcHandlers[p.Name] = handler
+				handler, err := tchandler.NewHandler(direction)
+				if err != nil {
+					return fmt.Errorf("creating tc network tracer: %w", err)
+				}
+
+				i.tcHandlers[p.Name] = handler
+			}
 		}
 	}
 
@@ -541,6 +575,34 @@ func (i *ebpfInstance) ExtraParams(gadgetCtx operators.GadgetContext) api.Params
 
 	// MapIter params
 	res = append(res, i.mapParams()...)
+
+	// Iterate over programs
+	filters := make(map[string]struct{})
+	for programName, program := range i.collectionSpec.Programs {
+		// check for packet filters
+		for _, inst := range program.Instructions {
+			name, ok := strings.CutPrefix(inst.Symbol(), packetFilterPrefix)
+			if !ok {
+				continue
+			}
+			if _, ok := filters[name]; ok {
+				continue
+			}
+			paramName := packetFilterParam + "-" + name
+			// if no name was given, use `pf` directly
+			if name == "" {
+				paramName = packetFilterParam
+			}
+
+			i.logger.Debugf("> program %q uses packet filter named %q", programName, name)
+			res = append(res, &api.Param{
+				Key:         paramName,
+				Description: fmt.Sprintf("packet filter %s", name),
+				TypeHint:    api.TypeString,
+			})
+			filters[name] = struct{}{}
+		}
+	}
 	return res
 }
 

--- a/pkg/operators/ebpf/types.go
+++ b/pkg/operators/ebpf/types.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,4 +33,7 @@ const (
 
 	// Prefix used to mark variables used by operators
 	varPrefix = "gadget_var_"
+
+	packetFilterPrefix = "gadget_pf_"
+	packetFilterParam  = "pf"
 )


### PR DESCRIPTION
This adds support for generic packet filters compiled using libpcap (needs to present on the system).
Also introduces a new gadget `tcpdump` that allows capturing (filtered) packets on the system that can be written to pcap files.

```
$ cd gadgets/tcpdump
$ ig image build -t tcpdump:mine .
$ ig run --verify-image=false tcpdump:mine --pf "port 80" -o pcap-ng | tcpdump -nvr -
reading from file -, link-type EN10MB (Ethernet), snapshot length 65535
2025/06/06 13:00:45 failed to upload metrics: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.16.37.20:4317: connect: connection refused"
13:00:58.045870 IP (tos 0x0, ttl 64, id 9615, offset 0, flags [DF], proto TCP (6), length 60)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [S], cksum 0xb6d9 (incorrect -> 0x52b2), seq 2293594051, win 64240, options [mss 1460,sackOK,TS val 3150948366 ecr 0,nop,wscale 7], length 0
13:00:58.066287 IP (tos 0x0, ttl 127, id 57611, offset 0, flags [none], proto TCP (6), length 48)
    13.107.253.44.80 > 172.17.0.2.57098: Flags [S.], cksum 0x1332 (correct), seq 273959432, ack 2293594052, win 32768, options [mss 1460,wscale 1,nop], length 0
13:00:58.066333 IP (tos 0x0, ttl 64, id 9616, offset 0, flags [DF], proto TCP (6), length 40)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [.], cksum 0xb6c5 (incorrect -> 0xbd01), ack 1, win 502, length 0
13:00:58.066337 IP (tos 0x0, ttl 64, id 9617, offset 0, flags [DF], proto TCP (6), length 116)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [P.], cksum 0xb711 (incorrect -> 0xbcad), seq 1:77, ack 1, win 502, length 76: HTTP
13:00:58.066396 IP (tos 0x0, ttl 127, id 57612, offset 0, flags [none], proto TCP (6), length 40)
    13.107.253.44.80 > 172.17.0.2.57098: Flags [.], cksum 0x7eab (correct), ack 77, win 16384, length 0
13:00:58.091520 IP (tos 0x0, ttl 127, id 57613, offset 0, flags [none], proto TCP (6), length 319)
    13.107.253.44.80 > 172.17.0.2.57098: Flags [P.], cksum 0xa8d7 (correct), seq 1:280, ack 77, win 16384, length 279: HTTP, length: 279
	HTTP/1.1 307 Temporary Redirect
	Date: Fri, 06 Jun 2025 11:00:58 GMT
	Content-Type: text/html
	Content-Length: 0
	Connection: keep-alive
	Location: https://microsoft.com/
	x-azure-ref: 20250606T110058Z-174fcd5bb4dl6jrhhC1FRAh8s0000000085g00000000k4w6
	X-Cache: CONFIG_NOCACHE

13:00:58.091541 IP (tos 0x0, ttl 64, id 9618, offset 0, flags [DF], proto TCP (6), length 40)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [.], cksum 0xb6c5 (incorrect -> 0xbb9f), ack 280, win 501, length 0
13:00:58.091639 IP (tos 0x0, ttl 64, id 9619, offset 0, flags [DF], proto TCP (6), length 40)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [F.], cksum 0xb6c5 (incorrect -> 0xbb9e), seq 77, ack 280, win 501, length 0
13:00:58.091974 IP (tos 0x0, ttl 127, id 57614, offset 0, flags [none], proto TCP (6), length 40)
    13.107.253.44.80 > 172.17.0.2.57098: Flags [.], cksum 0x7d93 (correct), ack 78, win 16384, length 0
13:00:58.114661 IP (tos 0x0, ttl 127, id 57615, offset 0, flags [none], proto TCP (6), length 40)
    13.107.253.44.80 > 172.17.0.2.57098: Flags [F.], cksum 0x7d92 (correct), seq 280, ack 78, win 16384, length 0
13:00:58.114679 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 40)
    172.17.0.2.57098 > 13.107.253.44.80: Flags [.], cksum 0xbb9d (correct), ack 281, win 501, length 0
^Ctcpdump: pcap_loop: error reading dump file: Interrupted system call
```

## Remarks

* Metadata currently only can be added to interfaces (using annotations, see tcpdump example)
* Metadata transport is currently very inefficient, as we're sending all enrichments with every packet

## Todos

* [x] Tests
* [ ] Provide WireShark plugin to extract metadata ([WIP](https://gist.github.com/flyth/82d4993cbd2a306d7dfff59a4e5f1603))

Implements #4564 