### PR TITLE
run: Remove operator. prefix requirement for default params

### DIFF
--- a/gadgets/advise_networkpolicy/gadget.yaml
+++ b/gadgets/advise_networkpolicy/gadget.yaml
@@ -11,4 +11,6 @@ datasources:
       generate_networkpolicy.enable: true
       kubenameresolver.enable: true
 paramDefaults:
-  operator.oci.ebpf.map-fetch-interval: "0"
+  oci:
+    ebpf:
+      map-fetch-interval: "0"

--- a/gadgets/advise_seccomp/gadget.yaml
+++ b/gadgets/advise_seccomp/gadget.yaml
@@ -13,4 +13,6 @@ datasources:
       cli.supported-output-modes: advise
       cli.default-output-mode: advise
 paramDefaults:
-  operator.oci.ebpf.map-fetch-interval: "0"
+  oci:
+    ebpf:
+      map-fetch-interval: "0"


### PR DESCRIPTION
Allow users to specify the default params without using the operator. prefix. Also support declaring them in a tree:

```
paramDefaults
  oci:
    ebpf:
      paramfoo: bar
```

Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/4649#discussion_r2170488706