### PR TITLE
kallsyms/cache: preload kallsyms that cilium/ebpf will need

### DIFF
--- a/pkg/kallsyms/symscache/symscache.go
+++ b/pkg/kallsyms/symscache/symscache.go
@@ -1,0 +1,84 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package symscache provides a way to register and populate the cilium/ebpf's
+// kallsyms cache in an efficient way.
+//
+// The cost of loading many symbols at once is lower than loading few symbols
+// multiple times for multiple ebpf collections.
+//
+// How to use this package:
+// 1. Call RegisterSymbolsFromSpec from an init() function.
+// 2. Call PopulateKallsymsCache just before loading your ebpf collection.
+package symscache
+
+import (
+	"sync"
+
+	"github.com/cilium/ebpf"
+)
+
+var (
+	requestedSymbols []string
+
+	populateKallsymsCache = sync.OnceFunc(func() {
+		spec := &ebpf.CollectionSpec{
+			Programs:  make(map[string]*ebpf.ProgramSpec),
+			Maps:      make(map[string]*ebpf.MapSpec),
+			Variables: make(map[string]*ebpf.VariableSpec),
+		}
+		for _, sym := range requestedSymbols {
+			spec.Programs[sym] = &ebpf.ProgramSpec{
+				Name:     sym,
+				Type:     ebpf.Kprobe,
+				AttachTo: sym,
+			}
+		}
+		requestedSymbols = nil
+		coll, err := ebpf.NewCollection(spec)
+		if err != nil {
+			// error is expected: "instructions cannot be empty"
+			// cilium/ebpf will still load kallsyms in the cache
+			return
+		}
+		coll.Close()
+	})
+)
+
+// RegisterSymbolsFromSpec registers the symbols from the given
+// ebpf.CollectionSpec. RegisterSymbolsFromSpec can be called from an init()
+// function.
+//
+// Once all symbols are registered, the cache can be populated with
+// PopulateKallsymsCache.
+func RegisterSymbolsFromSpec(spec *ebpf.CollectionSpec) {
+	for _, prog := range spec.Programs {
+		if prog.AttachTo == "" {
+			continue
+		}
+		if prog.Type != ebpf.Kprobe && prog.Type != ebpf.Tracing {
+			continue
+		}
+		requestedSymbols = append(requestedSymbols, prog.AttachTo)
+	}
+}
+
+// PopulateKallsymsCache populates cilium/ebpf's kallsyms cache with the
+// symbols that were registered by RegisterSymbolsFromSpec.
+//
+// After the first call, subsequent calls will have no effect and have no
+// performance impact.
+func PopulateKallsymsCache() {
+	populateKallsymsCache()
+}


### PR DESCRIPTION
Introduce a new package pkg/kallsyms/cache used by:
- kfilefield
- container-hook
- kfilefields

The cost of loading many symbols at once is lower than loading few symbols multiple times for multiple ebpf collections. This is because most of the cpu time is used for reading /proc/kallsyms in the kernel function module_get_kallsym. So it is better to read /proc/kallsyms only one time.
https://github.com/torvalds/linux/blob/v6.15/kernel/module/kallsyms.c#L376

The cache package provides two separate functions:
- RegisterSymbolsFromSpec: to be called from init()
- PopulateKallsymsCache: to be called just before loading your ebpf collection

In this way, different users of the cache don't have to collaborate to collect the symbols they use.

This is a follow up to #4652.

Supersedes #4625

This approach does not require any change from cilium/ebpf. https://github.com/cilium/ebpf/pull/1802 can be discarded.

## Testing done

Before the patch:
```
$ hyperfine -w 2 --runs 10 "expect -c 'spawn sudo ig run trace_dns ; expect \"Gadget started successfully\" { puts \"\n--- OK ---\" } timeout { puts \"\n--- Timeout ---\"; exit 1 } eof { puts \"\n--- EOF ---\"; exit 1 }; exit 0'"
Benchmark 1: expect -c 'spawn sudo ig run trace_dns ; expect "Gadget started successfully" { puts "\n--- OK ---" } timeout { puts "\n--- Timeout ---"; exit 1 } eof { puts "\n--- EOF ---"; exit 1 }; exit 0'
  Time (mean ± σ):      3.041 s ±  0.128 s    [User: 0.003 s, System: 0.001 s]
  Range (min … max):    2.946 s …  3.393 s    10 runs
```

After the patch:
```
$ hyperfine -w 2 --runs 10 "expect -c 'spawn sudo ig run trace_dns ; expect \"Gadget started successfully\" { puts \"\n--- OK ---\" } timeout { puts \"\n--- Timeout ---\"; exit 1 } eof { puts \"\n--- EOF ---\"; exit 1 }; exit 0'"
Benchmark 1: expect -c 'spawn sudo ig run trace_dns ; expect "Gadget started successfully" { puts "\n--- OK ---" } timeout { puts "\n--- Timeout ---"; exit 1 } eof { puts "\n--- EOF ---"; exit 1 }; exit 0'
  Time (mean ± σ):      2.619 s ±  0.077 s    [User: 0.002 s, System: 0.002 s]
  Range (min … max):    2.519 s …  2.740 s    10 runs
```

Speedup: 0.4s (14%)
(in addition to the previous speedup from #4652)