### PR TITLE
pkg/k8sutil/client: Ensure config is there before using it

### DIFF
--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -16,6 +16,7 @@ package k8sutil
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -48,7 +49,12 @@ func NewKubeConfig(kubeconfigPath, userAgentComment string) (*rest.Config, error
 					return nil, err
 				}
 			}
+		} else if err != nil {
+			return nil, fmt.Errorf("creating in-cluster config: %w", err)
 		}
+	}
+	if config == nil {
+		return nil, errors.New("no kubeconfig found, please set the KUBECONFIG environment variable or use the --kubeconfig flag")
 	}
 	config.UserAgent = version.UserAgent()
 	if userAgentComment != "" {


### PR DESCRIPTION
# pkg/k8sutil/client: Ensure config is there before using it

I found this issue by mistake when trying to run ig within a node-shell-pod and missed the `--kubeconfig` flag.

Setup the env to reproduce it:

```bash
$ kubectl node-shell aks-nodepool-41788306-vmss000002
spawning "nsenter-llpuop" on "aks-nodepool-41788306-vmss000002"
If you don't see a command prompt, try pressing enter.
root@aks-nodepool-41788306-vmss000002:/# export NODE_NAME=aks-nodepool-41788306-vmss000002
```

### Before this PR

```bash
$ ig run trace_dns  --enrich-with-k8s-apiserver
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1a8 pc=0x1c34557]

goroutine 1 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil.NewKubeConfig({0x0?, 0x10?}, {0x33aefe1, 0x2d})
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil/client.go:53 +0x157
github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil.NewClientset({0x0?, 0xc002d9f3e8?}, {0x33aefe1?, 0x223a40d?})
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil/client.go:62 +0x1d
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManager).Init.WithKubernetesEnrichment.func3(0xc00033cf00)
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection/options.go:526 +0x65
github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection.(*ContainerCollection).Initialize(0xc00033cf00, {0xc00022d830, 0xb, 0x0?})
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection/container-collection.go:107 +0x9b
github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager.NewManager({0xc00007c7c8, 0x1, 0x3?}, {0xc0002fefd0, 0x2, 0x0?})
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/ig-manager/ig-manager.go:113 +0x648
github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager.(*localManager).Init(0xc000410d80, 0xc00015bd88)
        /go/src/github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager/localmanager.go:289 +0xc78
github.com/inspektor-gadget/inspektor-gadget/cmd/common.NewRunCommand.func1(0xc00034b208, {0xc0003295c0, 0x2, 0x2})
        /go/src/github.com/inspektor-gadget/inspektor-gadget/cmd/common/oci.go:170 +0x68a
github.com/spf13/cobra.(*Command).execute(0xc00034b208, {0xc0003295c0, 0x2, 0x2})
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1000 +0xa13
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001f7808)
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
        /go/src/github.com/inspektor-gadget/inspektor-gadget/cmd/ig/main.go:124 +0x556
```

### After this PR

```bash
$ ig run trace_dns  --enrich-with-k8s-apiserver
WARN[0000] Failed to create container-collection
Error: starting operators: pre-starting operator "LocalManager": container-collection isn't available
```

```bash
$ ig run trace_dns  --enrich-with-k8s-apiserver -v 2>&1 | grep container-collection
time="2025-06-10T18:44:05Z" level=warning msg="Failed to create container-collection"
time="2025-06-10T18:44:05Z" level=debug msg="Failed to create container-collection: getting Kubernetes client: failed to create in-cluster config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"
Error: starting operators: pre-starting operator "LocalManager": container-collection isn't available
```
