### PR TITLE
ops/snapshotter: Don't error out when the NS path doesn't exist

### DIFF
--- a/pkg/operators/ebpf/snapshotter.go
+++ b/pkg/operators/ebpf/snapshotter.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/cilium/ebpf"
@@ -196,9 +197,9 @@ func (i *ebpfInstance) runSnapshotters() error {
 
 						return nil
 					})
-					if err != nil {
+					if err != nil && !errors.Is(err, os.ErrNotExist) {
 						return fmt.Errorf("entering container %q's netns to run iterator %q: %w",
-							container.Runtime.RuntimeName, pName, err)
+							container.Runtime.ContainerName, pName, err)
 					}
 				}
 			}


### PR DESCRIPTION
When running the snapshotter in a containers network namespace it can happen that the container, and therefore the namespace, was deleted right before entering it.

Instead of returning an error in this case, the program should just "skip" this now removed container and continue executing.

---

This came from analysing a spurious CI failure. Specifically 
```
2025-07-04T15:37:50.6845404Z === RUN   TestSnapshotSocket
2025-07-04T15:37:50.6845930Z     docker.go:161: Container "test-snapshot-socket" output:
2025-07-04T15:37:50.6846523Z     command.go:92: Run command(Run_snapshot_socket):
2025-07-04T15:37:50.6847132Z     command.go:94: Command returned(Run_snapshot_socket):
2025-07-04T15:37:50.6849121Z         Error: starting operators: starting operator "oci": starting operator "ebpf": running snapshotters: entering container "docker"'s netns to run iterator "ig_snap_tcp": no such file or directory
```
from
https://productionresultssa11.blob.core.windows.net/actions-results/55c470b5-1e62-485e-bb30-944af26f51b7/workflow-job-run-347bc47a-f196-51d1-a1bf-0a17528fe07f/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-07-08T10%3A22%3A18Z&sig=to%2BAyQHJr4GbNSzBmMMQgww5zD2y1UCDpCViN2APYjg%3D&ske=2025-07-08T21%3A01%3A29Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-07-08T09%3A01%3A29Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-07-08T10%3A12%3A13Z&sv=2025-05-05