### PR TITLE
ustack,symbolizer: refactor to build on different platform

### DIFF
--- a/pkg/operators/ustack/ustack_linux.go
+++ b/pkg/operators/ustack/ustack_linux.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package ustack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	ebpftypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/symbolizer"
+)
+
+func readUserStackMap(gadgetCtx operators.GadgetContext, userStackMap *ebpf.Map, stackId uint32) (string, []symbolizer.StackItemQuery, error) {
+	logger := gadgetCtx.Logger()
+
+	stack := [ebpftypes.UserPerfMaxStackDepth]uint64{}
+	err := userStackMap.Lookup(stackId, &stack)
+	if err != nil {
+		logger.Warnf("stack with ID %d is lost: %s", stackId, err.Error())
+		return "", nil, nil
+	}
+
+	var addressesBuilder strings.Builder
+	stackQueries := make([]symbolizer.StackItemQuery, 0, ebpftypes.UserPerfMaxStackDepth)
+	for i, addr := range stack {
+		if addr == 0 {
+			break
+		}
+		stackQueries = append(stackQueries, symbolizer.StackItemQuery{Addr: addr})
+		fmt.Fprintf(&addressesBuilder, "[%d]0x%016x; ", i, addr)
+	}
+	addressesStr := addressesBuilder.String()
+
+	return addressesStr, stackQueries, nil
+}

--- a/pkg/operators/ustack/ustack_others.go
+++ b/pkg/operators/ustack/ustack_others.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package ustack
+
+import (
+	"errors"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/symbolizer"
+)
+
+func readUserStackMap(gadgetCtx operators.GadgetContext, userStackMap *ebpf.Map, stackId uint32) (string, []symbolizer.StackItemQuery, error) {
+	return "", nil, errors.ErrUnsupported
+}

