### PR TITLE
New gadget: ttysnoop

### DIFF
--- a/docs/gadgets/ttysnoop.mdx
+++ b/docs/gadgets/ttysnoop.mdx
@@ -1,0 +1,1 @@
+../../gadgets/ttysnoop/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -53,6 +53,7 @@ GADGETS ?= \
 	top_file \
 	top_process \
 	top_tcp \
+	ttysnoop \
 	snapshot_process \
 	snapshot_socket \
 	ci/datasource-containers \

--- a/gadgets/ttysnoop/README.md
+++ b/gadgets/ttysnoop/README.md
@@ -1,0 +1,5 @@
+# ttysnoop
+
+The `ttysnoop` gadget watches the output from a tty or pts device
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/ttysnoop

--- a/gadgets/ttysnoop/README.mdx
+++ b/gadgets/ttysnoop/README.mdx
@@ -1,0 +1,144 @@
+---
+title: ttysnoop
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# ttysnoop
+
+The ttysnoop gadget watches the output from a tty or pts device.
+
+## Use Cases
+
+This gadget captures the interactive shell activity within your Kubernetes
+pods, in containers and on the host.
+
+### Audit trail
+
+This gadget helps you keep an audit trail of actions performed by
+administrators in interactive shells on your Kubernetes clusters. This covers
+commands executed using `kubectl exec -ti` or `kubectl run -ti`, which allow
+direct interaction with pods. Implementing such an audit trail can be
+particularly useful for clusters that should otherwise not be tampered with,
+or where stricter control over administrator actions is desired.
+
+For more use cases and how this tool can be applied, you can refer to
+[Scribery](https://scribery.github.io/).
+
+### Foundation for Intrusion Detection Systems
+
+While it doesn't directly trigger alerts or manage keyword lists, the
+collected data can serve as a foundation for building your own intrusion
+detection systems. You can then integrate this data with other security tools
+to analyze what's typed or displayed in the pod, enabling you to detect
+potential intrusions based on your own defined keywords or regular expressions.
+
+### Recording and Replaying Terminal Sessions
+
+While the gadget itself doesn't offer a replay feature, the recorded data
+provides all the necessary information for you to build your own solution for
+replaying these sessions. This capability is especially useful for
+demonstrations, analysis, or creating reproducible scenarios.
+
+For a well-known example of how recorded terminal data can be used for
+replaying, you can refer to [Asciinema](https://asciinema.org/).
+
+### Training and Certification
+
+The gadget's ability to record interactive terminal sessions can be beneficial
+in educational and certification contexts. For instance, these recordings can
+be used to document practical exercises, track progress during training, or
+review performance in hands-on certification exams. This can be useful for
+assessments like the [Certified Kubernetes Administrator (CKA)
+exam](https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/),
+where candidates perform tasks in a live environment.
+
+## Requirements
+
+- Minimum Kernel Version : 6.1
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/ttysnoop:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/ttysnoop:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+No flags.
+
+## Guide
+
+First, we need to run an application that generates some events.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl run -ti mypod --restart=Never --image=busybox -- sh -c 'while /bin/true ; do echo foo ; sleep 3 ; done'
+        pod/mypod created
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker run --name test-ttysnoop -ti busybox /bin/sh -c 'while /bin/true ; do echo foo ; sleep 3 ; done'
+        ```
+    </TabItem>
+</Tabs>
+
+Then, let's run the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ttysnoop:%IG_TAG% --podname mypod
+        K8S.NODE          K8S.NAMESPACE  K8S.PODNAME  K8S.CONTAINERNAME  COMM     PID     TID LEN  BUF
+        minikube-docker   default        mypod        mypod              sh    542352  542352 4    foo
+        minikube-docker   default        mypod        mypod              sh    542352  542352 4    foo
+        ^C
+        ```
+
+        We can stop the gadget by hitting Ctrl-C.
+
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ttysnoop:%IG_TAG% --containername test-ttysnoop
+        RUNTIME.CONTAINERNAME  COMM     PID     TID LEN  BUF
+        test-ttysnoop          sh    542352  542352 4    foo
+        test-ttysnoop          sh    542352  542352 4    foo
+        ^C
+        ```
+    </TabItem>
+</Tabs>
+
+Finally, clean the system:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl delete pod mypod
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker rm -f test-ttysnoop
+        ```
+    </TabItem>
+</Tabs>

--- a/gadgets/ttysnoop/gadget.yaml
+++ b/gadgets/ttysnoop/gadget.yaml
@@ -1,0 +1,17 @@
+name: 'ttysnoop'
+description: 'Watch live output from a tty or pts device'
+homepageURL: 'https://inspektor-gadget.io/'
+documentationURL: 'https://www.inspektor-gadget.io/docs/latest/gadgets/ttysnoop'
+sourceURL: 'https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/ttysnoop'
+datasources:
+  ttysnoop:
+    fields:
+      buf:
+        annotations:
+          description: 'buffer'
+          columns.width: 32
+      len:
+      ino:
+      inoptr:
+        annotations:
+          columns.hidden: "true"

--- a/gadgets/ttysnoop/program.bpf.c
+++ b/gadgets/ttysnoop/program.bpf.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2016 Brendan Gregg */
+/* Copyright (c) 2022-2023 Rong Tao */
+/* Copyright (c) 2025 The Inspektor Gadget authors */
+
+/* Initially based on BCC ttysnoop tool:
+ * https://github.com/iovisor/bcc/blob/master/tools/ttysnoop.py
+ */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/filter.h>
+#include <gadget/macros.h>
+#include <gadget/types.h>
+#include <gadget/filesystem.h>
+
+#define MAX_BUF_SIZE 8192
+
+struct event {
+	gadget_timestamp timestamp_raw;
+	struct gadget_process proc;
+
+	u64 ino;
+	u64 inoptr;
+
+	u32 len;
+	char buf[MAX_BUF_SIZE];
+};
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER(ttysnoop, events, event);
+
+#define READ 0
+#define WRITE 1
+
+SEC("kprobe/tty_write")
+int BPF_KPROBE(tty_write_e, struct kiocb *iocb, struct iov_iter *from)
+{
+	struct event *event;
+
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	if (BPF_CORE_READ(from, data_source) != WRITE)
+		return 0;
+
+	event = gadget_reserve_buf(&events, sizeof(struct event));
+	if (!event)
+		return 0;
+
+	gadget_process_populate(&event->proc);
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
+	event->inoptr = (u64)BPF_CORE_READ(iocb, ki_filp, f_inode);
+	event->ino = BPF_CORE_READ(iocb, ki_filp, f_inode, i_ino);
+
+	if (!bpf_core_field_exists(from->iter_type))
+		return 0;
+
+	// enum iter_type does not have ITER_UBUF prior to Linux v6.0:
+	// https://github.com/torvalds/linux/commit/fcb14cb1bdacec5b4374fe161e83fb8208164a85
+
+	// In Linux v6.4, the __ubuf_iovec field was added to iov_iter
+	// https://github.com/torvalds/linux/commit/747b1f65d39ae729b7914075899b0c82d7f667db
+
+	const struct iovec *iov = NULL;
+	if (bpf_core_field_exists(struct iov_iter, __ubuf_iovec) &&
+	    bpf_core_enum_value_exists(enum iter_type, ITER_UBUF) &&
+	    BPF_CORE_READ(from, iter_type) ==
+		    bpf_core_enum_value(enum iter_type, ITER_UBUF))
+		iov = &from->__ubuf_iovec;
+	else if (bpf_core_field_exists(struct iov_iter, __iov))
+		iov = BPF_CORE_READ(from, __iov);
+
+	if (iov)
+		bpf_probe_read_kernel(&event->len, sizeof(event->len),
+				      &iov->iov_len);
+	else
+		event->len = BPF_CORE_READ(from, count);
+
+	u32 len = event->len;
+	if (len > MAX_BUF_SIZE) {
+		len = MAX_BUF_SIZE;
+	}
+	if (iov)
+		bpf_probe_read_user(&event->buf, len,
+				    BPF_CORE_READ(iov, iov_base));
+	else
+		bpf_probe_read_user(&event->buf, len,
+				    BPF_CORE_READ(from, ubuf));
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/ttysnoop/test/unit/ttysnoop_test.go
+++ b/gadgets/ttysnoop/test/unit/ttysnoop_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/internal/test"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type ExpectedTtysnoopEvent struct {
+	Proc utils.Process `json:"proc"`
+	Len  int           `json:"len"`
+	Buf  string        `json:"buf"`
+}
+
+type testDef struct {
+	runnerConfig *utilstest.RunnerConfig
+	text         string
+	validate     func(t *testing.T, info *utilstest.RunnerInfo, events []ExpectedTtysnoopEvent, text string)
+}
+
+func TestTtysnoopFull(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+
+	_, err := os.Stat("/dev/pts/ptmx")
+	if err != nil {
+		t.Skipf("Skipping test: /dev/pts/ptmx not found, this test requires a PTY device. Error: %v", err)
+	}
+
+	gadgettesting.MinimumKernelVersion(t, "6.1")
+
+	testCases := map[string]testDef{
+		"simple_write": {
+			runnerConfig: &utilstest.RunnerConfig{},
+			text:         "hello world",
+			validate: func(t *testing.T, info *utilstest.RunnerInfo, events []ExpectedTtysnoopEvent, text string) {
+				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
+				require.Equal(t, len(text), events[0].Len, "Expected Len %d, got %d", len(text), events[0].Len)
+				require.Equal(t, text, events[0].Buf, "Expected Args %q, got %q", text, events[0].Buf)
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runner := utilstest.NewRunnerWithTest(t, testCase.runnerConfig)
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, func() error {
+					generateEventFromThread(t, testCase.text)
+					return nil
+				})
+				return nil
+			}
+			opts := gadgetrunner.GadgetRunnerOpts[ExpectedTtysnoopEvent]{
+				Image:          "ttysnoop",
+				Timeout:        5 * time.Second,
+				ParamValues:    api.ParamValues{},
+				MntnsFilterMap: utilstest.CreateMntNsFilterMap(t, runner.Info.MountNsID),
+				OnGadgetRun:    onGadgetRun,
+			}
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+			gadgetRunner.RunGadget()
+			testCase.validate(t, runner.Info, gadgetRunner.CapturedEvents, testCase.text)
+		})
+	}
+}
+
+func generateEventFromThread(t *testing.T, text string) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		// Fails when /dev/pts is not mounted.
+		// It can happen with old versions of vimto.
+		// See https://github.com/lmb/vimto/pull/26
+		t.Fatalf("Failed to open pty: %v", err)
+	}
+	defer ptmx.Close()
+	defer tty.Close()
+
+	_, err = ptmx.WriteString(text)
+	if err != nil {
+		t.Fatalf("Failed to write to pty: %v", err)
+	}
+}


