### PR TITLE
github actions: disable some cron jobs on forks

### DIFF
--- a/.github/workflows/check-artifacthub-tags.yml
+++ b/.github/workflows/check-artifacthub-tags.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   check-gadgets:
+    if: github.repository == 'inspektor-gadget/inspektor-gadget'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-link:
     name: Links check
+    if: github.repository == 'inspektor-gadget/inspektor-gadget'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -15,6 +15,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'inspektor-gadget/inspektor-gadget'
     runs-on: ubuntu-latest
     permissions:
       # Needed for Code scanning upload


### PR DESCRIPTION
Before this patch, forks would run daily github actions to check the links, check the artifact hub tags and run the scorecard analysis.

Most of the time, forks are just there to make pull requests. The main branch is unused and becomes stale. It is a waste of resources to run daily checks on it.

This patch disables these 3 cron jobs. Other cron jobs are left unchanged because they are already disabled by default (unless the fork configures environment variables to enable them).

