### PR TITLE
deploy: Add support for config file

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -47,7 +47,7 @@ runs:
           # Inspektor-Gadget container image is loaded into the cluster using "minikube image load" instead of pushing the container image to a registry.
           EXTRA_FLAGS='--image-pull-policy=Never'
         fi
-        ./kubectl-gadget deploy --verify-gadgets=${{ inputs.gadget_verify_image }} $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
+        ./kubectl-gadget deploy --set-daemon-config=operator.oci.verify-image=${{ inputs.gadget_verify_image }} $EXTRA_FLAGS --debug --experimental --image=${{ inputs.container_repo }}:${{ inputs.image_tag }}
     - name: Integration tests
       id: integration-tests
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
 		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
-	./kubectl-gadget deploy --verify-gadgets=$(VERIFY_GADGETS) --liveness-probe=$(LIVENESS_PROBE) \
+	./kubectl-gadget deploy --set-daemon-config=operator.oci.verify-image=$(VERIFY_GADGETS) --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never
 	kubectl rollout status daemonset -n gadget gadget --timeout 30s
 	@echo "Image used by the gadget pod:"

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,3 +1,3 @@
 # Inspektor Gadget Charts
 
-This repository contains Helm charts for installing Inspektor Gadget on Kubernetes.
+This repository contains Helm charts for [installing Inspektor Gadget on Kubernetes](https://inspektor-gadget.io/docs/latest/reference/install-kubernetes#installation-with-the-helm-chart).

--- a/charts/gadget/templates/_helpers.tpl
+++ b/charts/gadget/templates/_helpers.tpl
@@ -61,3 +61,53 @@ Image tag
 {{- .Chart.AppVersion }}
 {{- end }}
 {{- end }}
+
+{{/*
+Operator configuration
+*/}}
+{{- define "gadget.operatorConfig" -}}
+{{- $operator := deepCopy .Values.config.operator | default (dict) -}}
+{{- if hasKey .Values.config "verifyGadgets" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "oci" | default dict)
+      (dict "verify-image" .Values.config.verifyGadgets)
+    }}
+  {{- $operator = set $operator "oci" $merged }}
+{{- end }}
+{{- if hasKey .Values.config "gadgetsPublicKeys" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "oci" | default dict)
+      (dict "public-keys" .Values.config.gadgetsPublicKeys)
+    }}
+  {{- $operator = set $operator "oci" $merged }}
+{{- end }}
+{{- if hasKey .Values.config "allowedGadgets" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "oci" | default dict)
+      (dict "allowed-gadgets" .Values.config.allowedGadgets)
+    }}
+  {{- $operator = set $operator "oci" $merged }}
+{{- end }}
+{{- if hasKey .Values.config "disallowGadgetsPulling" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "oci" | default dict)
+      (dict "disallow-pulling" .Values.config.disallowGadgetsPulling)
+    }}
+  {{- $operator = set $operator "oci" $merged }}
+{{- end }}
+{{- if hasKey .Values.config "otelMetricsListen" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "otel-metrics" | default dict)
+      (dict "otel-metrics-listen" .Values.config.otelMetricsListen)
+    }}
+  {{- $operator = set $operator "otel-metrics" $merged }}
+{{- end }}
+{{- if hasKey .Values.config "otelMetricsAddress" }}
+  {{- $merged := mergeOverwrite
+      (get $operator "otel-metrics" | default dict)
+      (dict "otel-metrics-listen-address" .Values.config.otelMetricsAddress)
+    }}
+  {{- $operator = set $operator "otel-metrics" $merged }}
+{{- end }}
+{{- toYaml $operator }}
+{{- end }}

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -19,13 +19,4 @@ data:
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
       gadget-namespace: {{ .Values.config.gadgetNamespace }}
       operator:
-        oci:
-          verify-image: {{ .Values.config.verifyGadgets }}
-          public-keys:{{ toYaml $.Values.config.gadgetsPublicKeys | nindent 12 }}
-          allowed-gadgets:{{ toYaml .Values.config.allowedGadgets | nindent 12 }}
-          disallow-pulling: {{ .Values.config.disallowGadgetsPulling }}
-      {{- if .Values.config.otelMetricsListen }}
-        otel-metrics:
-            otel-metrics-listen: {{ .Values.config.otelMetricsListen }}
-            otel-metrics-listen-address: {{ .Values.config.otelMetricsAddress }}
-      {{- end }}
+        {{- include "gadget.operatorConfig" . | nindent 8 -}}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         # Otherwise, we can have error like:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
-        container.apparmor.security.beta.kubernetes.io/gadget: {{ .Values.config.appArmorProfile | quote }}
+        container.apparmor.security.beta.kubernetes.io/gadget: {{ default .Values.appArmorProfile .Values.config.appArmorProfile | quote }}
         inspektor-gadget.kinvolk.io/option-hook-mode: "auto"
         # keep aligned with values in pkg/operators/prometheus/prometheus.go
         prometheus.io/scrape: "true"
