### PR TITLE
localmanager/kubemanager: Allow runtime/k8s filtering

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -486,6 +486,11 @@ nextParam:
 			desc += " [" + strings.Join(p.PossibleValues, ", ") + "]"
 		}
 
+		if p.AlternativeKey != "" {
+			cmd.PersistentFlags().Var(&Param{p}, p.AlternativeKey, desc)
+			cmd.PersistentFlags().MarkHidden(p.AlternativeKey)
+			desc += " (alias: " + p.AlternativeKey + ")"
+		}
 		flag := cmd.PersistentFlags().VarPF(&Param{p}, p.Key, p.Alias, desc)
 		if p.IsMandatory {
 			cmd.MarkPersistentFlagRequired(p.Key)

--- a/cmd/ig/containers/containers.go
+++ b/cmd/ig/containers/containers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/columns"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
 
@@ -58,6 +59,13 @@ func NewListContainersCmd() *cobra.Command {
 			selector := containercollection.ContainerSelector{
 				Runtime: containercollection.RuntimeSelector{
 					ContainerName: commonFlags.Containername,
+				},
+				K8s: containercollection.K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodName:       commonFlags.K8sPodName,
+						Namespace:     commonFlags.K8sNamespace,
+						ContainerName: commonFlags.K8sContainerName,
+					},
 				},
 			}
 

--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -42,6 +42,12 @@ type CommonFlags struct {
 	// Containername allows to filter containers by name.
 	Containername string
 
+	// Kubernetes-related filters
+	K8sPodName       string
+	K8sNamespace     string
+	K8sSelector      []string
+	K8sContainerName string
+
 	// Comma-separated list of container runtimes.
 	Runtimes string
 
@@ -144,8 +150,14 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		"containername",
 		"c",
 		"",
-		"Show only data from containers with that name",
+		"Show data only from containers with the runtime-assigned name (not the name defined in the pod spec) (alias: runtime-containername)",
 	)
+	command.PersistentFlags().StringVarP(
+		&commonFlags.Containername,
+		"runtime-containername", "", "", "",
+	)
+	command.PersistentFlags().MarkHidden("runtime-containername")
+
 	command.PersistentFlags().BoolVarP(
 		&commonFlags.Host,
 		"host",
@@ -182,6 +194,28 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 		containerutilsTypes.RuntimeProtocolInternal,
 		fmt.Sprintf("Container runtime protocol (docker and containerd). Supported values are: %s",
 			strings.Join(containerutils.AvailableRuntimeProtocols, ", ")),
+	)
+
+	// Kubernetes-related flags
+	command.PersistentFlags().StringVar(
+		&commonFlags.K8sPodName,
+		"k8s-podname",
+		"",
+		"Show only data from Kubernetes pods with that name",
+	)
+
+	command.PersistentFlags().StringVar(
+		&commonFlags.K8sNamespace,
+		"k8s-namespace",
+		"",
+		"Show only data from pods in a given Kubernetes namespace",
+	)
+
+	command.PersistentFlags().StringVar(
+		&commonFlags.K8sContainerName,
+		"k8s-containername",
+		"",
+		"Show data only from containers with the name defined in the pod spec",
 	)
 }
 

--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -86,10 +86,11 @@ common fields:
  * `--node string`, show only data from pods running in that node
  * `-n string`, `--namespace string`, show data from pods in that namespace
  * `-A`, `--all-namespaces`, show data from pods in all namespaces
- * `-p string`, `--podname string`, show only data from pods with that name
- * `-c string`, `--containername string`, show only data from containers with that name
- * `-l string`, `--selector string`: show only data that matches the given
-   label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
+ * `-p string`, `--podname string`, `--k8s-podname` show only data from pods with that name
+ * `-c string`, `--containername string`, `--k8s-containername`, show only data from containers with the name defined in the pod spec
+ * `--runtime-containername string`, show only data from containers with the runtime-assigned name (not the name defined in the pod spec)
+ * `-l string`, `--selector string`, `--k8s-selector`, show only data that matches the given
+   Kubernetes label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
 
 We can use one or more of these parameters to choose which pods or
 containers will be inspected by our gadgets. For example:
