### PR TITLE
trace_dns: Use correct type for per cpu map

### DIFF
--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -134,7 +134,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__uint(key_size, sizeof(__u32));
-	__uint(value_size, sizeof(struct event_t));
+	__uint(value_size, sizeof(struct event_header_t));
 } tmp_events SEC(".maps");
 
 // https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1


### PR DESCRIPTION
The tmp_events map can use the event_header_t structure that is smaller, this saves a few KBs of memory.

before:
$ sudo bpftool map show name tmp_events
2324: percpu_array  name tmp_events  flags 0x0
        key 4B  value 10448B  max_entries 1  memlock 83976B

after:
$ sudo bpftool map show name tmp_events
2355: percpu_array  name tmp_events  flags 0x0
        key 4B  value 1232B  max_entries 1  memlock 10248B

Fixes: 059d3e299954 ("trace_dns: add fields cwd & exepath (--paths)")


