### PR TITLE
Change ARM64 EKS node type to a current gen

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2026,7 +2026,7 @@ jobs:
         # many gadgets running on parallel
         node_type='t2.xlarge'
         if [ ${{ matrix.arch }} = 'arm64' ]; then
-          node_type='a1.xlarge'
+          node_type='t4g.xlarge'
         fi
         eksctl create cluster --name ${{ env.CLUSTER_NAME }} --tags "ig-ci=true,ig-ci-timestamp=$(date -u +'%Y-%m-%dT%H:%M:%S%:z')" --node-type $node_type
     - name: Run integration tests


### PR DESCRIPTION
For the EKS tests most of the time the `arm64` platform had failures while waiting for the K8s Cluster to come up. We used a legacy type and changing it to a current one improved the K8s cluster creation speed imo.

I just tested it with running the EKS arm64 job 3 times and the cluster was created quite quickly. You can check the citest runs for this commit. (Failure of this EKS job doesn't mean the cluster creation failed)