### PR TITLE
gadgets: Print logs to indicate when they're ready

### DIFF
--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -390,7 +390,7 @@ func (c *GadgetContext) LoadGadgetInfo(info *api.GadgetInfo, paramValues api.Par
 		if err := c.start(c.localOperators); err != nil {
 			return fmt.Errorf("starting local operators: %w", err)
 		}
-		c.Logger().Debugf("running...")
+		c.Logger().Infof("running...")
 	}
 
 	if c.ExtraInfo() && extraInfo != nil {

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -160,11 +160,13 @@ func (c *GadgetContext) stop(dataOperatorInstances []operators.DataOperatorInsta
 }
 
 func (c *GadgetContext) PrepareGadgetInfo(paramValues api.ParamValues) error {
+	c.Logger().Info("preparing gadget info...")
 	_, err := c.initAndPrepareOperators(paramValues)
 	return err
 }
 
 func (c *GadgetContext) Run(paramValues api.ParamValues) error {
+	c.Logger().Info("starting gadget...")
 	defer c.cancel()
 
 	metricAttribs := attribute.NewSet(
@@ -183,7 +185,7 @@ func (c *GadgetContext) Run(paramValues api.ParamValues) error {
 		return fmt.Errorf("starting operators: %w", err)
 	}
 
-	c.Logger().Debugf("running...")
+	c.Logger().Infof("running...")
 
 	WaitForTimeoutOrDone(c)
 	c.stop(dataOperatorInstances)

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -55,6 +55,7 @@ func (r *Runtime) GetGadgetInfo(gadgetCtx runtime.GadgetContext, runtimeParams *
 		in.Flags |= api.GadgetInfoRequestFlagUseInstance
 	}
 
+	gadgetCtx.Logger().Info("getting gadget info...")
 	out, err := client.GetGadgetInfo(gadgetCtx.Context(), in)
 	if err != nil {
 		return nil, fmt.Errorf("getting gadget info: %w", err)
@@ -94,6 +95,7 @@ func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext, runtimeParams *para
 
 	gadgetCtx.SetVar(runtime.NumRunTargets, len(targets))
 
+	gadgetCtx.Logger().Info("starting gadget...")
 	_, err = r.runGadgetOnTargets(gadgetCtx, paramValues, targets)
 	return err
 }


### PR DESCRIPTION
Some times running a gadget takes a bit long: while the image is pulled,
wasm and ebpf programs are loaded, etc. This commit introduces a mechanism
to inform the user about the different steps when running a gadget.

```bash
$ sudo ig run trace_open --verify-image=false --pull always
INFO[0000] preparing gadget info...
WARN[0004] image signature verification is disabled due to using corresponding option
WARN[0004] This gadget was built with ig v0.41.0 and it's being run with v0.0.0. Gadget could be incompatible
INFO[0004] starting gadget...
WARN[0006] image signature verification is disabled due to using corresponding option
WARN[0006] This gadget was built with ig v0.41.0 and it's being run with v0.0.0. Gadget could be incompatible
RUNTIME.CONTAINERNAME       COMM                  PID        TID  FD FNAME                        MODE           ERROR
INFO[0006] running...
```

