### PR TITLE
gadgettracermanager: Remove deprecated environment variables

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -84,16 +84,10 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "{{ .Values.image.repository }}"
-            - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
-              value: {{ .Values.config.hookMode | quote }}
-            - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
-              value: {{ .Values.config.fallbackPodInformer | quote }}
             - name: HOST_ROOT
               value: "/host"
             - name: IG_EXPERIMENTAL
               value: {{ .Values.config.experimental | quote }}
-            - name: EVENTS_BUFFER_LENGTH
-              value: {{ .Values.config.eventsBufferLength | quote }}
             - name: GADGET_TRACER_MANAGER_LOG_LEVEL
               value: {{ .Values.config.daemonLogLevel | quote }}
           securityContext:

--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -832,10 +832,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				switch gadgetContainer.Env[i].Name {
 				case "GADGET_IMAGE":
 					gadgetContainer.Env[i].Value = image
-				case "INSPEKTOR_GADGET_OPTION_HOOK_MODE":
-					gadgetContainer.Env[i].Value = hookMode
-				case "INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER":
-					gadgetContainer.Env[i].Value = strconv.FormatBool(fallbackPodInformer)
 				case utils.GadgetEnvironmentContainerdSocketpath:
 					gadgetContainer.Env[i].Value = runtimesConfig.Containerd
 				case utils.GadgetEnvironmentCRIOSocketpath:
@@ -847,8 +843,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				case experimental.EnvName:
 					value := experimental.Enabled() || experimentalVar
 					gadgetContainer.Env[i].Value = strconv.FormatBool(value)
-				case "EVENTS_BUFFER_LENGTH":
-					gadgetContainer.Env[i].Value = strconv.FormatUint(eventBufferLength, 10)
 				case "GADGET_TRACER_MANAGER_LOG_LEVEL":
 					if !slices.Contains(strLevels, daemonLogLevel) {
 						return fmt.Errorf("invalid log level %q, valid levels are: %v", daemonLogLevel, strings.Join(strLevels, ", "))

--- a/gadget-container/entrypoint/entrypoint.go
+++ b/gadget-container/entrypoint/entrypoint.go
@@ -29,7 +29,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/config/gadgettracermanagerconfig"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/gadgettracermanagerloglevel"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
@@ -241,12 +240,6 @@ func Init(hookMode string) (string, error) {
 
 	log.Infof("Gadget Image: %s", os.Getenv("GADGET_IMAGE"))
 
-	log.Info("Deployment options:")
-	for _, variable := range os.Environ() {
-		if strings.HasPrefix(variable, "INSPEKTOR_GADGET_OPTION_") {
-			log.Infof("[DEPRECATED] %s", variable)
-		}
-	}
 	if hasGadgetPullSecret() {
 		err = prepareGadgetPullSecret()
 		if err != nil {
@@ -266,10 +259,6 @@ func Init(hookMode string) (string, error) {
 		crio = true
 	}
 
-	if hookMode == "" {
-		log.Warnf("INSPEKTOR_GADGET_OPTION_HOOK_MODE is deprecated. Use %q instead in configmap", gadgettracermanagerconfig.HookModeKey)
-		hookMode = os.Getenv("INSPEKTOR_GADGET_OPTION_HOOK_MODE")
-	}
 	if (hookMode == "auto" || hookMode == "") && crio {
 		log.Info("Hook mode CRI-O detected")
 		hookMode = "crio"

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -200,16 +200,10 @@ spec:
                   fieldPath: metadata.uid
             - name: GADGET_IMAGE
               value: "ghcr.io/inspektor-gadget/inspektor-gadget"
-            - name: INSPEKTOR_GADGET_OPTION_HOOK_MODE
-              value: "auto"
-            - name: INSPEKTOR_GADGET_OPTION_FALLBACK_POD_INFORMER
-              value: "true"
             - name: HOST_ROOT
               value: "/host"
             - name: IG_EXPERIMENTAL
               value: "false"
-            - name: EVENTS_BUFFER_LENGTH
-              value: "16384"
             - name: GADGET_TRACER_MANAGER_LOG_LEVEL
               value: "info"
           securityContext:


### PR DESCRIPTION
This change removes the deprecated environment variables as part of https://github.com/inspektor-gadget/inspektor-gadget/pull/3150 (part of release `v0.31.0`).

## Testing Done:

### default:
```bash
$ make minikube-deploy
$ kubectl logs -n gadget ds/gadget | grep "Config:"
time="2025-06-27T07:38:28Z" level=info msg="Config: hook-mode=auto"
time="2025-06-27T07:38:28Z" level=info msg="Config: fallback-pod-informer=true"
time="2025-06-27T07:38:29Z" level=info msg="Config: events-buffer-length=16384"
time="2025-06-27T07:38:29Z" level=info msg="Config: gadget-namespace=gadget"
```

###: custom:

#### daemon-config.yaml
```yaml
events-buffer-length: 1024
hook-mode: "fanotify+ebpf"
fallback-pod-informer: false
```

```bash
$ ./kubectl-gadget deploy --liveness-probe=true  --image-pull-policy=Never --daemon-config=daemon-config.yaml
$ kubectl rollout restart -n gadget ds/gadget
$ kubectl logs -n gadget ds/gadget | grep "Config:"
time="2025-06-27T07:39:50Z" level=info msg="Config: hook-mode=fanotify+ebpf"
time="2025-06-27T07:39:50Z" level=info msg="Config: fallback-pod-informer=false"
time="2025-06-27T07:39:50Z" level=info msg="Config: events-buffer-length=1024"
time="2025-06-27T07:39:50Z" level=info msg="Config: gadget-namespace=gadget"

```
