### PR TITLE
make all flags of duration type

### DIFF
--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -53,8 +53,8 @@ type CommonFlags struct {
 	// with their specific socket path.
 	RuntimeConfigs []*containerutilsTypes.RuntimeConfig
 
-	// Number of seconds that the gadget will run for
-	Timeout int
+	// Time in duration that the gadget will run for
+	Timeout string
 
 	// ContainerdNamespace is the namespace used by containerd
 	ContainerdNamespace string
@@ -162,11 +162,11 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 			strings.Join(containerutils.AvailableRuntimes, ", ")),
 	)
 
-	command.PersistentFlags().IntVar(
+	command.PersistentFlags().StringVar(
 		&commonFlags.Timeout,
 		"timeout",
-		0,
-		"Number of seconds that the gadget will run for",
+		"",
+		"Time in duration that the gadget will run for",
 	)
 
 	command.PersistentFlags().StringVar(

--- a/cmd/kubectl-gadget/utils/flags.go
+++ b/cmd/kubectl-gadget/utils/flags.go
@@ -67,8 +67,8 @@ type CommonFlags struct {
 	// Containername allows to filter containers by name
 	Containername string
 
-	// Number of seconds that the gadget will run for
-	Timeout int
+	// Time in duration that the gadget will run for
+	Timeout string
 }
 
 // GetNamespace returns the namespace specified by '-n' or the default
@@ -180,10 +180,10 @@ func AddCommonFlags(command *cobra.Command, params *CommonFlags, gadgetNamespace
 		"Show data from pods in all namespaces",
 	)
 
-	command.PersistentFlags().IntVar(
+	command.PersistentFlags().StringVar(
 		&params.Timeout,
 		"timeout",
-		0,
-		"Number of seconds that the gadget will run for",
+		"",
+		"Time in duration that the gadget will run for",
 	)
 }


### PR DESCRIPTION
This is the error I'm receiving and I think that it the function `cmd.ParseFlags()` expects the `--timeout` flag to be of `Int` type. I could be wrong.
```sudo ./ig run trace_oomkill:main --timeout 5s
Error: invalid argument "5s" for "-t, --timeout" flag: strconv.ParseInt: parsing "5s": invalid syntax
```