@@ -112,9 +113,15 @@ fields in [user space](#filtering-in-user-space).
 
 The current supported fields to filter in kernel are:
 
- * `-c string`, `--containername string`, show only data from containers with
+ * `-c string`, `--containername string`, `--runtime-containername`, show only data from containers with
    that name. Notice that this container name is the one set by the runtime, and
-   it may be different from the one set by Kubernetes depending on the runtime.
+   it may be different from the one set by Kubernetes (defined in the pod spec) depending on the runtime.
+* `--k8s-containername string`, show only data from containers with the name
+   defined in the pod spec.
+* `--k8s-namespace string`, show data from pods in that Kubernetes namespace.
+* `--k8s-podname`, show only data from containers with the name defined in the pod spec
+* `--k8s-selector string`, show only data that matches the given
+Kubernetes label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
 
 For example, the following command will show only data from the container named
 `mycontainer`:

--- a/docs/spec/operators/kubemanager.md
+++ b/docs/spec/operators/kubemanager.md
@@ -7,6 +7,7 @@ as a DaemonSet. This operator keeps track of the pods running on the node by
 talking to the kube-apiserver and to the different container runtimes. This
 operator uses the pod informer and/or fanotify mechanisms to detect when
 containers are created. This information is used to:
+
 - Update the eBPF maps used to filter events in eBPF by Kubernetes concepts like
   pod and container names, namespace, labels, etc.
 - Enrich events with container information (see below).
@@ -17,19 +18,19 @@ This operator uses the mount or network namespace inode IDs to enrich events
 with the following fields:
 
 - k8s
-  - node name
-  - container name
-  - pod name
-  - namespace
-  - pod labels
-  - owner
+    - node name
+    - container name
+    - pod name
+    - namespace
+    - pod labels
+    - owner
 - runtime
-  - runtime name
-  - container name
-  - container ID
-  - container image name
-  - container image digest
-  - container started time
+    - runtime name
+    - container name
+    - container ID
+    - container image name
+    - container image digest
+    - container started time
 
 ## Priority
 
@@ -37,32 +38,38 @@ with the following fields:
 
 ## Instance Parameters
 
-### `containername`
+### `containername` / `k8s-containername`
 
 Show only data from containers with that name
 
-Fully qualified name: `operator.KubeManager.containername`
+Fully qualified name: `operator.KubeManager.containername` or `operator.KubeManager.k8s-containername`
 
-### `podname`
+### `podname` / `k8s-podname`
 
 Show only data from pods with that name
 
-Fully qualified name: `operator.KubeManager.podname`
+Fully qualified name: `operator.KubeManager.podname` or `operator.KubeManager.k8s-podname`
 
-### `selector`
+### `selector` / `k8s-selector`
 
-Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2)
+Kubernetes Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2)
 
-Fully qualified name: `operator.KubeManager.selector`
+Fully qualified name: `operator.KubeManager.selector` / `operator.KubeManager.k8s-selector`
 
-### `namespace`
+### `namespace` / `k8s-namespace`
 
 Show only data from pods in a given namespace
 
-Fully qualified name: `operator.KubeManager.namespace`
+Fully qualified name: `operator.KubeManager.namespace` / `operator.KubeManager.k8s-namespace`
 
 ### `all-namespaces`
 
 Show data from pods in all namespaces
 
 Fully qualified name: `operator.KubeManager.all-namespaces`
+
+### `runtime-containername`
+
+Show data only from containers with the runtime-assigned name (not the name defined in the pod spec)
+
+Fully qualified name: `operator.KubeManager.runtime-containername`

--- a/docs/spec/operators/localmanager.md
+++ b/docs/spec/operators/localmanager.md
@@ -69,7 +69,7 @@ Containerd CRI Unix socket path
 
 Default: `/run/containerd/containerd.sock`
 
-### `container-namespace`
+### `containerd-namespace`
 
 Containerd namespace to use
 
@@ -92,11 +92,35 @@ Default: `false`
 
 ## Instance Parameters
 
-### `containername`
+### `containername` / `runtime-containername`
 
-Show only data from containers with that name
+Show data only from containers with the runtime-assigned name (not the name defined in the pod spec)
 
-Fully qualified name: `operator.LocalManager.containername`
+Fully qualified name: `operator.LocalManager.containername` / `operator.LocalManager.runtime-containername`
+
+### `k8s-containername`
+
+Show data only from containers with the name defined in the pod spec
+
+Fully qualified name: `operator.LocalManager.k8s-containername`
+
+### `k8s-namespace`
+
+Show only data from containers in that Kubernetes namespace
+
+Fully qualified name: `operator.LocalManager.k8s-namespace`
+
+### `k8s-podname`
+
+Show only data from containers in that Kubernetes pod
+
+Fully qualified name: `operator.LocalManager.k8s-podname`
+
+### `k8s-selector`
+
+Kubernetes Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2).
+
+Fully qualified name: `operator.LocalManager.k8s-selector`
 
 ### `host`
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -60,6 +60,7 @@ GADGETS ?= \
 	ci/inner_fields \
 	ci/sched_cls_drop \
 	ci/image_inspect \
