### PR TITLE
charts: Add mount for wasm-cache

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -221,6 +221,11 @@ spec:
             - mountPath: /etc/ig
               name: config
               readOnly: true
+            # We need a dedicated volume to store the wasm cache
+            # otherwise it will fail as the container root filesystem is read only.
+            - mountPath: /var/run/ig/wasm-cache
+              name: wasm-cache
+              readOnly: false
       nodeSelector:
         {{- .Values.nodeSelector | toYaml | nindent 8 }}
       affinity:
@@ -290,3 +295,5 @@ spec:
           configMap:
             name: {{ include "gadget.fullname" . }}
             defaultMode: 0o400
+        - name: wasm-cache
+          emptyDir: {}

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/tetratelabs/wazero"
 	wapi "github.com/tetratelabs/wazero/api"
@@ -62,7 +63,7 @@ type wasmOperator struct {
 func newWasmOperator() *wasmOperator {
 	cache, err := wazero.NewCompilationCacheWithDir(cacheDir)
 	if err != nil {
-		logger.DefaultLogger().Debugf("failed to create wasm compilation cache: %v", err)
+		log.Warnf("failed to setup wasm compilation cache, skipping cache: %v", err)
 		return &wasmOperator{}
 	}
 	return &wasmOperator{

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -322,6 +322,11 @@ spec:
             - mountPath: /etc/ig
               name: config
               readOnly: true
+            # We need a dedicated volume to store the wasm cache
+            # otherwise it will fail as the container root filesystem is read only.
+            - mountPath: /var/run/ig/wasm-cache
+              name: wasm-cache
+              readOnly: false
       nodeSelector:
         kubernetes.io/os: linux
       affinity:
@@ -379,3 +384,5 @@ spec:
           configMap:
             name: gadget
             defaultMode: 0o400
+        - name: wasm-cache
+          emptyDir: {}


### PR DESCRIPTION
This change fixes the wasm-cache in Kubernetes cluster. We weren't able to catch this error since logging wasn't configured correctly, and it doesn't happen on minikube (It seems `/var/run `is writeable in minikube but not in AKS). 

Fixes: ef09eaea2e445e393dbbf413d47e2e7918312e08

## Testing Done

### main

```bash
$ make kubectl-gadget
# use 'ghcr.io/mqasimsarfraz/inspektor-gadget:qasim-k8s-wasm-cache' to include log fix
$ ./kubectl-gadget deploy --image=ghcr.io/mqasimsarfraz/inspektor-gadget:qasim-k8s-wasm-cache
$ kubectl logs -n gadget ds/gadget
Found 3 pods, using pod/gadget-s95sg
time="2025-07-16T16:13:36Z" level=warning msg="failed to setup wasm compilation cache, skipping cache: create directory /var/run/ig/wasm-cache: mkdir /var/run/ig: read-only file system"
# few runs to get an idea of gadget runs
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m10,508s
user    0m0,149s
sys     0m0,042s
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m9,135s
user    0m0,174s
sys     0m0,029s
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m8,919s
user    0m0,140s
sys     0m0,036s
```

## with this PR

```
$ make kubectl-gadget
$ ./kubectl-gadget deploy --image=ghcr.io/mqasimsarfraz/inspektor-gadget:qasim-k8s-wasm-cache
$ kubectl logs -n gadget ds/gadget
Found 3 pods, using pod/gadget-cd2wm
time="2025-07-16T16:19:22Z" level=info msg="Config: daemon-log-level=info"
time="2025-07-16T16:19:22Z" level=info msg="Inspektor Gadget version: 0.42.0-52-gf0a9406ee"
# few runs to get an idea of gadget runs
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m10,832s
user    0m0,115s
sys     0m0,035s
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m7,274s
user    0m0,165s
sys     0m0,036s
$ time ./kubectl-gadget run trace_dns:main --timeout 1 --pull always
K8S.NODE                            K8S.NAMESPACE                       K8S.PODNAME                         K8S.CONTAINERNAME                   SRC                                             DST                                             NAMESERVER          COMM                    PID        TID QR  QTYPE              NAME                               RCODE     ADDRESSES                       LATENCY_NS

real    0m7,083s
user    0m0,155s
sys     0m0,035s

```
