### PR TITLE
wasmapi: rust: Use $crate to import LogLevel.

### DIFF
--- a/pkg/operators/wasm/rusttestdata/config/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/config/src/lib.rs
@@ -14,7 +14,7 @@
 
 use api::{
     errorf,
-    {config::set_config, log::LogLevel},
+    config::set_config,
 };
 
 #[no_mangle]

--- a/pkg/operators/wasm/rusttestdata/dataarray/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/dataarray/src/lib.rs
@@ -15,7 +15,6 @@
 use api::{
     datasources::{DataArray, DataSource, FieldKind},
     fields::FieldData,
-    log::LogLevel,
     warnf,
 };
 

--- a/pkg/operators/wasm/rusttestdata/dataemit/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/dataemit/src/lib.rs
@@ -15,7 +15,6 @@
 use api::{
     datasources::{Data, DataSource, DataSourceType, FieldKind, Packet},
     fields::FieldData,
-    log::LogLevel,
     warnf,
 };
 

--- a/pkg/operators/wasm/rusttestdata/fields/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/fields/src/lib.rs
@@ -1,7 +1,6 @@
 use api::{
     datasources::{DataSource, Field, FieldKind},
     errorf,
-    log::LogLevel,
 };
 use std::{any::Any, sync::Arc};
 

--- a/pkg/operators/wasm/rusttestdata/filtering/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/filtering/src/lib.rs
@@ -14,7 +14,7 @@
 
 use api::{
     errorf,
-    {filter::should_discard_mntns_id, log::LogLevel},
+    filter::should_discard_mntns_id,
 };
 
 const MNTNS_DISCARDED: u64 = 555;

--- a/pkg/operators/wasm/rusttestdata/kallsyms/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/kallsyms/src/lib.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api::errorf;
-use api::{kallsyms, log::LogLevel};
+use api::{
+    errorf,
+    kallsyms,
+};
 
 #[no_mangle]
 #[allow(non_snake_case)]

--- a/pkg/operators/wasm/rusttestdata/map/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/map/src/lib.rs
@@ -14,10 +14,7 @@
 
 use api::{
     errorf,
-    {
-        log::LogLevel,
-        map::{Map, MapSpec, MapType, MapUpdateFlags},
-    },
+    map::{Map, MapSpec, MapType, MapUpdateFlags},
 };
 
 #[no_mangle]

--- a/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api::errorf;
 use api::{
-    log::LogLevel,
+    errorf,
     map::{Map, MapSpec, MapType},
 };
 

--- a/pkg/operators/wasm/rusttestdata/params/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/params/src/lib.rs
@@ -1,6 +1,6 @@
 use api::{
     errorf,
-    {log::LogLevel, params::get_param_value},
+    params::get_param_value,
 };
 
 #[no_mangle]

--- a/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
@@ -14,7 +14,7 @@
 
 use api::{
     errorf, info,
-    {log::LogLevel, map::Map, perf::PerfReader},
+    map::Map, perf::PerfReader,
 };
 
 #[repr(C)]

--- a/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
@@ -14,10 +14,7 @@
 
 use api::{
     errorf,
-    {
-        log::LogLevel,
-        syscall::{get_syscall_declaration, get_syscall_id, get_syscall_name},
-    },
+    syscall::{get_syscall_declaration, get_syscall_id, get_syscall_name},
 };
 
 const UNKNOWN_SYSCALL_ID: u16 = 1337;

--- a/wasmapi/rust/src/log.rs
+++ b/wasmapi/rust/src/log.rs
@@ -34,7 +34,7 @@ pub fn log(level: LogLevel, message: &str) {
     }
 }
 
-// Rust doesn't support default vardiac, but similar functionality are provided by macros allow for multiple arguments
+// Rust doesn't support default variadic, but similar functionality are provided by macros allow for multiple arguments
 #[macro_export]
 macro_rules! log {
     ($level:expr, $($arg:expr),+ $(,)?) => {{
@@ -61,62 +61,62 @@ macro_rules! error {
 #[macro_export]
 macro_rules! errorf {
     ($fmt:literal $(, $arg:tt)* ) => {
-        $crate::logf!(LogLevel::Error, $fmt $(, $arg)*);
+        $crate::logf!($crate::log::LogLevel::Error, $fmt $(, $arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => {
-        $crate::log!(LogLevel::Warn, $($arg)*);
+        $crate::log!($crate::log::LogLevel::Warn, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! warnf {
     ($fmt:literal $(, $arg:tt)* ) => {
-        $crate::logf!(LogLevel::Warn, $fmt $(, $arg)*);
+        $crate::logf!($crate::log::LogLevel::Warn, $fmt $(, $arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => {
-        $crate::log!(LogLevel::Info, $($arg)*);
+        $crate::log!($crate::log::LogLevel::Info, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! infof {
     ($fmt:literal $(, $arg:tt)* ) => {
-        $crate::logf!(LogLevel::Info, $fmt $(, $arg)*);
+        $crate::logf!($crate::log::LogLevel::Info, $fmt $(, $arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => {
-        $crate::log!(LogLevel::Debug, $($arg)*);
+        $crate::log!($crate::log::LogLevel::Debug, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! debugf {
     ($fmt:literal $(, $arg:tt)* ) => {
-        $crate::logf!(LogLevel::Debug, $fmt $(, $arg)*);
+        $crate::logf!($crate::log::LogLevel::Debug, $fmt $(, $arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => {
-        $crate::log!(LogLevel::Trace, $($arg)*);
+        $crate::log!($crate::log::LogLevel::Trace, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! tracef {
     ($fmt:literal $(, $arg:tt)* ) => {
-        $crate::logf!(LogLevel::Trace, $fmt $(, $arg)*);
+        $crate::logf!($crate::log::LogLevel::Trace, $fmt $(, $arg)*);
     };
 }


### PR DESCRIPTION
This way, users do not need to use log::LogLevel to use the macros.
