### PR TITLE
ci: Workaround failing TestTraceExec

### DIFF
--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -63,7 +63,9 @@ func TestTraceExec(t *testing.T) {
 	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
 	require.NoError(t, err, "new container factory")
 	containerName := "test-trace-exec"
-	containerImage := gadgettesting.GccImage
+	// TODO: It should use gadgettesting.GccImage, but the latest tag on that
+	// image is breaking this test. See issue #4810 for more details.
+	containerImage := "ghcr.io/inspektor-gadget/ci/gcc:test"
 
 	execProgram := `
 #define _GNU_SOURCE


### PR DESCRIPTION
Use a different tag on the gcc image as the previous one was making the test fail. See issue #4810 for more details.

