### PR TITLE
Dockerfiles: Specify IMAGE for linter.

### DIFF
--- a/Dockerfiles/linter.Dockerfile
+++ b/Dockerfiles/linter.Dockerfile
@@ -1,4 +1,5 @@
-ARG IMAGE
+# This version number must be kept in sync with CI workflow lint one.
+ARG IMAGE=golangci/golangci-lint:v2.1.6@sha256:568ee1c1c53493575fa9494e280e579ac9ca865787bafe4df3023ae59ecf299b
 FROM ${IMAGE}
 
 # The timeout specified below is used by 'make lint'. Please keep in sync with


### PR DESCRIPTION
This avoids the following warning when building the image: 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG ${IMAGE} results in empty or invalid base image name (line 2)