### PR TITLE
ci: Revome usage of ttl.sh

### DIFF
--- a/.github/actions/set-container-repo-and-determine-image-tag/action.yml
+++ b/.github/actions/set-container-repo-and-determine-image-tag/action.yml
@@ -63,9 +63,6 @@ runs:
         fi
 
         gadget_repository=${{ inputs.registry }}/${{ github.repository_owner }}/gadget
-        if [ ${{ github.event_name }} == 'pull_request' ]; then
-          gadget_repository=ttl.sh/${{ github.sha }}
-        fi
 
         echo "gadget-repository=${gadget_repository}" >> $GITHUB_OUTPUT
     - name: Output gadgets image tag

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -14,6 +14,7 @@ env:
   # release job as they seem to not be downloadable.
   # So, for now, let's deactivate this feature.
   DOCKER_BUILD_NO_SUMMARY: true
+  JUNK_REPOSITORY: ghcr.io/${{ github.repository_owner }}/junk
 concurrency:
   group: ${{ github.ref }}
   # We do not want to cancel job in progress on main to be sure to catch new

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -6,6 +6,17 @@ GADGET_TAG ?= $(shell ../tools/image-tag branch)
 GADGET_REPOSITORY ?= ghcr.io/inspektor-gadget/gadget
 BUILDER_IMAGE ?= ghcr.io/inspektor-gadget/gadget-builder:main
 KERNEL_REPOSITORY ?= ghcr.io/inspektor-gadget/ci-kernels
+
+# GetGadgetImageName returns the full image name to be used in the tests.
+# If running locally, it returns $GADGET_REPOSITORY/<gadget>:$GADGET_TAG
+# If running on github actions, it returns <JUNK_REPOSITORY>:<GITHUB_RUN_ID>-<gadget>.
+# The whole purpose of this is to be able to push gadgets testing to the junk
+# repository, as the repository name can't contain any slash because github will
+# create a new repository, we use the tag to push multiple gadgets to the same
+# one.
+# keep aligned with GetGadgetImageName in pkg/testing/gadgetrunner/gadgetrunner.go
+get_gadget_image_name = $(if $(filter pull_request,$(GITHUB_EVENT_NAME)),$(JUNK_REPOSITORY):$(GITHUB_RUN_ID)-$(subst /,-,$(1)),$(GADGET_REPOSITORY)/$(1):$(GADGET_TAG))
+
 IG ?= ig
 KUBECTL_GADGET ?= kubectl-gadget
 IG_RUNTIME ?= docker
@@ -87,7 +98,7 @@ $(GADGETS): pull-builder-image
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
-		-t $(GADGET_REPOSITORY)/$@:$(GADGET_TAG) \
+		-t $(call get_gadget_image_name,$@) \
 		--builder-image-pull=never \
 		$$GADGET_BUILD_PARAMS \
 		$@
@@ -127,51 +138,44 @@ $(GADGETS_README_DEV):
 
 %-push: %-build
 	@echo "Pushing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@sudo -E $(IG) image push $(call get_gadget_image_name,$*)
 
 .PHONY:
 push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@sudo -E $(IG) image push $(call get_gadget_image_name,$*)
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
 
 %-sign: %-push
 	@echo "Signing $*"
-	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	digest=$$(sudo -E $(IG) image inspect $(call get_gadget_image_name,$*) -o json | jq -r .Digest) ; \
+	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(call get_gadget_image_name,$*)@$$digest
 
 sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
 	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(call get_gadget_image_name,$*)@$$digest
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 
 %-clean:
-	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	sudo -E $(IG) image remove $(call get_gadget_image_name,$*)
 
 .PHONY:
 clean: $(addsuffix -clean,$(GADGETS))
 
 .PHONY:
-pull:
-	GADGET_TAG=$(GADGET_TAG) \
-	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
-	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
-	done
+pull: $(addsuffix -pull,$(GADGETS))
 
 .PHONY:
-%/pull:
-	GADGET_TAG=$(GADGET_TAG) \
-	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+%-pull:
+	sudo -E $(IG) image pull $(call get_gadget_image_name,$*)
 
 .PHONY:
 test-unit: build
@@ -229,7 +233,7 @@ test-k8s: test-integration
 
 .PHONY:
 %-update-latest-tag:
-	$(CRANE) copy $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(GADGET_REPOSITORY)/$*:latest
+	$(CRANE) copy $(call get_gadget_image_name,$*) $(GADGET_REPOSITORY)/$*:latest
 
 .PHONY:
 update-latest-tag: $(addsuffix -update-latest-tag,$(GADGETS))

--- a/pkg/testing/gadgetrunner/gadgetrunner.go
+++ b/pkg/testing/gadgetrunner/gadgetrunner.go
@@ -242,11 +242,19 @@ func splitIGDomain(name string) (domain, remainder string) {
 	return
 }
 
+// GetGadgetImageName returns the full image name to be used in the tests.
+// If running locally, it returns $GADGET_REPOSITORY/<gadget>:$GADGET_TAG
+// If running on github actions, it returns <JUNK_REPOSITORY>:<GITHUB_RUN_ID>-<gadget>.
 func GetGadgetImageName(gadget string) string {
 	// if the image already specifies a domain, don't append GADGET_REPOSITORY
 	domain, _ := splitIGDomain(gadget)
 	if domain != defaultDomain {
 		return gadget
+	}
+
+	if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
+		gadget = strings.ReplaceAll(gadget, "/", "-")
+		return fmt.Sprintf("%s:%s-%s", os.Getenv("JUNK_REPOSITORY"), os.Getenv("GITHUB_RUN_ID"), gadget)
 	}
 
 	repository := os.Getenv("GADGET_REPOSITORY")


### PR DESCRIPTION
The CI uses ttl.sh as a "junk" repository to store gadget images. Unfortunately, it fails some times, so this commit switches to use ghcr.io instead. As ghcr.io isn't designed for that purpose, we need to use the tag to store multiple gadgets (even from different runs) on the same repo.

Fixes #4026

### TODO

- [ ] worflow to cleanup junk repository
