### PR TITLE
traceloop: more space for the parameters column

### DIFF
--- a/gadgets/traceloop/gadget.yaml
+++ b/gadgets/traceloop/gadget.yaml
@@ -17,6 +17,7 @@ datasources:
         annotations:
           description: CPU number where the syscall was executed
           columns.maxwidth: 4
+          columns.hidden: true
       pid:
         annotations:
           template: pid
@@ -29,7 +30,7 @@ datasources:
       parameters:
         annotations:
           description: Syscall's parameters
-          columns.width: 20
+          columns.width: 64
       ret:
         annotations:
           description: Syscall's return value


### PR DESCRIPTION
Before:
```
RUNTIME.CONTAINERNAME                           CPU         PID COMM             SYSCALL                       PARAMETERS                                  RET
test                                            2        812636 cat              openat                        dfd=4294967196, filename="/etc…               3
```

After:
```
RUNTIME.CONTAINERNAME                   PID COMM              SYSCALL            PARAMETERS                                                                RET
test                                 815052 cat               openat             dfd=4294967196, filename="/etc/os-releaseaa", flags=0, mode=0      -1 (Permi…
```
