### PR TITLE
trace_dns: Improve `description` and `value.one-of` annotations in the yaml

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -53,8 +53,7 @@ datasources:
       latency_ns_raw:
         annotations:
           columns.hidden: "true"
-          columns.width: "8"
-          description: DNS request latency
+          description: Raw numeric latency_ns value
       name:
         annotations:
           description: Domain name being queried in the DNS request or response.
@@ -77,6 +76,8 @@ datasources:
           value.one-of: "HOST, BROADCAST, MULTICAST, OTHERHOST, OUTGOING, LOOPBACK, USER, KERNEL"
       pkt_type_raw:
         annotations:
+          description: Raw numeric pkt_type value (0=HOST, 1=BROADCAST, 2=MULTICAST, 3=OTHERHOST, 4=OUTGOING, 5=LOOPBACK, 6=USER, 7=KERNEL)
+          value.one-of: "0, 1, 2, 3, 4, 5, 6, 7"
           columns.hidden: "true"
       qr:
         annotations:
@@ -86,6 +87,8 @@ datasources:
           columns.width: "2"
       qr_raw:
         annotations:
+          description: Raw numeric qr value (0=Q, 1=R)
+          value.one-of: "0, 1"
           columns.hidden: "true"
       qtype:
         annotations:
@@ -93,6 +96,8 @@ datasources:
           value.one-of: "A, NS, CNAME, SOA, PTR, MX, TXT, AAAA, SRV, OPT, WKS, HINFO, MINFO, AXFR, ALL"
       qtype_raw:
         annotations:
+          description: Raw numeric qtype value (1=A, 2=NS, 5=CNAME, 6=SOA, 12=PTR, 15=MX, 16=TXT, 28=AAAA, 33=SRV, 41=OPT, 44=WKS, 13=HINFO, 14=MINFO, 252=AXFR, 255=ALL)
+          value.one-of: "1, 2, 5, 6, 12, 15, 16, 28, 33, 41, 44, 13, 14, 252, 255"
           columns.hidden: "true"
       rcode:
         annotations:
@@ -102,6 +107,8 @@ datasources:
           columns.width: "8"
       rcode_raw:
         annotations:
+          description: Raw numeric rcode value (0=Success, 1=FormatError, 2=ServerFailure, 3=NameError, 4=NotImplemented, 5=Refused)
+          value.one-of: "0, 1, 2, 3, 4, 5"
           columns.hidden: "true"
       src:
         annotations:


### PR DESCRIPTION
# trace_dns: Improve `description` and `value.one-off` annotations for `trace_dns`

Several fields where missing the `description` annotation, some others were missing the `value.one-off` one.

Notice the output doesn't change but only the description printed with `--help` or `image inspect` commands. Notice this is preparing gadget for https://github.com/inspektor-gadget/inspektor-gadget/issues/4561 which will hopefully automatically generate the gadget documentation from the yaml.

#### Before this PR
```bash
$ kubectl gadget run trace_dns:v0.41.0 -n kube-system
K8S.NODE       K8S.NAMESPACE  K8S.PODNAME    K8S.CONTAINER… SRC                    DST                    NAMESE… COMM       PID     TID QR QTYPE  NAME          RCODE    ADDRE… LATENCY…
aks-nod…000000 kube-system    ama-met…-6rtbv addon-token-ad p/kube-syst…rtbv:60304 s/kube-syst…ube-dns:53 10.0.0… fluen…   17871   18053 Q  A      dc.services.…                      0ns

$ kubectl gadget run trace_dns:v0.41.0 --help | grep -i addresses
                                                   addresses
```

#### After this PR

```bash
$ kubectl gadget run ghcr.io/blanquicet/gadget/trace_dns:jose-dns-descriptions -n kube-system
K8S.NODE       K8S.NAMESPACE  K8S.PODNAME    K8S.CONTAINER… SRC                    DST                    NAMESE… COMM       PID     TID QR QTYPE  NAME          RCODE    ADDRE… LATENCY…
aks-nod…000000 kube-system    ama-logs-42ggf addon-token-ad p/kube-syst…2ggf:57007 s/kube-syst…ube-dns:53 10.0.0… mdsd     16393   16448 Q  A      global.handl…                      0ns

$ kubectl gadget run ghcr.io/blanquicet/gadget/trace_dns:jose-dns-descriptions --help | grep addresses
                                                   addresses
                                                     Comma-separated list of IP addresses returned in the DNS responses (A and AAAA records, see qtype field).
```

