### PR TITLE
Ref: Update filter-gadgets step logic in check-artifacthub-tags workflow

### DIFF
--- a/.github/workflows/check-artifacthub-tags.yml
+++ b/.github/workflows/check-artifacthub-tags.yml
@@ -26,8 +26,15 @@ jobs:
     - name: Gather valid gadgets
       id: filter-gadgets
       run: |
-        gadgets=$(find gadgets -name 'artifacthub-pkg.yml' | cut -d'/' -f2 | perl -p -e 's/_/-/g')
-        gadgets=$(echo "$gadgets" | tr '\n' ',' | sed 's/,$//')
+        gadgets=""
+        for file in $(find gadgets -name 'artifacthub-pkg.yml'); do
+          name=$(grep '^name:' "$file" | awk -F': ' '{print $2}' | tr -d '"' | sed 's/ /-/g')
+          if [ -n "$name" ]; then
+            gadgets+="$name,"
+          fi
+        done
+        # Remove trailing comma
+        gadgets=${gadgets%,}
 
         echo "valid-gadgets-string=${gadgets}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Description

Updated logic for filtering gadget names in `check-artifacthub-tags` workflow. Which checks for existence of offical and cncf flags set to true on images owned by inspektor-gadget.

Previously we were extracting gadget names from directory name. But to handle edge cases with naming convention, updating logic to extract names from artifacthub-pkg.yml file of each indivdual gadget.

### Edge Case of naming convention

The previous workflow will fail to validate the gadget `advise_networkpolicy`.
Which doesn't fit into prev filtering rule, with updated filtering logic - this gadget will also be validated correctly.

### Other considerations

We need to discuss some kind of naming convention for gadget names to maintain consistency across gadgets.

## Testing done

This new edge case validation is done through [this workflow](https://github.com/4rivappa/inspektor-gadget/actions/runs/16575726338/job/46879420513)
