### PR TITLE
pkg/datasource/expr: improve performance

### DIFF
--- a/pkg/datasource/expr/expr.go
+++ b/pkg/datasource/expr/expr.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,70 +25,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 )
-
-type wrap struct {
-	d datasource.Data
-}
-
-func (w wrap) GetString(f datasource.FieldAccessor) string {
-	d, _ := f.String(w.d)
-	return d
-}
-
-func (w wrap) GetUint8(f datasource.FieldAccessor) uint8 {
-	d, _ := f.Uint8(w.d)
-	return d
-}
-
-func (w wrap) GetUint16(f datasource.FieldAccessor) uint16 {
-	d, _ := f.Uint16(w.d)
-	return d
-}
-
-func (w wrap) GetUint32(f datasource.FieldAccessor) uint32 {
-	d, _ := f.Uint32(w.d)
-	return d
-}
-
-func (w wrap) GetUint64(f datasource.FieldAccessor) uint64 {
-	d, _ := f.Uint64(w.d)
-	return d
-}
-
-func (w wrap) GetInt8(f datasource.FieldAccessor) int8 {
-	d, _ := f.Int8(w.d)
-	return d
-}
-
-func (w wrap) GetInt16(f datasource.FieldAccessor) int16 {
-	d, _ := f.Int16(w.d)
-	return d
-}
-
-func (w wrap) GetInt32(f datasource.FieldAccessor) int32 {
-	d, _ := f.Int32(w.d)
-	return d
-}
-
-func (w wrap) GetInt64(f datasource.FieldAccessor) int64 {
-	d, _ := f.Int64(w.d)
-	return d
-}
-
-func (w wrap) GetFloat32(f datasource.FieldAccessor) float32 {
-	d, _ := f.Float32(w.d)
-	return d
-}
-
-func (w wrap) GetFloat64(f datasource.FieldAccessor) float64 {
-	d, _ := f.Float64(w.d)
-	return d
-}
-
-func (w wrap) GetBool(f datasource.FieldAccessor) bool {
-	d, _ := f.Bool(w.d)
-	return d
-}
 
 type dsPatcher struct {
 	ds datasource.DataSource
@@ -145,7 +81,7 @@ func replaceNode(node *ast.Node, f datasource.FieldAccessor) {
 
 	callNode := &ast.CallNode{
 		Callee:    &ast.IdentifierNode{Value: fn},
-		Arguments: []ast.Node{&ast.ConstantNode{Value: f}},
+		Arguments: []ast.Node{&ast.ConstantNode{Value: f}, &ast.IdentifierNode{Value: "$env"}},
 	}
 	ast.Patch(node, callNode)
 	(*node).SetType(ft)
@@ -182,11 +118,91 @@ func getFnAndReflectType(f datasource.FieldAccessor) (string, reflect.Type) {
 	}
 }
 
+func getBuiltInExpressions() []expr.Option {
+	return []expr.Option{
+		expr.Function("GetString",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).String(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) string),
+		),
+		expr.Function("GetUint8",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Uint8(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) uint8),
+		),
+		expr.Function("GetUint16",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Uint16(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) uint16),
+		),
+		expr.Function("GetUint32",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Uint32(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) uint32),
+		),
+		expr.Function("GetUint64",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Uint64(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) uint64),
+		),
+		expr.Function("GetInt8",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Int8(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) int8),
+		),
+		expr.Function("GetInt16",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Int16(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) int16),
+		),
+		expr.Function("GetInt32",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Int32(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) int32),
+		),
+		expr.Function("GetInt64",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Int64(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) int64),
+		),
+		expr.Function("GetFloat32",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Float32(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) float32),
+		),
+		expr.Function("GetFloat64",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Float64(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) float64),
+		),
+		expr.Function("GetBool",
+			func(params ...any) (any, error) {
+				return params[0].(datasource.FieldAccessor).Bool(params[1].(datasource.Data))
+			},
+			new(func(datasource.FieldAccessor, datasource.Data) bool),
+		),
+	}
+}
+
 func CompileStringProgram(ds datasource.DataSource, expression string) (*vm.Program, error) {
 	dsp := dsPatcher{
 		ds: ds,
 	}
-	prog, err := expr.Compile(expression, expr.AsKind(reflect.String), expr.Patch(dsp), expr.Env(&wrap{}))
+
+	options := append(getBuiltInExpressions(), expr.AsKind(reflect.String), expr.Patch(dsp))
+
+	prog, err := expr.Compile(expression, options...)
 	if err != nil {
 		return nil, fmt.Errorf("compiling string expression: %w", err)
 	}
@@ -197,7 +213,10 @@ func CompileFilterProgram(ds datasource.DataSource, expression string) (*vm.Prog
 	dsp := dsPatcher{
 		ds: ds,
 	}
-	prog, err := expr.Compile(expression, expr.AsBool(), expr.Patch(dsp), expr.Env(&wrap{}))
+
+	options := append(getBuiltInExpressions(), expr.AsBool(), expr.Patch(dsp), expr.Env(datasource.Data(nil)))
+
+	prog, err := expr.Compile(expression, options...)
 	if err != nil {
 		return nil, fmt.Errorf("compiling filter expression: %w", err)
 	}
@@ -205,5 +224,5 @@ func CompileFilterProgram(ds datasource.DataSource, expression string) (*vm.Prog
 }
 
 func Run(program *vm.Program, data datasource.Data) (any, error) {
-	return expr.Run(program, wrap{data})
+	return expr.Run(program, data)
 }

--- a/pkg/datasource/expr/expr_test.go
+++ b/pkg/datasource/expr/expr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package expr
 import (
 	"testing"
 
-	"github.com/expr-lang/expr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
@@ -104,7 +103,7 @@ func TestExpressionString(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			res, err := expr.Run(filter, wrap{d: data})
+			res, err := Run(filter, data)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.result, res.(string), tc.name)
@@ -380,7 +379,7 @@ func TestExpressionFilter(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			res, err := expr.Run(filter, wrap{d: data})
+			res, err := Run(filter, data)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.match, res.(bool), tc.name)


### PR DESCRIPTION
This improves performance of the expr-lang support for datasources, reducing cpu time by roughly 97%.
This is achieved by simplifying the way that fields of datasources are accessed and taking the `Data` object directly as environment.

Thanks to @alban for making me aware that the speed was not that great before by comparing it to the gval package.

```text
$ benchstat old.bench new.bench
goos: linux
goarch: arm64
pkg: github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/expr
                                             │   old.bench   │              new.bench              │
                                             │    sec/op     │   sec/op     vs base                │
Expression/string_match_positive-4             2845.50n ± 3%   95.81n ± 1%  -96.63% (p=0.000 n=10)
Expression/string_match_negative-4             2836.00n ± 0%   95.29n ± 1%  -96.64% (p=0.000 n=10)
Expression/string_not_match_positive-4         2843.50n ± 0%   98.57n ± 0%  -96.53% (p=0.000 n=10)
Expression/string_not_match_negative-4         2843.50n ± 0%   98.03n ± 1%  -96.55% (p=0.000 n=10)
Expression/string_lte_positive-4               2845.50n ± 0%   96.57n ± 1%  -96.61% (p=0.000 n=10)
Expression/string_gte_negative-4               2845.50n ± 0%   96.65n ± 0%  -96.60% (p=0.000 n=10)
Expression/string_regex_match_positive-4        2904.0n ± 0%   139.1n ± 1%  -95.21% (p=0.000 n=10)
Expression/string_regex_match_negative-4        2916.0n ± 0%   144.0n ± 1%  -95.06% (p=0.000 n=10)
Expression/string_regex_not_match_positive-4    2920.0n ± 0%   148.2n ± 1%  -94.92% (p=0.000 n=10)
Expression/string_regex_not_match_negative-4    2918.0n ± 0%   144.1n ± 1%  -95.06% (p=0.000 n=10)
Expression/int_match_positive-4                2822.00n ± 1%   69.97n ± 0%  -97.52% (p=0.000 n=10)
Expression/int_match_negative-4                2818.50n ± 1%   69.83n ± 1%  -97.52% (p=0.000 n=10)
Expression/int_gte_positive-4                  2816.00n ± 0%   69.47n ± 1%  -97.53% (p=0.000 n=10)
Expression/int_gte_positive#01-4               2823.00n ± 0%   69.69n ± 0%  -97.53% (p=0.000 n=10)
Expression/int_gte_negative-4                  2821.00n ± 0%   69.77n ± 2%  -97.53% (p=0.000 n=10)
Expression/int_lte_positive-4                  2816.00n ± 0%   70.35n ± 1%  -97.50% (p=0.000 n=10)
Expression/int_lte_positive#01-4               2823.00n ± 0%   69.92n ± 0%  -97.52% (p=0.000 n=10)
Expression/int_lte_negative-4                  2815.00n ± 0%   70.46n ± 1%  -97.50% (p=0.000 n=10)
Expression/int_gt_positive-4                   2817.50n ± 0%   72.04n ± 2%  -97.44% (p=0.000 n=10)
Expression/int_gt_negative-4                   2818.00n ± 0%   70.00n ± 3%  -97.52% (p=0.000 n=10)
Expression/int_lt_positive-4                   2819.00n ± 0%   71.13n ± 3%  -97.48% (p=0.000 n=10)
Expression/int_lt_negative-4                   2823.00n ± 0%   70.45n ± 1%  -97.50% (p=0.000 n=10)
Expression/float_match_positive-4              2832.00n ± 0%   84.10n ± 1%  -97.03% (p=0.000 n=10)
Expression/float_match_positive#01-4           2823.50n ± 0%   84.02n ± 1%  -97.02% (p=0.000 n=10)
Expression/float_match_negative-4              2826.00n ± 0%   84.27n ± 1%  -97.02% (p=0.000 n=10)
Expression/float_match_negative#01-4           2824.00n ± 0%   84.45n ± 1%  -97.01% (p=0.000 n=10)
Expression/float_gte_positive-4                2825.00n ± 0%   83.91n ± 1%  -97.03% (p=0.000 n=10)
Expression/float_gte_positive#01-4             2831.00n ± 1%   83.96n ± 1%  -97.03% (p=0.000 n=10)
Expression/float_gte_negative-4                2826.00n ± 0%   84.45n ± 1%  -97.01% (p=0.000 n=10)
Expression/float_lte_positive-4                2821.50n ± 0%   84.50n ± 1%  -97.01% (p=0.000 n=10)
Expression/float_lte_positive#01-4             2820.00n ± 0%   84.12n ± 2%  -97.02% (p=0.000 n=10)
Expression/float_lte_negative-4                2821.00n ± 0%   85.00n ± 1%  -96.99% (p=0.000 n=10)
Expression/float_gt_positive-4                 2823.50n ± 0%   84.36n ± 1%  -97.01% (p=0.000 n=10)
Expression/float_gt_negative-4                 2821.50n ± 0%   84.42n ± 1%  -97.01% (p=0.000 n=10)
Expression/float_lt_positive-4                 2825.50n ± 0%   83.52n ± 1%  -97.04% (p=0.000 n=10)
Expression/float_lt_negative-4                 2826.00n ± 0%   83.63n ± 1%  -97.04% (p=0.000 n=10)
Expression/bool_match_positive-4               2816.00n ± 3%   69.01n ± 0%  -97.55% (p=0.000 n=10)
Expression/bool_match_negative-4               2800.00n ± 0%   69.03n ± 1%  -97.53% (p=0.000 n=10)
Expression/bool_not_match_positive-4           2807.00n ± 0%   72.80n ± 1%  -97.41% (p=0.000 n=10)
Expression/bool_not_match_negative-4           2803.50n ± 0%   72.55n ± 1%  -97.41% (p=0.000 n=10)
geomean                                          2.833µ        84.44n       -97.02%

                                             │  old.bench  │             new.bench              │
                                             │    B/op     │    B/op     vs base                │
Expression/string_match_positive-4             347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_match_negative-4             347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_not_match_positive-4         347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_not_match_negative-4         347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_lte_positive-4               347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_gte_negative-4               347.00 ± 0%   83.00 ± 0%  -76.08% (p=0.000 n=10)
Expression/string_regex_match_positive-4       349.00 ± 0%   83.00 ± 0%  -76.22% (p=0.000 n=10)
Expression/string_regex_match_negative-4       349.00 ± 0%   83.00 ± 0%  -76.22% (p=0.000 n=10)
Expression/string_regex_not_match_positive-4   349.00 ± 0%   83.00 ± 0%  -76.22% (p=0.000 n=10)
Expression/string_regex_not_match_negative-4   349.00 ± 0%   83.00 ± 0%  -76.22% (p=0.000 n=10)
Expression/int_match_positive-4                336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_match_negative-4                336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_gte_positive-4                  336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_gte_positive#01-4               336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_gte_negative-4                  336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_lte_positive-4                  336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_lte_positive#01-4               336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_lte_negative-4                  336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_gt_positive-4                   336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_gt_negative-4                   336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_lt_positive-4                   336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/int_lt_negative-4                   336.00 ± 0%   64.00 ± 0%  -80.95% (p=0.000 n=10)
Expression/float_match_positive-4              336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_match_positive#01-4           336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_match_negative-4              336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_match_negative#01-4           336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_gte_positive-4                336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_gte_positive#01-4             336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_gte_negative-4                336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_lte_positive-4                336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_lte_positive#01-4             336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_lte_negative-4                336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_gt_positive-4                 336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_gt_negative-4                 336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_lt_positive-4                 336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/float_lt_negative-4                 336.00 ± 0%   72.00 ± 0%  -78.57% (p=0.000 n=10)
Expression/bool_match_positive-4               329.00 ± 0%   64.00 ± 0%  -80.55% (p=0.000 n=10)
Expression/bool_match_negative-4               329.00 ± 0%   64.00 ± 0%  -80.55% (p=0.000 n=10)
Expression/bool_not_match_positive-4           329.00 ± 0%   64.00 ± 0%  -80.55% (p=0.000 n=10)
Expression/bool_not_match_negative-4           329.00 ± 0%   64.00 ± 0%  -80.55% (p=0.000 n=10)
geomean                                         338.2        71.17       -78.96%

                                             │  old.bench  │             new.bench              │
                                             │  allocs/op  │ allocs/op   vs base                │
Expression/string_match_positive-4             14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_match_negative-4             14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_not_match_positive-4         14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_not_match_negative-4         14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_lte_positive-4               14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_gte_negative-4               14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_regex_match_positive-4       14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_regex_match_negative-4       14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_regex_not_match_positive-4   14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/string_regex_not_match_negative-4   14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
Expression/int_match_positive-4                13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_match_negative-4                13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_gte_positive-4                  13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_gte_positive#01-4               13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_gte_negative-4                  13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_lte_positive-4                  13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_lte_positive#01-4               13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_lte_negative-4                  13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_gt_positive-4                   13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_gt_negative-4                   13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_lt_positive-4                   13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/int_lt_negative-4                   13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/float_match_positive-4              13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_match_positive#01-4           13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_match_negative-4              13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_match_negative#01-4           13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_gte_positive-4                13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_gte_positive#01-4             13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_gte_negative-4                13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_lte_positive-4                13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_lte_positive#01-4             13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_lte_negative-4                13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_gt_positive-4                 13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_gt_negative-4                 13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_lt_positive-4                 13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/float_lt_negative-4                 13.000 ± 0%   3.000 ± 0%  -76.92% (p=0.000 n=10)
Expression/bool_match_positive-4               13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/bool_match_negative-4               13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/bool_not_match_positive-4           13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
Expression/bool_not_match_negative-4           13.000 ± 0%   2.000 ± 0%  -84.62% (p=0.000 n=10)
geomean                                         13.24        2.741       -79.30%
```