### PR TITLE
deletePodCommand: Add regex to optionally include ns

### DIFF
--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -176,7 +176,7 @@ func deletePodCommand(t *testing.T, podname, namespace string) *command.Command 
 	return &command.Command{
 		Name:           fmt.Sprintf("Delete %s", podname),
 		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl delete -n=%s pod %s", namespace, podname)),
-		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod \"%s\" deleted\n", podname)),
+		ValidateOutput: match.MatchRegexp(t, fmt.Sprintf("pod \"%s\" deleted( from %s namespace)?\n", podname, namespace)),
 	}
 }
 


### PR DESCRIPTION
There seems to be an update to the `kubectl delete` command which now includes the namespace in the output string.

This PR makes that optional, since we should support both versions.


```
Error:      	Not equal: 
            	expected: "pod \"test-advise-networkpolicy-client\" deleted\n"
            	actual  : "pod \"test-advise-networkpolicy-client\" deleted from test-advise-networkpolicy-6403532841951297483 namespace\n"
            	
            	Diff:
            	--- Expected
            	+++ Actual
            	@@ -1,2 +1,2 @@
            	-pod "test-advise-networkpolicy-client" deleted
            	+pod "test-advise-networkpolicy-client" deleted from test-advise-networkpolicy-6403532841951297483 namespace
            	 
Test:       	TestAdviseNetworkpolicyGadget
Messages:   	output didn't match the expected string
```