### PR TITLE
filter: implements --filter-expr with arbitrary expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
-	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -167,6 +167,7 @@ require (
 	github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
+	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sigstore/protobuf-specs v0.4.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,9 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
 github.com/Microsoft/hcsshim v0.12.9/go.mod h1:fJ0gkFAna6ukt0bLdKB8djt4XIJhF/vEPuoIWYVvZ8Y=
-github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.2.4 h1:rhX7MpjJlcxYwL2eTTYIOBUyEKZ+A96T9vQySWkVUiU=
+github.com/PaesslerAG/gval v1.2.4/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbVR+C6xac=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
@@ -354,6 +355,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.0 h1:rf1HIbL64nUpEIZnjLZ3
 github.com/secure-systems-lab/go-securesystemslib v0.9.0/go.mod h1:DVHKMcZ+V4/woA/peqr+L0joiRXbPpQ042GgJckkFgw=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sigstore/protobuf-specs v0.4.1 h1:5SsMqZbdkcO/DNHudaxuCUEjj6x29tS2Xby1BxGU7Zc=
 github.com/sigstore/protobuf-specs v0.4.1/go.mod h1:+gXR+38nIa2oEupqDdzg4qSBT0Os+sP7oYv6alWewWc=
 github.com/sigstore/sigstore v1.9.5 h1:Wm1LT9yF4LhQdEMy5A2JeGRHTrAWGjT3ubE5JUSrGVU=

--- a/pkg/datasource/accessors.go
+++ b/pkg/datasource/accessors.go
@@ -126,6 +126,7 @@ type FieldAccessor interface {
 	// Rename changes the name of the field. Currently it's not supported for subfields.
 	Rename(string) error
 
+	Any(Data) (any, error)
 	Uint8(Data) (uint8, error)
 	Uint16(Data) (uint16, error)
 	Uint32(Data) (uint32, error)
@@ -433,6 +434,37 @@ func (a *fieldAccessor) AddAnnotation(key, value string) {
 		a.f.Annotations = map[string]string{}
 	}
 	a.f.Annotations[key] = value
+}
+
+func (a *fieldAccessor) Any(data Data) (any, error) {
+	switch a.Type() {
+	default:
+		fallthrough // anything can be read as string
+	case api.Kind_CString, api.Kind_String:
+		return a.String(data)
+	case api.Kind_Uint8:
+		return a.Uint8(data)
+	case api.Kind_Uint16:
+		return a.Uint16(data)
+	case api.Kind_Uint32:
+		return a.Uint32(data)
+	case api.Kind_Uint64:
+		return a.Uint64(data)
+	case api.Kind_Int8:
+		return a.Int8(data)
+	case api.Kind_Int16:
+		return a.Int16(data)
+	case api.Kind_Int32:
+		return a.Int32(data)
+	case api.Kind_Int64:
+		return a.Int64(data)
+	case api.Kind_Float32:
+		return a.Float32(data)
+	case api.Kind_Float64:
+		return a.Float64(data)
+	case api.Kind_Bool:
+		return a.Bool(data)
+	}
 }
 
 func (a *fieldAccessor) Uint8(data Data) (uint8, error) {


### PR DESCRIPTION
```
/ # cat /dev/null|cat|tac|head|hexdump|cat

$ sudo ig run trace_exec --paths --filter-expr='exepath != "/bin/cat" && cwd == "/"'
RUNTIME.CONTAINERNAME   COMM         PID        TID ARGS          ERROR
heuristic_bassi         tac       235523     235523 /bin/tac
heuristic_bassi         hexdump   235525     235525 /bin/hexdump
heuristic_bassi         head      235524     235524 /bin/head
```

```
/ # cat /dev/null|head|tail|tac

$ sudo ig run trace_exec --paths --filter-expr='(proc.comm == "cat" || proc.comm == "head") && (runtime.containerImageName == "busybox" || runtime.containerImageName == "ubuntu")'
RUNTIME.CONTAINERNAME   COMM         PID        TID ARGS                     ERROR
happy_cartwright        head      258247     258247 /usr/bin/head
happy_cartwright        cat       258246     258246 /usr/bin/cat /dev/null
```

```
/ # cat /dev/null|head|tail|tac

$ sudo ig run trace_exec --paths --filter-expr='len(proc.comm) == 3 && runtime.containerImageName in ["busybox", "ubuntu"]'
RUNTIME.CONTAINERNAME   COMM         PID        TID ARGS                                                                         ERROR
heuristic_bassi         cat       260243     260243 /bin/cat /dev/null
heuristic_bassi         tac       260246     260246 /bin/tac
happy_cartwright        cat       260253     260253 /usr/bin/cat /dev/null
happy_cartwright        tac       260256     260256 /usr/bin/tac
```


cc @flyth @johananl 

Fixes: #4590

## How to use

TODO

## Testing done

TODO

## TODO

- [x] Test access to sub fields
- [x] Test access to fields of different types
- [x] Don't prefix fields with `data.`
- [ ] ~Find fields at compilation-time instead of evaluation-time~
- [x] Benchmarks