### PR TITLE
gadgets: trace_exec: use nbsp to join args

### DIFF
--- a/gadgets/trace_exec/consts/consts.go
+++ b/gadgets/trace_exec/consts/consts.go
@@ -1,0 +1,18 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+// ArgsSeparator is a non-breaking space used to separate function arguments in the "args" field of exec events.
+const ArgsSeparator = string('\u00a0')

--- a/gadgets/trace_exec/go/program.go
+++ b/gadgets/trace_exec/go/program.go
@@ -17,6 +17,7 @@ package main
 import (
 	"strings"
 
+	"github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/consts"
 	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
 )
 
@@ -88,9 +89,9 @@ func gadgetInit() int32 {
 		}
 
 		// TODO: The datasource doesn't support arrays yet, hence we have to
-		// join the args in a single string. This could be wrong as it's
-		// possible to execute a process with arguments that contain spaces.
-		argsF.SetString(data, strings.Join(args, " "))
+		// join the args in a single string. We are using a non-breaking space
+		// as separator to avoid collisions with arguments that contain spaces.
+		argsF.SetString(data, strings.Join(args, consts.ArgsSeparator))
 	}, 0)
 
 	return 0

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/consts"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
 	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
@@ -228,7 +229,7 @@ int main(int argc, char *argv[], char **envp) {
 						CommonData:    utils.BuildCommonData(containerName, commonDataOpts...),
 						Proc:          utils.BuildProc("sh2", 1000, 1111),
 						Cwd:           "/",
-						Args:          strings.Join(innerShArgs, " "),
+						Args:          strings.Join(innerShArgs, consts.ArgsSeparator),
 						PupperLayer:   false,
 						UpperLayer:    true,
 						FupperLayer:   true,
@@ -249,7 +250,7 @@ int main(int argc, char *argv[], char **envp) {
 						CommonData:    utils.BuildCommonData(containerName, commonDataOpts...),
 						Proc:          utils.BuildProc("sleep", 1000, 1111),
 						Cwd:           "/tmp",
-						Args:          strings.Join(sleep1Args, " "),
+						Args:          strings.Join(sleep1Args, consts.ArgsSeparator),
 						PupperLayer:   true,
 						UpperLayer:    false,
 						FupperLayer:   false,
@@ -269,7 +270,7 @@ int main(int argc, char *argv[], char **envp) {
 						CommonData:    utils.BuildCommonData(containerName, commonDataOpts...),
 						Proc:          utils.BuildProc("sleep", 1000, 1111),
 						Cwd:           "/tmp",
-						Args:          strings.Join(sleep2Args, " "),
+						Args:          strings.Join(sleep2Args, consts.ArgsSeparator),
 						PupperLayer:   true,
 						UpperLayer:    false,
 						FupperLayer:   false,

--- a/gadgets/trace_exec/test/unit/trace_exec_test.go
+++ b/gadgets/trace_exec/test/unit/trace_exec_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	traceexec "github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/consts"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
@@ -55,7 +56,7 @@ func TestTraceExecGadget(t *testing.T) {
 			argv:         []string{"/bin/echo", "hello", "world"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
-				expectedArgs := strings.Join(inputArgs, " ")
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[0].Args, "Expected Args %q, got %q", expectedArgs, events[0].Args)
 			},
 		},
@@ -65,7 +66,7 @@ func TestTraceExecGadget(t *testing.T) {
 			argv: []string{"/bin/echo", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10", "arg11", "arg12", "arg13", "arg14", "arg15", "arg16", "arg17", "arg18", "arg19", "arg20", "arg21"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
-				expectedArgs := strings.Join(inputArgs[:20], " ")
+				expectedArgs := strings.Join(inputArgs[:20], traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[0].Args, "Expected Args %q, got %q", expectedArgs, events[0].Args)
 			},
 		},
@@ -78,7 +79,7 @@ func TestTraceExecGadget(t *testing.T) {
 			argv: []string{"/bin/ls", "-l", "/"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
-				expectedArgs := strings.Join(inputArgs, " ")
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[0].Args, "Expected Args %q, got %q", expectedArgs, events[0].Args)
 				require.Equal(t, uint32(info.Uid), events[0].Proc.Creds.Uid)
 				require.Equal(t, uint32(info.Gid), events[0].Proc.Creds.Gid)
@@ -99,7 +100,7 @@ func TestTraceExecGadget(t *testing.T) {
 			argv:         []string{"/bin/foobar", "hello"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
-				expectedArgs := strings.Join(inputArgs, " ")
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[0].Args, "Expected Args %q, got %q", expectedArgs, events[0].Args)
 				require.Equal(t, "ENOENT", events[0].Error)
 			},
@@ -111,8 +112,8 @@ func TestTraceExecGadget(t *testing.T) {
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 2, "Expected 2 events but got %d", len(events))
 				// We do not check the full path of the executable/symlink here, as it may vary depending on the environment.
-				require.Contains(t, events[0].Args, "/bin/python3 -c")
-				expectedArgs := strings.Join(inputArgs, " ")
+				require.Contains(t, events[0].Args, "/bin/python3"+traceexec.ArgsSeparator+"-c")
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[1].Args, "Expected Args %q, got %q", expectedArgs, events[0].Args)
 			},
 		},
@@ -123,8 +124,8 @@ func TestTraceExecGadget(t *testing.T) {
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 2, "Expected 2 events but got %d", len(events))
 				// We do not check the full path of the executable/symlink here, as it may vary depending on the environment.
-				require.Contains(t, events[0].Args, "/bin/python3 -c")
-				expectedArgs := strings.Join(inputArgs, " ")
+				require.Contains(t, events[0].Args, "/bin/python3"+traceexec.ArgsSeparator+"-c")
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[1].Args, "Expected Args %q, got %q", expectedArgs, events[1].Args)
 				require.Equal(t, "ENOENT", events[1].Error)
 			},


### PR DESCRIPTION
# trace_exec: use nbsp to join args in return string

The idea is to allow splitting back args into a []string that represents exactly the arguments (that might contain spaces) by using a different Unicode character that is also printable as a space.

## How to use

Run the tracer with ig and see that the output remains the same.
Run the tracer with the Go API and split the args field with gadgets.ArgsSeparator

## Testing done

Works on my PC ;-p


## Breaking Change

### What is breaking?

The `args` field of the `trace_exec` gadget now uses the "non-breaking space" (unicode 00a0) character to join different arguments instead of the standard space (` `).

### Which users are impacted?

`trace_exec` users that parse and split the `args` field to get the list arguments list. 

### How to adapt?

Update the logic to use the "non-breaking space"  to split the field.
