### PR TITLE
in-tree gadget build: use intree vmlinux

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -442,7 +442,7 @@ func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 		gadgetSourcePath = filepath.Join("/work", gadgetRelativePath)
 
 		// use in-tree headers too
-		conf.CFlags += " -I /work/include/"
+		conf.CFlags += " -I /work/include/ -I /work/include/gadget/@ARCH@/ "
 	}
 
 	wasmFullPath := ""

--- a/cmd/common/image/helpers/Makefile.build
+++ b/cmd/common/image/helpers/Makefile.build
@@ -25,7 +25,7 @@ TARGETS = $(foreach ARCH,$(ARCHS),$(OUTPUTDIR)/$(ARCH).bpf.o)
 ebpf: $(TARGETS)
 
 $(OUTPUTDIR)/%.bpf.o: $(EBPFSOURCE)
-	$(CLANG) $(BASECFLAGS) $(CFLAGS) -D __TARGET_ARCH_$(subst amd64,x86,$*) \
+	$(CLANG) $(BASECFLAGS) $(subst @ARCH@,$*,$(CFLAGS)) -D __TARGET_ARCH_$(subst amd64,x86,$*) \
 		-c $< -I /usr/include/gadget/$*/ -o $@
 	$(LLVM_STRIP) -g $@
 


### PR DESCRIPTION
When building in-tree gadgets, the $IG_SOURCE_PATH environment variable is set to use the header files from the IG sources rather than the builder container. This was done correctly for the headers in include/gadget/ such as mntns.h, but not for vmlinux.h.

This patch adds support for using vmlinux.h from the IG sources.

The problem was found out after updating vmlinux.h in #4680: the new types were not available for in-tree gadgets.

