### PR TITLE
ustack: fix bias for Go PIE programs

### DIFF
--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -54,9 +54,16 @@ type symbolTable struct {
 	// symbols is a slice of symbols. Order is preserved for binary search.
 	symbols []*symbol
 
-	// PIE (Position Independent Executable) needs addresses to be adjusted with
-	// base address.
+	// PIE (Position Independent Executable). Useful information for debugging.
 	isPIE bool
+
+	// elfBaseAddr is the link-time base address as defined in the ELF headers.
+	// Typical values:
+	// - 0 for C PIE programs
+	// - 0x400000 for C non-PIE programs (unless chosen otherwise with
+	//   flag "-Wl,-Ttext=0x1234")
+	// - 0x400000 for all Go programs, regardless of PIE.
+	elfBaseAddr uint64
 
 	timestamp time.Time
 }


### PR DESCRIPTION
# ustack: fix bias for Go PIE programs

Before #4921:

|  | PIE | Non-PIE |
|---|---|---|
| C | ❌ | ✅ |
| Go | ❌ | ✅ |

After #4921, but before this patch:

|  | PIE | Non-PIE |
|---|---|---|
| C | ✅ | ✅ |
| Go | ❌ | ✅ |

After this patch:

|  | PIE | Non-PIE |
|---|---|---|
| C | ✅ | ✅ |
| Go | ✅ | ✅ |

To look up a symbol in the symbol table from its address, the correct formula is:

```
lookup_address := runtime_address - runtime_base_address + elf_base_address
```
Before this patch, the formula was only applied for PIE executable, and we had the following behaviour
- Usually fine with C non-PIE programs because C non-PIE programs have a elf_base_address of 0x400000 (unless chosen otherwise with compilation flag `-Wl,-Ttext=0x1234`) and the runtime_base_address is typically 0x400000 as well, so the two errors cancel out.
- Usually fine with C PIE programs because C PIE programs have a elf_base_address of 0, so it didn't matter if the previous formula forgot to consider elf_base_address.
- However, Go programs typically have a elf_base_address of 0x400000, regardless of whether the program was compiled with the PIE option (e.g. `go build -buildmode=pie`), so the two errors don't cancel out.

Fixes: 2cb874d2cb6a ("symbolizer: implement support for PIE (Position Independent Executable)")

## How to use

See testing below.

## Testing done

### Automatic tests, for C programs only

```
IG_FLAGS="--verify-image=false" IG_PATH=$PWD/ig IG_RUNTIME=docker make -C gadgets/ trace_capabilities/test-integration
```

### Manual tests, for Go programs

<details>
<summary>gochroot.go</summary>

```go
package main

import (
	"fmt"
	"os"
	"syscall"
	"time"
)

func level3() {
	for range 2 {
		err := syscall.Chroot("/")
		fmt.Printf("chroot: %v\n", err)
		time.Sleep(2 * time.Second)
	}
	os.Exit(0)
}

func level2() {
	level3()
	level3()
}
func level1() {
	level2()
	level2()
}

func main() {
	level1()
	time.Sleep(time.Second)
	level1()
}
```

</details>

<details>
<summary>Makefile</summary>

```Makefile
.PHONY: gochroot
gochroot:
	go build -ldflags="-w"                -o gochroot1 gochroot.go
	go build -ldflags="-w" -buildmode=pie -o gochroot2 gochroot.go
```

</details>

<details>
<summary>Reproducible steps</summary>

* Test a Go non-PIE program
```bash
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_ustack_pie_go --verify-image=false --collect-ustack --comm=gochroot1 --host -o yaml -v
```
* Test a Go PIE program
```bash
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_ustack_pie_go --verify-image=false --collect-ustack --comm=gochroot2 --host -o yaml -v
```
* Check symbols in the output
```yaml
  symbols: '[0]internal/runtime/syscall.Syscall6; [1]syscall.Syscall; [2]syscall.Chroot;
    [3]main.level3; [4]main.level2; [5]main.level1; [6]main.main; [7]runtime.main;
    [8]runtime.goexit.abi0; '
```
</details>

### Manual tests, for C programs

<details>
<summary>chroot.c</summary>

```c
#include <stdio.h>
#include <unistd.h>
#include <stdlib.h>

__attribute__((noinline)) void level3() {
    int ret = chroot("/");
    printf("chroot: %d\n", ret);
}
__attribute__((noinline)) void level2() {
    level3();
}
__attribute__((noinline)) void level1() {
    level2();
}

int main() {
    level1();
    sleep(1);
    return 0;
}
```

</details>

<details>
<summary>Makefile</summary>

```Makefile
all:
	gcc -Wall            -o chroot1 chroot.c
	gcc -Wall -fPIE -pie -o chroot2 chroot.c
```

</details>

<details>
<summary>Reproducible steps</summary>

* Test a C non-PIE program
```bash
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_ustack_pie_go --verify-image=false --collect-ustack --comm=chroot1 --host -o yaml -v
```
* Test a C PIE program
```bash
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_capabilities:alban_ustack_pie_go --verify-image=false --collect-ustack --comm=chroot2 --host -o yaml -v
```
* Check symbols in the output
```yaml
  symbols: '[0][unknown]; [1]level2; [2]level1; [3]main; [4][unknown]; [5][unknown];
    [6]_start; '
```

</details>
