### PR TITLE
operators: wasm: Add gadgetGetLogLevel() and log only if level is enabled.

### DIFF
--- a/pkg/operators/wasm/consts_test.go
+++ b/pkg/operators/wasm/consts_test.go
@@ -42,7 +42,7 @@ func TestConsts(t *testing.T) {
 
 	// logLevel
 	assert.EqualValues(t, wasmapi.ErrorLevel, errorLevel)
-	assert.EqualValues(t, wasmapi.WarnLevel, arnLevel)
+	assert.EqualValues(t, wasmapi.WarnLevel, warnLevel)
 	assert.EqualValues(t, wasmapi.InfoLevel, infoLevel)
 	assert.EqualValues(t, wasmapi.DebugLevel, debugLevel)
 	assert.EqualValues(t, wasmapi.TraceLevel, traceLevel)

--- a/wasmapi/go/log.go
+++ b/wasmapi/go/log.go
@@ -24,6 +24,10 @@ import (
 //go:linkname gadgetLog gadgetLog
 func gadgetLog(level uint32, str uint64)
 
+//go:wasmimport ig gadgetShouldLog
+//go:linkname gadgetShouldLog gadgetShouldLog
+func gadgetShouldLog(level uint32) uint32
+
 type logLevel uint32
 
 const (
@@ -40,11 +44,15 @@ func log(level logLevel, message string) {
 }
 
 func Log(level logLevel, args ...any) {
-	log(level, fmt.Sprint(args...))
+	if gadgetShouldLog(uint32(level)) == 1 {
+		log(level, fmt.Sprint(args...))
+	}
 }
 
 func Logf(level logLevel, format string, args ...any) {
-	log(level, fmt.Sprintf(format, args...))
+	if gadgetShouldLog(uint32(level)) == 1 {
+		log(level, fmt.Sprintf(format, args...))
+	}
 }
 
 func Error(params ...any) {


### PR DESCRIPTION
fmt.Sprint() and fmt.Sprintf() are always called when using gadgetLog() even if the result is not logged due to level being not enabled.
This PR adds a function to get logger level from WASM and skip logging if the param level is not enabled.
Thus, no formatting will occur which result in gadgetStop() being more 50% shorter for traceloop:
* with this commit:
![profile-no-log](https://github.com/user-attachments/assets/becdda9e-7915-46ec-9aa9-789374cb5fec)
* without this commit:
![profile-log](https://github.com/user-attachments/assets/25bca023-fa22-4f6e-abd3-f5402a7c8334)

TODO:
- [ ] Port to rust wasm api once agreed on the solution.