### PR TITLE
wasmapi: Use std::sync::LazyLock instead of once_cell::sync::Lazy.

### DIFF
--- a/pkg/operators/wasm/rusttestdata/badguest/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/badguest/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "badguest"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/badguest/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/badguest/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/config/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/config/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "config"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/config/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/config/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/dataarray/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/dataarray/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "dataarray"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/dataarray/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/dataarray/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/dataemit/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/dataemit/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "dataemit"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/dataemit/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/dataemit/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/fields/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/fields/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "fields"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/fields/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/fields/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/filtering/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/filtering/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "filtering"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/filtering/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/filtering/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "kallsyms"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/map/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/map/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "rust_wasm"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]

--- a/pkg/operators/wasm/rusttestdata/map/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/map/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "mapofmap"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"

--- a/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/params/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/params/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "params"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]

--- a/pkg/operators/wasm/rusttestdata/params/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/params/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/perf/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/perf/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "perf"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]

--- a/pkg/operators/wasm/rusttestdata/perf/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/perf/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/pkg/operators/wasm/rusttestdata/syscall/Cargo.lock
+++ b/pkg/operators/wasm/rusttestdata/syscall/Cargo.lock
@@ -5,20 +5,10 @@ version = 4
 [[package]]
 name = "api"
 version = "0.1.0"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "syscall"
 version = "0.1.0"
 dependencies = [
  "api",
- "once_cell",
 ]

--- a/pkg/operators/wasm/rusttestdata/syscall/Cargo.toml
+++ b/pkg/operators/wasm/rusttestdata/syscall/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 crate-type=["cdylib"]
 
 [dependencies]
-once_cell="1.18"
 api={path="../../../../../wasmapi/rust"}

--- a/wasmapi/rust/Cargo.toml
+++ b/wasmapi/rust/Cargo.toml
@@ -2,6 +2,3 @@
 name = "api"
 version = "0.1.0"
 edition = "2021"
-
-[dependencies]
-once_cell = "1.18"

--- a/wasmapi/rust/src/datasources.rs
+++ b/wasmapi/rust/src/datasources.rs
@@ -11,13 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, Mutex,
+        Arc, LazyLock, Mutex
     },
 };
 
@@ -138,8 +136,7 @@ extern "C" {
 }
 
 static DS_SUBSCRIPTION_CTR: AtomicU64 = AtomicU64::new(0);
-static DS_SUBCRIPTION: Lazy<Mutex<HashMap<u64, CallBack>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+static DS_SUBCRIPTION: LazyLock<Mutex<HashMap<u64, CallBack>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Clone, Copy, Debug)]
 pub struct DataSource(pub u32);


### PR DESCRIPTION
LazyLock is thread-safe like Lazy [1, 2].
We still need to use a Mutex to have the inner mutability [3].

[1]: https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html
[2]: https://doc.rust-lang.org/std/sync/struct.LazyLock.html
[3]: https://users.rust-lang.org/t/lazylock-mutable-global-vars-supported/115685/3
