### PR TITLE
ebpf: Support configuring length of big fields for gadgets

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -60,6 +60,7 @@ GADGETS ?= \
 	snapshot_process \
 	snapshot_socket \
 	ci/datasource-containers \
+	ci/flex_string \
 	ci/inner_fields \
 	ci/sched_cls_drop \
 	ci/image_inspect \

--- a/gadgets/ci/flex_string/gadget.yaml
+++ b/gadgets/ci/flex_string/gadget.yaml
@@ -1,0 +1,5 @@
+name: flex_string
+description: gadget used by the CI
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://inspektor-gadget.io/docs/latest/
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget

--- a/gadgets/ci/flex_string/program.bpf.c
+++ b/gadgets/ci/flex_string/program.bpf.c
@@ -1,0 +1,48 @@
+// program.bpf.c
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/macros.h>
+#include <gadget/types.h>
+#include <gadget/filter.h>
+#include <gadget/filesystem.h>
+
+struct event {
+	__u32 foo;
+	gadget_flex_string fname[255];
+};
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER(open, events, event);
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int enter_openat(struct syscall_trace_enter *ctx)
+{
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	struct event *event;
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	event->foo = 42;
+
+	bool fname_exists = bpf_core_field_exists(event->fname);
+	if (fname_exists) {
+		char *fname = (char *)ctx->args[1];
+		bpf_probe_read_user_str(
+			event->fname, bpf_core_field_size(event->fname), fname);
+	}
+
+	unsigned int event_size = bpf_core_type_size(struct event);
+	gadget_submit_buf(ctx, &events, event, event_size);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/ci/flex_string/test/unit/flex_string_test.go
+++ b/gadgets/ci/flex_string/test/unit/flex_string_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	utilstest "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+type Event struct {
+	Foo   uint32 `json:"foo"`
+	Fname string `json:"fname"`
+}
+
+func TestFlexString(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+	t.Parallel()
+
+	// As this gadget has / on this name, we need to use the full path to avoid
+	// a lookup failure when running it.
+	image := "ci/flex_string"
+	if _, ok := os.LookupEnv("GADGET_REPOSITORY"); !ok {
+		image = fmt.Sprintf("ghcr.io/inspektor-gadget/gadget/%s", image)
+	}
+
+	type testDef struct {
+		name          string
+		fname         string
+		fnameSize     uint32
+		expectedEvent *Event
+	}
+
+	const (
+		path254 = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" // 254 characters
+		path16  = "abcdefghijklmnop"                                                                                                                                                                                                                                         // 16 characters
+	)
+
+	tests := []testDef{
+		{
+			name:      "path254",
+			fname:     path254,
+			fnameSize: 255,
+			expectedEvent: &Event{
+				Foo:   42,
+				Fname: path254,
+			},
+		},
+		{
+			name:      "path16",
+			fname:     path16,
+			fnameSize: 32,
+			expectedEvent: &Event{
+				Foo:   42,
+				Fname: path16,
+			},
+		},
+		{
+			name:      "path254-trimmed",
+			fname:     path254,
+			fnameSize: 8,
+			expectedEvent: &Event{
+				Foo:   42,
+				Fname: path254[:7], // 8 - 1 for null terminator
+			},
+		},
+		{
+			name:      "disabled",
+			fname:     path254,
+			fnameSize: 0,
+			expectedEvent: &Event{
+				Foo:   42,
+				Fname: "",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runnerConfig := &utilstest.RunnerConfig{}
+			runner := utilstest.NewRunnerWithTest(t, runnerConfig)
+			mntnsFilterMap := utilstest.CreateMntNsFilterMap(t, runner.Info.MountNsID)
+
+			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+				utilstest.RunWithRunner(t, runner, generateEvent(test.fname))
+				return nil
+			}
+
+			opts := gadgetrunner.GadgetRunnerOpts[Event]{
+				Image:          image,
+				Timeout:        5 * time.Second,
+				OnGadgetRun:    onGadgetRun,
+				MntnsFilterMap: mntnsFilterMap,
+				ParamValues: map[string]string{
+					"operator.oci.ebpf.fname-size": fmt.Sprintf("%d", test.fnameSize),
+				},
+			}
+			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+			gadgetRunner.RunGadget()
+
+			utilstest.ExpectAtLeastOneEvent(func(info *utilstest.RunnerInfo, _ int) *Event {
+				return test.expectedEvent
+			})(t, runner.Info, 0, gadgetRunner.CapturedEvents)
+		})
+	}
+}
+
+// generateEvent simulates an event by opening and closing a file
+func generateEvent(path string) func() error {
+	return func() error {
+		fd, err := unix.Open(path, 0, 0)
+		if err == nil {
+			unix.Close(fd)
+		}
+
+		return nil
+	}
+}