@@ -214,7 +214,7 @@ spec:
             # For this, we use an emptyDir without size limit.
             - mountPath: /var/lib/ig
               name: oci
-            {{- if .Values.config.mountPullSecret }}
+            {{- if (default .Values.mountPullSecret .Values.config.mountPullSecret) }}
             - mountPath: /var/run/secrets/gadget/pull-secret
               name: pull-secret
               readOnly: true
@@ -278,7 +278,7 @@ spec:
             path: /sys/kernel/debug
         - name: oci
           emptyDir:
-        {{- if .Values.config.mountPullSecret }}
+        {{- if (default .Values.mountPullSecret .Values.config.mountPullSecret) }}
         - name: pull-secret
           secret:
             defaultMode: 0o400

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -44,6 +44,45 @@
         },
         "eventsBufferLength": {
           "type": "string"
+        },
+        "verifyGadgets": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "gadgetsPublicKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "deprecated": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "allowedGadgets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "deprecated": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "disallowGadgetsPulling": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "otelMetricsListen": {
+          "type": "boolean",
+          "deprecatred": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "otelMetricsAddress": {
+          "type": "string",
+          "deprecated": true,
+          "description": "The value is deprecated and will be removed in +v0.43.0. Use operator configuration instead"
+        },
+        "operator": {
+          "type": "object"
         }
       }
     },

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Inspektor Gadget configuration.
 config:
   # -- How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify+ebpf")
   hookMode: auto
@@ -30,35 +31,24 @@ config:
   # -- Namespace where Inspektor Gadget is running
   gadgetNamespace: "gadget"
 
-  # -- Verify image-based gadgets
-  verifyGadgets: true
+  # -- Operator configuration, this will only be used if deprecated values are not set.
+  operator:
+    oci:
+      verify-image: true
+      public-keys:
+        - |
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
+          Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
+          -----END PUBLIC KEY-----
+      allowed-gadgets: [ ]
+      disallow-pulling: false
+      insecure-registries: [ ]
+    otel-metrics:
+      otel-metrics-listen: false
+      otel-metrics-listen-address: "0.0.0.0:2224"
 
-  # -- Public keys used to verify image-based gadgets
-  gadgetsPublicKeys:
-    - |
-      -----BEGIN PUBLIC KEY-----
-      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
-      Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
-      -----END PUBLIC KEY-----
-
-  # -- List of allowed gadgets.
-  allowedGadgets: []
-
-  # -- Disallow pulling gadgets.
-  disallowGadgetsPulling: false
-
-  # -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from private registry
-  mountPullSecret: false
-
-  # -- Set AppArmor profile.
-  appArmorProfile: "unconfined"
-
-  # -- Enable OpenTelemetry metrics listener
-  otelMetricsListen: false
-
-  # -- Address to listen for OpenTelemetry metrics
-  otelMetricsAddress: "0.0.0.0:2224"
-
+# -- All configurations below are specific to Kubernetes resources created by the gadget chart.
 image:
   # -- Container repository for the container image
   repository: ghcr.io/inspektor-gadget/inspektor-gadget
@@ -89,3 +79,9 @@ additionalLabels:
 
 # -- RuntimeClassName used by daemonset
 runtimeClassName: ""
+
+# -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from private registry
+mountPullSecret: false
+
+# -- Set AppArmor profile.
+appArmorProfile: "unconfined"

