### PR TITLE
tests: Fix usage of same ocihandler instance

### DIFF
--- a/gadgets/ci/image_inspect/test/unit/image_inspect_test.go
+++ b/gadgets/ci/image_inspect/test/unit/image_inspect_test.go
@@ -196,13 +196,10 @@ func TestExtraInfoLeak(t *testing.T) {
 
 func extractGadgetInfo(extraInfo bool) (*api.GadgetInfo, error) {
 	image := gadgetrunner.GetGadgetImageName("ci/image_inspect")
+	ocihandlerOp := ocihandler.New()
 
 	opGlobalParams := make(map[string]*params.Params)
-	ociParams := apihelpers.ToParamDescs(ocihandler.OciHandler.InstanceParams()).ToParams()
-
-	ocihandler.OciHandler.Init(ociParams)
-
-	opGlobalParams["oci"] = apihelpers.ToParamDescs(ocihandler.OciHandler.GlobalParams()).ToParams()
+	opGlobalParams["oci"] = apihelpers.ToParamDescs(ocihandlerOp.GlobalParams()).ToParams()
 	verifyImage := "false"
 	if verifyImage == "true" || verifyImage == "false" {
 		opGlobalParams["oci"].Set("verify-image", verifyImage)
@@ -214,11 +211,11 @@ func extractGadgetInfo(extraInfo bool) (*api.GadgetInfo, error) {
 	runtimeParams := runtime.ParamDescs().ToParams()
 
 	ops := make([]operators.DataOperator, 0)
-	err := ocihandler.OciHandler.Init(opGlobalParams["oci"])
+	err := ocihandlerOp.Init(opGlobalParams["oci"])
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing OCI handler: %w\n", err)
 	}
-	ops = append(ops, ocihandler.OciHandler)
+	ops = append(ops, ocihandlerOp)
 
 	gadgetCtx := gadgetcontext.New(
 		context.Background(),
@@ -228,6 +225,7 @@ func extractGadgetInfo(extraInfo bool) (*api.GadgetInfo, error) {
 		gadgetcontext.IncludeExtraInfo(extraInfo),
 	)
 
+	ociParams := apihelpers.ToParamDescs(ocihandlerOp.InstanceParams()).ToParams()
 	paramValueMap := make(map[string]string)
 	ociParams.CopyToMap(paramValueMap, "operator.oci.")
 

--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -62,11 +62,18 @@ type ociHandler struct {
 	globalParams *params.Params
 }
 
+func New() *ociHandler {
+	return &ociHandler{}
+}
+
 func (o *ociHandler) Name() string {
 	return "oci"
 }
 
 func (o *ociHandler) Init(params *params.Params) error {
+	if o.globalParams != nil {
+		return fmt.Errorf("ociHandler already initialized")
+	}
 	o.globalParams = params
 	return nil
 }
@@ -562,4 +569,4 @@ func (o *ociHandler) Priority() int {
 }
 
 // OciHandler is a singleton of ociHandler
-var OciHandler = &ociHandler{}
+var OciHandler = New()

--- a/pkg/testing/gadgetrunner/gadgetrunner.go
+++ b/pkg/testing/gadgetrunner/gadgetrunner.go
@@ -173,7 +173,7 @@ func (g *GadgetRunner[T]) RunGadget() {
 		gadgetOperatorOpts = append(gadgetOperatorOpts, simple.OnStart(g.onGadgetRun))
 	}
 
-	g.DataOperator = append(g.DataOperator, ocihandler.OciHandler)
+	g.DataOperator = append(g.DataOperator, ocihandler.New())
 	for _, dataOperator := range operators.GetDataOperators() {
 		g.DataOperator = append(g.DataOperator, dataOperator)
 	}


### PR DESCRIPTION
The same global Ocihandler was used in all the tests, this caused issues as they this object is not thread safe. Add an explicit error to avoid the same instance being initialized multiple times and create different instances for the tests around.

Fixes #4661