### PR TITLE
charts: Add support for extra environment variables in DaemonSet

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -90,6 +90,9 @@ spec:
               value: {{ .Values.config.experimental | quote }}
             - name: GADGET_TRACER_MANAGER_LOG_LEVEL
               value: {{ .Values.config.daemonLogLevel | quote }}
+            {{- if .Values.additionalEnv }}
+            {{- toYaml .Values.additionalEnv | nindent 12 }}
+            {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             # With hostPID/hostNetwork/privileged [1] set to false, we need to set appropriate

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -85,3 +85,13 @@ mountPullSecret: false
 
 # -- Set AppArmor profile.
 appArmorProfile: "unconfined"
+
+# -- Additional environment variables to add to the gadget container
+additionalEnv: []
+  # - name: EXAMPLE_VAR
+  #   value: "example_value"
+  # - name: EXAMPLE_SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: secret-name
+  #       key: secret-key


### PR DESCRIPTION
# Add support for extra environment variables in Helm chart DaemonSet  
This change allows users to add custom environment variables to the Inspektor Gadget DaemonSet through the Helm chart values configuration. Previously, users had no way to
  inject additional environment variables into the gadget container without modifying the chart directly.

  The implementation adds a new `extraEnv` field to the values.yaml file that accepts an array of environment variable definitions, supporting both simple key-value pairs and
  references to secrets or config maps. This provides flexibility for users who need to configure IG using `INSPEKTOR_GADGET_` prefixed env vars.

  ## How to use
```bash
     # Create test values file
     cat > test-values.yaml << EOF
     additionalEnv:
       - name: TEST_VAR
         value: "test_value"
       - name: SECRET_VAR
         valueFrom:
           secretKeyRef:
             name: my-secret
             key: secret-key
     EOF
```
     # Template the chart
     helm template gadget bin/gadget --values test-values.yaml

  ## Testing done

  Helm chart validation:
```
  $ cd charts && make build
  ```
Building chart:
```
  $ helm lint bin/gadget
  ==> Linting bin/gadget
  1 chart(s) linted, 0 chart(s) failed
```
  Template rendering with additionalEnv:
```
  $ helm template gadget bin/gadget --values /tmp/test-values.yaml --show-only templates/daemonset.yaml
```
  Successfully renders extra environment variables:
```
  env:
    [... existing env vars ...]
    - name: TEST_VAR
      value: test_value
    - name: SECRET_VAR
      valueFrom:
        secretKeyRef:
          key: secret-key
          name: my-secret
```
  Template rendering without extraEnv:
```
  $ helm template gadget bin/gadget --show-only templates/daemonset.yaml
```
  Works normally without extra variables, preserving backward compatibility

  Chart structure validation:
  - Values.yaml includes documented examples with comments
  - Template logic uses proper conditional rendering ({{- if .Values.extraEnv }})
  - YAML indentation is correct (nindent 12)
  - Supports both simple values and valueFrom references