--- a/cmd/kubectl-gadget/deploy_test.go
+++ b/cmd/kubectl-gadget/deploy_test.go
@@ -16,7 +16,13 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
@@ -35,5 +41,143 @@ func TestPrintOnly(t *testing.T) {
 	cmd.Execute()
 	if stdErr.Len() != 0 {
 		t.Fatalf("Error while running command: %s", stdErr.String())
+	}
+}
+
+func TestApplyConfigToConfgMap(t *testing.T) {
+	// Helper to create a ConfigMap with config.yaml data
+	makeCM := func(yaml string) *v1.ConfigMap {
+		return &v1.ConfigMap{
+			Data: map[string]string{
+				"config.yaml": yaml,
+			},
+		}
+	}
+
+	tmpFileWith := func(content string) (string, func()) {
+		f, err := os.CreateTemp("", "ig-config-*.yaml")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		if _, err := f.WriteString(content); err != nil {
+			t.Fatalf("failed to write temp file: %v", err)
+		}
+		return f.Name(), func() { os.Remove(f.Name()) }
+	}
+
+	tests := []struct {
+		name          string
+		cm            *v1.ConfigMap
+		configContent string
+		setConfig     []string
+		flagSetup     func(*pflag.FlagSet)
+		wantContains  []string
+		wantErr       bool
+	}{
+		{
+			name:         "default configmap only",
+			cm:           makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			flagSetup:    func(fs *pflag.FlagSet) {},
+			wantContains: []string{"disallow-pulling: false"},
+		},
+		{
+			name:         "set-config overrides configmap",
+			cm:           makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			setConfig:    []string{"operator.oci.disallow-pulling=true"},
+			flagSetup:    func(fs *pflag.FlagSet) {},
+			wantContains: []string{"disallow-pulling: true"},
+		},
+		{
+			name:          "config file overrides configmap",
+			cm:            makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			configContent: "operator:\n  oci:\n    disallow-pulling: true\n",
+			flagSetup:     func(fs *pflag.FlagSet) {},
+			wantContains:  []string{"disallow-pulling: true"},
+		},
+		{
+			name: "flag overrides configmap",
+			cm:   makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			flagSetup: func(fs *pflag.FlagSet) {
+				fs.Set("disallow-gadgets-pulling", "true")
+			},
+			wantContains: []string{"disallow-pulling: true"},
+		},
+		{
+			name:          "set-config overrides config file",
+			cm:            makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			setConfig:     []string{"operator.oci.disallow-pulling=true"},
+			configContent: "operator:\n  oci:\n    disallow-pulling: false\n",
+			flagSetup:     func(fs *pflag.FlagSet) {},
+			wantContains:  []string{"disallow-pulling: true"},
+		},
+		{
+			name:      "flag overrides set-config",
+			cm:        makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			setConfig: []string{"operator.oci.disallow-pulling=false"},
+			flagSetup: func(fs *pflag.FlagSet) {
+				fs.Set("disallow-gadgets-pulling", "true")
+			},
+			wantContains: []string{"disallow-pulling: true"},
+		},
+		{
+			name:          "Merge configmap, set-config, and config file",
+			cm:            makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			setConfig:     []string{"operator.oci.verify-image=true"},
+			configContent: "operator:\n  oci:\n    insecure-registries: registry.example.com\n",
+			wantContains:  []string{"disallow-pulling: false", "verify-image: \"true\"", "insecure-registries: registry.example.com"},
+		},
+		{
+			name:      "invalid set-config format",
+			cm:        makeCM("operator:\n  oci:\n    disallow-pulling: false\n"),
+			setConfig: []string{"badformat"},
+			flagSetup: func(fs *pflag.FlagSet) {},
+			wantErr:   true,
+		},
+		{
+			name:      "missing config.yaml",
+			cm:        &v1.ConfigMap{Data: map[string]string{}},
+			flagSetup: func(fs *pflag.FlagSet) {},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			fs.Bool("disallow-gadgets-pulling", false, "")
+
+			if tt.flagSetup != nil {
+				tt.flagSetup(fs)
+			}
+
+			// Patch global setDaemonConfig for this test
+			oldSetConfig := setDaemonConfig
+			setDaemonConfig = tt.setConfig
+			defer func() { setDaemonConfig = oldSetConfig }()
+
+			// if configContent is provided, create a temp file
+			var configPath string
+			if tt.configContent != "" {
+				var cleanup func()
+				configPath, cleanup = tmpFileWith(tt.configContent)
+				defer cleanup()
+				fs.String("config", configPath, "Path to the configuration file")
+			} else {
+				fs.String("config", "", "Path to the configuration file")
+			}
+
+			err := applyConfigToConfigMap(tt.cm, configPath, fs)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			got := tt.cm.Data["config.yaml"]
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("config.yaml does not contain %q, got:\n%s", want, got)
+				}
+			}
+		})
 	}
 }

