### PR TITLE
docs: ignore link unsupported by github-action-markdown-link-check

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,5 +1,7 @@
 {
-   "ignorePatterns" : [],
+   "ignorePatterns" : [
+      "%23"
+   ],
    "replacementPatterns" : [
       {
          "pattern" : "%IG_BRANCH%",


### PR DESCRIPTION
We use the GitHub Action markdown-link-check to check if links in markdown documents are still valid.

However, the underlying tool does not support URLs with %23. I reported the bug (https://github.com/tcort/link-check/issues/105). For now, this patch disables the test on that URL.

Symptoms:
```
  ERROR: 1 dead links found in ./README.md !
  [✖] https://img.shields.io/badge/slack-%23inspektor--gadget-brightgreen.svg?logo=slack → Status: 404
```

## Testing done

Let's check the CI...
