### PR TITLE
helm: allow setting imagePullSecrets for daemonset image

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -41,9 +41,9 @@ spec:
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
-      {{- if .Values.image.imagePullSecrets }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.image.imagePullSecrets | nindent 8 }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: gadget

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -99,7 +99,7 @@
         "pullPolicy": {
           "type": "string"
         },
-        "imagePullSecrets": {
+        "pullSecrets": {
           "type": "array",
           "items": {
             "type": "object",

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -57,7 +57,7 @@ image:
   # -- Tag for the container image
   tag: ""
   # -- Pull secrets for the daemonset image
-  imagePullSecrets: []
+  pullSecrets: []
 
 # -- Node selector used by `gadget` container
 nodeSelector:


### PR DESCRIPTION
# Allow setting imagePullSecrets for daemonset image in Helm chart

Fixes #4703 
Allow setting imagePullSecrets for daemonset image in case a private registry is used

## How to use

Set in values.yaml
```yaml
image:
  imagePullSecrets:
  - name: my-pull-secret
```

run
`helm template gadget <chart path> -f values.yaml`

## Testing done

- Valid setup for imagePullSecrets
```yaml
image:
  imagePullSecrets:
  - name: my-pull-secret
```

Expected success:
```
helm template gadget gadget/ -f values.yaml | yq 'select(.kind == "DaemonSet") | .spec.template.spec.imagePullSecrets'
- name: my-pull-secret
```

- Invalid setup for imagePullSecrets
```yaml
image:
  imagePullSecrets:
  - my-pull-secret
```

Expected schema error:
```
helm template gadget gadget/ -f values.yaml | yq 'select(.kind == "DaemonSet") | .spec.template.spec.imagePullSecrets'
Error: values don't meet the specifications of the schema(s) in the following chart(s):
gadget:
- image.imagePullSecrets.0: Invalid type. Expected: object, given: string
```

- Nothing set (default)

Expected nothing set:
```
helm template gadget gadget/ | yq 'select(.kind == "DaemonSet") | .spec.template.spec.imagePullSecrets'
null
```