### PR TITLE
top_process: UX improvements

### DIFF
--- a/gadgets/top_process/gadget.yaml
+++ b/gadgets/top_process/gadget.yaml
@@ -7,10 +7,59 @@ operator:
   process:
     emitstats: true
     interval: 3s
+    first-interval: 250ms
 datasources:
   processes:
     annotations:
       cli.clear-screen-before: "true"
+    fields:
+      startTimeStr:
+        annotations:
+          columns.alias: 'STARTTIME'
+      priority:
+        annotations:
+          columns.alias: 'PR'
+      nice:
+        annotations:
+          columns.alias: 'NI'
+      cpuTimeStr:
+        annotations:
+          columns.alias: 'TIME+'
+      cpuUsage:
+        annotations:
+          columns.alias: '%CPU'
+      cpuUsageRelative:
+        annotations:
+          columns.alias: '%RELCPU'
+      memoryRelative:
+        annotations:
+          columns.alias: '%MEM'
+      memoryRSS:
+        annotations:
+          columns.alias: 'RES'
+          columns.maxWidth: 12
+      memoryShared:
+        annotations:
+          columns.alias: 'SHR'
+          columns.maxWidth: 12
+      memoryVirtual:
+        annotations:
+          columns.alias: 'VIRT'
+          columns.maxWidth: 12
+      comm:
+        annotations:
+          columns.alias: 'COMMAND'
+          columns.with: 32
+          columns.maxwidth: 80
+          columns.ellipsis: end
+      threadCount:
+        annotations:
+          columns.alias: 'THR'
+          columns.maxWidth: 3
+      state:
+        annotations:
+          columns.alias: 'S'
+          columns.maxWidth: 1
 params:
   custom:
     interval:

