### PR TITLE
github: Fix release notes to add all other changes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,14 @@ changelog:
     - title: Breaking Changes
       labels:
         - breaking-change
+    - title: Other Changes
+      labels:
+        - "*"
+    - title: Dependencies updates
+      labels:
+        - dependencies
+        - go
+    - title: CI updates
+      labels:
+        - dependencies
+        - github_actions


### PR DESCRIPTION
The current will only generate release notes with breaking changes.

Fixes: 04f5cfc9c147 ("github: Document how to use the breaking-change label")