--- a/pkg/symbolizer/symtab_linux.go
+++ b/pkg/symbolizer/symtab_linux.go
@@ -1,0 +1,213 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package symbolizer
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+)
+
+const (
+	maxExecutableSize   = 512 * 1024 * 1024 // 512MB
+	maxSymbolLength     = 256
+	maxSymbolCount      = 10 * 1000 * 1000
+	maxSymbolCountTotal = 50 * 1000 * 1000
+)
+
+func getHostProcFsPidNs() (uint32, error) {
+	pid1PidNsInfo, err := os.Stat(fmt.Sprintf("%s/1/ns/pid", host.HostProcFs))
+	if err != nil {
+		return 0, err
+	}
+	pid1PidNsStat, ok := pid1PidNsInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("reading inode of %s/1/ns/pid", host.HostProcFs)
+	}
+	return uint32(pid1PidNsStat.Ino), nil
+}
+
+func (s *Symbolizer) resolveWithSymtab(task Task, stackQueries []StackItemQuery, res []StackItemResponse) error {
+	key := exeKey{task.Ino, task.MtimeSec, task.MtimeNsec}
+	s.lockSymbolTables.RLock()
+	table, ok := s.symbolTables[key]
+	if ok {
+		s.resolveStackItemsWithTable(table, stackQueries, res)
+		s.lockSymbolTables.RUnlock()
+		return nil
+	}
+	s.lockSymbolTables.RUnlock()
+
+	var err error
+	pid := uint32(0)
+	for _, pidnr := range task.PidNumbers {
+		if pidnr.PidNsId == s.hostProcFsPidNs {
+			pid = pidnr.Pid
+			break
+		}
+	}
+	if pid == 0 {
+		return fmt.Errorf("procfs for %q not found", task.Name)
+	}
+	table, err = s.newSymbolTableFromPid(pid, key)
+	if err != nil {
+		return fmt.Errorf("creating new symbolTable for %q: %w", task.Name, err)
+	}
+
+	s.lockSymbolTables.Lock()
+	defer s.lockSymbolTables.Unlock()
+	if len(table.symbols)+s.symbolCountTotal > maxSymbolCountTotal {
+		return fmt.Errorf("too many symbols in all symbol tables: %d (max: %d)",
+			len(table.symbols)+s.symbolCountTotal, maxSymbolCountTotal)
+	}
+
+	s.symbolTables[key] = table
+	s.symbolCountTotal += len(table.symbols)
+
+	log.Debugf("symbol table for %q (pid %d) loaded: %d symbols (total: %d symbol tables with %d symbols)",
+		task.Name, pid, len(table.symbols), len(s.symbolTables), s.symbolCountTotal)
+
+	s.resolveStackItemsWithTable(table, stackQueries, res)
+
+	return nil
+}
+
+func (s *Symbolizer) newSymbolTableFromPid(pid uint32, expectedExeKey exeKey) (*symbolTable, error) {
+	path := fmt.Sprintf("%s/%d/exe", host.HostProcFs, pid)
+	file, err := os.Open(path)
+	if err != nil {
+		// The process might have terminated, or it might be in an unreachable
+		// pid namespace. Either way, we can't resolve symbols.
+		return nil, fmt.Errorf("opening process executable: %w", err)
+	}
+	defer file.Close()
+	fs, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat process executable: %w", err)
+	}
+	stat, ok := fs.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, errors.New("getting syscall.Stat_t failed")
+	}
+	ino := stat.Ino
+	newKey := exeKey{ino, stat.Mtim.Sec, uint32(stat.Mtim.Nsec)}
+	if newKey != expectedExeKey {
+		newComm, _ := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", file.Fd()))
+		newComm = filepath.Base(newComm)
+		return nil, fmt.Errorf("opening executable: got %q inode %d, mtime %d.%d (expected %s)",
+			newComm, ino, stat.Mtim.Sec, stat.Mtim.Nsec,
+			expectedExeKey)
+	}
+	if fs.Size() > maxExecutableSize {
+		return nil, fmt.Errorf("executable is too large (%d bytes)", fs.Size())
+	}
+
+	return s.newSymbolTableFromFile(file)
+}
+
+func (s *Symbolizer) newSymbolTableFromFile(file *os.File) (*symbolTable, error) {
+	var symbols []*symbol
+
+	elfFile, err := elf.NewFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("parsing ELF file: %w", err)
+	}
+	defer elfFile.Close()
+
+	symtab, err := elfFile.Symbols()
+	if err != nil {
+		// No symbols found. This is not an error.
+		return &symbolTable{}, nil
+	}
+
+	symbolCount := 0
+	for _, sym := range symtab {
+		if sym.Name == "" {
+			continue
+		}
+		if sym.Size == 0 {
+			continue
+		}
+		if len(sym.Name) > maxSymbolLength {
+			sym.Name = sym.Name[:maxSymbolLength]
+		}
+		symbols = append(symbols, &symbol{
+			name:  sym.Name,
+			value: sym.Value,
+			size:  sym.Size,
+		})
+		symbolCount++
+	}
+	if symbolCount > maxSymbolCount {
+		return nil, fmt.Errorf("too many symbols: %d", symbolCount)
+	}
+	slices.SortFunc(symbols, func(a, b *symbol) int {
+		if a.value < b.value {
+			return -1
+		}
+		if a.value > b.value {
+			return 1
+		}
+		return 0
+	})
+
+	return &symbolTable{
+		symbols:   symbols,
+		timestamp: time.Now(),
+	}, nil
+}
+
+func (s *Symbolizer) resolveStackItemsWithTable(table *symbolTable, stackQueries []StackItemQuery, res []StackItemResponse) {
+	table.timestamp = time.Now()
+	for idx := range stackQueries {
+		symbol := table.lookupByAddr(stackQueries[idx].Addr)
+		if symbol != "" {
+			res[idx].Found = true
+			res[idx].Symbol = symbol
+		}
+	}
+}
+
+// lookupByAddr returns the symbol name for the given address.
+func (e *symbolTable) lookupByAddr(address uint64) string {
+	// Similar to a trivial binary search, but each symbol is a range.
+	n, found := slices.BinarySearchFunc(e.symbols, address, func(a *symbol, b uint64) int {
+		if a.value <= b && a.value+a.size > b {
+			return 0
+		}
+		if a.value > b {
+			return 1
+		}
+		if a.value < b {
+			return -1
+		}
+		return 0
+	})
+	if found {
+		return e.symbols[n].name
+	}
+	return "[unknown]"
+}

--- a/pkg/symbolizer/symtab_others.go
+++ b/pkg/symbolizer/symtab_others.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package symbolizer
+
+import (
+	"errors"
+)
+
+func getHostProcFsPidNs() (uint32, error) {
+	return 0, errors.ErrUnsupported
+}
+
+func (s *Symbolizer) resolveWithSymtab(task Task, stackQueries []StackItemQuery, res []StackItemResponse) error {
+	return errors.ErrUnsupported
+}


### PR DESCRIPTION
Before this patch, the ustack and symbolizer packages only build on Linux. In preparation for making the ustack operator work client-side, this patch moves part of the code in _linux.go files. It will make it easier for future patches.

Tested by adding the import in a cmd package:
```
+++ b/cmd/common/oci.go
+       _ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ustack"
``` 
And running "make gadgetctl-all"

## Testing done

TODO, let's run the CI first.


- [x] Depends on https://github.com/inspektor-gadget/inspektor-gadget/pull/4919