--- a/pkg/operators/cli/clioperator.go
+++ b/pkg/operators/cli/clioperator.go
@@ -398,6 +398,7 @@ func (o *cliOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 				// screen later on, otherwise it could be printed multiple
 				// times.
 				if clearScreenBefore {
+					clearScreen()
 					printHeader()
 				}
 				p.SetEventCallback(formatter.EventHandlerFuncArray(headerFuncs...))

--- a/pkg/operators/process/helpers.go
+++ b/pkg/operators/process/helpers.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import "strconv"
+
+func pad2(n int) string {
+	if n < 10 {
+		return "0" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}
+
+func pad3(n int) string {
+	if n < 10 {
+		return "00" + strconv.Itoa(n)
+	} else if n < 100 {
+		return "0" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}

--- a/pkg/operators/process/process.go
+++ b/pkg/operators/process/process.go
@@ -47,9 +47,10 @@ const (
 	Priority = -1000
 
 	// Configuration keys
-	configKeyEnabled  = "operator.process.emitstats"
-	configKeyInterval = "operator.process.interval"
-	configKeyFields   = "operator.process.fields"
+	configKeyEnabled       = "operator.process.emitstats"
+	configKeyInterval      = "operator.process.interval"
+	configKeyFirstInterval = "operator.process.first-interval"
+	configKeyFields        = "operator.process.fields"
 
 	// Default values
 	defaultInterval = 60 * time.Second
@@ -58,11 +59,16 @@ const (
 	fieldPID              = "pid"
 	fieldPPID             = "ppid"
 	fieldComm             = "comm"
+	fieldNice             = "nice"
+	fieldPriority         = "priority"
+	fieldCPUTime          = "cpuTime"
+	fieldCPUTimeStr       = "cpuTimeStr"
 	fieldCPUUsage         = "cpuUsage"
 	fieldCPUUsageRelative = "cpuUsageRelative"
 	fieldMemoryRSS        = "memoryRSS"
 	fieldMemoryVirtual    = "memoryVirtual"
 	fieldMemoryRelative   = "memoryRelative"
+	fieldMemoryShared     = "memoryShared"
 	fieldThreadCount      = "threadCount"
 	fieldState            = "state"
 	fieldUid              = "uid"
@@ -115,6 +121,8 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 		gadgetCtx.Logger().Debugf("Using default interval: %s", interval)
 	}
 
+	firstInterval := viperConfig.GetDuration(configKeyFirstInterval)
+
 	// Get fields from config
 	fields := viperConfig.GetStringSlice(configKeyFields)
 
@@ -125,15 +133,19 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 			fieldPID,
 			fieldPPID,
 			fieldComm,
+			fieldPriority,
+			fieldNice,
 			fieldCPUUsage,
 			fieldCPUUsageRelative,
 			fieldMemoryRSS,
 			fieldMemoryVirtual,
+			fieldMemoryShared,
 			fieldMemoryRelative,
 			fieldThreadCount,
 			fieldState,
 			fieldUid,
 			fieldStartTime,
+			fieldCPUTime,
 		}
 	}
 
@@ -146,9 +158,10 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 	ds.AddAnnotation(api.FetchIntervalAnnotation, interval.String())
 
 	instance := &processOperatorInstance{
-		interval:   interval,
-		done:       make(chan struct{}),
-		dataSource: ds,
+		interval:      interval,
+		firstInterval: firstInterval,
+		done:          make(chan struct{}),
+		dataSource:    ds,
 	}
 
 	// Add fields to the data source based on enabled fields
@@ -178,6 +191,40 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 			if err != nil {
 				return nil, fmt.Errorf("adding comm field: %w", err)
 			}
+		case fieldNice:
+			instance.niceField, err = ds.AddField(fieldNice, api.Kind_Int8, datasource.WithAnnotations(map[string]string{
+				metadatav1.ColumnsAlignmentAnnotation: "right",
+				metadatav1.DescriptionAnnotation:      "The nice value of the process.",
+			}))
+			if err != nil {
+				return nil, fmt.Errorf("adding nice field: %w", err)
+			}
+			requireCPUInfo = true
+		case fieldPriority:
+			instance.priorityField, err = ds.AddField(fieldPriority, api.Kind_Int8, datasource.WithAnnotations(map[string]string{
+				metadatav1.ColumnsAlignmentAnnotation: "right",
+				metadatav1.DescriptionAnnotation:      "The priority of the process.",
+			}))
+			if err != nil {
+				return nil, fmt.Errorf("adding priority field: %w", err)
+			}
+			requireCPUInfo = true
+		case fieldCPUTime:
+			instance.cpuTimeField, err = ds.AddField(fieldCPUTime, api.Kind_Int64, datasource.WithAnnotations(map[string]string{
+				metadatav1.ColumnsHiddenAnnotation: "true",
+				metadatav1.DescriptionAnnotation:   "Total CPU time",
+			}))
+			if err != nil {
+				return nil, fmt.Errorf("adding cpuTime field: %w", err)
+			}
+			instance.cpuTimeStrField, err = ds.AddField(fieldCPUTimeStr, api.Kind_String, datasource.WithAnnotations(map[string]string{
+				metadatav1.DescriptionAnnotation:      "Total CPU time, formatted as duration",
+				metadatav1.ColumnsAlignmentAnnotation: "right",
+				metadatav1.ColumnsMaxWidthAnnotation:  "12",
+			}))
+			if err != nil {
+				return nil, fmt.Errorf("adding cpuTimeStr field: %w", err)
+			}
 		case fieldCPUUsage:
 			instance.cpuField, err = ds.AddField(fieldCPUUsage, api.Kind_Float64, datasource.WithAnnotations(map[string]string{
 				metadatav1.ColumnsPrecisionAnnotation: "1",
@@ -194,7 +241,7 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 				metadatav1.ColumnsPrecisionAnnotation: "1",
 				metadatav1.ColumnsAlignmentAnnotation: "right",
 				metadatav1.DescriptionAnnotation:      "The CPU usage percentage relative to the number of CPUs available.",
-				metadatav1.ColumnsMaxWidthAnnotation:  "16",
+				metadatav1.ColumnsMaxWidthAnnotation:  "8",
 			}))
 			if err != nil {
 				return nil, fmt.Errorf("adding cpuUsageRelative field: %w", err)
@@ -227,10 +274,21 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 				metadatav1.ColumnsAlignmentAnnotation: "right",
 				metadatav1.ColumnsPrecisionAnnotation: "1",
 				metadatav1.DescriptionAnnotation:      "Percentage of RSS memory used relative to available memory.",
-				metadatav1.ColumnsMaxWidthAnnotation:  "14",
+				metadatav1.ColumnsMaxWidthAnnotation:  "8",
 			}))
 			if err != nil {
 				return nil, fmt.Errorf("adding memoryRelative field: %w", err)
+			}
+		case fieldMemoryShared:
+			instance.memorySharedField, err = ds.AddField(fieldMemoryShared+"_raw", api.Kind_Uint64,
+				datasource.WithAnnotations(map[string]string{
+					metadatav1.ColumnsAlignmentAnnotation: "right",
+					metadatav1.DescriptionAnnotation:      "The Shared Memory Size of the process in bytes.",
+				}),
+				datasource.WithTags("type:gadget_bytes"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("adding memoryShared field: %w", err)
 			}
 		case fieldThreadCount:
 			instance.threadCountField, err = ds.AddField(fieldThreadCount, api.Kind_Int32, datasource.WithAnnotations(map[string]string{
@@ -270,6 +328,7 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 			instance.startTimeStrField, err = ds.AddField(fieldStartTimeStr, api.Kind_String, datasource.WithAnnotations(map[string]string{
 				metadatav1.DescriptionAnnotation:     "The time when the process started, represented as a formatted date-time string in RFC3339 format (e.g., \"2023-06-15T14:30:45Z\").",
 				metadatav1.ColumnsEllipsisAnnotation: "start",
+				metadatav1.ColumnsMaxWidthAnnotation: "25",
 			}))
 			if err != nil {
 				return nil, fmt.Errorf("adding startTimeStr field: %w", err)
@@ -300,16 +359,22 @@ func (p *processOperator) Priority() int {
 
 type processOperatorInstance struct {
 	interval            time.Duration
+	firstInterval       time.Duration
 	dataSource          datasource.DataSource
 	done                chan struct{}
 	wg                  sync.WaitGroup
 	pidField            datasource.FieldAccessor
 	ppidField           datasource.FieldAccessor
 	commField           datasource.FieldAccessor
+	priorityField       datasource.FieldAccessor
+	niceField           datasource.FieldAccessor
 	cpuField            datasource.FieldAccessor
+	cpuTimeField        datasource.FieldAccessor
+	cpuTimeStrField     datasource.FieldAccessor
 	cpuRelativeField    datasource.FieldAccessor
 	memoryRSSField      datasource.FieldAccessor
 	memoryVirtualField  datasource.FieldAccessor
+	memorySharedField   datasource.FieldAccessor
 	memoryRelativeField datasource.FieldAccessor
 	threadCountField    datasource.FieldAccessor
 	stateField          datasource.FieldAccessor
@@ -402,6 +467,21 @@ func (p *processOperatorInstance) monitorProcesses(gadgetCtx operators.GadgetCon
 	err := p.collectProcessInfo(gadgetCtx, false)
 	if err != nil {
 		gadgetCtx.Logger().Errorf("Error collecting process info: %v", err)
+	}
+
+	// Run a first interval, if configured, to provide early data
+	if p.firstInterval > 0 {
+		timer := time.NewTimer(p.firstInterval)
+		defer timer.Stop()
+		select {
+		case <-p.done:
+			return
+		case <-timer.C:
+			err := p.collectProcessInfo(gadgetCtx, true)
+			if err != nil {
+				gadgetCtx.Logger().Errorf("Error collecting process info: %v", err)
+			}
+		}
 	}
 
 	ticker := time.NewTicker(p.interval)
@@ -520,6 +600,14 @@ func (p *processOperatorInstance) collectProcessInfo(gadgetCtx operators.GadgetC
 			p.commField.PutString(packet, proc.Comm)
 		}
 
+		if p.priorityField != nil {
+			p.priorityField.PutInt8(packet, int8(proc.Priority))
+		}
+
+		if p.niceField != nil {
+			p.niceField.PutInt8(packet, int8(proc.Nice))
+		}
+
 		if p.cpuField != nil {
 			p.cpuField.PutFloat64(packet, proc.CPUUsage)
 		}
@@ -534,6 +622,10 @@ func (p *processOperatorInstance) collectProcessInfo(gadgetCtx operators.GadgetC
 
 		if p.memoryVirtualField != nil {
 			p.memoryVirtualField.PutUint64(packet, proc.MemoryVirtual)
+		}
+
+		if p.memorySharedField != nil {
+			p.memorySharedField.PutUint64(packet, proc.MemoryShared)
 		}
 
 		if p.memoryRelativeField != nil {
@@ -555,6 +647,16 @@ func (p *processOperatorInstance) collectProcessInfo(gadgetCtx operators.GadgetC
 		if p.startTimeField != nil {
 			p.startTimeField.PutUint64(packet, proc.StartTime)
 			p.startTimeStrField.PutString(packet, proc.StartTimeStr.Format(time.RFC3339))
+		}
+
+		if p.cpuTimeField != nil {
+			p.cpuTimeField.PutUint64(packet, proc.CPUTime)
+
+			d := time.Duration(proc.CPUTime) * time.Millisecond * 10
+			mins := int(d.Minutes())
+			secs := int(d.Seconds()) % 60
+			ms := int(d.Milliseconds() % 1000)
+			p.cpuTimeStrField.PutString(packet, strconv.Itoa(mins)+":"+pad2(secs)+"."+pad3(ms))
 		}
 
 		// Always emit mount namespace ID


### PR DESCRIPTION
This PR contains some UX improvements for the top_process gadget and aligns it more with the `top` command on Linux.

* rename columns for CLI output to match those from 'top' command
* add some maxWidths to shrink output size
* increase width/max-width of `comm` (as it's not limited as usually) and add ellipsis
* add priority, nice, cpuTime / cpuTimeStr and shared memory information
* add first-interval for a faster start (shows first results after 250ms instead of 3s)

## Todo

* [x] shared memory not accurate in all cases (uses `RssFile+RssShmem` now)

## Notes

RSS & SHM values are said to be "inaccurate" in the man pages, but those values are still being used by the tools.

```
Some of these values are inaccurate because of a kernel-
              internal scalability optimization.  If accurate values are
              required, use /proc/pid/smaps or /proc/pid/smaps_rollup
              instead, which are much slower but provide accurate,
              detailed information.
```
[Source](https://man7.org/linux/man-pages/man5/proc_pid_statm.5.html)

## Comparison

### Before

<img width="1113" height="320" alt="Bildschirmfoto 2025-07-22 um 11 14 29" src="https://github.com/user-attachments/assets/14bcc1a3-a8df-4385-bc0c-40f9ef22ba10" />

### After

<img width="1155" height="321" alt="Bildschirmfoto 2025-07-22 um 11 13 12" src="https://github.com/user-attachments/assets/f649db90-0258-43c6-a563-5c3599595adf" />
