### PR TITLE
[RFC] security: add VEX documents

### DIFF
--- a/.vex/v0.41.0.vex.json
+++ b/.vex/v0.41.0.vex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v0.41.0/v0.41.0.vex.json",
+  "author": "Inspektor Gadget Security Team <security@inspektor-gadget.io>",
+  "timestamp": "2025-08-21T08:52:32.416055456+02:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-54388"
+      },
+      "timestamp": "2025-08-21T08:52:32.416057292+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/inspektor-gadget/inspektor-gadget@v0.41.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/.vex/v0.42.0.vex.json
+++ b/.vex/v0.42.0.vex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v0.42.0/v0.42.0.vex.json",
+  "author": "Inspektor Gadget Security Team <security@inspektor-gadget.io>",
+  "timestamp": "2025-08-21T08:52:50.431237874+02:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-54388"
+      },
+      "timestamp": "2025-08-21T08:52:50.431242261+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/inspektor-gadget/inspektor-gadget@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,3 +17,77 @@ It will then create a non-public issue specific to security.
 If you do not know which information you need to fill out when using the first option, then the second option is the way to go.
 
 In all cases, we ask that you do not open a public issue.
+
+## Vulnerability Exploitability eXchange (VEX)
+
+VEX (Vulnerability Exploitability eXchange) is a standard for communicating the
+exploitability of known vulnerabilities in software projects.
+
+Inspektor Gadget publishes VEX documents to provide a clear, machine-readable
+assessment of our software's relationship to known vulnerabilities (CVEs). VEX
+helps users and security tools to:
+- Suppress false positives for vulnerabilities that do not affect our project.
+- Understand why a specific vulnerability is or is not exploitable in our code.
+
+Our VEX documents follow the [OpenVEX specification](https://openvex.dev/).
+
+The VEX statements are not exhaustive due to resource constraints. As of today,
+we don't have a commitment to publish VEX statements for all known
+vulnerabilities. When we check if a vulnerability applies to Inspektor Gadget,
+we use VEX statements as the primary method to record and communicate our
+findings. This ensures our results are shared in an open way.
+
+Inspektor Gadget does not provide Long-Term Support (LTS) releases. This means
+that only the latest release receives security updates and maintenance, and
+older versions may not be updated or supported. When writing VEX statements, we
+focus our effort on the latest release. Other previous versions might be
+considered based on user demand. For example, v0.41.0 may be considered because
+it is the last release with [builtin
+gadgets](gadgets/switching_to_image_based_gadgets.mdx), which some users may
+still rely on.
+
+All VEX documents are published in the following locations:
+
+- In the .vex directory of this repository, at
+  [https://github.com/inspektor-gadget/inspektor-gadget/tree/main/.vex](https://github.com/inspektor-gadget/inspektor-gadget/tree/main/.vex).
+  This helps discovery by tools such as [VEX
+  Hub](https://github.com/aquasecurity/vexhub?tab=readme-ov-file#discovery-of-vex-documents)
+- Assets attached to their [corresponding official GitHub
+  Releases](https://github.com/inspektor-gadget/inspektor-gadget/releases). For
+  each release (e.g., v0.42.0), you will find a corresponding vex.json file
+  available for download alongside the source code and other release artifacts.
+
+### How to Create or Update VEX Documents
+
+To add a VEX document when none exists for a specific version yet, use the
+[vexctl command](https://github.com/openvex/vexctl):
+
+```bash
+VER=v0.41.0
+vexctl create --file .vex/$VER.vex.json \
+--product "pkg:github/inspektor-gadget/inspektor-gadget@$VER" \
+--vuln "CVE-2025-54388" \
+--status "not_affected" \
+--justification "vulnerable_code_not_in_execute_path" \
+--id "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/$VER/$VER.vex.json" \
+--author "Inspektor Gadget Security Team <security@inspektor-gadget.io>"
+```
+
+The [possible
+statuses](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md#status-labels)
+and [possible
+justifications](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md#status-justifications)
+are listed in the [OpenVEX
+Specification](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md).
+
+When a VEX document already exists for a specific version, use `vexctl add`
+instead of `vexctl create`. For example:
+
+```bash
+VER=v0.41.0
+vexctl add --in-place .vex/$VER.vex.json \
+--product "pkg:github/inspektor-gadget/inspektor-gadget@$VER" \
+--vuln "CVE-2099-12345" \
+--status "not_affected" \
+--justification "vulnerable_code_not_in_execute_path"
+```


### PR DESCRIPTION
VEX documents to provide a clear, machine-readable assessment of our software's relationship to known vulnerabilities (CVEs). VEX helps users and security tools to:
- Suppress false positives for vulnerabilities that do not affect our project.
- Understand why a specific vulnerability is or is not exploitable in our code.

This patch adds VEX documents in the .vex directory, making it easily discoverable by tools such as VEX Hub (https://github.com/aquasecurity/vexhub).

Once merged, I plan to add the VEX documents as assets attached to the GitHub releases.

We might publish the VEX documents on our website, as suggested by the document id ("@id": https://inspektor-gadget.io/vex/v0.41.0.vex.json), but this will require separate changes in the website repository. For now, I just added a symlink from docs/vex.

In these initial VEX documents, I only go back to v0.41.0 because it's the last release with builtin gadgets, and I have not heard of user interest to go further back.

I used the following command to generate the VEX documents:

```
for VER in v0.41.0 v0.42.0 ; do
vexctl create --product "pkg:github/inspektor-gadget/inspektor-gadget@$VER" \
--vuln "CVE-2025-54388" \
--status "not_affected" \
--justification "vulnerable_code_not_in_execute_path" \
--id "https://inspektor-gadget.io/vex/$VER.vex.json" \
--author "Inspektor Gadget Security Team <security@inspektor-gadget.io" \
> $VER.vex.json
done
```

Update to existing VEX documents will need to be done with the "vexctl add" command.

## How to use

Reviewers should:

- Check CVE-2025-54388 to see if my VEX documents make sense
- Check if the description in SECURITY.md makes sense.

## Testing done

None.

## TODO (for future PRs)

- [ ] Updating website repo for URLs like the one in the documents ids ("@id" in *.vex.json) to work, as hinted in the description above.
- [ ] Release process:
  - [ ] a SBOM of a release should reference the VEX document for that release
  - [ ] automatically add a small VEX document with no statements (`"statements": []`) for new releases.

cc @eiffel-fl 