### PR TITLE
docs: fix various broken links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,12 +272,6 @@ test: generate-testdata
 	# skip gadgets tests
 	go test -exec sudo -v $$(go list ./... | grep -v 'github.com/inspektor-gadget/inspektor-gadget/gadgets')
 
-# Individual tests can be selected with a command such as:
-# go test -exec sudo -ldflags="-s=false" -bench='^BenchmarkAllGadgetsWithContainers$/^container100$/snapshot-socket' -run=Benchmark ./internal/benchmarks/... -count 10
-.PHONY: gadgets-benchmarks
-gadgets-benchmarks:
-	go test -exec sudo -ldflags="-s=false" -bench=. -run=Benchmark ./pkg/gadgets/... ./internal/benchmarks/...
-
 # INTEGRATION_TESTS_PARAMS can be used to pass additional parameters locally e.g
 # INTEGRATION_TESTS_PARAMS="-run TestTraceExec -no-deploy-spo" make integration-tests
 .PHONY: integration-tests

--- a/docs/api/grpc.md
+++ b/docs/api/grpc.md
@@ -11,9 +11,3 @@ TODO
 TODO
 
 [pkg/gadget-service/api/api.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/pkg/gadget-service/api/api.proto)
-
-## gadgettracermanager.proto
-
-[pkg/gadgettracermanager/api/gadgettracermanager.proto](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/pkg/gadgettracermanager/api/gadgettracermanager.proto)
-
-TODO

--- a/docs/design/002-containerized-gadgets.md
+++ b/docs/design/002-containerized-gadgets.md
@@ -655,7 +655,7 @@ Nothing special is needed.
 
 #### trace dns
 
-- [Socket filter](#socketfilter-programs)
+- [Socket filter](#socket_filter-programs)
 - [Socket enricher](#socket-enricher)
 - [Enum convert](#enum-convert)
 - [Endpoint enrichment](#endpoint-enrichment)
@@ -696,7 +696,7 @@ Already ported in gadgets/trace_open.bpf.c.
 
 #### trace sni
 
-- [Socket filter](#socketfilter-programs)
+- [Socket filter](#socket_filter-programs)
 - [Socket enricher](#socket-enricher)
 - [Endpoint enrichment](#endpoint-enrichment)
 
@@ -734,10 +734,12 @@ revisit later on:
 
 ### Support Inspektor Gadget API changes
 
-Inspektor Gadget exposes a small [API](#inspektor-gadget-api) composed by some C headers to gadget
-developers. Gadgets have to be compiled against it. In this iteration, we don't want to introduce
-additional complexity by supporting changes to that API, i.e. gadgets need to be recompiled to take
-changes in that API.
+Inspektor Gadget exposes a small
+[API](#inspektor-gadget-api-for-gadgets-developers) composed by some C headers
+to gadget developers. Gadgets have to be compiled against it. In this
+iteration, we don't want to introduce additional complexity by supporting
+changes to that API, i.e. gadgets need to be recompiled to take changes in that
+API.
 
 Later on we will consider solutions like bpf extensions or other forms of dynamic loading to solve
 this problem.

--- a/docs/devel/ci.md
+++ b/docs/devel/ci.md
@@ -285,10 +285,10 @@ You can see the guide [here](https://cloud.google.com/kubernetes-engine/docs/how
 
 ## Benchmarks
 
-Inspektor Gadget has
-[benchmark tests](https://github.com/inspektor-gadget/inspektor-gadget/blob/%IG_BRANCH%/internal/benchmarks/benchmarks_test.go)
-that are automatically executed and published by
-[github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark). You can see the results on:
+Inspektor Gadget has benchmark tests that are automatically executed and
+published by
+[github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark).
+You can see the results on:
 
 https://inspektor-gadget.github.io/ig-benchmarks/dev/bench/index.html
 

--- a/docs/devel/contributing.md
+++ b/docs/devel/contributing.md
@@ -160,26 +160,6 @@ runtime installed. Currently supported runtime is `docker` only, You can run the
 $ make -C integration/ig/non-k8s test-docker
 ```
 
-### Benchmarks
-
-You can run the different benchmark tests with:
-
-```bash
-$ make gadgets-benchmarks
-```
-
-Or you can run an individual test with:
-
-```bash
-$ go test -exec sudo \
-    -bench='BenchmarkAllGadgetsWithContainers/container10$/trace-tcpconnect' \
-    -run=Benchmark \
-    ./internal/benchmarks/...
-```
-
-Records of previous benchmarks are available [here](https://inspektor-gadget.github.io/ig-benchmarks/dev/bench/index.html).
-See details in the [CI documentation (benchmarks)](ci.md#benchmarks).
-
 #### Explaining performance improvements in a PR
 
 If you want to contribute a performance improvement, it is useful to use benchmarks to explain the impact on


### PR DESCRIPTION
See individual commits for details.

Broken links detected by the CI:
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/17391500787/job/49365920204

```
ERROR: 2 dead links found in ./docs/design/002-containerized-gadgets.md !
[✖] #socketfilter-programs → Status: 404
[✖] #inspektor-gadget-api → Status: 404

ERROR: 1 dead links found in ./docs/api/grpc.md !
[✖] https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/gadgettracermanager/api/gadgettracermanager.proto → Status: 404

ERROR: 1 dead links found in ./docs/devel/ci.md !
[✖] https://github.com/inspektor-gadget/inspektor-gadget/blob/main/internal/benchmarks/benchmarks_test.go → Status: 404
```

Fixes: fb0115c86df5 ("design: Add containerized gadgets design doc")
Fixes: 3e9f17e9d010 ("gadget-container: Use KubeManager for hook API and container+tracer collections")
Fixes: 0a0d86a3720a ("benchmarks: Remove built-in gadgets benchmarks")

