### PR TITLE
operators/ebpf: Add missing annotations to ds

### DIFF
--- a/pkg/operators/process/process.go
+++ b/pkg/operators/process/process.go
@@ -143,6 +143,8 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 		return nil, fmt.Errorf("registering processes data source: %w", err)
 	}
 
+	ds.AddAnnotation(api.FetchIntervalAnnotation, interval.String())
+
 	instance := &processOperatorInstance{
 		interval:   interval,
 		done:       make(chan struct{}),


### PR DESCRIPTION
Array datasources need the the count and interval annotations for the combiner to work fine.

This issue was breaking the bpfstats and top_process gadgets when the combiner operator was used: in gadgetctl and kubect-gadget.

Fixes: f9febfbec8d4 ("combiner: Disable timeout if interval and count is zero")

---

Another option is to update the combiner to suppose the count annotation is 0 if empty.