### PR TITLE
wasm: only log cache setup failure for root user

### DIFF
--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -63,7 +64,9 @@ type wasmOperator struct {
 func newWasmOperator() *wasmOperator {
 	cache, err := wazero.NewCompilationCacheWithDir(cacheDir)
 	if err != nil {
-		log.Warnf("failed to setup wasm compilation cache, skipping cache: %v", err)
+		if os.Geteuid() == 0 {
+			log.Warnf("failed to setup wasm compilation cache, skipping cache: %v", err)
+		}
 		return &wasmOperator{}
 	}
 	return &wasmOperator{


### PR DESCRIPTION
This PR updates the logging behavior to only log a failure when the current user is root. The motivation is to avoid unnecessary logs in non-root scenarios, such as in [this case](https://github.com/inspektor-gadget/inspektor-gadget/pull/4721#issuecomment-3159922846) given we expect users to run with root e.g:

- https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/runtime/local/local.go#L33
- https://github.com/inspektor-gadget/inspektor-gadget/blob/main/cmd/ig/daemon.go#L103
- 

The original intent behind the logging was to detect and report issues like a read-only `cacheDir`.

Fixes: f0a9406ee617a8412b774330b989d922601b7ba3

cc: @chewi 