### PR TITLE
charts: Add default gadget namespace

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1256,6 +1256,71 @@ jobs:
         name: gadget-charts-tgz
         path: charts/bin/*.tgz
 
+  test-helm-charts:
+    name: Test Helm charts
+    # level: 2
+    runs-on: ubuntu-latest
+    needs:
+      - package-helm-charts
+      - build-gadget-container-images
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Install Helm
+      uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download Helm charts
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: gadget-charts-tgz
+    - name: Setup minikube
+      uses: ./.github/actions/setup-minikube
+      with:
+        runtime: "docker"
+    - name: Set container repository and determine image tag
+      id: set-repo-determine-image-tag
+      uses: ./.github/actions/set-container-repo-and-determine-image-tag
+      with:
+        registry: ${{ env.REGISTRY }}
+        container-image: ${{ env.CONTAINER_REPO }}
+    - name: Get gadget-container-image-linux-amd64.tar from artifact.
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: gadget-container-image-linux-amd64.tar
+        path: /home/runner/work/inspektor-gadget/
+    - name: Prepare minikube by loading gadget-container-image-linux-amd64.tar
+      env:
+        CONTAINER_REPO: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}
+        IMAGE_TAG: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
+      run: |
+        # 'docker load' ensures the image is named correctly e.g podman has issues loading untagged images from archive
+        docker load -i /home/runner/work/inspektor-gadget/gadget-container-image-linux-amd64.tar
+        minikube image load "${CONTAINER_REPO}:${IMAGE_TAG}"
+    - name: Test Helm charts
+      # default shell is "bash -e {0}" which will fail-fast if the command returns a non-zero exit code
+      # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+      shell: bash {0}
+      run: |
+        # Install the Helm chart
+        helm install gadget gadget-*.tgz \
+          --namespace gadget --create-namespace \
+          --set image.repository=${{ steps.set-repo-determine-image-tag.outputs.container-repo }} \
+          --set image.tag=${{ steps.set-repo-determine-image-tag.outputs.image-tag }} \
+          --set image.pullPolicy=Never
+
+        # Validate the installation
+        kubectl rollout status daemonset/gadget --namespace gadget --timeout=60s
+        if [[ $? -ne 0 ]]; then
+          echo "DaemonSet gadget is not available"
+          kubectl get pods --namespace gadget
+          kubectl describe daemonset gadget --namespace gadget
+          kubectl logs -n gadget daemonset/gadget
+          exit 1
+        fi
+        
+        # Uninstall the chart
+        helm uninstall gadget --namespace gadget
+
   publish-helm-charts:
     name: Publish Helm charts
     # level: 1

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
       crio-socketpath: {{ .Values.config.crioSocketPath }}
       docker-socketpath: {{ .Values.config.dockerSocketPath }}
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
+      gadget-namespace: {{ .Values.config.gadgetNamespace }}
       operator:
         oci:
           verify-image: {{ .Values.config.verifyGadgets }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -27,6 +27,9 @@ config:
   # -- Daemon Log Level. Valid values are: "trace", "debug", "info", "warning", "error", "fatal", "panic"
   daemonLogLevel: "info"
 
+  # -- Namespace where Inspektor Gadget is running
+  gadgetNamespace: "gadget"
+
   # -- Verify image-based gadgets
   verifyGadgets: true
 

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -27,6 +27,7 @@ data:
       crio-socketpath: /run/crio/crio.sock
       docker-socketpath: /run/docker.sock
       podman-socketpath: /run/podman/podman.sock
+      gadget-namespace: gadget
       operator:
         oci:
           verify-image: true


### PR DESCRIPTION
The helm installation keeps on failing with gadget-namespace not set. This change ensure we have the default namespace set. Also, it adds a job to test helm charts installtion to avoid such issues in future:

```
time="2025-06-12T10:45:31Z" level=info msg="Starting Pod controller"
time="2025-06-12T10:45:31Z" level=info msg="gadget tracermgr set in kubemanager"
time="2025-06-12T10:45:31Z" level=info msg="Serving on gRPC socket /run/gadgettracermanager.socket"
time="2025-06-12T10:45:31Z" level=fatal msg="gadget namespace must not be empty"
```

Fixes 1dcced3cc2f9b534f6f4a8d7c1da09af315c7460

## Testing done

Failing run on fork: https://github.com/mqasimsarfraz/inspektor-gadget/actions/runs/15608382968/job/43963570152#step:9:182

