### PR TITLE
container-utils: Add WithExpectedExitCode

### DIFF
--- a/pkg/container-utils/testutils/containerd.go
+++ b/pkg/container-utils/testutils/containerd.go
@@ -119,6 +119,9 @@ func (c *ContainerdContainer) Run(t *testing.T) {
 	if c.options.expectStartError {
 		t.Fatalf("testutils/containerd: ExpectStartError is not supported yet")
 	}
+	if c.options.expectedExitCode != nil {
+		t.Fatalf("testutils/containerd: ExpectedExitCode is not supported yet")
+	}
 
 	var spec specs.Spec
 	container, err := c.client.NewContainer(c.nsCtx, c.name,

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -43,6 +43,7 @@ type containerOptions struct {
 	portBindings         nat.PortMap
 	privileged           bool
 	limits               map[string]string
+	expectedExitCode     *int
 
 	// forceDelete is mostly used for debugging purposes, when a container
 	// fails to be deleted and we want to force it.
@@ -70,6 +71,12 @@ func WithContext(ctx context.Context) Option {
 func WithExpectStartError() Option {
 	return func(opts *containerOptions) {
 		opts.expectStartError = true
+	}
+}
+
+func WithExpectedExitCode(code int) Option {
+	return func(opts *containerOptions) {
+		opts.expectedExitCode = &code
 	}
 }
 

--- a/pkg/testing/containers/options.go
+++ b/pkg/testing/containers/options.go
@@ -89,3 +89,9 @@ func WithWaitOrOomKilled() ContainerOption {
 		opts.options = append(opts.options, testutils.WithWaitOrOomKilled())
 	}
 }
+
+func WithExpectedExitCode(code int) ContainerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithExpectedExitCode(code))
+	}
+}


### PR DESCRIPTION
Allow test to check that a container exited with a specific exit code.

To be used in #4730 