### PR TITLE
fixes histogram slots for gadget where log2l is being used and also changes it's implementation to counter the one-off error

### DIFF
--- a/gadgets/profile_blockio/program.bpf.c
+++ b/gadgets/profile_blockio/program.bpf.c
@@ -187,7 +187,7 @@ int BPF_PROG(ig_profio_done, struct request *rq, int error,
 		delta /= 1000000U;
 	else
 		delta /= 1000U;
-	slot = log2l(delta);
+	slot = get_slot_idx(delta);
 	if (slot >= PROFILER_MAX_SLOTS)
 		slot = PROFILER_MAX_SLOTS - 1;
 	__sync_fetch_and_add(&histp->latency[slot], 1);

--- a/gadgets/profile_qdisc_latency/program.bpf.c
+++ b/gadgets/profile_qdisc_latency/program.bpf.c
@@ -75,7 +75,7 @@ static __always_inline void trace_stop(struct sk_buff *skb)
 		delta /= 1000000U;
 	else
 		delta /= 1000U;
-	slot = log2l(delta);
+	slot = get_slot_idx(delta);
 	if (slot >= PROFILER_MAX_SLOTS)
 		slot = PROFILER_MAX_SLOTS - 1;
 	__sync_fetch_and_add(&histp->latency[slot], 1);

--- a/gadgets/profile_tcprtt/program.bpf.c
+++ b/gadgets/profile_tcprtt/program.bpf.c
@@ -170,7 +170,7 @@ static int handle_tcp_rcv_established(struct sock *sk)
 	srtt = BPF_CORE_READ(ts, srtt_us) >> 3;
 	if (targ_ms)
 		srtt /= 1000U;
-	slot = log2l(srtt);
+	slot = get_slot_idx(srtt);
 	if (slot >= PROFILER_MAX_SLOTS)
 		slot = PROFILER_MAX_SLOTS - 1;
 	__sync_fetch_and_add(&histp->latency[slot], 1);

--- a/include/gadget/bits.bpf.h
+++ b/include/gadget/bits.bpf.h
@@ -22,14 +22,14 @@ static __always_inline u64 log2(u32 v)
 	return r;
 }
 
-static __always_inline u64 log2l(u64 v)
+//get_slot_idx returns the index of the slot to display on the histogram.
+static __always_inline u64 get_slot_idx(u64 v)
 {
-	u32 hi = v >> 32;
+	if (v == 0)
+		return 0;
 
-	if (hi)
-		return log2(hi) + 32;
-	else
-		return log2(v);
+	u32 hi = v >> 32;
+	return hi ? log2(hi) + 33 : log2(v) + 1;
 }
 
 #endif /* __BITS_BPF_H */


### PR DESCRIPTION
Fixes #3996 


Testing done

![Screenshot from 2025-06-07 01-48-18](https://github.com/user-attachments/assets/85449974-505c-4469-82d0-191876214865)

