### PR TITLE
kubectl-gadget: Fix undeploy method when gadget isnt' running

### DIFF
--- a/cmd/kubectl-gadget/undeploy.go
+++ b/cmd/kubectl-gadget/undeploy.go
@@ -113,7 +113,9 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 	// Determine the deployment version to decide on undeploy strategy
 	deployedVersion, err := GetDeployedVersion()
 	if err != nil {
-		return fmt.Errorf("determining deployed version: %w", err)
+		fmt.Printf("Error determining deployed version: %s. Assuming v0.43.0+\n", err)
+		errs := runLabelBasedUndeploy(k8sClient, crdClient, dynClient, discoveryClient, gadgetNamespace)
+		return finishUndeploy(errs)
 	}
 
 	// Check if this is a pre-0.43.0 deployment (no labels)


### PR DESCRIPTION
If the gadget isn't running, then it was impossible to undeploy it with `kubectl gadget undeploy`.

Fixes: a8b0f6a2f3e8 ("undeploy: Remove known resources for version <0.43.0")

## Reproducer

1. Create a failed deployment of IG 
```bash
$ kubectl-gadget deploy --image=foobar
WARN[0000] No policy controller found, the container image will not be verified
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ConfigMap/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
Creating DaemonSet/gadget...
Waiting for gadget pod(s) to be ready...
0/1 gadget pod(s) ready
0/1 gadget pod(s) ready


Error: timed out waiting for the condition
```

2. Try to undeploy it (usually, to deploy it with the right image)

### Before this PR

```bash 
$ kubectl-gadget undeploy
ERRO[0000] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:28 socat[8463] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0000] Please make sure the --connection-method value matches your installation.
ERRO[0001] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:29 socat[8464] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0001] Please make sure the --connection-method value matches your installation.
ERRO[0002] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:31 socat[8481] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0002] Please make sure the --connection-method value matches your installation.
ERRO[0004] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:33 socat[8482] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0004] Please make sure the --connection-method value matches your installation.
WARN[0005] Failed to load deploy info: dialing random target: dialing "gadget-4ftld" ("minikube"): dialing "gadget-4ftld" ("minikube"): context deadline exceeded: connection error: desc = "error reading server preface: EOF"
ERRO[0005] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:33 socat[8483] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0005] Please make sure the --connection-method value matches your installation.
ERRO[0006] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:34 socat[8484] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0006] Please make sure the --connection-method value matches your installation.
ERRO[0007] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:34:36 socat[8501] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0007] Please make sure the --connection-method value matches your installation.
Error: determining deployed version: getting remote info: dialing random target: dialing "gadget-4ftld" ("minikube"): dialing "gadget-4ftld" ("minikube"): context deadline exceeded: connection error: desc = "error reading server preface: EOF"
```

It's still there:

```bash
$ kubectl -n gadget get ds
NAME     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
gadget   1         1         0       1            0           kubernetes.io/os=linux   6m21s
```

### With this PR 

Undeploy now works fine:

```bash
$ kubectl-gadget undeploy
ERRO[0000] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:29 socat[8897] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0000] Please make sure the --connection-method value matches your installation.
ERRO[0001] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:30 socat[8898] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0001] Please make sure the --connection-method value matches your installation.
ERRO[0002] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:31 socat[8915] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0002] Please make sure the --connection-method value matches your installation.
WARN[0005] Failed to load deploy info: dialing random target: dialing "gadget-4ftld" ("minikube"): dialing "gadget-4ftld" ("minikube"): context deadline exceeded: connection error: desc = "error reading server preface: EOF"
ERRO[0005] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:34 socat[8916] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0005] Please make sure the --connection-method value matches your installation.
ERRO[0006] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:35 socat[8917] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0006] Please make sure the --connection-method value matches your installation.
ERRO[0007] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:36 socat[8934] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0007] Please make sure the --connection-method value matches your installation.
ERRO[0009] k8sPortFwd tcp connection: forwarding port: error forwarding port 8080 to pod f83aa6d8ba778a9c8044a8bff9ee6bb1f6acb769a91efec4f91e7d6f484d6b59, uid : exit status 1: 2025/09/12 20:36:38 socat[8935] E connect(5, AF=2 127.0.0.1:8080, 16): Connection refused
ERRO[0009] Please make sure the --connection-method value matches your installation.
Error determining deployed version: getting remote info: dialing random target: dialing "gadget-4ftld" ("minikube"): dialing "gadget-4ftld" ("minikube"): context deadline exceeded: connection error: desc = "error reading server preface: EOF". Using modern undeploy method...
Discovering and removing labeled resources...
Removing ServiceAccount: gadget
Removing Pod: gadget-4ftld
Removing ConfigMap: gadget
Removing DaemonSet: gadget
Removing Role: gadget-role
Removing RoleBinding: gadget-role-binding
Removing ClusterRoleBinding: gadget-cluster-role-binding
Removing ClusterRole: gadget-cluster-role
Waiting for labeled resources to be fully removed...
Inspektor Gadget successfully removed
```

```bash
$ kubectl -n gadget get ds
No resources found in gadget namespace.
```

