### PR TITLE
trace_exec: fix test for nsenter from util-linux 2.41

### DIFF
--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -63,9 +63,7 @@ func TestTraceExec(t *testing.T) {
 	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
 	require.NoError(t, err, "new container factory")
 	containerName := "test-trace-exec"
-	// TODO: It should use gadgettesting.GccImage, but the latest tag on that
-	// image is breaking this test. See issue #4810 for more details.
-	containerImage := "ghcr.io/inspektor-gadget/ci/gcc:test"
+	containerImage := gadgettesting.GccImage
 
 	execProgram := `
 #define _GNU_SOURCE

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -133,7 +133,7 @@ int main(int argc, char *argv[], char **envp) {
 		execScriptsCmd,
 	)
 	// copies /usr/bin/sh to /usr/bin/sh2 to check that the upper_layer is true when executing /usr/bin/sh2
-	cmd := fmt.Sprintf("%s %s && cp /usr/bin/sh /usr/bin/sh2 && nsenter --setuid 1000 --setgid 1111 /usr/bin/sh2 -c '%s'", prepareScriptsCmd, buildCmd, innerCmd)
+	cmd := fmt.Sprintf("%s %s && cp /usr/bin/sh /usr/bin/sh2 && setpriv --reuid 1000 --regid 1111 --clear-groups /usr/bin/sh2 -c '%s'", prepareScriptsCmd, buildCmd, innerCmd)
 	innerShArgs := []string{"/usr/bin/sh2", "-c", innerCmd}
 
 	testContainer := containerFactory.NewContainer(containerName, cmd, containerOpts...)


### PR DESCRIPTION
nsenter from util-linux 2.38.1 used to be able to set some options like setuid and setgid without changing namespaces:
```
docker run --rm -ti --name gcctest ghcr.io/inspektor-gadget/ci/gcc:test nsenter --setuid 1000 --setgid 1111 /usr/bin/sh -c '/bin/echo OK'
OK
```
But it is not possible anymore with nsenter from util-linux 2.41:
```
docker run --rm -ti --name gcclatest ghcr.io/inspektor-gadget/ci/gcc:latest nsenter --setuid 1000 --setgid 1111 /usr/bin/sh -c '/bin/echo OK'
nsenter: no namespace specified
```
This patch changes the command line to change the ipc namespace. It does not really change since I use the "$$" target process.

Fixes: #4810

We use the new nsenter since #4804.

After this, the workaround from #4811 should no longer be necessary.

## Testing done

Let's run the CI.