### PR TITLE
gadgets/trace_signal: Add sleep to integration test container

### DIFF
--- a/gadgets/trace_signal/test/integration/trace_signal_test.go
+++ b/gadgets/trace_signal/test/integration/trace_signal_test.go
@@ -59,7 +59,7 @@ func TestTraceSignal(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do sleep 3 & kill $!; done",
+		"while true; do sleep 1; sleep 3 & kill $!; done",
 		containerOpts...,
 	)
 


### PR DESCRIPTION
The CI logs is half full of events from this gadget. This sleep slows down the event production