--- a/docs/reference/disallow-pulling.mdx
+++ b/docs/reference/disallow-pulling.mdx
@@ -12,10 +12,18 @@ By default, pulling is allowed.
 
 <Tabs groupId="env">
 <TabItem value="kubectl-gadget" label="kubectl gadget">
-You can specify this option only at deploy time:
+You can specify this option only at deploy time. Start by creating a daemon configuration file, for example `daemon-config.yaml`:
 
 ```bash
-$ kubectl gadget deploy --disallow-gadgets-pulling
+cat <<EOF > daemon-config.yaml
+operator:
+  oci:
+    disallow-pulling: true
+EOF
+```
+
+```bash
+$ kubectl gadget deploy --daemon-config=daemon-config.yaml
 ...
 Inspektor Gadget successfully deployed
 $ kubectl gadget run trace_exec

--- a/docs/reference/insecure-registries.mdx
+++ b/docs/reference/insecure-registries.mdx
@@ -14,10 +14,20 @@ Inspektor Gadget allows pulling, pushing and running Gadget images from insecure
 <Tabs groupId="env">
 <TabItem value="kubectl-gadget" label="kubectl gadget">
 
-For `kubectl gadget`, it can only be configured at deploy time:
+For `kubectl gadget`, it can only be configured at deploy time. Start by creating a daemon config file:
 
 ```bash
-$ kubectl gadget deploy --insecure-registries=192.168.1.16:5000
+cat <<EOF > daemon-config.yaml
+operator:
+  oci:
+    insecure-registries:
+    - 192.168.1.16:5000
+    - localhost:5000
+EOF
+```
+
+```bash
+$ kubectl gadget deploy --daemon-config=daemon-config.yaml
 ...
 
 $ kubectl gadget run 192.168.1.16:5000/trace_exec:latest

--- a/docs/reference/verify-assets.mdx
+++ b/docs/reference/verify-assets.mdx
@@ -140,15 +140,36 @@ gadget      gadge…hbh8n gadget      40265… 22867… 53387  53369  0      0  
 ...
 ```
 
-You can specify a custom public key at deploy time using `--gadgets-public-keys`:
+You can specify a custom public key at deployment time using `--daemon-config`. Start by creating daemon config file:
 
 ```bash
-$ kubectl gadget deploy --gadgets-public-keys="$(cat your-key.pub)"
+cat <<EOF > daemon-config.yaml
+operator:
+    oci:
+        public-keys:
+        - |
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp3pbyFZOnEz4ZtkXY0Zm
+            Q78zbdZ9Pyhgje+oD1T49r7HYeUdf2vKyc1ObcCwT3EZyzv48IC6cBcdNu4RjbS8
+            snpzFVK5P9szolYJfuMJyLkMTGOAc6AjA0YY8b3wJtV8F3N3IjzA0HtJ3vIqDxIb
+            e8rm52uh4RV7SooxMyh5SAdPi06/kAV2ZClQK1z5Vob9zM2U8w2M8Ib4h/cHBY4e
+            7W9IuQZTvwlAEyEZng7GUPf/dke69/9I3/N9UoKXIJ8cHg0pxtWKPmCGoFqFT9qR
+            ehd9nJdWmLfFT7y1KmfkxknC0TAl3lA4ArZqYYzRmX8cUFz2mGNzNnWgkxN7qVMS
+            LQIDAQAB
+            -----END PUBLIC KEY-----
+EOF
+```
+
+Then, you can deploy Inspektor Gadget with this configuration:
+
+```bash
+
+$ kubectl gadget deploy --daemon-config=daemon-config.yaml
 ...
 Inspektor Gadget successfully deployed
 # Without the official public key, official gadgets will be rejected.
 $ kubectl gadget run trace_exec -A
-Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "trace_exec": verifying signature: invalid signature when validating ASN.1 encoded signature
+Error: fetching gadget information: getting gadget info: rpc error: code = Unknown desc = getting gadget info: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "trace_exec": the image was not signed by the provided keys: crypto/rsa: verification error
 $ kubectl-gadget run ghcr.io/your_repo/trace_exec -A
 K8S.NAMESP… K8S.PODNAME K8S.CONTAI… MNTNS… TIMES… PID    PPID   UID    GID    LOGIN… SESSI… RETVAL ARGS_… UPPER… ARGS_… COMM  ARGS  K8S.…
 gadget      gadge…hbh8n gadget      40265… 22867… 53386  53368  0      0      42949… 42949… 0      2      false  35     gadg… /bin… mini…
