### PR TITLE
bpfstats fixes

### DIFF
--- a/pkg/bpfstats/bpfstats.go
+++ b/pkg/bpfstats/bpfstats.go
@@ -62,6 +62,7 @@ func EnableBPFStats() error {
 	defer mutex.Unlock()
 
 	if refCnt != 0 {
+		refCnt++
 		return nil
 	}
 

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -212,13 +212,19 @@ func (c *GadgetContext) close() error {
 
 func (c *GadgetContext) PrepareGadgetInfo(paramValues api.ParamValues) error {
 	err := c.instantiateOperators(paramValues)
-	c.close()
+	if err := c.close(); err != nil {
+		c.logger.Warn("error closing operators after preparing gadget info:", err)
+	}
 	return err
 }
 
 func (c *GadgetContext) Run(paramValues api.ParamValues) error {
 	defer c.cancel()
-	defer c.close()
+	defer func() {
+		if err := c.close(); err != nil {
+			c.logger.Warn("error closing operators after run gadget:", err)
+		}
+	}()
 
 	metricAttribs := attribute.NewSet(
 		attribute.KeyValue{Key: "gadget_image", Value: attribute.StringValue(c.imageName)},

--- a/pkg/operators/ebpf/stats.go
+++ b/pkg/operators/ebpf/stats.go
@@ -566,15 +566,14 @@ func (i *ebpfOperatorDataInstance) Start(gadgetCtx operators.GadgetContext) erro
 }
 
 func (i *ebpfOperatorDataInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	if err := bpfstats.DisableBPFStats(); err != nil {
+		return fmt.Errorf("disabling bpf stats: %w", err)
+	}
+
 	return nil
 }
 
 func (i *ebpfOperatorDataInstance) Close(gadgetCtx operators.GadgetContext) error {
 	defer close(i.done)
-
-	if err := bpfstats.DisableBPFStats(); err != nil {
-		return fmt.Errorf("disabling bpf stats: %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
Fixes a couple of issues related to bpfstats. One of the fixes is taking from #3976 

### Testing 

On main, the following bug happened.

Start ig on daemon mode

```bash
$ sudo ig daemon
INFO[0000] starting Inspektor Gadget daemon at "unix:///var/run/ig/ig.socket"
```

Run any gadget to have something to trace

```bash 
$ sudo gadgetctl run trace_open 
```

Start a first instance of bpfstats gadget

```bash
$ sudo gadgetctl run bpfstats
GADGE… GADGETNAME   GADGETIMAGE  PRO… PROGNAME     PROGTYPE            RUNTIME RUNCOUNT MAPMEM… MA… COMMS       PIDS
                    trace_open      0                                   1.11ms      636   12 MB   7
```

It works fine and keeping updating the runcount column

Now, run a second instance of the bpfstats gadget

```bash 
$ sudo gadgetctl run bpfstats
GADGE… GADGETNAME   GADGETIMAGE  PRO… PROGNAME     PROGTYPE            RUNTIME RUNCOUNT MAPMEM… MA… COMMS       PIDS
                    trace_open      0                                   1.08ms      579   12 MB   7
```

it works fine as well. 

Finally, when the second instance is stopped, the first one stops working:

```bash
GADGE… GADGETNAME   GADGETIMAGE  PRO… PROGNAME     PROGTYPE            RUNTIME RUNCOUNT MAPMEM… MA… COMMS       PIDS
                    trace_open      0                                      0ns        0   12 MB   7
```

(notice that runcount and runtime are always 0)