--- a/gadgets/trace_dns/program.bpf.c
+++ b/gadgets/trace_dns/program.bpf.c
@@ -20,9 +20,6 @@
 #include <gadget/sockets-map.h>
 #include <gadget/filter.h>
 
-// Use a custom size for these fields until their size can be configured
-#define TRACE_DNS_PATH_MAX 512
-
 unsigned long long load_byte(const void *skb,
 			     unsigned long long off) asm("llvm.bpf.load.byte");
 unsigned long long load_half(const void *skb,
@@ -70,6 +67,10 @@ enum pkt_type_t : __u8 {
 	KERNEL,
 };
 
+#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
+#pragma clang attribute push(__attribute__((preserve_access_index)), \
+			     apply_to = record)
+#endif
 struct event_t {
 	gadget_timestamp timestamp_raw;
 	struct gadget_l4endpoint_t src;
@@ -77,8 +78,8 @@ struct event_t {
 	struct gadget_l3endpoint_t nameserver;
 	gadget_netns_id netns_id;
 	struct gadget_process proc;
-	char cwd[TRACE_DNS_PATH_MAX];
-	char exepath[TRACE_DNS_PATH_MAX];
+	gadget_flex_string cwd[GADGET_SE_PATH_MAX];
+	gadget_flex_string exepath[GADGET_SE_PATH_MAX];
 
 	enum pkt_type_t pkt_type_raw;
 	gadget_duration
@@ -87,6 +88,10 @@ struct event_t {
 	__u16 dns_off; // DNS offset in the packet
 	__u32 data_len;
 };
+
+#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
+#pragma clang attribute pop
+#endif
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
@@ -291,8 +296,10 @@ int ig_trace_dns(struct __sk_buff *skb)
 	event->latency_ns_raw = 0;
 	event->proc = empty_proc;
 	if (paths) {
-		event->cwd[0] = '\0';
-		event->exepath[0] = '\0';
+		if (bpf_core_field_exists(event->cwd))
+			event->cwd[0] = '\0';
+		if (bpf_core_field_exists(event->exepath))
+			event->exepath[0] = '\0';
 	}
 
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
@@ -340,23 +347,25 @@ int ig_trace_dns(struct __sk_buff *skb)
 	gadget_process_populate_from_socket(skb_val, &event->proc);
 
 	if (paths && skb_val != NULL) {
-		unsigned int cwd_len = min(bpf_core_field_size(skb_val->cwd),
-					   TRACE_DNS_PATH_MAX);
-		unsigned int exepath_len =
-			min(bpf_core_field_size(skb_val->exepath),
-			    TRACE_DNS_PATH_MAX);
-		bool cwd_exists = bpf_core_field_exists(skb_val->cwd);
-		bool exepath_exists = bpf_core_field_exists(skb_val->exepath);
 		bool probe_read_kernel_str_exists = bpf_core_enum_value_exists(
 			enum bpf_func_id, BPF_FUNC_probe_read_kernel_str);
 
 		if (probe_read_kernel_str_exists) {
+			bool cwd_exists = bpf_core_field_exists(skb_val->cwd);
+			bool exepath_exists =
+				bpf_core_field_exists(skb_val->exepath);
 			if (cwd_exists) {
+				unsigned int cwd_len =
+					min(bpf_core_field_size(event->cwd),
+					    bpf_core_field_size(skb_val->cwd));
 				bpf_probe_read_kernel_str(&event->cwd, cwd_len,
 							  skb_val->cwd);
 			}
 
 			if (exepath_exists) {
+				unsigned int exepath_len = min(
+					bpf_core_field_size(event->exepath),
+					bpf_core_field_size(skb_val->exepath));
 				bpf_probe_read_kernel_str(&event->exepath,
 							  exepath_len,
 							  skb_val->exepath);
@@ -423,8 +432,9 @@ int ig_trace_dns(struct __sk_buff *skb)
 	}
 
 	__u64 skb_len = skb->len;
+	unsigned int headersize = bpf_core_type_size(struct event_t);
 	bpf_perf_event_output(skb, &events, skb_len << 32 | BPF_F_CURRENT_CPU,
-			      event, sizeof(*event));
+			      event, headersize);
 
 	return 0;
 }

--- a/include/gadget/types.h
+++ b/include/gadget/types.h
@@ -73,6 +73,16 @@ typedef __u32 gadget_file_flags;
 
 typedef __u32 gadget_kernel_stack;
 
+// gadget_flex_string is used to define c strings which max size can be set by
+// the user at runtime. This is done by the bpf operator by exposing a
+// <fieldName>-size parameter to the user.
+typedef char gadget_flex_string;
+
+// gadget_flex_bytes is used to define byte arrays which max size can be set by
+// the user at runtime. This is done by the bpf operator by exposing a
+// <fieldName>-size parameter to the user.
+typedef __u8 gadget_flex_bytes;
+
 struct gadget_user_stack {
 	// Leave fields as 0 to disable user stacks.
 

--- a/pkg/operators/ebpf/btf.go
+++ b/pkg/operators/ebpf/btf.go
@@ -1,0 +1,288 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpfoperator
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/cilium/ebpf/btf"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/btfhelpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
+)
+
+func flexStringParamName(name string) string {
+	return fmt.Sprintf("%s-size", name)
+}
+
+func typeIsFlexString(typ btf.Type) bool {
+	_, typeNames := btfhelpers.GetType(typ)
+
+	// only check the top type name to avoid issues if somebody does something like:
+	// typedef char              gadget_se_exepath;
+	// typedef gadget_se_exepath gadget_se_cwd;
+	if len(typeNames) == 0 {
+		return false
+	}
+
+	switch typeNames[0] {
+	case types.FlexStringTypeName, types.FlexBytesTypeName:
+		return true
+	default:
+		return false
+	}
+}
+
+func (i *ebpfInstance) fixFlexStrings(typesCpy *btf.Spec) (*btf.Spec, error) {
+	uint32T := &btf.Int{
+		Size:     4,
+		Encoding: btf.Unsigned,
+	}
+	charT := &btf.Int{
+		Name:     "char",
+		Size:     1,
+		Encoding: btf.Signed, // TODO: Why ebpf operator requires signed for char?
+	}
+
+	types := []btf.Type{}
+
+	for typ, err := range typesCpy.All() {
+		if err != nil {
+			return nil, fmt.Errorf("getting type: %w", err)
+		}
+
+		eventStructure, ok := typ.(*btf.Struct)
+		if !ok {
+			continue
+		}
+
+		found := false
+
+		for _, member := range eventStructure.Members {
+			if !typeIsFlexString(member.Type) {
+				continue
+			}
+
+			arr, ok := member.Type.(*btf.Array)
+			if !ok {
+				return nil, fmt.Errorf("type is not an array: %s", member.Type.TypeName())
+			}
+			under := btfhelpers.ResolveType(arr.Type)
+
+			intT, ok := under.(*btf.Int)
+			if !ok || intT.Size != 1 {
+				return nil, fmt.Errorf("array type is not 1-byte big: %s", member.Type.TypeName())
+			}
+
+			var fieldSize int
+
+			fieldSizeStr, ok := i.paramValues[flexStringParamName(member.Name)]
+			if !ok {
+				fieldSize, err = btf.Sizeof(member.Type)
+				if err != nil {
+					return nil, fmt.Errorf("getting size of member %q in struct %q: %w",
+						member.Name, eventStructure.Name, err)
+				}
+			} else {
+				fieldSize, err = strconv.Atoi(fieldSizeStr)
+				if err != nil {
+					return nil, fmt.Errorf("parsing size for member %q in struct %q: %w", member.Name, eventStructure.Name, err)
+				}
+			}
+
+			i.logger.Debugf("Fixing member %q in struct %q with size %d\n", member.Name, eventStructure.Name, fieldSize)
+
+			if fieldSize == 0 {
+				// If the size is 0, we remove the member
+				if err := removeBTFStructMember(eventStructure, member.Name); err != nil {
+					return nil, fmt.Errorf("removing member %q from struct %q: %w", member.Name, eventStructure.Name, err)
+				}
+			} else {
+
+				// Do this here to keep CodeQL happy, otherwise it complains about
+				// possible integer overflow in the uint32 conversion
+				if fieldSize < 0 || fieldSize > int(math.MaxUint32) {
+					return nil, fmt.Errorf("size for member %q in struct %q out of uint32 range: %d", member.Name, eventStructure.Name, fieldSize)
+				}
+
+				seType := &btf.Array{
+					Index:  uint32T,
+					Type:   charT,
+					Nelems: uint32(fieldSize),
+				}
+				if err := replaceBTFStructMember(eventStructure, member.Name, seType); err != nil {
+					return nil, fmt.Errorf("replacing member %q in struct %q: %w", member.Name, eventStructure.Name, err)
+				}
+			}
+
+			found = true
+		}
+
+		if found {
+			types = append(types, eventStructure)
+		}
+	}
+
+	// Now we need to fix the size of the maps that are using these structures
+	for _, m := range i.collectionSpec.Maps {
+		if m.Value == nil || m.Key == nil {
+			continue
+		}
+
+		for _, typ := range types {
+			// we need to compare the IDs because we can't compare the types
+			// directly as one is a copy of the other
+			typeID, err := typesCpy.TypeID(typ)
+			if err != nil {
+				return nil, fmt.Errorf("getting type ID: %w", err)
+			}
+
+			valueTypeID, err := i.collectionSpec.Types.TypeID(m.Value)
+			if err != nil {
+				return nil, fmt.Errorf("getting map type ID: %w", err)
+			}
+			if typeID == valueTypeID {
+				m.Value = typ
+				s, err := btf.Sizeof(typ)
+				if err != nil {
+					return nil, fmt.Errorf("getting size of type %s: %w", typ.TypeName(), err)
+				}
+				m.ValueSize = uint32(s)
+			}
+
+			keyTypeID, err := i.collectionSpec.Types.TypeID(m.Key)
+			if err != nil {
+				return nil, fmt.Errorf("getting map type ID: %w", err)
+			}
+			if typeID == keyTypeID {
+				m.Key = typ
+				s, err := btf.Sizeof(typ)
+				if err != nil {
+					return nil, fmt.Errorf("getting size of type %s: %w", typ.TypeName(), err)
+				}
+				m.KeySize = uint32(s)
+			}
+		}
+	}
+
+	types = append(types, uint32T, charT)
+
+	ret, err := btfhelpers.BuildSpec(types)
+	if err != nil {
+		return nil, fmt.Errorf("building BTF spec for event structure: %w", err)
+	}
+
+	return ret, nil
+}
+
+func findBTFStructMemberIndex(s *btf.Struct, memberName string) (int, error) {
+	for i, m := range s.Members {
+		if m.Name == memberName {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("member %q not found in struct %q", memberName, s.Name)
+}
+
+func removeBTFStructMember(s *btf.Struct, memberName string) error {
+	return replaceBTFStructMember(s, memberName, nil)
+}
+
+// replaceBTFStructMember replaces memberName in struct s with typ. If typ is
+// nil, the member is removed.
+func replaceBTFStructMember(s *btf.Struct, memberName string, typ btf.Type) error {
+	memberIdx, err := findBTFStructMemberIndex(s, memberName)
+	if err != nil {
+		return err
+	}
+
+	member := &s.Members[memberIdx]
+
+	memberSize, err := btf.Sizeof(member.Type)
+	if err != nil {
+		return fmt.Errorf("getting size of member %q in struct %q: %w",
+			memberName, s.Name, err)
+	}
+
+	newSize := int(0)
+	if typ != nil {
+		var err error
+		newSize, err = btf.Sizeof(typ)
+		if err != nil {
+			return fmt.Errorf("getting size of new type for member %q in struct %q: %w", memberName, s.Name, err)
+		}
+
+		if newSize > memberSize {
+			return fmt.Errorf("new size %d is bigger than current size %d for member %q in struct %q",
+				newSize, memberSize, memberName, s.Name)
+		}
+
+		member.Type = typ
+	}
+
+	sizeDiff := memberSize - newSize
+	s.Size -= uint32(sizeDiff)
+
+	// shift all members after the resized one
+	for i := memberIdx + 1; i < len(s.Members); i++ {
+		s.Members[i].Offset -= btf.Bits(sizeDiff * 8)
+	}
+
+	if typ == nil {
+		// remove the member
+		s.Members = append(s.Members[:memberIdx], s.Members[memberIdx+1:]...)
+	}
+
+	return nil
+}
+
+func (i *ebpfInstance) populateVariableSizeParams() error {
+	for typ, err := range i.btfTypes.All() {
+		if err != nil {
+			return fmt.Errorf("iterating over types: %w", err)
+		}
+
+		typStruct, ok := typ.(*btf.Struct)
+		if !ok {
+			continue
+		}
+
+		for _, member := range typStruct.Members {
+			if !typeIsFlexString(member.Type) {
+				continue
+			}
+
+			memberSize, err := btf.Sizeof(member.Type)
+			if err != nil {
+				return fmt.Errorf("getting size of member %q in struct %q: %w",
+					member.Name, typStruct.Name, err)
+			}
+
+			paramName := flexStringParamName(member.Name)
+			i.params[paramName] = &param{
+				Param: &api.Param{
+					Key:          paramName,
+					Description:  fmt.Sprintf("Size of the %s field", member.Name),
+					TypeHint:     api.TypeInt,
+					DefaultValue: fmt.Sprintf("%d", memberSize),
+				},
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/operators/ebpf/iter.go
+++ b/pkg/operators/ebpf/iter.go
@@ -111,7 +111,7 @@ func (i *ebpfInstance) populateIterators(t btf.Type, varName string) error {
 	}
 
 	var btfStruct *btf.Struct
-	if err := i.collectionSpec.Types.TypeByName(structName, &btfStruct); err != nil {
+	if err := i.btfTypes.TypeByName(structName, &btfStruct); err != nil {
 		return fmt.Errorf("finding struct %q in eBPF object: %w", structName, err)
 	}
 

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -97,7 +97,7 @@ func (i *ebpfInstance) populateTracer(t btf.Type, varName string) error {
 	}
 
 	var btfStruct *btf.Struct
-	if err := i.collectionSpec.Types.TypeByName(structName, &btfStruct); err != nil {
+	if err := i.btfTypes.TypeByName(structName, &btfStruct); err != nil {
 		return fmt.Errorf("finding struct %q in eBPF object: %w", structName, err)
 	}
 

--- a/pkg/operators/ebpf/types/types.go
+++ b/pkg/operators/ebpf/types/types.go
@@ -43,6 +43,8 @@ const (
 	ParentTypeName      = "gadget_parent"
 	FileModeTypeName    = "gadget_file_mode"
 	FileFlagsTypeName   = "gadget_file_flags"
+	FlexStringTypeName  = "gadget_flex_string"
+	FlexBytesTypeName   = "gadget_flex_bytes"
 
 	// Metrics
 	CounterU32TypeName       = "gadget_counter__u32"

--- a/pkg/operators/socketenricher/socketenricher.go
+++ b/pkg/operators/socketenricher/socketenricher.go
@@ -232,6 +232,8 @@ func (i *SocketEnricherInstance) SetSocketEnricherMap(m *ebpf.Map) {
 }
 
 func init() {
-	op := &SocketEnricher{}
+	op := &SocketEnricher{
+		seConfig: &tracer.Config{},
+	}
 	operators.RegisterDataOperator(op)
 }


### PR DESCRIPTION
Some gadgets provide some fields that can be quite big (cwd, exepath, etc). In some scenarios it's needed to change their maximum size to save memory. This commit completes the work initiated in a9ceda8 ("gadgets/trace_dns: Use optional fields on socket enricher") by allowing users to set the max size of expensive fields in the event structure. This is done by creating a new BTF spec with the modified structures and passing it as a target relocation.

This PR is an alternative to #4688 as it covers all gadgets, not the only ones using the socket enricher.

### Testing

```bash 

# 0. Compile ig and the trace_exec gadgets

# 1.  Run trace_exec with default parameters
$ sudo ig run trace_exec --verify-image=false  --fields=+exepath,+cwd --paths
```

See how the size of the exec map is 7288 bytes

```bash
$ sudo bpftool map list name execs
3009: hash  name execs  flags 0x0
        key 4B  value 7288B  max_entries 1024  memlock 7773888B
        btf_id 4872
        pids ig(2472139)
```

Running the gadget with some custom values for the sizes reduces the size of that map to 1672

```bash
$ sudo ig run trace_exec --verify-image=false  --fields=+exepath,+cwd --paths --exepath-size=8 --cwd-size=8 --args-size=512
```

```bash
$ sudo bpftool map list name execs
3041: hash  name execs  flags 0x0
        key 4B  value 1672B  max_entries 1024  memlock 1843392B
        btf_id 4927
        pids ig(2472368)
```

### TODO
- [x] Documentation: How to use and how to implement gadgets that make use of this 
- [x] Testing 
- [x] Should we support setting fields to size 0 (disabling) fields in all gadgets?
- [ ] Use in other gadgets?

### Discussion

This commit bumps the default path len for trace_exec to 4096 bytes, it was 512 before this. Is this ok? 

