### PR TITLE
formatters/json: Return a copy of the data bytes

### DIFF
--- a/pkg/datasource/formatters/json/json.go
+++ b/pkg/datasource/formatters/json/json.go
@@ -400,7 +400,11 @@ func (f *Formatter) Marshal(data datasource.Data) []byte {
 	for _, fn := range f.fns {
 		fn(e, data)
 	}
-	return e.Bytes()
+	// Make a copy of the bytes to avoid race conditions when the buffer
+	// is returned to the pool and reused by other goroutines
+	result := make([]byte, e.Len())
+	copy(result, e.Bytes())
+	return result
 }
 
 func (f *Formatter) MarshalArray(a datasource.DataArray) []byte {
@@ -436,7 +440,11 @@ func (f *Formatter) MarshalArray(a datasource.DataArray) []byte {
 	}
 	e.Write([]byte(cArray))
 
-	return e.Bytes()
+	// Make a copy of the bytes to avoid race conditions when the buffer
+	// is returned to the pool and reused by other goroutines
+	result := make([]byte, e.Len())
+	copy(result, e.Bytes())
+	return result
 }
 
 type floatEncoder int // number of bits


### PR DESCRIPTION
This PR fixes a race condition. We need to copy the bytes instead of referencing them. This results of course in some overhead

Returning a copy is neccessary since the returned slice is referencing a memory area which we returned back to the bufpool. Therefore the underlying bytes can change right after the Marshal method returns the slice.

## Go playground
to see the problem with the slice and buffpool in action: https://play.golang.com/p/inDEnuOZUHU

## Example scenario in which this can happen
1. [The `bpfstats/unit` tests](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/bpfstats/test/unit/bpfstats_test.go) 
2. Here we have 2 `gadgetRunners` executing a gadget in parallel in the same process
3. In the `GadgetRunner` [DataFunc method](https://github.com/inspektor-gadget/inspektor-gadget/blob/142825bbee54db284901e75e904ff7b3d9d0bae7/pkg/testing/gadgetrunner/gadgetrunner.go#L132) we first marshal the data we got into a JSON byte array 
4. The `Marshal` function of the Json Formatter [first gets a buffer from a shared global pool](https://github.com/inspektor-gadget/inspektor-gadget/blob/142825bbee54db284901e75e904ff7b3d9d0bae7/pkg/datasource/formatters/json/json.go#L397)
5. We[ return a slice ](https://github.com/inspektor-gadget/inspektor-gadget/blob/142825bbee54db284901e75e904ff7b3d9d0bae7/pkg/datasource/formatters/json/json.go#L403)(and therefore reference) from that function and [put the buffer pack into the shared global pool](https://github.com/inspektor-gadget/inspektor-gadget/blob/142825bbee54db284901e75e904ff7b3d9d0bae7/pkg/datasource/formatters/json/json.go#L399)
6. Now back in the `GadgetRunner` we [try to `Unmarshal` the byte slice](https://github.com/inspektor-gadget/inspektor-gadget/blob/142825bbee54db284901e75e904ff7b3d9d0bae7/pkg/testing/gadgetrunner/gadgetrunner.go#L133) and here it can now happen that the underlying byte slice changes. This results in errors like
  ```
  2025-07-07T13:35:32.7114147Z panic: JSON decoder out of sync - data changing underfoot?
  2025-07-07T13:35:32.7114607Z 
  2025-07-07T13:35:32.7114782Z goroutine 6644 [running]:
  2025-07-07T13:35:32.7115488Z encoding/json.(*decodeState).object(0xc0001d9830, {0x345e220?, 0xc001cc7290?, 0x150a77d?})
  2025-07-07T13:35:32.7116668Z 	/opt/hostedtoolcache/go/1.24.4/x64/src/encoding/json/decode.go:669 +0x1a6b
  2025-07-07T13:35:32.7117654Z encoding/json.(*decodeState).value(0xc0001d9830, {0x345e220?, 0xc001cc7290?, 0x14f0819?})
  2025-07-07T13:35:32.7118660Z 	/opt/hostedtoolcache/go/1.24.4/x64/src/encoding/json/decode.go:375 +0x3e
  2025-07-07T13:35:32.7119595Z encoding/json.(*decodeState).unmarshal(0xc0001d9830, {0x345e220?, 0xc001cc7290?})
  2025-07-07T13:35:32.7120589Z 	/opt/hostedtoolcache/go/1.24.4/x64/src/encoding/json/decode.go:178 +0x11e
  2025-07-07T13:35:32.7121494Z encoding/json.Unmarshal({0xc000ce4200, 0x120, 0x200}, {0x345e220, 0xc001cc7290})
  2025-07-07T13:35:32.7122450Z 	/opt/hostedtoolcache/go/1.24.4/x64/src/encoding/json/decode.go:108 +0xf9
  2025-07-07T13:35:32.7124069Z github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner.(*GadgetRunner[...]).RunGadget.func1({0x3efc9f0?, 0xc000bf3600?})
  2025-07-07T13:35:32.7125741Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner/gadgetrunner.go:133 +0xab
  2025-07-07T13:35:32.7127259Z github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).Subscribe.func2({0x0?, 0x0?}, {0x3efca18?, 0xc000304bb0})
  2025-07-07T13:35:32.7128731Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/datasource/data.go:602 +0xae
  2025-07-07T13:35:32.7130130Z github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*dataSource).EmitAndRelease(0xc001dc8180, {0x3efca18, 0xc000304bb0})
  2025-07-07T13:35:32.7131557Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/datasource/data.go:664 +0xdf
  2025-07-07T13:35:32.7133172Z github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*ebpfOperatorDataInstance).sendStats(0xc001cbc240, {0xc000c25408, 0x5, 0x0?})
  2025-07-07T13:35:32.7134735Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/stats.go:363 +0x458
  2025-07-07T13:35:32.7136022Z github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*ebpfOperatorDataInstance).Start.func1()
  2025-07-07T13:35:32.7137341Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/stats.go:557 +0x168
  2025-07-07T13:35:32.7138724Z created by github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf.(*ebpfOperatorDataInstance).Start in goroutine 20
  2025-07-07T13:35:32.7140461Z 	/home/runner/work/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/stats.go:545 +0xbc
  2025-07-07T13:35:32.7141591Z FAIL	github.com/inspektor-gadget/inspektor-gadget/gadgets/bpfstats/test/unit	16.856s
  ```

## Outside of testing
This can happen also outside of testing. Looking at the above example we only need parallel calls to `Marshal`. While in IG a single datasource always sends packets in serial, one after another, we also support multiple datasources. Especially with `bpfstats` we can see that a fully async datasource can emit packets in parallel to other eBPF datasources