### PR TITLE
gadgetCtx: add IsClient

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -215,6 +215,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			imageName,
 			gadgetcontext.WithDataOperators(ops...),
 			gadgetcontext.WithUseInstance(commandMode == CommandModeAttach),
+			gadgetcontext.WithIsClient(runtime.IsClient()),
 		)
 
 		// GetOCIGadget needs at least the params from the oci handler, so let's prepare those in here
@@ -330,6 +331,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 
 			if isDetach {
 				return runInstanceSpecsDetached(ctx, runtime, specs, runtimeParams,
+					gadgetcontext.WithIsClient(runtime.IsClient()),
 					gadgetcontext.WithDataOperators(ops...),
 					gadgetcontext.WithTimeout(timeoutDuration),
 					gadgetcontext.WithUseInstance(false),
@@ -366,6 +368,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			gadgetcontext.WithDataOperators(ops...),
 			gadgetcontext.WithTimeout(timeoutDuration),
 			gadgetcontext.WithUseInstance(commandMode == CommandModeAttach),
+			gadgetcontext.WithIsClient(runtime.IsClient()),
 		)
 
 		// Write back param values

--- a/cmd/common/runwithspec_test.go
+++ b/cmd/common/runwithspec_test.go
@@ -295,3 +295,7 @@ name: invalid-#name*
 		}
 	}
 }
+
+func (r *testRuntime) IsClient() bool {
+	return false
+}

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -162,6 +162,19 @@ func (c *GadgetContext) IsRemoteCall() bool {
 	return bVal
 }
 
+func (c *GadgetContext) IsClient() bool {
+	val := c.ctx.Value(clientKey)
+	if val == nil {
+		return false
+	}
+	bVal, ok := val.(bool)
+	if !ok {
+		c.logger.Errorf("invalid type of variable %s on context, expected bool, got %T", clientKey, val)
+		return false
+	}
+	return bVal
+}
+
 func (c *GadgetContext) UseInstance() bool {
 	return c.useInstance
 }

--- a/pkg/gadget-context/options.go
+++ b/pkg/gadget-context/options.go
@@ -29,6 +29,7 @@ type contextKey string
 
 const (
 	remoteKey contextKey = "gadgetRemote"
+	clientKey contextKey = "gadgetClient"
 	attachKey contextKey = "gadgetAttach"
 )
 
@@ -61,6 +62,12 @@ func WithOrasReadonlyTarget(ociStore oras.ReadOnlyTarget) Option {
 func WithAsRemoteCall(val bool) Option {
 	return func(gadgetCtx *GadgetContext) {
 		gadgetCtx.ctx = context.WithValue(gadgetCtx.ctx, remoteKey, val)
+	}
+}
+
+func WithIsClient(val bool) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.ctx = context.WithValue(gadgetCtx.ctx, clientKey, val)
 	}
 }
 

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -46,6 +46,7 @@ type GadgetContext interface {
 	SetMetadata([]byte)
 	OrasTarget() oras.ReadOnlyTarget
 	IsRemoteCall() bool
+	IsClient() bool
 }
 
 // MapPrefix is used to avoid clash with maps and other eBPF objects when added

--- a/pkg/operators/sort/sort.go
+++ b/pkg/operators/sort/sort.go
@@ -67,6 +67,9 @@ func (s *sortOperator) InstanceParams() api.Params {
 }
 
 func (s *sortOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext, instanceParamValues api.ParamValues) (operators.DataOperatorInstance, error) {
+	logger := gadgetCtx.Logger()
+	logger.Debugf("instantiating %s operator: client=%v, remote_call=%v", name, gadgetCtx.IsClient(), gadgetCtx.IsRemoteCall())
+
 	activate := false
 
 	sortBy := instanceParamValues[ParamSortBy]

--- a/pkg/runtime/grpc/oci.go
+++ b/pkg/runtime/grpc/oci.go
@@ -299,3 +299,7 @@ func (r *Runtime) runGadget(gadgetCtx runtime.GadgetContext, target target, allP
 	}
 	return result, runErr
 }
+
+func (r *Runtime) IsClient() bool {
+	return true
+}

--- a/pkg/runtime/local/oci.go
+++ b/pkg/runtime/local/oci.go
@@ -33,3 +33,7 @@ func (r *Runtime) GetGadgetInfo(gadgetCtx runtime.GadgetContext, runtimeParams *
 func (r *Runtime) RunGadget(gadgetCtx runtime.GadgetContext, runtimeParams *params.Params, paramValues api.ParamValues) error {
 	return gadgetCtx.Run(paramValues)
 }
+
+func (r *Runtime) IsClient() bool {
+	return false
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -121,4 +121,6 @@ type Runtime interface {
 	RunGadget(gadgetCtx GadgetContext, runtimeParams *params.Params, paramValueMap api.ParamValues) error
 	SetDefaultValue(params.ValueHint, string)
 	GetDefaultValue(params.ValueHint) (string, bool)
+
+	IsClient() bool
 }


### PR DESCRIPTION
Some operators are used both server-side and client-side. Soon, the ustack operator will also be able to operator client-side and server-side.

The IsClient method allows to detect which side they are running and behave differently. This is similar to IsRemoteCall to detect if we are on a server.

Command           | IsClient | IsRemoteCall |
------------------|----------|--------------|
ig run            | false    | false        |
ig image inspect  | false    | false        |
ig daemon         | false    | true         |
gadgetctl run     | true     | false (*)    |

*: Note that gadgetctl can display logs from the server, so gadgetctl will print both lines:
```
    client=true, remote_call=false
    client=false, remote_call=true
```
Depending if the log was generated from the server or the client.

## How to use

Reviewers can test the following scenarios:

### ig run

```
sudo ig run     ghcr.io/inspektor-gadget/gadget/trace_exec     --verify-image=false      -c test -v 2>&1|grep "instantiating sort operator"
instantiating sort operator: client=false, remote_call=false
instantiating sort operator: client=false, remote_call=false
```

### ig image inspect
```
sudo ig image inspect     ghcr.io/inspektor-gadget/gadget/trace_exec     --verify-image=false  -v 2>&1|grep "instantiating sort operator"
instantiating sort operator: client=false, remote_call=false
```

### ig daemon

```
sudo ig daemon --verify-image=false -v 2>&1|grep "instantiating sort operator"
instantiating sort operator: client=false, remote_call=true
instantiating sort operator: client=false, remote_call=true
```

### gadgetctl run
```
sudo ./gadgetctl run     ghcr.io/inspektor-gadget/gadget/trace_exec  -v 2>&1|grep "instantiating sort operator"
instantiating sort operator: client=true, remote_call=false
local                | instantiating sort operator: client=false, remote_call=true
instantiating sort operator: client=true, remote_call=false
```

## Testing done

I have run the scenarios above.