### PR TITLE
Add Node field to BuildCommonData helper functions

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -66,6 +66,13 @@ func WithPodLabels(podName string, namespace string, enable bool) CommonDataOpti
 	}
 }
 
+// WithNode sets the node name in the common data
+func WithNode(nodeName string) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		commonData.K8s.Node = nodeName
+	}
+}
+
 func BuildCommonData(namespace string, options ...CommonDataOption) eventtypes.CommonData {
 	e := eventtypes.CommonData{
 		K8s: eventtypes.K8sMetadata{
@@ -75,8 +82,8 @@ func BuildCommonData(namespace string, options ...CommonDataOption) eventtypes.C
 				PodName:       "test-pod",
 				ContainerName: "test-pod",
 			},
+			Node: "test-node",
 		},
-		// TODO: Include the Node
 	}
 	for _, option := range options {
 		option(&e)

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -61,6 +61,13 @@ func WithK8sNamespace(namespace string) CommonDataOption {
 	}
 }
 
+// WithNode sets the node name in the common data
+func WithNode(nodeName string) CommonDataOption {
+	return func(commonData *eventtypes.CommonData) {
+		commonData.K8s.Node = nodeName
+	}
+}
+
 func BuildCommonData(containerName string, options ...CommonDataOption) eventtypes.CommonData {
 	var e eventtypes.CommonData
 
@@ -82,8 +89,8 @@ func BuildCommonData(containerName string, options ...CommonDataOption) eventtyp
 					ContainerName: containerName,
 					PodLabels:     map[string]string{"run": containerName},
 				},
+				Node: "test-node",
 			},
-			// TODO: Include the Node
 		}
 	}
 


### PR DESCRIPTION
# Add Node field to BuildCommonData helper functions #4586 

This PR adds proper Node field initialization to the BuildCommonData functions in both helpers.go and utils.go. Previously, these functions had a TODO comment indicating that the Node field should be included, but it wasn't implemented.

This change improves test case completeness by providing a default "test-node" value and adding a new WithNode helper function to allow overriding the default value when needed. This creates more complete test data that better represents a real Kubernetes environment.

Reviewers should check that:
The Node field is correctly initialized with "test-node" in both helper functions
The new WithNode  helper function works correctly when customizing the node name
Existing tests continue to run as expected with this change