### PR TITLE
wasmapi: go: syscall: Remove unused unsafe blank import.

### DIFF
--- a/wasmapi/go/syscall.go
+++ b/wasmapi/go/syscall.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"runtime"
 	"unsafe"
-	_ "unsafe"
 )
 
 //go:wasmimport ig getSyscallName


### PR DESCRIPTION
We already properly import it.

Fixes: 490785f4138c ("wasm: Remove malloc requirement for guest")
