### PR TITLE
pkg/oci: Make default URL for image based gadgets configurable at build time

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -88,9 +88,12 @@ const (
 	PullImageNever   = "never"
 )
 
-const (
+var (
 	defaultDomain      = "ghcr.io"
 	officialRepoPrefix = "inspektor-gadget/gadget/"
+)
+
+const (
 	// localhost is treated as a special value for domain-name. Any other
 	// domain-name without a "." or a ":port" are considered a path component.
 	localhost = "localhost"


### PR DESCRIPTION
When building `ig` I want to be able to define a custom default domain and prefix.

To change the default values at build time through `-ldflags "-X github.com/inspektor-gadget/inspektor-gadget/pkg/oci.officialRepoPrefix=burak-ok/gadget/"` they variables need to be a `var` instead of `const`