+	ci/container_filtering \
 	#
 
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/gadgets/ci/container_filtering/program.bpf.c
+++ b/gadgets/ci/container_filtering/program.bpf.c
@@ -1,0 +1,35 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/macros.h>
+#include <gadget/filter.h>
+#include <gadget/types.h>
+
+struct event {
+	struct gadget_process proc;
+};
+
+GADGET_TRACER_MAP(open_events, 1024 * 256);
+GADGET_TRACER(open, open_events, event);
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int enter_openat(struct trace_event_raw_sys_enter *ctx)
+{
+	struct event *event;
+
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	event = gadget_reserve_buf(&open_events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	gadget_process_populate(&event->proc);
+
+	gadget_submit_buf(ctx, &open_events, event, sizeof(*event));
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/ci/container_filtering/test/integration/container_filtering_test.go
+++ b/gadgets/ci/container_filtering/test/integration/container_filtering_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type containerFilteringEvent struct {
+	utils.CommonData
+}
+
+func TestContainerFiltering(t *testing.T) {
+	t.Parallel()
+
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+	containerName := "test-container-filtering"
+	containerImage := gadgettesting.BusyBoxImage
+
+	var ns string
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(containerImage),
+	}
+
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		ns = utils.GenerateTestNamespaceName(t, "test-container-filtering")
+		containerOpts = append(containerOpts, containers.WithContainerNamespace(ns))
+	}
+
+	testContainer := containerFactory.NewContainer(
+		containerName,
+		"while true; do sleep 1 && cat /etc/hostname >/dev/null; done",
+		containerOpts...,
+	)
+
+	testContainer.Start(t)
+	t.Cleanup(func() {
+		testContainer.Stop(t)
+	})
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+	commonDataOpts := []utils.CommonDataOption{utils.WithContainerImageName(containerImage), utils.WithContainerID(testContainer.ID())}
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts, igrunner.WithFlags(fmt.Sprintf("-r=%s", utils.Runtime)))
+	case utils.KubectlGadgetTestComponent:
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
+	}
+
+	// TODO: Maybe we should have separate test for each flag
+	switch utils.Runtime {
+	case containers.RuntimeKubernetes:
+		// FIXME: Use --runtime-containername once following issue is fixed
+		// https://github.com/inspektor-gadget/inspektor-gadget/issues/4844
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("--k8s-namespace=%s", ns),
+				fmt.Sprintf("--k8s-podname=%s", containerName),
+				fmt.Sprintf("--k8s-containername=%s", containerName),
+			),
+		)
+	default:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("--runtime-containername=%s", containerName),
+			),
+		)
+	}
+
+	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
+		func(t *testing.T, output string) {
+			expectedContainer := &containerFilteringEvent{
+				CommonData: utils.BuildCommonData(containerName, commonDataOpts...),
+			}
+
+			normalize := func(e *containerFilteringEvent) {
+				utils.NormalizeCommonData(&e.CommonData)
+			}
+
+			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedContainer)
+		},
+	))
+
+	runnerOpts = append(runnerOpts, igrunner.WithStartAndStop())
+	containerFilteringCmd := igrunner.New("ci/container_filtering", runnerOpts...)
+
+	testSteps := []igtesting.TestStep{
+		containerFilteringCmd,
+		utils.Sleep(3 * time.Second),
+	}
+	igtesting.RunTestSteps(testSteps, t, testingOpts...)
+}

--- a/integration/k8s/list_containers_test.go
+++ b/integration/k8s/list_containers_test.go
@@ -164,6 +164,105 @@ func TestListContainers(t *testing.T) {
 		)
 		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
 	})
