### PR TITLE
trace_dns: Use trailing data support in ebpf operator

### DIFF
--- a/gadgets/trace_dns/gadget.yaml
+++ b/gadgets/trace_dns/gadget.yaml
@@ -5,6 +5,9 @@ documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_dns
 datasources:
   dns:
+    annotations:
+      ebpf.rest.name: data
+      ebpf.rest.len: data_len
     fields:
       cwd:
         annotations:

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -90,32 +90,6 @@ struct event_t {
 
 	__u16 dns_off; // DNS offset in the packet
 	__u32 data_len;
-
-	// Only on this structure
-	__u8 data[MAX_PACKET];
-};
-
-// TODO: We need this header structure as the packet itself is appended by
-// bpf_perf_event_output(). Hence the event we send over the perf ring buffer is
-// only the header without the packet. We can use the full structure above as
-// it exceeds the stack limit of 512 bytes in bpf.
-// TODO: We'll need to find a clearer way to implement this
-struct event_header_t {
-	gadget_timestamp timestamp_raw;
-	struct gadget_l4endpoint_t src;
-	struct gadget_l4endpoint_t dst;
-	struct gadget_l3endpoint_t nameserver;
-	gadget_netns_id netns_id;
-	struct gadget_process proc;
-	char cwd[GADGET_PATH_MAX];
-	char exepath[GADGET_PATH_MAX];
-
-	enum pkt_type_t pkt_type_raw;
-	gadget_duration
-		latency_ns_raw; // Set only if the packet is a response and pkt_type is 0 (Host).
-
-	__u16 dns_off; // DNS offset in the packet
-	__u32 data_len;
 };
 
 struct {
@@ -198,7 +172,7 @@ static __always_inline unsigned int min(unsigned int a, unsigned int b)
 SEC("socket1")
 int ig_trace_dns(struct __sk_buff *skb)
 {
-	struct event_header_t *event;
+	struct event_t *event;
 	int zero = 0;
 	__u16 sport, dport, l4_off, dns_off, h_proto, id;
 	__u8 proto;

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -452,6 +452,19 @@ func (i *ebpfInstance) register(gadgetCtx operators.GadgetContext) error {
 			return fmt.Errorf("adding datasource: %w", err)
 		}
 		m.accessor = accessor
+		if restName, ok := ds.Annotations()["ebpf.rest.name"]; ok {
+			m.restAccessor, err = ds.AddField(restName, api.Kind_Bytes)
+			if err != nil {
+				return fmt.Errorf("adding rest accessor: %w", err)
+			}
+			if restLenName, ok := ds.Annotations()["ebpf.rest.len"]; ok {
+				field := ds.GetField(restLenName)
+				if field == nil {
+					return fmt.Errorf("rest length accessor field %q not found", restLenName)
+				}
+				m.restLenAccessor = field
+			}
+		}
 		m.ds = ds
 	}
 	for name, m := range i.snapshotters {

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Inspektor Gadget authors
+// Copyright 2024-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,8 +35,10 @@ type Tracer struct {
 	mapName    string
 	structName string
 
-	ds       datasource.DataSource
-	accessor datasource.FieldAccessor
+	ds              datasource.DataSource
+	accessor        datasource.FieldAccessor
+	restAccessor    datasource.FieldAccessor
+	restLenAccessor datasource.FieldAccessor
 
 	mapType       ebpf.MapType
 	eventSize     uint32 // needed to trim trailing bytes when reading for perf event array
@@ -151,6 +153,25 @@ func (t *Tracer) processEvent(gadgetCtx operators.GadgetContext, fullSample []by
 	if err := t.accessor.Set(pSingle, sample); err != nil {
 		t.ds.Release(pSingle)
 		return fmt.Errorf("setting buffer: %w", err)
+	}
+
+	if t.restAccessor != nil && sampleLen > t.eventSize {
+		xlen := sampleLen - t.eventSize
+
+		if t.restLenAccessor != nil {
+			// Read length
+			xlen, err = t.restLenAccessor.Uint32(pSingle)
+			if err != nil {
+				return fmt.Errorf("getting rest length: %w", err)
+			}
+
+			if t.eventSize+xlen > sampleLen {
+				return fmt.Errorf("rest length %d is larger than data length %d - event size %d",
+					xlen, sampleLen, t.eventSize)
+			}
+		}
+
+		t.restAccessor.Set(pSingle, fullSample[t.eventSize:t.eventSize+xlen])
 	}
 
 	if err := t.ds.EmitAndRelease(pSingle); err != nil {

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -42,6 +42,7 @@ type Tracer struct {
 	eventSize     uint32 // needed to trim trailing bytes when reading for perf event array
 	ringbufReader *ringbuf.Reader
 	perfReader    *perf.Reader
+	slowBuf       []byte
 }
 
 func validateTracerMap(traceMap *ebpf.MapSpec) error {
@@ -125,9 +126,42 @@ func (t *Tracer) receiveEvents(gadgetCtx operators.GadgetContext, wg *sync.WaitG
 	}
 }
 
+func (t *Tracer) processEvent(gadgetCtx operators.GadgetContext, fullSample []byte) error {
+	pSingle, err := t.ds.NewPacketSingle()
+	if err != nil {
+		return fmt.Errorf("creating new packet: %w", err)
+	}
+
+	sample := fullSample
+	sampleLen := uint32(len(fullSample))
+	if sampleLen < t.eventSize {
+		// event is truncated; we need to copy
+		copy(t.slowBuf, fullSample)
+
+		// zero difference; TODO: improve
+		for i := len(fullSample); i < int(t.eventSize); i++ {
+			t.slowBuf[i] = 0
+		}
+		sample = t.slowBuf
+	} else if sampleLen > t.eventSize {
+		// event has trailing garbage, remove it
+		sample = sample[:t.eventSize]
+	}
+
+	if err := t.accessor.Set(pSingle, sample); err != nil {
+		t.ds.Release(pSingle)
+		return fmt.Errorf("setting buffer: %w", err)
+	}
+
+	if err := t.ds.EmitAndRelease(pSingle); err != nil {
+		return fmt.Errorf("emitting data: %w", err)
+	}
+
+	return nil
+}
+
 func (t *Tracer) receiveEventsFromRingReader(gadgetCtx operators.GadgetContext) error {
-	slowBuf := make([]byte, t.eventSize)
-	lastSlowLen := 0
+	t.slowBuf = make([]byte, t.eventSize)
 	for {
 		rec, err := t.ringbufReader.Read()
 		if err != nil {
@@ -137,41 +171,16 @@ func (t *Tracer) receiveEventsFromRingReader(gadgetCtx operators.GadgetContext) 
 			gadgetCtx.Logger().Warnf("error reading ringbuf event: %v", err)
 			continue
 		}
-		pSingle, err := t.ds.NewPacketSingle()
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error creating new packet: %v", err)
-			continue
-		}
-		sample := rec.RawSample
-		if uint32(len(rec.RawSample)) < t.eventSize {
-			// event is truncated; we need to copy
-			copy(slowBuf, rec.RawSample)
 
-			// zero difference; TODO: improve
-			if len(rec.RawSample) < lastSlowLen {
-				for i := len(rec.RawSample); i < lastSlowLen; i++ {
-					slowBuf[i] = 0
-				}
-			}
-			lastSlowLen = len(rec.RawSample)
-			sample = slowBuf
-		}
-		err = t.accessor.Set(pSingle, sample)
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error setting buffer: %v", err)
-			t.ds.Release(pSingle)
+		if err := t.processEvent(gadgetCtx, rec.RawSample); err != nil {
+			gadgetCtx.Logger().Warnf("error processing event: %v", err)
 			continue
-		}
-		err = t.ds.EmitAndRelease(pSingle)
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error emitting data: %v", err)
 		}
 	}
 }
 
 func (t *Tracer) receiveEventsFromPerfReader(gadgetCtx operators.GadgetContext) error {
-	slowBuf := make([]byte, t.eventSize)
-	lastSlowLen := 0
+	t.slowBuf = make([]byte, t.eventSize)
 	for {
 		rec, err := t.perfReader.Read()
 		if err != nil {
@@ -189,38 +198,9 @@ func (t *Tracer) receiveEventsFromPerfReader(gadgetCtx operators.GadgetContext) 
 			continue
 		}
 
-		pSingle, err := t.ds.NewPacketSingle()
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error creating new packet: %v", err)
+		if err := t.processEvent(gadgetCtx, rec.RawSample); err != nil {
+			gadgetCtx.Logger().Warnf("error processing event: %v", err)
 			continue
-		}
-		sample := rec.RawSample
-		sampleLen := len(rec.RawSample)
-		if uint32(sampleLen) < t.eventSize {
-			// event is truncated; we need to copy
-			copy(slowBuf, rec.RawSample)
-
-			// zero difference; TODO: improve
-			if sampleLen < lastSlowLen {
-				for i := sampleLen; i < lastSlowLen; i++ {
-					slowBuf[i] = 0
-				}
-			}
-			lastSlowLen = sampleLen
-			sample = slowBuf
-		} else if uint32(sampleLen) > t.eventSize {
-			// event has trailing garbage, remove it
-			sample = sample[:t.eventSize]
-		}
-		err = t.accessor.Set(pSingle, sample)
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error setting buffer: %v", err)
-			t.ds.Release(pSingle)
-			continue
-		}
-		err = t.ds.EmitAndRelease(pSingle)
-		if err != nil {
-			gadgetCtx.Logger().Warnf("error emitting data: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
- pkg/operators/ebpf: add support for trailing data 
- trace_dns: Use trailing data support from ebpf operator

Uses a commit from #4567
Could simplify #4688
