### PR TITLE
wasmapi: rust: Check if map was created before dropping it.

### DIFF
--- a/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
+++ b/pkg/operators/wasm/rusttestdata/mapofmap/src/lib.rs
@@ -30,7 +30,7 @@ struct MapTestStruct {
 #[allow(non_snake_case)]
 fn gadgetStart() -> i32 {
     let map_of_map_name = "map_of_map";
-    let mut inner_map: Map = Map(0);
+    let mut inner_map = Map::default();
     let key = MapTestStruct {
         a: 42,
         b: 42,
@@ -72,12 +72,12 @@ fn gadgetStart() -> i32 {
         return 1;
     }
 
-    if inner_map.0 == 0 {
+    if inner_map.handle == 0 {
         errorf!("expected handle to be different than 0");
         return 1;
     }
 
-    if inner_map.0 == hash_map.0 {
+    if inner_map.handle == hash_map.handle {
         errorf!("expected handle to be different than hashMap");
         return 1;
     }

--- a/wasmapi/rust/src/perf.rs
+++ b/wasmapi/rust/src/perf.rs
@@ -49,7 +49,7 @@ impl Drop for PerfReader {
 impl PerfReader {
     pub fn new(map: Map, size: u32, is_overwritable: bool) -> Result<Self> {
         let flag = if is_overwritable { 1 } else { 0 };
-        let handle = unsafe { _perfreader_new(map.0, size, flag) };
+        let handle = unsafe { _perfreader_new(map.handle, size, flag) };
         if handle == 0 {
             Err(String::from("failed to create perf reader"))
         } else {


### PR DESCRIPTION
mapRelease() should only be called on map created with newMap() [1]. So far, the Drop trait was called on all maps.
A boolean was added to differentiate between map created with new() and others. This way, we can call mapRelease() on the proper map type.

Fixes: 9c6e27a5f887 ("rust api map.rs")

[1]: https://github.com/inspektor-gadget/inspektor-gadget/blob/5612fb7f7e42/pkg/operators/wasm/maps.go#L403-L407