+
+	t.Run("FilteredListK8sContainerName", func(t *testing.T) {
+		t.Parallel()
+		listContainerTestStep := newListContainerTestStep(
+			fmt.Sprintf("ig list-containers -o json --runtimes=%s --k8s-containername=%s", containerRuntime, cn),
+			cn, pod, podUID, ns, containerRuntime, runtimeContainerName,
+			func(t *testing.T, output string, f func(*containercollection.Container), c *containercollection.Container) {
+				match.MatchAllEntries(t, match.JSONSingleArrayMode, output, f, c)
+			},
+		)
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("FilteredListWithPodName", func(t *testing.T) {
+		t.Parallel()
+
+		listContainerTestStep := newListContainerTestStep(
+			fmt.Sprintf("ig list-containers -o json --runtimes=%s --containername=%s --k8s-podname=%s", containerRuntime, runtimeContainerName, cn),
+			cn, pod, podUID, ns, containerRuntime, runtimeContainerName,
+			func(t *testing.T, output string, f func(*containercollection.Container), c *containercollection.Container) {
+				match.MatchAllEntries(t, match.JSONSingleArrayMode, output, f, c)
+			},
+		)
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("FilteredListWithNamespace", func(t *testing.T) {
+		t.Parallel()
+
+		listContainerTestStep := newListContainerTestStep(
+			fmt.Sprintf("ig list-containers -o json --runtimes=%s --containername=%s --k8s-namespace=%s", containerRuntime, runtimeContainerName, ns),
+			cn, pod, podUID, ns, containerRuntime, runtimeContainerName,
+			func(t *testing.T, output string, f func(*containercollection.Container), c *containercollection.Container) {
+				match.MatchAllEntries(t, match.JSONSingleArrayMode, output, f, c)
+			},
+		)
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("NegativeFilteredList", func(t *testing.T) {
+		t.Parallel()
+
+		listContainerTestStep := &Command{
+			Name: "RunListContainers",
+			Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --containername=non-existing", containerRuntime),
+			ValidateOutput: func(t *testing.T, output string) {
+				var containers []containercollection.Container
+				err := json.Unmarshal([]byte(output), &containers)
+				require.NoError(t, err, "unmarshalling list-containers output")
+				require.Len(t, containers, 0, "expected no containers")
+			},
+		}
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("NegativeFilteredListK8sContainerName", func(t *testing.T) {
+		t.Parallel()
+		listContainerTestStep := &Command{
+			Name: "RunListContainers",
+			Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --k8s-containername=non-existing", containerRuntime),
+			ValidateOutput: func(t *testing.T, output string) {
+				var containers []containercollection.Container
+				err := json.Unmarshal([]byte(output), &containers)
+				require.NoError(t, err, "unmarshalling list-containers output")
+				require.Len(t, containers, 0, "expected no containers")
+			},
+		}
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("NegativeFilteredListWithPodName", func(t *testing.T) {
+		t.Parallel()
+		listContainerTestStep := &Command{
+			Name: "RunListContainers",
+			Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --containername=%s --k8s-podname=non-existing", containerRuntime, runtimeContainerName),
+			ValidateOutput: func(t *testing.T, output string) {
+				var containers []containercollection.Container
+				err := json.Unmarshal([]byte(output), &containers)
+				require.NoError(t, err, "unmarshalling list-containers output")
+				require.Len(t, containers, 0, "expected no containers")
+			},
+		}
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
+
+	t.Run("NegativeFilteredListWithNamespace", func(t *testing.T) {
+		t.Parallel()
+		listContainerTestStep := &Command{
+			Name: "RunListContainers",
+			Cmd:  fmt.Sprintf("ig list-containers -o json --runtimes=%s --containername=%s --k8s-namespace=non-existing", containerRuntime, runtimeContainerName),
+			ValidateOutput: func(t *testing.T, output string) {
+				var containers []containercollection.Container
+				err := json.Unmarshal([]byte(output), &containers)
+				require.NoError(t, err, "unmarshalling list-containers output")
+				require.Len(t, containers, 0, "expected no containers")
+			},
+		}
+		RunTestSteps([]TestStep{listContainerTestStep}, t, WithCbBeforeCleanup(PrintLogsFn(ns)))
+	})
 }
 
 func TestWatchCreatedContainers(t *testing.T) {

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -58,6 +58,8 @@ func (c *GadgetContext) instantiateOperators(paramValues api.ParamValues) error 
 		instanceParams := op.InstanceParams().AddPrefix(opParamPrefix)
 		opParamValues := paramValues.ExtractPrefixedValues(opParamPrefix)
 
+		apihelpers.MergeWithAlternativeKeys(instanceParams, opParamValues)
+
 		// Ensure all params are present
 		err := apihelpers.NormalizeWithDefaults(instanceParams, opParamValues)
 		if err != nil {

--- a/pkg/gadget-service/api-helpers/apihelpers.go
+++ b/pkg/gadget-service/api-helpers/apihelpers.go
@@ -33,6 +33,7 @@ func ParamDescsToParams(descs params.ParamDescs) (res api.Params) {
 	for _, desc := range descs {
 		res = append(res, &api.Param{
 			Key:            desc.Key,
+			AlternativeKey: desc.AlternativeKey,
 			Description:    desc.Description,
 			DefaultValue:   desc.DefaultValue,
 			TypeHint:       string(desc.TypeHint),
@@ -50,6 +51,7 @@ func ParamDescsToParams(descs params.ParamDescs) (res api.Params) {
 func ParamToParamDesc(p *api.Param) *params.ParamDesc {
 	return &params.ParamDesc{
 		Key:            p.Key,
+		AlternativeKey: p.AlternativeKey,
 		Alias:          p.Alias,
 		Title:          p.Title,
 		DefaultValue:   p.DefaultValue,
@@ -79,6 +81,18 @@ func NormalizeWithDefaults(p api.Params, v api.ParamValues) error {
 		}
 	}
 	return nil
+}
+
+// MergeWithAlternativeKeys will merge values from AlternativeKey into Key if Key is not set
+func MergeWithAlternativeKeys(p api.Params, v api.ParamValues) {
+	for _, param := range p {
+		if _, ok := v[param.Key]; !ok && param.AlternativeKey != "" {
+			if val, ok := v[param.AlternativeKey]; ok {
+				v[param.Key] = val
+				delete(v, param.AlternativeKey)
+			}
+		}
+	}
 }
 
 func Validate(p api.Params, v api.ParamValues) error {

--- a/pkg/gadget-service/api/api.pb.go
+++ b/pkg/gadget-service/api/api.pb.go
@@ -750,6 +750,7 @@ type Param struct {
 	PossibleValues []string               `protobuf:"bytes,9,rep,name=possibleValues,proto3" json:"possibleValues,omitempty"`
 	IsMandatory    bool                   `protobuf:"varint,10,opt,name=isMandatory,proto3" json:"isMandatory,omitempty"`
 	Prefix         string                 `protobuf:"bytes,11,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	AlternativeKey string                 `protobuf:"bytes,12,opt,name=alternativeKey,proto3" json:"alternativeKey,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -857,6 +858,13 @@ func (x *Param) GetIsMandatory() bool {
 func (x *Param) GetPrefix() string {
 	if x != nil {
 		return x.Prefix
+	}
+	return ""
+}
+
+func (x *Param) GetAlternativeKey() string {
+	if x != nil {
+		return x.AlternativeKey
 	}
 	return ""
 }
@@ -1848,7 +1856,7 @@ const file_api_api_proto_rawDesc = "" +
 	"\x0fGadgetDataArray\x12\x12\n" +
 	"\x04node\x18\x01 \x01(\tR\x04node\x12\x10\n" +
 	"\x03seq\x18\x02 \x01(\rR\x03seq\x12.\n" +
-	"\tdataArray\x18\x03 \x03(\v2\x10.api.DataElementR\tdataArray\"\xbb\x02\n" +
+	"\tdataArray\x18\x03 \x03(\v2\x10.api.DataElementR\tdataArray\"\xe3\x02\n" +
 	"\x05Param\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\"\n" +
@@ -1861,7 +1869,8 @@ const file_api_api_proto_rawDesc = "" +
 	"\x0epossibleValues\x18\t \x03(\tR\x0epossibleValues\x12 \n" +
 	"\visMandatory\x18\n" +
 	" \x01(\bR\visMandatory\x12\x16\n" +
-	"\x06prefix\x18\v \x01(\tR\x06prefix\"\xf3\x02\n" +
+	"\x06prefix\x18\v \x01(\tR\x06prefix\x12&\n" +
+	"\x0ealternativeKey\x18\f \x01(\tR\x0ealternativeKey\"\xf3\x02\n" +
 	"\n" +
 	"GadgetInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +

--- a/pkg/gadget-service/api/api.proto
+++ b/pkg/gadget-service/api/api.proto
@@ -107,6 +107,7 @@ message Param {
   repeated string possibleValues = 9;
   bool isMandatory = 10;
   string prefix = 11;
+  string alternativeKey = 12;
 }
 
 message GadgetInfo {

--- a/pkg/operators/common/container-selector.go
+++ b/pkg/operators/common/container-selector.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+const (
+	ParamContainerName        = "containername"
+	ParamPodName              = "podname"
+	ParamNamespace            = "namespace"
+	ParamSelector             = "selector"
+	ParamK8sContainerName     = "k8s-containername"
+	ParamK8sPodName           = "k8s-podname"
+	ParamK8sNamespace         = "k8s-namespace"
+	ParamK8sSelector          = "k8s-selector"
+	ParamRuntimeContainerName = "runtime-containername"
+)
+
+// NewContainerSelector creates a ContainerSelector from parameter values
+func NewContainerSelector(params *params.Params) containercollection.ContainerSelector {
+	labels := parseLabelsSelector(params.Get(ParamK8sSelector).AsStringSlice())
+
+	containerSelector := containercollection.ContainerSelector{
+		Runtime: containercollection.RuntimeSelector{
+			ContainerName: params.Get(ParamRuntimeContainerName).AsString(),
+		},
+		K8s: containercollection.K8sSelector{
+			BasicK8sMetadata: eventtypes.BasicK8sMetadata{
+				Namespace:     params.Get(ParamK8sNamespace).AsString(),
+				PodName:       params.Get(ParamK8sPodName).AsString(),
+				ContainerName: params.Get(ParamK8sContainerName).AsString(),
+				PodLabels:     labels,
+			},
+		},
+	}
+
+	return containerSelector
+}
+
+func parseLabelsSelector(selectorSlice []string) map[string]string {
+	labels := make(map[string]string)
+	for _, pair := range selectorSlice {
+		kv := strings.Split(pair, "=")
+		if len(kv) == 2 {
+			labels[kv[0]] = kv[1]
+		}
+	}
+	return labels
+}
+
+func GetContainerSelectorParams(isKubeManager bool) params.ParamDescs {
+	k8sPodName := params.ParamDesc{
+		Key:         ParamK8sPodName,
+		Description: "Show only data from Kubernetes pods with that name",
+		ValueHint:   gadgets.K8SPodName,
+	}
+	k8sNamespace := params.ParamDesc{
+		Key:         ParamK8sNamespace,
+		Description: "Show only data from pods in a given Kubernetes namespace",
+		ValueHint:   gadgets.K8SNamespace,
+	}
+	k8sSelector := params.ParamDesc{
+		Key:         ParamK8sSelector,
+		Description: "Kubernetes Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2).",
+		ValueHint:   gadgets.K8SLabels,
+		Validator:   labelSelectorValidator,
+	}
+	k8sContainerNameParam := params.ParamDesc{
+		Key:         ParamK8sContainerName,
+		Description: "Show data only from containers with the name defined in the pod spec",
+		ValueHint:   gadgets.K8SContainerName,
+	}
+	runtimeContainerParam := params.ParamDesc{
+		Key:         ParamRuntimeContainerName,
+		Description: "Show data only from containers with the runtime-assigned name (not the name defined in the pod spec)",
+		ValueHint:   gadgets.LocalContainer,
+	}
+
+	// For backward compatibility, we swap the main keys and alternative keys, ensuring
+	// things like '--podname' (vs '--k8s-podname') or 'operator.KubeManager.podname' (vs 'operator.KubeManager.k8s-podname')
+	// still work fine for older clients since alternative key requires client side support.
+	// Perhaps we can revisit this in future releases and only add alternative
+	// keys without swapping once we are sure this won't be breaking change
+	// for clients (e.g. kubectl-gadget).
+	//
+	// Also, for ease of use e.g. allowing using '--podname' instead of
+	// '--k8s-podname' we set alternative keys for k8s params in the case
+	// of KubeManager and runtime params in the case of LocalManager since they
+	// both work in context for Kubernetes and Container runtimes respectively.
+	if isKubeManager {
+		// setup keys/aliases for Kubernetes metadata params
+		k8sPodName.Key = ParamPodName
+		k8sPodName.AlternativeKey = ParamK8sPodName
+		k8sPodName.Alias = "p"
+
+		k8sNamespace.Key = ParamNamespace
+		k8sNamespace.AlternativeKey = ParamK8sNamespace
+		k8sNamespace.Alias = "n"
+
+		k8sSelector.Key = ParamSelector
+		k8sSelector.AlternativeKey = ParamK8sSelector
+		k8sSelector.Alias = "l"
+
+		k8sContainerNameParam.Key = ParamContainerName
+		k8sContainerNameParam.AlternativeKey = ParamK8sContainerName
+		k8sContainerNameParam.Alias = "c"
+	} else {
+		// setup keys/aliases for runtime metadata params
+		runtimeContainerParam.Key = ParamContainerName
+		runtimeContainerParam.AlternativeKey = ParamRuntimeContainerName
+		runtimeContainerParam.Alias = "c"
+	}
+
+	return params.ParamDescs{&k8sPodName, &k8sNamespace, &k8sSelector, &k8sContainerNameParam, &runtimeContainerParam}
+}
+
+func labelSelectorValidator(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	pairs := strings.Split(value, ",")
+	for _, pair := range pairs {
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return fmt.Errorf("should be a comma-separated list of key-value pairs (key=value[,key=value,...])")
+		}
+	}
+
+	return nil
+}

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
@@ -44,23 +43,18 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
-	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 )
 
 const (
 	OperatorName = "KubeManager"
 
-	// Instance parameter keys
-	ParamContainerName = "containername"
-	ParamSelector      = "selector"
-	ParamAllNamespaces = "all-namespaces"
-	ParamPodName       = "podname"
-	ParamNamespace     = "namespace"
-
 	// Global parameter keys
 	ParamHookMode               = "hook-mode"
 	ParamFallbackPodInformer    = "fallback-podinformer"
 	ParamHookLivenessSocketFile = "hook-liveness-socketfile"
+
+	// Instance parameter keys
+	ParamAllNamespaces = "all-namespaces"
 )
 
 type MountNsMapSetter interface {
@@ -110,54 +104,14 @@ func (k *KubeManager) GlobalParamDescs() params.ParamDescs {
 }
 
 func (k *KubeManager) ParamDescs() params.ParamDescs {
-	return params.ParamDescs{
-		{
-			Key:         ParamContainerName,
-			Alias:       "c",
-			Description: "Show only data from containers with that name",
-			ValueHint:   gadgets.K8SContainerName,
-		},
-		{
-			Key:         ParamSelector,
-			Alias:       "l",
-			Description: "Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2).",
-			ValueHint:   gadgets.K8SLabels,
-			Validator: func(value string) error {
-				if value == "" {
-					return nil
-				}
-
-				pairs := strings.Split(value, ",")
-				for _, pair := range pairs {
-					kv := strings.Split(pair, "=")
-					if len(kv) != 2 {
-						return fmt.Errorf("should be a comma-separated list of key-value pairs (key=value[,key=value,...])")
-					}
-				}
-
-				return nil
-			},
-		},
-		{
-			Key:         ParamPodName,
-			Alias:       "p",
-			Description: "Show only data from pods with that name",
-			ValueHint:   gadgets.K8SPodName,
-		},
-		{
+	return append(common.GetContainerSelectorParams(true),
+		&params.ParamDesc{
 			Key:          ParamAllNamespaces,
 			Alias:        "A",
 			Description:  "Show data from pods in all namespaces",
 			TypeHint:     params.TypeBool,
 			DefaultValue: "false",
-		},
-		{
-			Key:         ParamNamespace,
-			Alias:       "n",
-			Description: "Show only data from pods in a given namespace",
-			ValueHint:   gadgets.K8SNamespace,
-		},
-	}
+		})
 }
 
 func (k *KubeManager) Init(params *params.Params) error {
@@ -269,31 +223,6 @@ func (m *KubeManagerInstance) Name() string {
 	return OperatorName
 }
 
-func newContainerSelector(selectorSlice []string, namespace, podName, containerName string, useAllNamespace bool) containercollection.ContainerSelector {
-	labels := make(map[string]string)
-	for _, pair := range selectorSlice {
-		kv := strings.Split(pair, "=")
-		labels[kv[0]] = kv[1]
-	}
-
-	containerSelector := containercollection.ContainerSelector{
-		K8s: containercollection.K8sSelector{
-			BasicK8sMetadata: eventtypes.BasicK8sMetadata{
-				Namespace:     namespace,
-				PodName:       podName,
-				ContainerName: containerName,
-				PodLabels:     labels,
-			},
-		},
-	}
-
-	if useAllNamespace {
-		containerSelector.K8s.Namespace = ""
-	}
-
-	return containerSelector
-}
-
 func (m *KubeManagerInstance) PreGadgetRun() error {
 	log := m.gadgetCtx.Logger()
 
@@ -308,13 +237,7 @@ func (m *KubeManagerInstance) PreGadgetRun() error {
 }
 
 func (m *KubeManagerInstance) handleGadgetInstance(log logger.Logger) error {
-	containerSelector := newContainerSelector(
-		m.params.Get(ParamSelector).AsStringSlice(),
-		m.params.Get(ParamNamespace).AsString(),
-		m.params.Get(ParamPodName).AsString(),
-		m.params.Get(ParamContainerName).AsString(),
-		m.params.Get(ParamAllNamespaces).AsBool(),
-	)
+	containerSelector := newContainerSelector(m.params)
 
 	if setter, ok := m.gadgetInstance.(MountNsMapSetter); ok {
 		err := m.manager.tracerCollection.AddTracer(m.id, containerSelector)
@@ -401,6 +324,14 @@ func (m *KubeManagerInstance) handleGadgetInstance(log logger.Logger) error {
 		}
 	}
 	return nil
+}
+
+func newContainerSelector(params *params.Params) containercollection.ContainerSelector {
+	containerSelector := common.NewContainerSelector(params)
+	if params.Get(ParamAllNamespaces).AsBool() {
+		containerSelector.K8s.Namespace = ""
+	}
+	return containerSelector
 }
 
 func (m *KubeManagerInstance) PostGadgetRun() error {
@@ -536,27 +467,7 @@ func (m *KubeManagerInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 		0,
 	)
 
-	labels := make(map[string]string)
-	selectorSlice := m.params.Get(ParamSelector).AsStringSlice()
-	for _, pair := range selectorSlice {
-		kv := strings.Split(pair, "=")
-		labels[kv[0]] = kv[1]
-	}
-
-	containerSelector := containercollection.ContainerSelector{
-		K8s: containercollection.K8sSelector{
-			BasicK8sMetadata: eventtypes.BasicK8sMetadata{
-				Namespace:     m.params.Get(ParamNamespace).AsString(),
-				PodName:       m.params.Get(ParamPodName).AsString(),
-				ContainerName: m.params.Get(ParamContainerName).AsString(),
-				PodLabels:     labels,
-			},
-		},
-	}
-
-	if m.params.Get(ParamAllNamespaces).AsBool() {
-		containerSelector.K8s.Namespace = ""
-	}
+	containerSelector := newContainerSelector(m.params)
 
 	if m.manager.containerCollection == nil {
 		return fmt.Errorf("container-collection isn't available")
@@ -588,13 +499,7 @@ func (m *KubeManagerInstance) Start(gadgetCtx operators.GadgetContext) error {
 		return nil
 	}
 
-	containerSelector := newContainerSelector(
-		m.params.Get(ParamSelector).AsStringSlice(),
-		m.params.Get(ParamNamespace).AsString(),
-		m.params.Get(ParamPodName).AsString(),
-		m.params.Get(ParamContainerName).AsString(),
-		m.params.Get(ParamAllNamespaces).AsBool(),
-	)
+	containerSelector := newContainerSelector(m.params)
 
 	return m.containersPublisher.PublishContainers(true, []*containercollection.Container{}, containerSelector)
 }

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -50,6 +50,9 @@ type ParamDesc struct {
 	// getting a key/value map
 	Key string `json:"key" yaml:"key"`
 
+	// AlternativeKey is an optional alternative key for this parameter
+	AlternativeKey string `json:"alternativeKey" yaml:"alternativeKey,omitempty"`
+
 	// Alias is a shortcut for this parameter, usually a single character used for command line
 	// interfaces
 	Alias string `json:"alias" yaml:"alias,omitempty"`
@@ -172,7 +175,7 @@ func (p *ParamDescs) Add(other ...*ParamDesc) {
 // Get returns the parameter with the given key or nil
 func (p *ParamDescs) Get(key string) *ParamDesc {
 	for _, param := range *p {
-		if key == param.Key {
+		if key == param.Key || key == param.AlternativeKey {
 			return param
 		}
 	}
@@ -205,7 +208,7 @@ func (p *Params) AddKeyValuePair(key, value string) {
 // Get returns the parameter with the given key or nil
 func (p *Params) Get(key string) *Param {
 	for _, param := range *p {
-		if key == param.Key {
+		if key == param.Key || key == param.AlternativeKey {
 			return param
 		}
 	}
@@ -214,7 +217,7 @@ func (p *Params) Get(key string) *Param {
 
 func (p *Params) Set(key, val string) error {
 	for _, e := range *p {
-		if e.Key == key {
+		if e.Key == key || e.AlternativeKey == key {
 			return e.Set(val)
 		}
 	}

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -513,3 +513,17 @@ func TestIsDefault(t *testing.T) {
 	p.Set("bar")
 	require.False(t, p.IsDefault())
 }
+
+func TestAlternativeKey(t *testing.T) {
+	pd := &ParamDesc{
+		Key:            "foo",
+		AlternativeKey: "bar",
+	}
+	params := Params{pd.ToParam()}
+	require.Equal(t, "foo", params[0].Key)
+	require.Equal(t, "bar", params[0].AlternativeKey)
+	params.Set("foo", "baz")
+	require.Equal(t, "baz", params.Get("bar").AsString())
+	params.Set("bar", "quux")
+	require.Equal(t, "quux", params.Get("foo").AsString())
+}


### PR DESCRIPTION
This change allows filtering by k8s resources in `ig`. Given `ig` works in the context of (container) runtime and `kubectl-gadget` in the context of Kubernetes, the idea here is to define fully qualified names for runtime/k8s so:

## ig:

- `--runtime-containername`
- `--k8s-containername`
- `--k8s-podname`
- `--k8s-namespace`
- `--k8s-selector` 

## kubectl-gadget

- `--k8s-containername`
- `--k8s-podname`
- `--k8s-namespace`
- `--k8s-selector` 
- `--runtime-containername`

For ease of use / backward compatibility, we will be creating aliases for k8s specifix params in `kubectl-gadget` and runtime specific params in `ig` so complete list:

## ig:

- `--runtime-containername` or `--containername` or `c`
- `--k8s-containername`
- `--k8s-podname`
- `--k8s-namespace`
- `--k8s-selector` 

## kubectl-gadget

- `--k8s-containername` or `--containername` or `-c`
- `--k8s-podname` or `--podname` or `-p`
- `--k8s-namespace` or `--namespace` or `n`
- `--k8s-selector`  or `--selector` or `-l`
- `--runtime-containername` 

In future runtime namespace (e.g for containerd namespace) could be renamed and an alias could be added for it as well. 

```
→ sudo ig run trace_dns -h | grep 'containername'
      --containername string                                 Show only data from containers with that name (alias: runtime-containername) (default "")
      --k8s-containername string                             Show only data from kubernetes containers with that name (default "")
  -c, --runtime-containername string                         Show only data from containers with that name (default "")
``` 

```
→ ./kubectl-gadget run trace_dns -h | grep containername
  -c, --containername string                   Show only data from containers with that name (alias: k8s-containername) (default "")
      --k8s-containername string               Show only data from containers with that name (default "")
      --runtime-containername string           Show only data from containers with that runtime container name (default "")
```

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/1403

## Testing Done

```
$ make minikube-start-containerd
$ docker cp ig minikube-containerd:/bin/ig
# runtime-containername
$ docker exec -it minikube-containerd ig run trace_tcp --containername coredns
# k8s-podname
$ docker exec -it minikube-containerd ig run trace_tcp --k8s-podname coredns-7db6d8ff4d-hbwsp
# k8s-selector
$ docker exec -it minikube-containerd bash -c 'NODE_NAME=minikube-containerd ig run trace_tcp -l k8s-app=kube-dns --enrich-with-k8s-apiserver --kubeconfig /etc/kubernetes/admin.conf'
```