@@ -158,9 +179,20 @@ gadget      gadge…hbh8n gadget      40265… 22867… 53387  53369  0      0  
 
 You can also instruct Inspektor Gadget to skip the verification by disabling it at deploy time.
 Please note that we do not recommend doing so and that it should only be used for development purposes.
+Again start by creating a daemon config file:
 
 ```bash
-$ kubectl gadget deploy --verify-gadgets=false
+cat <<EOF > daemon-config.yaml
+operator:
+    oci:
+        verify-image: false
+EOF
+```
+
+Then, you can deploy Inspektor Gadget with this configuration:
+
+```bash
+$ kubectl gadget deploy --daemon-config=daemon-config.yaml
 ...
 Inspektor Gadget successfully deployed
 $ kubectl gadget run trace_exec -A

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -17,23 +17,72 @@ package gadgettracermanagerconfig
 const ConfigPath = "/etc/ig/config.yaml"
 
 const (
-	HookModeKey              = "hook-mode"
-	FallbackPodInformerKey   = "fallback-pod-informer"
-	EventsBufferLengthKey    = "events-buffer-length"
-	ContainerdSocketPath     = "containerd-socketpath"
-	CrioSocketPath           = "crio-socketpath"
-	DockerSocketPath         = "docker-socketpath"
-	PodmanSocketPath         = "podman-socketpath"
-	Operator                 = "operator"
-	Oci                      = "oci"
-	VerifyImage              = "verify-image"
-	PublicKeys               = "public-keys"
-	AllowedGadgets           = "allowed-gadgets"
-	InsecureRegistries       = "insecure-registries"
-	DisallowPulling          = "disallow-pulling"
-	OtelMetrics              = "otel-metrics"
+	HookModeKey            = "hook-mode"
+	FallbackPodInformerKey = "fallback-pod-informer"
+	EventsBufferLengthKey  = "events-buffer-length"
+	ContainerdSocketPath   = "containerd-socketpath"
+	CrioSocketPath         = "crio-socketpath"
+	DockerSocketPath       = "docker-socketpath"
+	PodmanSocketPath       = "podman-socketpath"
+	GadgetNamespace        = "gadget-namespace"
+
+	VerifyImage        = "verify-image"
+	PublicKeys         = "public-keys"
+	InsecureRegistries = "insecure-registries"
+	DisallowPulling    = "disallow-pulling"
+	AllowedGadgets     = "allowed-gadgets"
+
 	OtelMetricsListen        = "otel-metrics-listen"
 	OtelMetricsListenAddress = "otel-metrics-listen-address"
-	EBPFOperator             = "ebpf"
-	GadgetNamespace          = "gadget-namespace"
 )
+
+// IsValidKey checks if the given key is a valid configuration key for the GadgetTracerManager.
+// TODO: Remove in the future once we remove the flags from kubectl-gadget deploy.
+func IsValidKey(key string) bool {
+	return isRootKey(key) || isOciKey(key) || isOtelKey(key)
+}
+
+// FullKeyPath returns the full key path for the given key.
+// TODO: Remove in the future once we remove the flags from kubectl-gadget deploy.
+func FullKeyPath(key string) string {
+	if isRootKey(key) {
+		return key
+	} else if isOciKey(key) {
+		return "operator.oci." + key
+	} else if isOtelKey(key) {
+		return "operator.otel-metrics." + key
+	}
+	return ""
+}
+
+// TODO: Remove in the future once we remove the flags from kubectl-gadget deploy.
+func isRootKey(key string) bool {
+	switch key {
+	case HookModeKey, FallbackPodInformerKey, EventsBufferLengthKey,
+		ContainerdSocketPath, CrioSocketPath, DockerSocketPath,
+		PodmanSocketPath, GadgetNamespace:
+		return true
+	default:
+		return false
+	}
+}
+
+// TODO: Remove in the future once we remove the flags from kubectl-gadget deploy.
+func isOciKey(key string) bool {
+	switch key {
+	case VerifyImage, PublicKeys, AllowedGadgets, InsecureRegistries, DisallowPulling:
+		return true
+	default:
+		return false
+	}
+}
+
+// TODO: Remove in the future once we remove the flags from kubectl-gadget deploy.
+func isOtelKey(key string) bool {
+	switch key {
+	case OtelMetricsListen, OtelMetricsListenAddress:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -30,16 +30,19 @@ data:
       gadget-namespace: gadget
       operator:
         oci:
-          verify-image: true
-          public-keys:
-            - |
-              -----BEGIN PUBLIC KEY-----
-              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
-              Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
-              -----END PUBLIC KEY-----
-          allowed-gadgets:
-            []
+          allowed-gadgets: []
           disallow-pulling: false
+          insecure-registries: []
+          public-keys:
+          - |
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
+            Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
+            -----END PUBLIC KEY-----
+          verify-image: true
+        otel-metrics:
+          otel-metrics-listen: false
+          otel-metrics-listen-address: 0.0.0.0:2224
 ---
 # Source: gadget/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Currently, we have to add flag for each operator configuration resulting in the need to 
- Implement support in deploy.go whenever global operator's param is added.
- Limitation not able to specify nested configuration like
```
operator:
    otel-metrics:
        otel-metrics-listen: true
        exporters:
            grpc:
                exporter: otlp-grpc
                endpoint: "127.0.0.1:4317"
                insecure: true
                temporality: delta
                interval: 30s
