### PR TITLE
Makefile: Fix checking image in minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,8 +351,9 @@ minikube-deploy: minikube-start gadget-container kubectl-gadget
 		$(MINIKUBE) image load $(CONTAINER_REPO):$(IMAGE_TAG) ; \
 	fi
 	@echo "Image in Minikube:"
-	$(MINIKUBE) image ls --format=table | grep "$(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG)" || \
-		(echo "Image $(CONTAINER_REPO)\s*|\s*$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
+	$(MINIKUBE) image ls --format=json | jq -e \
+	  '.[] | select(.repoTags[] == "$(CONTAINER_REPO):$(IMAGE_TAG)")' || \
+	  (echo "Image $(CONTAINER_REPO):$(IMAGE_TAG) was not correctly loaded into Minikube" && false)
 	@echo
 	./kubectl-gadget deploy --set-daemon-config=operator.oci.verify-image=$(VERIFY_GADGETS) --liveness-probe=$(LIVENESS_PROBE) \
 		--image-pull-policy=Never


### PR DESCRIPTION
It seems `minikube` changed table rendering and now we get following error when running `make minikube-deploy`:

```
Image in Minikube:
/home/qasim/work/cloud/github.com/inspektor-gadget/inspektor-gadget/bin/minikube/minikube-v1.37.0 image ls --format=table | grep "ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*main" || \
        (echo "Image ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*main was not correctly loaded into Minikube" && false)
Image ghcr.io/inspektor-gadget/inspektor-gadget\s*|\s*main was not correctly loaded into Minikube
make: *** [Makefile:350: minikube-deploy] Error 1
```

## v1.34.0

```
|-------------------------------------------|----------|---------------|--------|
|                   Image                   |   Tag    |   Image ID    |  Size  |
|-------------------------------------------|----------|---------------|--------|
| gcr.io/k8s-minikube/storage-provisioner   | v5       | 6e38f40d628db | 31.5MB |
| ghcr.io/inspektor-gadget/inspektor-gadget | main     | bf7671f98757c | 157MB  |
| registry.k8s.io/kube-apiserver            | v1.30.0  | c42f13656d0b2 | 117MB  |
| registry.k8s.io/etcd                      | 3.5.12-0 | 3861cfcd7c04c | 149MB  |
| registry.k8s.io/pause                     | 3.9      | e6f1816883972 | 744kB  |
| registry.k8s.io/kube-controller-manager   | v1.30.0  | c7aad43836fa5 | 111MB  |
| registry.k8s.io/kube-scheduler            | v1.30.0  | 259c8277fcbbc | 62MB   |
| registry.k8s.io/kube-proxy                | v1.30.0  | a0bf559e280cf | 84.7MB |
| registry.k8s.io/coredns/coredns           | v1.11.1  | cbb01a7bd410d | 59.8MB |
|-------------------------------------------|----------|---------------|--------|
```

## v1.37.0

```
┌───────────────────────────────────────────┬─────────┬───────────────┬────────┐
│                   IMAGE                   │   TAG   │   IMAGE ID    │  SIZE  │
├───────────────────────────────────────────┼─────────┼───────────────┼────────┤
│ registry.k8s.io/kube-proxy                │ v1.34.0 │ df0860106674d │ 71.9MB │
│ registry.k8s.io/kube-controller-manager   │ v1.34.0 │ a0af72f2ec6d6 │ 74.9MB │
│ registry.k8s.io/kube-scheduler            │ v1.34.0 │ 46169d968e920 │ 52.8MB │
│ registry.k8s.io/coredns/coredns           │ v1.12.1 │ 52546a367cc9e │ 75MB   │
│ gcr.io/k8s-minikube/storage-provisioner   │ v5      │ 6e38f40d628db │ 31.5MB │
│ ghcr.io/inspektor-gadget/inspektor-gadget │ main    │ bf7671f98757c │ 157MB  │
│ registry.k8s.io/kube-apiserver            │ v1.34.0 │ 90550c43ad2bc │ 88MB   │
│ registry.k8s.io/etcd                      │ 3.6.4-0 │ 5f1f5298c888d │ 195MB  │
│ registry.k8s.io/pause                     │ 3.10.1  │ cd073f4c5f6a8 │ 736kB  │
└───────────────────────────────────────────┴─────────┴───────────────┴────────┘

```

Fixes: 4980d60064ce3110132270fc6ee52381ee8e20ea

nit: Can also use `--format=json` to avoid this but not sure why we went for `--format=table` in the start.
