### PR TITLE
top_process: add count annotation / parameter

### DIFF
--- a/gadgets/top_process/gadget.yaml
+++ b/gadgets/top_process/gadget.yaml
@@ -70,3 +70,11 @@ params:
           process:
             interval: >-
               {{call .getParamValue "custom.interval"}}
+    count:
+      description: "number of reports"
+      defaultValue: 0
+      patch:
+        operator:
+          process:
+            count: >-
+              {{call .getParamValue "custom.count"}}


### PR DESCRIPTION
This adds a `--count` parameter and matching annotation to the top_process gadget / process operator to limit the number of times the operator fetches the metrics.

Requires #3485 

Partially implements #4595 (missing "closing" the output, which is out of scope here).