### PR TITLE
wasmapi: rust: Use references for some function arguments.

### DIFF
--- a/pkg/operators/wasm/rusttestdata/map/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/map/src/lib.rs
@@ -147,23 +147,20 @@ fn gadgetStart() -> i32 {
         max_entries: 1,
     };
 
-    let Ok(new_map) = Map::new(map_spec.clone()) else {
-        let name = map_spec.name.clone();
-        api::errorf!("creating map {:?}", name);
+    let Ok(new_map) = Map::new(&map_spec) else {
+        api::errorf!("creating map {:?}", &map_spec.name);
         return 1;
     };
 
     let k: i32 = 42;
     val = 43;
     if let Err(_) = new_map.put(&k, &val) {
-        let name = map_spec.name.clone();
-        api::errorf!("setting {} value for key {} in {:?}", val, k, name);
+        api::errorf!("setting {} value for key {} in {:?}", val, k, &map_spec.name);
         return 1;
     }
 
     if let Err(_) = new_map.lookup(&k, &mut val) {
-        let name = map_spec.name.clone();
-        api::errorf!("no value found for key {} in {:?}", k, name);
+        api::errorf!("no value found for key {} in {:?}", k, &map_spec.name);
         return 1;
     }
 
@@ -176,8 +173,7 @@ fn gadgetStart() -> i32 {
     let k2 = 0xdead;
     val = 0xcafe;
     if let Ok(_) = new_map.put(&k2, &val) {
-        let name = map_spec.name.clone();
-        api::errorf!("map {:?} has one max entry, trying to put two", name);
+        api::errorf!("map {:?} has one max entry, trying to put two", &map_spec.name);
         return 1;
     }
 

--- a/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
@@ -52,7 +52,7 @@ fn gadgetStart() -> i32 {
         max_entries: 1,
     };
 
-    let Ok(hash_map) = Map::new(inner_map_spec.clone()) else {
+    let Ok(hash_map) = Map::new(&inner_map_spec) else {
         errorf!("creating map {}", hash_map_name);
         return 1;
     };

--- a/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/perf/src/lib.rs
@@ -36,7 +36,7 @@ fn gadgetStart() -> i32 {
         return 1;
     };
 
-    let Ok(perf_reader) = PerfReader::new(perf_array, 4096, true) else {
+    let Ok(perf_reader) = PerfReader::new(&perf_array, 4096, true) else {
         errorf!("creating perf reader");
         return 1;
     };

--- a/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/syscall/src/lib.rs
@@ -63,7 +63,7 @@ fn gadgetInit() -> i32 {
 
     // open_tree has the same ID for both amd64 and arm64.
     syscall_name = "open_tree".to_string();
-    let Ok(id) = get_syscall_id(syscall_name.clone()) else {
+    let Ok(id) = get_syscall_id(&syscall_name) else {
         errorf!("failed to get ID for syscall {}", syscall_name);
         return 1;
     };
@@ -80,7 +80,7 @@ fn gadgetInit() -> i32 {
 
     // Test invalid syscall name
     let syscall_name = "foobar".to_string();
-    if let Ok(val) = get_syscall_id(syscall_name.clone()) {
+    if let Ok(val) = get_syscall_id(&syscall_name) {
         errorf!(
             "expected no syscall ID for syscall {}, got {}",
             syscall_name,

--- a/wasmapi/rust/src/map.rs
+++ b/wasmapi/rust/src/map.rs
@@ -112,7 +112,7 @@ impl Drop for Map {
 }
 
 impl Map {
-    pub fn new(spec: MapSpec) -> Result<Self> {
+    pub fn new(spec: &MapSpec) -> Result<Self> {
         let name_ptr = string_to_buf_ptr(&spec.name);
         let ret = unsafe {
             _map_new(

--- a/wasmapi/rust/src/perf.rs
+++ b/wasmapi/rust/src/perf.rs
@@ -47,7 +47,7 @@ impl Drop for PerfReader {
 }
 
 impl PerfReader {
-    pub fn new(map: Map, size: u32, is_overwritable: bool) -> Result<Self> {
+    pub fn new(map: &Map, size: u32, is_overwritable: bool) -> Result<Self> {
         let flag = if is_overwritable { 1 } else { 0 };
         let handle = unsafe { _perfreader_new(map.handle, size, flag) };
         if handle == 0 {

--- a/wasmapi/rust/src/syscall.rs
+++ b/wasmapi/rust/src/syscall.rs
@@ -68,7 +68,7 @@ pub fn get_syscall_name(id: u16) -> Result<String> {
     }
 }
 
-pub fn get_syscall_id(name: String) -> Result<i32> {
+pub fn get_syscall_id(name: &str) -> Result<i32> {
     let id = unsafe { _get_syscall_id(string_to_buf_ptr(&name).0) };
 
     if id == -1 {


### PR DESCRIPTION
Fixes: 9c6e27a5f887 ("rust api map.rs")
Fixes: 33971ff7f1e3 ("rust api perf.rs")
Fixes: 170bb31e3014 ("rust api syscall.rs")
