### PR TITLE
rfc: operators: wasm: Add profiling using wzprof.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cilium/ebpf v0.18.0
 	github.com/containerd/containerd v1.7.27
 	github.com/containerd/errdefs v1.0.0
-	github.com/containerd/nri v0.9.0
+	github.com/containerd/nri v0.8.0
 	github.com/containers/common v0.63.1
 	github.com/containers/image/v5 v5.35.0
 	github.com/coreos/go-systemd/v22 v22.5.0
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tetratelabs/wazero v1.9.0
+	github.com/tetratelabs/wazero v1.5.0
 	github.com/tklauser/numcpus v0.10.0
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
@@ -202,6 +202,10 @@ require (
 	sigs.k8s.io/release-utils v0.11.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 )
+
+require github.com/stealthrocket/wzprof v0.2.0
+
+require github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 
 // ebpf-go with some memory & cpu optimizations like
 // - https://github.com/cilium/ebpf/pull/1763

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containerd/nri v0.8.0/go.mod h1:uSkgBrCdEtAiEz4vnrq8gmAC4EnVAM5Klt0OuK5rZYQ=
 github.com/containerd/nri v0.9.0 h1:jribDJs/oQ95vLO4Yn19HKFYriZGWKiG6nKWjl9Y/x4=
 github.com/containerd/nri v0.9.0/go.mod h1:sDRoMy5U4YolsWthg7TjTffAwPb6LEr//83O+D3xVU4=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
@@ -372,6 +373,8 @@ github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
+github.com/stealthrocket/wzprof v0.2.0 h1:cUslde8NVVPwm+RkU5B9jYkAh8e/0adoLdgxZ7oaWOE=
+github.com/stealthrocket/wzprof v0.2.0/go.mod h1:LLuKDW7IhmJuQ6PwkFsQy4dTKCMNLhjiBBY3XpKYcWo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -388,6 +391,10 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
+github.com/tetratelabs/wazero v1.8.2-0.20241030035603-dc08732e57d5 h1:F+AT6Jxxww3j4/B/wXU01Raq4J8fg/Cg2HD4XsETGaU=
+github.com/tetratelabs/wazero v1.8.2-0.20241030035603-dc08732e57d5/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -28,7 +28,9 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tetratelabs/wazero"
 	wapi "github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/stealthrocket/wzprof"
 	"oras.land/oras-go/v2"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
@@ -124,6 +126,9 @@ type wasmOperatorInstance struct {
 	rt        wazero.Runtime
 	gadgetCtx operators.GadgetContext
 	mod       wapi.Module
+
+	cpu *wzprof.CPUProfiler
+	mem *wzprof.MemoryProfiler
 
 	logger logger.Logger
 
@@ -226,12 +231,46 @@ func (i *wasmOperatorInstance) init(
 	desc ocispec.Descriptor,
 	cache wazero.CompilationCache,
 ) error {
+	sampleRate := 1.0
+
 	ctx := gadgetCtx.Context()
+	reader, err := oci.GetContentFromDescriptor(ctx, target, desc)
+	if err != nil {
+		return fmt.Errorf("getting wasm program: %w", err)
+	}
+
+	wasmProgram, err := io.ReadAll(reader)
+	reader.Close()
+	if err != nil {
+		return fmt.Errorf("reading wasm program: %w", err)
+	}
+
+	p := wzprof.ProfilingFor(wasmProgram)
+	i.cpu = p.CPUProfiler()
+	i.mem = p.MemoryProfiler()
+
+	ctx = context.WithValue(ctx,
+													 experimental.FunctionListenerFactoryKey{},
+													experimental.MultiFunctionListenerFactory(
+														wzprof.Sample(sampleRate, i.cpu),
+																																		wzprof.Sample(sampleRate, i.mem),
+													),
+	)
 	rtConfig := wazero.NewRuntimeConfig().
 		WithCloseOnContextDone(true).
 		WithMemoryLimitPages(256). // 16MB (64KB per page)
 		WithCompilationCache(cache)
 	i.rt = wazero.NewRuntimeWithConfig(ctx, rtConfig)
+
+	module, err := i.rt.CompileModule(ctx, wasmProgram)
+	if err != nil {
+		return fmt.Errorf("compiling wasm module: %w", err)
+	}
+
+	p.Prepare(module)
+	if err != nil {
+		return fmt.Errorf("preparing wasm module: %w", err)
+	}
 
 	igModuleBuilder := i.rt.NewHostModuleBuilder("ig")
 
@@ -255,18 +294,8 @@ func (i *wasmOperatorInstance) init(
 		return fmt.Errorf("instantiating WASI: %w", err)
 	}
 
-	reader, err := oci.GetContentFromDescriptor(ctx, target, desc)
-	if err != nil {
-		return fmt.Errorf("getting wasm program: %w", err)
-	}
-
-	wasmProgram, err := io.ReadAll(reader)
-	reader.Close()
-	if err != nil {
-		return fmt.Errorf("reading wasm program: %w", err)
-	}
-
 	config := wazero.NewModuleConfig().WithStartFunctions("_initialize")
+	i.cpu.StartProfile()
 	mod, err := i.rt.InstantiateWithConfig(ctx, wasmProgram, config)
 	if err != nil {
 		return fmt.Errorf("instantiating wasm: %w", err)
@@ -374,6 +403,12 @@ func (i *wasmOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
 	}
 	if i.mod != nil {
 		errs = append(errs, i.mod.Close(gadgetCtx.Context()))
+
+		cpuProfile := i.cpu.StopProfile(1.0)
+		memProfile := i.mem.NewProfile(1.0)
+
+		errs = append(errs, wzprof.WriteProfile("cpu.pprof", cpuProfile))
+		errs = append(errs, wzprof.WriteProfile("mem.pprof", memProfile))
 	}
 
 	return errors.Join(errs...)


### PR DESCRIPTION
This commit adds profiling WASM code using wzprof:

```bash
$ sudo ./ig --timeout 5 --verify-image=false run traceloop:main -c test-container
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
WARN[0000] image signature verification is disabled due to using corresponding option 
WARN[0000] image signature verification is disabled due to using corresponding option 
RUNTIME.CONTAINERNAME                   CPU         PID COMM             SYSCALL                  PARAMETERS                          RET
test-container                          6         28196 sh               read                     fd=0, buf="\x1b@\bB\xb9C\…            1
...
$ /home/francis/go/bin/pprof -http=localhost:1337 cpu.pprof
```

I wrote this to profile traceloop rust performance and was thinking this could be interesting to have it.
If we decide to proceed because we deem this is a good idea, I would polish it and add proper UX.