### PR TITLE
gadget-container: Import kubenameresolver.

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -62,6 +62,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubeipresolver"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubenameresolver"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/limiter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-logs"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/otel-metrics"


### PR DESCRIPTION
This is needed to have this operator registered and in-used.

Fixes: fc2d3a1918ef ("KubeNameResolver: Add support for image based gadgets")

