### PR TITLE
operators: oci: Add local verifying.

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -51,6 +51,8 @@ const (
 	annotate                = "annotate"
 	verifyImage             = "verify-image"
 	publicKeys              = "public-keys"
+	signature               = "signature"
+	payload                 = "payload"
 	allowedGadgets          = "allowed-gadgets"
 )
 
@@ -163,6 +165,20 @@ func (o *ociHandler) InstanceParams() api.Params {
 				"  'datasource:annotation=value' to add an annotation to a datasource.\n" +
 				"  'datasource.field:annotation=value' to add an annotation to the field of a datasource\n",
 			TypeHint: api.TypeStringSlice,
+		},
+		{
+			Key:          signature,
+			Title:        "Signature",
+			Description:  "Gadget signature. Used to verify a gadget signed locally",
+			DefaultValue: "",
+			TypeHint:     api.TypeString,
+		},
+		{
+			Key:          payload,
+			Title:        "Payload",
+			Description:  "Gadget payload. Used to verify a gadget signed locally",
+			DefaultValue: "",
+			TypeHint:     api.TypeString,
 		},
 	}
 }
@@ -344,6 +360,8 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		VerifyOptions: oci.VerifyOptions{
 			VerifyPublicKey: o.globalParams.Get(verifyImage).AsBool(),
 			PublicKeys:      o.globalParams.Get(publicKeys).AsStringSlice(),
+			Signature:       o.instanceParams.Get(signature).AsString(),
+			Payload:         o.instanceParams.Get(payload).AsString(),
 		},
 		AllowedGadgetsOptions: oci.AllowedGadgetsOptions{
 			AllowedGadgets: o.globalParams.Get(allowedGadgets).AsStringSlice(),


### PR DESCRIPTION
```bash
$ git clone https://github.com/eiffel-fl/cosign.git
$ cd cosign
$ git checkout francis/with-patch-to-sign-locally
# Compile cosign with this patch enabling local signing rebased on main:
# https://github.com/sigstore/cosign/pull/4014
$ make
# Sign gadget built locally
$ ./cosign generate-key-pair --output-key-prefix='local'
$ ./cosign ign --key local.key --yes --tlog-upload=false --upload=false trace_exec@sha256:7192a8431a03074d8ba0b0974828731d444917c7e842594b5cf4d38160829ddf --output-signature gadget.sig --output-payload gadget.pld
$ mv gadget.* local.* ../inspektor-gadget
$ cd ../inspektor-gadget
# Compile ig to have latest modifications
$ make ig
$ sudo ./ig run --public-keys="$(cat local.pub)" --signature gadget.sig --payload gadget.pld trace_exec:local
WARN[0000] No digest found for image sha256:5ec7527ba87826d36c6ff8a8fbcf7b6e34ebac32c2f63fb3f23f5875a0ec59dc 
RUNTIME.CONTAINERNAME                               COMM                    PID        TID TTY       ARGS                           ERROR
^C%
```

TODO:
- [ ] Add documentation once agreed on the UX.