### PR TITLE
operators: remove GlobalParamDescs in favour of GlobalParams

### DIFF
--- a/docs/api/_golang/operators/main.go
+++ b/docs/api/_golang/operators/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	igjson "github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/formatters/json"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"
@@ -49,7 +50,7 @@ func do() error {
 
 	// Configure the local manager operator
 	localManagerOp := localmanager.LocalManagerOperator
-	localManagerParams := localManagerOp.GlobalParamDescs().ToParams()
+	localManagerParams := apihelpers.ToParamDescs(localManagerOp.GlobalParams()).ToParams()
 	localManagerParams.Get(localmanager.Runtimes).Set("docker")
 	if err := localManagerOp.Init(localManagerParams); err != nil {
 		return fmt.Errorf("init local manager: %w", err)

--- a/examples/gadgets/trace_dns/main.go
+++ b/examples/gadgets/trace_dns/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	igjson "github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/formatters/json"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/localmanager"
@@ -58,7 +59,8 @@ func do() error {
 
 	// Create the local manager operator
 	localManagerOp := localmanager.LocalManagerOperator
-	localManagerParams := localManagerOp.GlobalParamDescs().ToParams()
+	localManagerParams := apihelpers.ToParamDescs(localManagerOp.GlobalParams()).ToParams()
+
 	localManagerParams.Get(localmanager.Runtimes).Set("docker")
 	if err := localManagerOp.Init(localManagerParams); err != nil {
 		return fmt.Errorf("init local manager: %w", err)

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -79,30 +79,6 @@ func (k *KubeManager) Description() string {
 	return "KubeManager handles container/pod/namespace information using Container-Collection and Tracer-Collection."
 }
 
-func (k *KubeManager) GlobalParamDescs() params.ParamDescs {
-	return params.ParamDescs{
-		{
-			Key:          ParamFallbackPodInformer,
-			DefaultValue: "true",
-			Description:  "Use pod informer as a fallback for the main hook",
-			TypeHint:     params.TypeBool,
-		},
-		{
-			Key:            ParamHookMode,
-			DefaultValue:   hookModeAuto,
-			Description:    "Mechanism to collect container information",
-			TypeHint:       params.TypeString,
-			PossibleValues: supportedHookModes,
-		},
-		{
-			Key:          ParamHookLivenessSocketFile,
-			DefaultValue: types.DefaultHookAndLivenessSocketFile,
-			Description:  "Path to the socket file for serving hook's requests for adding/removing containers and for liveness checks",
-			TypeHint:     params.TypeString,
-		},
-	}
-}
-
 func (k *KubeManager) ParamDescs() params.ParamDescs {
 	return append(common.GetContainerSelectorParams(true),
 		&params.ParamDesc{
@@ -371,7 +347,27 @@ func (m *KubeManagerInstance) EnrichEvent(ev any) error {
 }
 
 func (k *KubeManager) GlobalParams() api.Params {
-	return apihelpers.ParamDescsToParams(k.GlobalParamDescs())
+	return apihelpers.ParamDescsToParams(params.ParamDescs{
+		{
+			Key:          ParamFallbackPodInformer,
+			DefaultValue: "true",
+			Description:  "Use pod informer as a fallback for the main hook",
+			TypeHint:     params.TypeBool,
+		},
+		{
+			Key:            ParamHookMode,
+			DefaultValue:   hookModeAuto,
+			Description:    "Mechanism to collect container information",
+			TypeHint:       params.TypeString,
+			PossibleValues: supportedHookModes,
+		},
+		{
+			Key:          ParamHookLivenessSocketFile,
+			DefaultValue: types.DefaultHookAndLivenessSocketFile,
+			Description:  "Path to the socket file for serving hook's requests for adding/removing containers and for liveness checks",
+			TypeHint:     params.TypeString,
+		},
+	})
 }
 
 func (k *KubeManager) InstanceParams() api.Params {

--- a/pkg/operators/kubenameresolver/kubenameresolver.go
+++ b/pkg/operators/kubenameresolver/kubenameresolver.go
@@ -48,10 +48,6 @@ func (k *KubeNameResolver) Description() string {
 	return "KubeNameResolver resolves pod name/namespace to IP addresses"
 }
 
-func (k *KubeNameResolver) GlobalParamDescs() params.ParamDescs {
-	return nil
-}
-
 func (k *KubeNameResolver) ParamDescs() params.ParamDescs {
 	return nil
 }

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
-	"github.com/containerd/containerd/pkg/cri/constants"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -84,60 +83,6 @@ func (l *localManager) Name() string {
 
 func (l *localManager) Description() string {
 	return "Handles enrichment of container data and attaching/detaching to and from containers"
-}
-
-func (l *localManager) GlobalParamDescs() params.ParamDescs {
-	return params.ParamDescs{
-		{
-			Key:          Runtimes,
-			Alias:        "r",
-			DefaultValue: strings.Join(containerutils.AvailableRuntimes, ","),
-			Description: fmt.Sprintf("Comma-separated list of container runtimes. Supported values are: %s",
-				strings.Join(containerutils.AvailableRuntimes, ", ")),
-			// PossibleValues: containerutils.AvailableRuntimes, // TODO
-		},
-		{
-			Key:          DockerSocketPath,
-			DefaultValue: runtimeclient.DockerDefaultSocketPath,
-			Description:  "Docker Engine API Unix socket path",
-		},
-		{
-			Key:          ContainerdSocketPath,
-			DefaultValue: runtimeclient.ContainerdDefaultSocketPath,
-			Description:  "Containerd CRI Unix socket path",
-		},
-		{
-			Key:          CrioSocketPath,
-			DefaultValue: runtimeclient.CrioDefaultSocketPath,
-			Description:  "CRI-O CRI Unix socket path",
-		},
-		{
-			Key:          PodmanSocketPath,
-			DefaultValue: runtimeclient.PodmanDefaultSocketPath,
-			Description:  "Podman Unix socket path",
-		},
-		{
-			Key:          ContainerdNamespace,
-			DefaultValue: constants.K8sContainerdNamespace,
-			Description:  "Containerd namespace to use",
-		},
-		{
-			Key:          RuntimeProtocol,
-			DefaultValue: "internal",
-			Description:  "Container runtime protocol. Supported values are: internal, cri",
-		},
-		{
-			Key:          EnrichWithK8sApiserver,
-			DefaultValue: "false",
-			Description:  "Connect to the K8s API server to get further K8s enrichment",
-			TypeHint:     params.TypeBool,
-		},
-		{
-			Key:          KubeconfigPath,
-			DefaultValue: "", // Try in-cluster config by default
-			Description:  "Path to kubeconfig file. If not set, in-cluster config will be used.",
-		},
-	}
 }
 
 func (l *localManager) ParamDescs() params.ParamDescs {
@@ -505,7 +450,57 @@ type localManagerTraceWrapper struct {
 }
 
 func (l *localManager) GlobalParams() api.Params {
-	return apihelpers.ParamDescsToParams(l.GlobalParamDescs())
+	return apihelpers.ParamDescsToParams(params.ParamDescs{
+		{
+			Key:          Runtimes,
+			Alias:        "r",
+			DefaultValue: strings.Join(containerutils.AvailableRuntimes, ","),
+			Description: fmt.Sprintf("Comma-separated list of container runtimes. Supported values are: %s",
+				strings.Join(containerutils.AvailableRuntimes, ", ")),
+			// PossibleValues: containerutils.AvailableRuntimes, // TODO
+		},
+		{
+			Key:          DockerSocketPath,
+			DefaultValue: runtimeclient.DockerDefaultSocketPath,
+			Description:  "Docker Engine API Unix socket path",
+		},
+		{
+			Key:          ContainerdSocketPath,
+			DefaultValue: runtimeclient.ContainerdDefaultSocketPath,
+			Description:  "Containerd CRI Unix socket path",
+		},
+		{
+			Key:          CrioSocketPath,
+			DefaultValue: runtimeclient.CrioDefaultSocketPath,
+			Description:  "CRI-O CRI Unix socket path",
+		},
+		{
+			Key:          PodmanSocketPath,
+			DefaultValue: runtimeclient.PodmanDefaultSocketPath,
+			Description:  "Podman Unix socket path",
+		},
+		{
+			Key:          ContainerdNamespace,
+			DefaultValue: "k8s.io",
+			Description:  "Containerd namespace to use",
+		},
+		{
+			Key:          RuntimeProtocol,
+			DefaultValue: "internal",
+			Description:  "Container runtime protocol. Supported values are: internal, cri",
+		},
+		{
+			Key:          EnrichWithK8sApiserver,
+			DefaultValue: "false",
+			Description:  "Connect to the K8s API server to get further K8s enrichment",
+			TypeHint:     params.TypeBool,
+		},
+		{
+			Key:          KubeconfigPath,
+			DefaultValue: "", // Try in-cluster config by default
+			Description:  "Path to kubeconfig file. If not set, in-cluster config will be used.",
+		},
+	})
 }
 
 func (l *localManager) InstanceParams() api.Params {

--- a/pkg/operators/localmanager/localmanager_test.go
+++ b/pkg/operators/localmanager/localmanager_test.go
@@ -26,6 +26,7 @@ import (
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/testutils"
+	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
@@ -49,7 +50,7 @@ func TestLocalManagerBasic(t *testing.T) {
 	require.NoError(t, err, "Failed to initialize host")
 
 	lm := &localManager{}
-	gParams := lm.GlobalParamDescs().ToParams()
+	gParams := apihelpers.ToParamDescs(lm.GlobalParams()).ToParams()
 	err = lm.Init(gParams)
 	require.NoError(t, err, "Failed to initialize localManager")
 	lm.Close()
@@ -64,7 +65,7 @@ func TestLocalManagerMountNsMap(t *testing.T) {
 	require.NoError(t, err, "Failed to initialize host")
 
 	lm := &localManager{}
-	gParams := lm.GlobalParamDescs().ToParams()
+	gParams := apihelpers.ToParamDescs(lm.GlobalParams()).ToParams()
 	err = lm.Init(gParams)
 	require.NoError(t, err, "Failed to initialize localManager")
 	defer func() {
@@ -137,7 +138,7 @@ func TestLocalManagerClose(t *testing.T) {
 	initialFdList := currentFdList(t)
 
 	lm := &localManager{}
-	gParams := lm.GlobalParamDescs().ToParams()
+	gParams := apihelpers.ToParamDescs(lm.GlobalParams()).ToParams()
 	gParams.Set(Runtimes, "docker")
 
 	for i := range 4 {

--- a/pkg/operators/socketenricher/socketenricher.go
+++ b/pkg/operators/socketenricher/socketenricher.go
@@ -58,10 +58,6 @@ func (s *SocketEnricher) Description() string {
 	return "Socket enricher provides process information for sockets"
 }
 
-func (s *SocketEnricher) GlobalParamDescs() params.ParamDescs {
-	return nil
-}
-
 func (s *SocketEnricher) ParamDescs() params.ParamDescs {
 	return nil
 }

--- a/pkg/operators/uidgidresolver/uidgidresolver.go
+++ b/pkg/operators/uidgidresolver/uidgidresolver.go
@@ -55,10 +55,6 @@ func (k *UidGidResolver) Description() string {
 	return "UidGidResolver resolves uid and gid to username and groupname"
 }
 
-func (k *UidGidResolver) GlobalParamDescs() params.ParamDescs {
-	return nil
-}
-
 func (k *UidGidResolver) GlobalParams() api.Params {
 	return nil
 }


### PR DESCRIPTION
Commit 2c81bb6cff35 ("tree-wide: Remove legacy operators code") says:

> Remove some code from operators and related things only needed for
> built-in gadgets. There is still some clean up to do:
> - Remove GlobalParamDescs, ParamDescs, PreGadgetRun and PostGadgetRun

This commit removes GlobalParamDescs as suggested. The other functions remain unchanged.

Fixes: aaa2ffd7bebd ("socketenricher: Use CO-RE to make it resilient against changes")
Fixes: 2c81bb6cff35 ("tree-wide: Remove legacy operators code")

cc @mauriciovasquezbernal @Sefi4 @flyth 