### PR DESCRIPTION
Based on [bcc's tool ttysnoop](https://github.com/iovisor/bcc/blob/master/tools/ttysnoop.py).


## How to use

Workload:
```
$ docker run -ti --rm busybox
/ # echo foo
foo
```

Output of the gadget:
```
$ sudo ig run ghcr.io/inspektor-gadget/gadget/ttysnoop:alban_ttysnoop --verify-image=false
WARN[0000] image signature verification is disabled due to using corresponding option
WARN[0001] image signature verification is disabled due to using corresponding option
RUNTIME.CONTAINERNAME                                COMM                    PID        TID LEN        BUF
elastic_cartwright                                   sh                   516940     516940 1          e
elastic_cartwright                                   sh                   516940     516940 1          c
elastic_cartwright                                   sh                   516940     516940 1          h
elastic_cartwright                                   sh                   516940     516940 1          o
elastic_cartwright                                   sh                   516940     516940 1
elastic_cartwright                                   sh                   516940     516940 1          f
elastic_cartwright                                   sh                   516940     516940 1          o
elastic_cartwright                                   sh                   516940     516940 1          o
elastic_cartwright                                   sh                   516940     516940 1

elastic_cartwright                                   sh                   516940     516940 4          foo

elastic_cartwright                                   sh                   516940     516940 4          / #
```

## Testing done

See command above. Tested on Linux 6.5.9-200.fc38.x86_64.

## TODO

- [x] Documentation
- [x] Tests
- [x] Support for Linux < v6.4
- [ ] For future PRs: filtering by PTS (e.g. /dev/pts/2, /dev/console, /dev/tty0)
