### PR TITLE
bpfstats/top_process: Provide human readable format for bytes and duration fields

### DIFF
--- a/gadgets/bpfstats/test/unit/bpfstats_test.go
+++ b/gadgets/bpfstats/test/unit/bpfstats_test.go
@@ -35,12 +35,12 @@ type ExpectedBpfstatsEvent struct {
 	GadgetImage string `json:"gadgetImage"`
 	GadgetName  string `json:"gadgetName"`
 	MapCount    int    `json:"mapCount"`
-	MapMemory   int    `json:"mapMemory"`
+	MapMemory   string `json:"mapMemory"`
 	ProgID      int    `json:"progID"`
 	ProgName    string `json:"progName"`
 	ProgType    string `json:"progType"`
 	Runcount    int    `json:"runcount"`
-	Runtime     int    `json:"runtime"`
+	Runtime     string `json:"runtime"`
 	Comms       string `json:"comms"`
 	Pids        string `json:"pids"`
 }
@@ -83,7 +83,7 @@ func TestBpfstatsGadget(t *testing.T) {
 			allPrograms:   true,
 			expectedEvents: []ExpectedBpfstatsEvent{
 				// programs from trace_open gadget. This introduces a dependency
-				// on the trace_open gadget, but it's almost guranteed that this
+				// on the trace_open gadget, but it's almost guaranteed that this
 				// gadget will have these two programs
 				{
 					GadgetImage: gadgetrunner.GetGadgetImageName(testGadgetImage),
@@ -113,13 +113,13 @@ func TestBpfstatsGadget(t *testing.T) {
 
 			normalizeEvent := func(event *ExpectedBpfstatsEvent) {
 				utils.NormalizeInt(&event.MapCount)
-				utils.NormalizeInt(&event.MapMemory)
 				utils.NormalizeInt(&event.ProgID)
+				utils.NormalizeString(&event.MapMemory)
+				utils.NormalizeString(&event.Runtime)
 
 				// Manually set the values to the normalized values because the
 				// function doesn't modify the value when is 0
 				event.Runcount = utils.NormalizedInt
-				event.Runtime = utils.NormalizedInt
 			}
 			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
 				utilstest.RunWithRunner(t, runner, func() error {
@@ -147,9 +147,9 @@ func TestBpfstatsGadget(t *testing.T) {
 
 			for _, expectedEvent := range testCase.expectedEvents {
 				expectedEvent.MapCount = utils.NormalizedInt
-				expectedEvent.MapMemory = utils.NormalizedInt
+				expectedEvent.MapMemory = utils.NormalizedStr
 				expectedEvent.Runcount = utils.NormalizedInt
-				expectedEvent.Runtime = utils.NormalizedInt
+				expectedEvent.Runtime = utils.NormalizedStr
 
 				require.Contains(t, gadgetRunner.CapturedEvents, expectedEvent)
 			}

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -523,6 +523,10 @@ func (ds *dataSource) AddField(name string, kind api.Kind, opts ...FieldOption) 
 	for _, opt := range opts {
 		opt(nf)
 	}
+	if nf.Order == 0 {
+		// If no order is set, use the current index as the order
+		nf.Order = int32(nf.Index)
+	}
 
 	if FieldFlagHasParent.In(nf.Flags) {
 		// resolve fullname

--- a/pkg/datasource/field.go
+++ b/pkg/datasource/field.go
@@ -106,6 +106,15 @@ func WithSameParentAs(otherField FieldAccessor) FieldOption {
 	}
 }
 
+func WithSameOrderAs(otherField FieldAccessor) FieldOption {
+	return func(f *field) {
+		if otherField == nil {
+			return
+		}
+		f.Order = otherField.(*fieldAccessor).f.Order
+	}
+}
+
 func WithTags(tags ...string) FieldOption {
 	return func(f *field) {
 		f.Tags = append(f.Tags, tags...)

--- a/pkg/operators/ebpf/stats.go
+++ b/pkg/operators/ebpf/stats.go
@@ -170,14 +170,14 @@ func (o *ebpfOperator) InstantiateDataOperator(
 	}
 
 	// stats fields
-	instance.runtimeField, err = instance.ds.AddField("runtime", api.Kind_Uint64,
+	instance.runtimeField, err = instance.ds.AddField("runtime_raw", api.Kind_Uint64,
 		datasource.WithAnnotations(map[string]string{
-			// TODO: provide human readable format
 			metadatav1.ColumnsWidthAnnotation:     "12",
 			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 			metadatav1.DescriptionAnnotation:      "Time that the eBPF program or Gadget has run in nanoseconds",
 			"metrics.type":                        "counter",
 		}),
+		datasource.WithTags("type:gadget_duration"),
 	)
 	if err != nil {
 		return nil, err
@@ -193,14 +193,14 @@ func (o *ebpfOperator) InstantiateDataOperator(
 	if err != nil {
 		return nil, err
 	}
-	instance.mapMemoryField, err = instance.ds.AddField("mapMemory", api.Kind_Uint64,
+	instance.mapMemoryField, err = instance.ds.AddField("mapMemory_raw", api.Kind_Uint64,
 		datasource.WithAnnotations(map[string]string{
-			// TODO provide human readable format
 			metadatav1.ColumnsWidthAnnotation:     "12",
 			metadatav1.ColumnsAlignmentAnnotation: string(metadatav1.AlignmentRight),
 			metadatav1.DescriptionAnnotation:      "Memory used by maps in bytes",
 			"metrics.type":                        "gauge",
 		}),
+		datasource.WithTags("type:gadget_bytes"),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/operators/formatters/formatters.go
+++ b/pkg/operators/formatters/formatters.go
@@ -196,6 +196,7 @@ var replacers = []replacer{
 					metadatav1.ValueOneOfAnnotation: strings.Join(signalNames, ", "),
 				}),
 				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
 			}
 			signalField, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {
@@ -237,6 +238,7 @@ var replacers = []replacer{
 					metadatav1.ValueOneOfAnnotation: strings.Join(errnoNames, ", "),
 				}),
 				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
 			}
 			errnoField, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {
@@ -272,7 +274,12 @@ var replacers = []replacer{
 			if err != nil {
 				return nil, err
 			}
-			syscallField, err := ds.AddField(outName, api.Kind_String, datasource.WithSameParentAs(in))
+
+			opts := []datasource.FieldOption{
+				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
+			}
+			syscallField, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {
 				return nil, err
 			}
@@ -316,6 +323,7 @@ var replacers = []replacer{
 					metadatav1.TemplateAnnotation: "timestamp",
 				}),
 				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
 			}
 			out, err := ds.AddField(outName, api.Kind_String, opts...)
 			if err != nil {
@@ -359,6 +367,7 @@ var replacers = []replacer{
 					metadatav1.TemplateAnnotation: "bytes",
 				}),
 				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
 			}
 
 			bytesField, err := ds.AddField(outName, api.Kind_String, opts...)
@@ -398,6 +407,7 @@ var replacers = []replacer{
 					metadatav1.TemplateAnnotation: "duration",
 				}),
 				datasource.WithSameParentAs(in),
+				datasource.WithSameOrderAs(in),
 			}
 
 			durationField, err := ds.AddField(outName, api.Kind_String, opts...)

--- a/pkg/operators/process/process.go
+++ b/pkg/operators/process/process.go
@@ -199,18 +199,24 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 			}
 			requireCPUInfo = true
 		case fieldMemoryRSS:
-			instance.memoryRSSField, err = ds.AddField(fieldMemoryRSS, api.Kind_Uint64, datasource.WithAnnotations(map[string]string{
-				metadatav1.ColumnsAlignmentAnnotation: "right",
-				metadatav1.DescriptionAnnotation:      "The Resident Set Size (RSS) of the process in bytes. This represents the portion of memory occupied by a process that is held in main memory (RAM).",
-			}))
+			instance.memoryRSSField, err = ds.AddField(fieldMemoryRSS+"_raw", api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					metadatav1.ColumnsAlignmentAnnotation: "right",
+					metadatav1.DescriptionAnnotation:      "The Resident Set Size (RSS) of the process in bytes. This represents the portion of memory occupied by a process that is held in main memory (RAM).",
+				}),
+				datasource.WithTags("type:gadget_bytes"),
+			)
 			if err != nil {
 				return nil, fmt.Errorf("adding memoryRSS field: %w", err)
 			}
 		case fieldMemoryVirtual:
-			instance.memoryVirtualField, err = ds.AddField(fieldMemoryVirtual, api.Kind_Uint64, datasource.WithAnnotations(map[string]string{
-				metadatav1.ColumnsAlignmentAnnotation: "right",
-				metadatav1.DescriptionAnnotation:      "The Virtual Memory Size of the process in bytes. This represents the total amount of virtual memory used by the process.",
-			}))
+			instance.memoryVirtualField, err = ds.AddField(fieldMemoryVirtual+"_raw", api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					metadatav1.ColumnsAlignmentAnnotation: "right",
+					metadatav1.DescriptionAnnotation:      "The Virtual Memory Size of the process in bytes. This represents the total amount of virtual memory used by the process.",
+				}),
+				datasource.WithTags("type:gadget_bytes"),
+			)
 			if err != nil {
 				return nil, fmt.Errorf("adding memoryVirtual field: %w", err)
 			}


### PR DESCRIPTION
# Provide human readable format for bytes and duration fields

Fixes https://github.com/inspektor-gadget/inspektor-gadget/issues/4321 (bpfstats/runtime and bpfstats/mapmemory) and same for top_process/memoryRSS, top_process/memoryVirtual.

## bpfstats (runtime and mapmemory fields)

### Before this PR

```bash
GADGETID GADGETNAME       GADGETIMAGE      PROG… PROGNAME         PROGTYPE            RUNTIME    RUNCOUNT   MAPMEMORY MAP… COMMS           PIDS
                                               2 hid_tail_call    Tracing                   0           0        8576    1
                                               5                  CGroupDevice              0           0           0    0 systemd         1
                                               6                  CGroupSKB                 0           0           0    0 systemd         1
                                               7                  CGroupSKB                 0           0           0    0 systemd         1
                                               8                  CGroupDevice              0           0           0    0 systemd         1
```

### After this PR

```bash
GADGETID GADGETNAME      GADGETIMAGE     PROG… PROGNAME        PROGTYPE                   RUNTIME    RUNCOUNT MAPMEMORY MAP… COMMS          PIDS
                                             2 hid_tail_call   Tracing                        0ns           0    8.6 kB    1
                                             5                 CGroupDevice                   0ns           0       0 B    0 systemd        1
                                             6                 CGroupSKB                      0ns           0       0 B    0 systemd        1
                                             7                 CGroupSKB                      0ns           0       0 B    0 systemd        1
                                             8                 CGroupDevice                   0ns           0       0 B    0 systemd        1
```

## top_process (memoryRSS and memoryVirtual fields)

### Before this PR

```bash
RUNTIME.CONTAINERNAME            PID COMM          CPUUSAGE CPUUSAGERELA…    MEMORYRSS MEMORYVIRTU… MEMORYRELAT… THREADCOUNT STATE        UID STARTTIMESTR
                                 966 systemd-udevd      0.0           0.0      7733248     28385280          0.0           1 S              0 …58:10-05:00
                                  99 kworker/R-kin      0.0           0.0            0            0          0.0           1 I              0 …49:47-05:00
                                  98 khugepaged         0.0           0.0            0            0          0.0           1 S              0 …49:47-05:00
                               98012 kworker/u24:5      0.0           0.0            0            0          0.0           1 I              0 …19:13-05:00
                                  96 ksmd               0.0           0.0            0            0          0.0           1 S              0 …49:47-05:0
```

### After this PR

```bash
RUNTIME.CONTAINERNAME              PID COMM           CPUUSAGE CPUUSAGERELAT… MEMORYRSS MEMORYVI… MEMORYRELATI… THREADCOUNT STATE        UID STARTTIMESTR
                                158601 ig                  4.0            0.3    100 MB    2.6 GB           0.3          17 S              0 …:58:57-05:00
                                 17826 Isolated Web C      2.7            0.2    354 MB    2.8 GB           1.1          30 S           1000 …:32:40-05:00
                                 16467 anytypeHelper       2.3            0.2    225 MB    1.7 GB           0.7          27 S           1000 …:17:13-05:00
                                  5107 gnome-shell         1.7            0.1    424 MB    6.7 GB           1.3          29 S           1000 …:58:26-05:00
                                  5961 slack               1.0            0.1    362 MB    1.5 TB           1.1          19 S           1000 …:58:31-05:0
```