### PR TITLE
annotations: Use middle ellipsis for l4endpoint

### DIFF
--- a/pkg/metadata/v1/annotations.go
+++ b/pkg/metadata/v1/annotations.go
@@ -133,6 +133,7 @@ var AnnotationsTemplates = map[string]map[string]string{
 		ColumnsMinWidthAnnotation: "22",
 		ColumnsWidthAnnotation:    "40",
 		ColumnsMaxWidthAnnotation: "52",
+		ColumnsEllipsisAnnotation: string(EllipsisMiddle),
 	},
 	"syscall": {
 		DescriptionAnnotation:     "Syscall",


### PR DESCRIPTION
# Use middle ellipsis for l4endpoint template

## Before this PR

For src and dst fields are too long the port is not visible:

```bash
SRC                             DST                            NAME                   ID           QR QTYPE        RCODE
p/kube-system/coredns-57c4c666… r/168.63.129.16:53             example.com.           33f5         Q  AAAA
p/kube-system/coredns-57c4c666… r/168.63.129.16:53             example.com.           54f5         Q  A
r/168.63.129.16:53              p/kube-system/coredns-57c4c66… example.com.           54f5         R  A            Success
r/168.63.129.16:53              p/kube-system/coredns-57c4c66… example.com.           33f5         R  AAAA         Success

```

## After this PR

Use middle ellipsis so that port is visible:

```bash
SRC                             DST                            NAME                   ID           QR QTYPE        RCODE
p/kube-system/c…6b9-rlqt5:56628 r/168.63.129.16:53             example.com.           a111         Q  AAAA
p/kube-system/c…6b9-rlqt5:34885 r/168.63.129.16:53             example.com.           d167         Q  A
r/168.63.129.16:53              p/kube-system/c…b9-rlqt5:56628 example.com.           a111         R  AAAA         Success
r/168.63.129.16:53              p/kube-system/c…b9-rlqt5:34885 example.com.           d167         R  A            Success
```