### PR TITLE
kubectl-gadget/undeploy: Don't remove namespace

### DIFF
--- a/charts/gadget/templates/clusterrole.yaml
+++ b/charts/gadget/templates/clusterrole.yaml
@@ -2,10 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "gadget.fullname" . }}-cluster-role
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes/proxy"]

--- a/charts/gadget/templates/clusterrolebinding.yaml
+++ b/charts/gadget/templates/clusterrolebinding.yaml
@@ -2,10 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "gadget.fullname" . }}-cluster-role-binding
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -2,10 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
   name: {{ include "gadget.fullname" . }}
   namespace: {{ include "gadget.namespace" . }}
 data:

--- a/charts/gadget/templates/role.yaml
+++ b/charts/gadget/templates/role.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
   name: {{ include "gadget.fullname" . }}-role
   namespace: {{ include "gadget.namespace" . }}
 rules:

--- a/charts/gadget/templates/rolebinding.yaml
+++ b/charts/gadget/templates/rolebinding.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
   name: {{ include "gadget.fullname" . }}-role-binding
   namespace: {{ include "gadget.namespace" . }}
 roleRef:

--- a/charts/gadget/templates/serviceaccount.yaml
+++ b/charts/gadget/templates/serviceaccount.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if not .Values.skipLabels }}
   labels:
+    {{- if not .Values.skipLabels }}
     {{- include "gadget.labels" . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
   name: {{ include "gadget.fullname" . }}
   namespace: {{ include "gadget.namespace" . }}

--- a/docs/reference/install-kubernetes.md
+++ b/docs/reference/install-kubernetes.md
@@ -471,13 +471,41 @@ For more information about the configuration file, check the [configuration guid
 Depending on your installation method, use one of the following command to
 remove all the resources created by Inspektor Gadget on the cluster:
 
+### Using kubectl gadget undeploy
+
 ```bash
 $ kubectl gadget undeploy
 ```
 
+This command removes all Inspektor Gadget resources while preserving the namespace and any user-deployed resources within it. The following resources are removed:
+
+- DaemonSet (gadget)
+- ServiceAccount (gadget)
+- ConfigMap (gadget)
+- Role (gadget-role)
+- RoleBinding (gadget-role-binding)
+- ClusterRole (gadget-cluster-role)
+- ClusterRoleBinding (gadget-cluster-role-binding)
+- ClusterImagePolicy (if image verification was enabled)
+- CRD (for backward compatibility with older versions)
+
+**Note**: SeccompProfile resources are not automatically removed as they are user-provided content. If you deployed Inspektor Gadget with a custom seccomp profile using the `--seccomp-profile` flag, you will need to manually remove the SeccompProfile resource after undeploying.
+
+To also remove the namespace and all resources within it, use:
+
+```bash
+$ kubectl gadget undeploy --delete-namespace
+```
+
+**Warning**: The `--delete-namespace` flag will remove ALL resources in the namespace, not just those created by Inspektor Gadget.
+
+### Using Helm
+
 ```bash
 $ helm uninstall -n gadget gadget
 ```
+
+### Using Minikube addon
 
 ```bash
 $ minikube addons disable inspektor-gadget

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -9,6 +9,8 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    k8s-app: gadget
   name: gadget
   namespace: gadget
 ---
@@ -16,6 +18,8 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  labels:
+    k8s-app: gadget
   name: gadget
   namespace: gadget
 data:
@@ -50,6 +54,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gadget-cluster-role
+  labels:
+    k8s-app: gadget
 rules:
   - apiGroups: [""]
     resources: ["nodes/proxy"]
@@ -88,6 +94,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gadget-cluster-role-binding
+  labels:
+    k8s-app: gadget
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -101,6 +109,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    k8s-app: gadget
   name: gadget-role
   namespace: gadget
 rules:
@@ -116,6 +126,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    k8s-app: gadget
   name: gadget-role-binding
   namespace: gadget
 roleRef:


### PR DESCRIPTION
The namespace could have been created by the user beforehand, or the user deployed other resources into the namespace created by Inspektor Gadget.

By default we should not remove the namespace in order to keep other resources running in the namespace.

Another idea was to only remove the namespace if we created it. But I think its still safer to assume that we do not want to delete the namespace by default.
With Helm deleting the namespace is not even possible, while a namespace can be created the namespace when deploying a chart with `--create-namespace`. But there is no way from the Helm side to remove the namespace. The user has to do that manually with `kubectl delete <ns>`

Fixes #2692 and fixes #4624