### PR TITLE
op/sort: Append the fields when same DS is specified

### DIFF
--- a/pkg/operators/sort/sort.go
+++ b/pkg/operators/sort/sort.go
@@ -172,8 +172,7 @@ func getCompareFunc(f datasource.FieldAccessor, negate bool) func(i, j datasourc
 	}
 }
 
-func (s *sortOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
-	s.sorters = make(map[datasource.DataSource][]func(i datasource.Data, j datasource.Data) bool)
+func (s *sortOperatorInstance) getFieldsByDs() map[string][]string {
 	dsSorts := make(map[string][]string)
 	for _, srt := range strings.Split(s.sortBy, ";") {
 		dsFields := strings.Split(srt, ":")
@@ -185,9 +184,19 @@ func (s *sortOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 		}
 		fields := strings.Split(fieldList, ",")
 		if len(fields) > 2 || fields[0] != "" {
-			dsSorts[dsName] = fields
+			if dsSorts[dsName] == nil {
+				dsSorts[dsName] = fields
+			} else {
+				dsSorts[dsName] = append(dsSorts[dsName], fields...)
+			}
 		}
 	}
+	return dsSorts
+}
+
+func (s *sortOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
+	s.sorters = make(map[datasource.DataSource][]func(i datasource.Data, j datasource.Data) bool)
+	dsSorts := s.getFieldsByDs()
 
 	// Check edge cases
 	dsSpecific := true

--- a/pkg/operators/sort/sort_test.go
+++ b/pkg/operators/sort/sort_test.go
@@ -227,3 +227,21 @@ func TestMultiple(t *testing.T) {
 		"string,number",
 	)
 }
+
+func TestGetFieldsByDsSimple(t *testing.T) {
+	s := &sortOperatorInstance{sortBy: "foo:string;bar:number"}
+	fieldsByDs := s.getFieldsByDs()
+	assert.EqualValues(t, map[string][]string{"foo": {"string"}, "bar": {"number"}}, fieldsByDs)
+}
+
+func TestGetFieldsByDsTwiceSameDs(t *testing.T) {
+	s := &sortOperatorInstance{sortBy: "foo:string;foo:number"}
+	fieldsByDs := s.getFieldsByDs()
+	assert.EqualValues(t, map[string][]string{"foo": {"string", "number"}}, fieldsByDs)
+}
+
+func TestGetFieldsByDsFieldSorting(t *testing.T) {
+	s := &sortOperatorInstance{sortBy: "foo:string,number"}
+	fieldsByDs := s.getFieldsByDs()
+	assert.EqualValues(t, map[string][]string{"foo": {"string", "number"}}, fieldsByDs)
+}


### PR DESCRIPTION
IMO we should append instead of overwriting the previously specified fields

Ran into this issue when I ran `./kubectl-gadget run top_tcp --sort "tcp:-sent_raw;tcp:-received_raw"`
One could argue this is user error (specifying the same ds multiple times), but if that is the case there should be a warning or an error message