```

Additionally, as mentioned in https://github.com/inspektor-gadget/inspektor-gadget/issues/3168, having the Kubernetes and operators configs together can create a lot of confusion. We can already see it in the kubectl gadget deploy flags where we have things like liveness-probe, image and image-pull-policy (which are related to the gadget k8s daemonset) alongside things like insecure-registries, --disallow-gadgets-pulling and gadgets-public-keys (which are operators' options and applies only to gadgets). So, moving operators' config to a config file will allows to separate these two configs:

- gadget k8s daemonset-related configs through kubectl gadget deploy's flags
- operators-related configs through config file.
- The same approach has been followed for helm charts where gadget pod related configuration lives in `config:` in `values.yaml` and K8s related at base level. 

## Usage

### kubectl-gadget  
```
$ cat /tmp/config.yaml
operator:
    otel-metrics:
        otel-metrics-listen: true
        exporters:
            grpc:
                exporter: otlp-grpc
                endpoint: "127.0.0.1:4317"
                insecure: true
                temporality: delta
                interval: 30s
```
```
./kubectl-gadget deploy --daemon-config=/tmp/config.yaml
```
or
```
/kubectl-gadget deploy --daemon-config=/tmp/config.yaml --print-only  | grep ConfigMap -B40
```

### helm

```
$ cat /tmp/values.yaml
config:
  operator:
    otel-metrics:
        otel-metrics-listen: true
        exporters:
            grpc:
                exporter: otlp-grpc
                endpoint: "127.0.0.1:4317"
                insecure: true
                temporality: delta
                interval: 30s

$ make -C charts clean build
$ helm template charts/bin/gadget/ -f /tmp/config.yaml  | grep ConfigMap -A30
kind: ConfigMap
metadata:
  name: gadget
  namespace: default
data:
    config.yaml: |-
      hook-mode: auto
      fallback-pod-informer: true
      events-buffer-length: 16384
      containerd-socketpath: /run/containerd/containerd.sock
      crio-socketpath: /run/crio/crio.sock
      docker-socketpath: /run/docker.sock
      podman-socketpath: /run/podman/podman.sock
      gadget-namespace: gadget
      operator:
        oci:
          allowed-gadgets: []
          disallow-pulling: false
          insecure-registries: []
          public-keys:
          - |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
            Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
            -----END PUBLIC KEY-----
          verify-image: true
        otel-metrics:
          exporters:
            grpc:
              endpoint: 127.0.0.1:4317
              exporter: otlp-grpc
              insecure: true
              interval: 30s
              temporality: delta
          otel-metrics-listen: true
          otel-metrics-listen-address: 0.0.0.0:2224

```

## Deprecation

**kubectl-gadget**: The `flags` for `kubectl-gadget` deploy still works fine and have priority compared to config file but will removed in future release.
**helm**: The `config` in `values.yaml` still supports flat structure so any older values.yaml will work fine but they will be remove in future. 

## Testing Done

A test has been added in deploy_test.go to validate the order for configuration support. But you can use command like following to verify things:

```
/kubectl-gadget deploy --print-only --verify-gadgets=false | grep ConfigMap -B 40
```

same for helm

```
$ helm template charts/bin/gadget --set config.verifyGadgets=false | grep ConfigMap -A30
$ helm template charts/bin/gadget --set config.operator.oci.verify-image=false | grep ConfigMap -A30
```

Also CI is using the new approach as well. 

## Follow Up

- Make sure documentation is updated.