### PR TITLE
go: remove unused gopacket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,10 +203,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 )
 
-// gopacket/gopacket with:
-// - https://github.com/gopacket/gopacket/pull/101
-replace github.com/gopacket/gopacket => github.com/gopacket/gopacket v1.3.2-0.20241202175635-b43272ae1eb8
-
 // ebpf-go with some memory & cpu optimizations like
 // - https://github.com/cilium/ebpf/pull/1763
 // - https://github.com/cilium/ebpf/pull/1772


### PR DESCRIPTION
Remove the unused gopacket reference. Also, I included a PR which requires us to use our fork of cilium/ebpf.

Fixes: 3ba4e5500d1ad3ac43c70a9af303a6ebed19d945


