### PR TITLE
add new command "ig init" and allow including gadget source in images

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ type cmdOpts struct {
 	validateMetadata bool
 	btfgen           bool
 	btfhubarchive    string
+	includeSource    bool
 }
 
 func NewBuildCmd() *cobra.Command {
@@ -113,6 +114,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.builderImagePull, "builder-image-pull", "always", "Specify when the builder image should be pulled [always, missing, never]")
 	cmd.Flags().BoolVar(&opts.updateMetadata, "update-metadata", false, "Update the metadata according to the eBPF code")
 	cmd.Flags().BoolVar(&opts.validateMetadata, "validate-metadata", true, "Validate the metadata file before building the gadget image")
+	cmd.Flags().BoolVar(&opts.includeSource, "include-source", true, "Include the source code in the image")
 
 	cmd.Flags().BoolVar(&opts.btfgen, "btfgen", false, "Enable btfgen")
 	cmd.Flags().StringVar(&opts.btfhubarchive, "btfhub-archive", "", "Path to the location of the btfhub-archive files")
@@ -342,6 +344,8 @@ func runBuild(cmd *cobra.Command, opts *cmdOpts) error {
 		MetadataPath:     conf.Metadata,
 		UpdateMetadata:   opts.updateMetadata,
 		ValidateMetadata: opts.validateMetadata,
+		IncludeSources:   opts.includeSource,
+		SourcePath:       opts.path,
 	}
 
 	if sourceDateEpoch, ok := os.LookupEnv("SOURCE_DATE_EPOCH"); ok {

--- a/cmd/common/init.go
+++ b/cmd/common/init.go
@@ -1,0 +1,118 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2"
+	orasoci "oras.land/oras-go/v2/content/oci"
+
+	"github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
+)
+
+type initOptions struct {
+	from  string
+	local bool
+}
+
+func sudoCallerIDs() (int, int) {
+	uidStr := os.Getenv("SUDO_UID")
+	gidStr := os.Getenv("SUDO_GID")
+	if uidStr == "" || gidStr == "" {
+		return -1, -1 // not running under sudo (or no env), keep root or current UID/GID
+	}
+	uid, err1 := strconv.Atoi(uidStr)
+	gid, err2 := strconv.Atoi(gidStr)
+	if err1 != nil || err2 != nil {
+		return -1, -1
+	}
+	return uid, gid
+}
+
+func NewInitCommand() *cobra.Command {
+	o := initOptions{}
+	var authOpts oci.AuthOptions
+	cmd := &cobra.Command{
+		Use:          "init PATH",
+		Short:        "Create a new gadget",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			targetDir := args[0]
+
+			// Check whether the diretory is existing already
+			if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s already exists", targetDir)
+			}
+
+			err := os.MkdirAll(args[0], 0o755)
+			if err != nil {
+				return fmt.Errorf("could not create directory %q: %w", targetDir, err)
+			}
+			if o.from != "" {
+				ctx := context.TODO()
+				var target oras.Target
+
+				uid, gid := -1, -1
+
+				if !o.local {
+					// Create and use temp dir; this avoids requiring to run as root at the price of
+					// always pulling the image
+					dir, err := os.MkdirTemp(os.TempDir(), "inspektor-gadget")
+					if err != nil {
+						return fmt.Errorf("could not create temporary directory: %w", err)
+					}
+					defer os.RemoveAll(dir)
+					target, err = orasoci.NewWithContext(ctx, dir)
+				} else {
+					// Fetch sudo caller uid/gid to chown to that user
+					uid, gid = sudoCallerIDs()
+
+					log.Printf("%d/%d\n", uid, gid)
+
+					if uid != -1 && gid != -1 {
+						log.Printf("Detected running with sudo; will chown files/directories to uid=%d, gid=%d\n", uid, gid)
+					}
+
+					err = os.Chown(targetDir, uid, gid)
+					if err != nil {
+						return fmt.Errorf("could not chown target: %w", err)
+					}
+				}
+
+				cmd.Printf("Extracting sources to %s...\n", targetDir)
+				found, err := oci.ExtractSources(ctx, target, o.from, targetDir, &authOpts, uid, gid)
+				if err != nil {
+					return fmt.Errorf("extracting sources: %w", err)
+				}
+				if !found {
+					return fmt.Errorf("image does not contain gadget sources")
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&o.local, "local", "", false, "use local store (probably requires root privileges)")
+	cmd.Flags().StringVarP(&o.from, "from", "", "", "use existing image as starting point")
+	utils.AddRegistryAuthVariablesAndFlags(cmd, &authOpts)
+	return cmd
+}

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -105,6 +105,7 @@ func main() {
 	rootCmd.AddCommand(common.NewLogoutCmd())
 	rootCmd.AddCommand(common.NewRunCommand(rootCmd, runtime, hiddenColumnTags, common.CommandModeRun))
 	rootCmd.AddCommand(common.NewConfigCmd(runtime, rootFlags))
+	rootCmd.AddCommand(common.NewInitCommand())
 
 	pprofAddr, _ := rootCmd.PersistentFlags().GetString("pprof-addr")
 	if pprofAddr != "" {

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,15 @@
 package oci
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -49,6 +52,7 @@ const (
 	wasmObjectMediaType = "application/vnd.gadget.wasm.program.v1+binary"
 	btfgenMediaType     = "application/vnd.gadget.btfgen.v1+binary"
 	metadataMediaType   = "application/vnd.gadget.config.v1+yaml"
+	sourceMediaType     = "application/vnd.gadget.source.v1+binary"
 )
 
 const (
@@ -78,6 +82,10 @@ type BuildGadgetImageOpts struct {
 	ValidateMetadata bool
 	// Date and time on which the image is built (date-time string as defined by RFC 3339).
 	CreatedDate string
+	// IncludeSources determines if the source directory should be included in the image
+	IncludeSources bool
+	// SourcePath points to the source root directory (usually src)
+	SourcePath string
 }
 
 // BuildGadgetImage creates an OCI image with the objects provided in opts. The image parameter in
@@ -169,6 +177,67 @@ func createLayerDesc(ctx context.Context, target oras.Target, progFilePath, medi
 		return ocispec.Descriptor{}, fmt.Errorf("pushing %q layer: %w", mediaType, err)
 	}
 
+	return progDesc, nil
+}
+
+func createCompressedBlobFromPath(ctx context.Context, rootPath string) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	gw := gzip.NewWriter(buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	rootPath = filepath.Clean(rootPath)
+
+	err := filepath.Walk(rootPath, func(path string, fi fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(fi, "")
+		if err != nil {
+			return fmt.Errorf("creating tar header: %w", err)
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("writing tar header: %w", err)
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		f, err := os.Open(filepath.Join(rootPath, path))
+		if err != nil {
+			return fmt.Errorf("opening file: %w", err)
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %q: %w", rootPath, err)
+	}
+
+	err = tw.Close()
+	if err != nil {
+		return nil, fmt.Errorf("closing tar writer: %w", err)
+	}
+	err = gw.Close()
+	if err != nil {
+		return nil, fmt.Errorf("closing gzip writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func createCompressedLayerDescFromPath(ctx context.Context, target oras.Target, rootPath, mediaType string) (ocispec.Descriptor, error) {
+	blob, err := createCompressedBlobFromPath(ctx, rootPath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("creating compressed blob from path %q: %w", rootPath, err)
+	}
+
+	progDesc := content.NewDescriptorFromBytes(mediaType, blob)
+	err = pushDescriptorIfNotExists(ctx, target, progDesc, bytes.NewReader(blob))
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing %q layer: %w", mediaType, err)
+	}
 	return progDesc, nil
 }
 
@@ -327,6 +396,14 @@ func createImageIndex(ctx context.Context, target oras.Target, o *BuildGadgetIma
 			return ocispec.Descriptor{}, fmt.Errorf("creating %s manifest: %w", arch, err)
 		}
 		layers = append(layers, manifestDesc)
+	}
+
+	if o.IncludeSources {
+		layer, err := createCompressedLayerDescFromPath(ctx, target, o.SourcePath, sourceMediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("creating %s layer: %w", sourceMediaType, err)
+		}
+		layers = append(layers, layer)
 	}
 
 	if len(layers) == 0 {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"cmp"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -951,4 +952,128 @@ func GetContentFromDescriptor(ctx context.Context, target oras.ReadOnlyTarget, d
 		return nil, fmt.Errorf("fetching descriptor: %w", err)
 	}
 	return reader, nil
+}
+
+// ExtractSources retrieves the gadget source blob (if present) from the given image
+// and extracts it (tar.gz) into destDir. It returns true if sources were found and extracted.
+func ExtractSources(ctx context.Context, imageStore oras.Target, image string, destDir string, authOpts *AuthOptions, uid, gid int) (bool, error) {
+	if imageStore == nil {
+		// If no store is given, use the default store; we assume the image is available in that case
+		ociStore, err := newLocalOciStore()
+		if err != nil {
+			return false, fmt.Errorf("getting oci store: %w", err)
+		}
+		imageStore = ociStore.Store
+	} else {
+		// If a store is given, we will pull the image
+		_, err := pullGadgetImageToStore(ctx, imageStore, image, authOpts)
+		if err != nil {
+			return false, fmt.Errorf("pulling gadget image: %w", err)
+		}
+	}
+
+	index, err := getIndex(ctx, imageStore, image)
+	if err != nil {
+		return false, fmt.Errorf("getting index: %w", err)
+	}
+
+	for _, desc := range index.Manifests {
+		if desc.MediaType == sourceMediaType {
+			reader, err := imageStore.Fetch(ctx, desc)
+			if err != nil {
+				return false, fmt.Errorf("fetching sources blob: %w", err)
+			}
+			defer reader.Close()
+			if err := extractTarGz(reader, destDir, uid, gid); err != nil {
+				return false, fmt.Errorf("extracting sources: %w", err)
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// extractTarGz extracts a gzip-compressed tar stream into destDir securely.
+func extractTarGz(r io.Reader, destDir string, uid, gid int) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	cleanDest := filepath.Clean(destDir)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		target := filepath.Join(cleanDest, hdr.Name)
+		cleanTarget := filepath.Clean(target)
+		// ensure target is within destDir
+		if !strings.HasPrefix(cleanTarget+string(os.PathSeparator), cleanDest+string(os.PathSeparator)) && cleanTarget != cleanDest {
+			return fmt.Errorf("invalid path in archive: %s", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(cleanTarget, 0o755); err != nil {
+				return fmt.Errorf("creating dir: %w", err)
+			}
+			if uid != -1 && gid != -1 {
+				if err := os.Chown(cleanTarget, uid, gid); err != nil {
+					return fmt.Errorf("setting uid/gid: %w", err)
+				}
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(cleanTarget), 0o755); err != nil {
+				return fmt.Errorf("creating parent dir: %w", err)
+			}
+			f, err := os.OpenFile(cleanTarget, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return fmt.Errorf("writing file: %w", err)
+			}
+			if uid != -1 && gid != -1 {
+				if err := f.Chown(uid, gid); err != nil {
+					return fmt.Errorf("setting uid/gid: %w", err)
+				}
+			}
+			f.Close()
+		case tar.TypeSymlink:
+			// Create symlink only if it stays within destDir
+			linkTarget := hdr.Linkname
+			// For safety, do not allow absolute links
+			if filepath.IsAbs(linkTarget) {
+				return fmt.Errorf("absolute symlink not allowed: %s", hdr.Name)
+			}
+			finalLink := filepath.Join(filepath.Dir(cleanTarget), linkTarget)
+			finalLink = filepath.Clean(finalLink)
+			if !strings.HasPrefix(finalLink+string(os.PathSeparator), cleanDest+string(os.PathSeparator)) && finalLink != cleanDest {
+				return fmt.Errorf("symlink escapes destination: %s -> %s", hdr.Name, linkTarget)
+			}
+			if err := os.MkdirAll(filepath.Dir(cleanTarget), 0o755); err != nil {
+				return fmt.Errorf("creating parent dir: %w", err)
+			}
+			if err := os.Symlink(linkTarget, cleanTarget); err != nil {
+				return fmt.Errorf("creating symlink: %w", err)
+			}
+			if uid != -1 && gid != -1 {
+				if err := os.Chown(cleanTarget, uid, gid); err != nil {
+					return fmt.Errorf("setting uid/gid: %w", err)
+				}
+			}
+		default:
+			// ignore other types
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds the possibility to add the gadget's source code to an additional layer inside the gadget image (currently opt-out, tbd.). It will use the working directory for that and tar/gzip the contents.

A gadget with source code added can then be used by the new `ig init` command like so:
```
$ ig init --from trace_exec my_trace_exec
```
This will create a new directory `my_trace_exec` and extract the source to that directory. Without specifying, only a new directory will be created - maybe we can still add some templates in that case.

### Goal

This will help with different things:

* onboarding gadget authors becomes easier as they can start from an existing gadget in an easy way
* gadgets will contain their sourcecode from the time of their build, if enabled; this can help with versioning
* community gadgets can be easily reproduced without trusting included binaries

### Caveats

In order to be able to run this command without root privileges, the init command will create a temporary oras store, always pull the image and extract it from there. However, this prevents the user from using images available in the local store.

If that is intended, the user can use the `--local` flag. Since that command likely has to be run as root, which then would mess up directory/file permissions if the user is using `sudo`, we check for the usage of `sudo` and chown any files created back to the callers uid/gid.

We discussed this internally and felt this would serve the best UX, given the restrictions. Happy to take feedback, however.

### Todos / Discussion points

* Should we honor `.gitignore` or similar files when including the source?
* gadget.yaml will effectively be included twice, once as source and once in its dedicated layer

/cc @mqasimsarfraz 