### PR TITLE
verifier: Use local store to load notation signatures

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -781,7 +781,7 @@ func getContentBytesFromDescriptor(ctx context.Context, fetcher content.Fetcher,
 	return bytes, nil
 }
 
-func ensureImage(ctx context.Context, imageStore oras.Target, image string, imgOpts *ImageOptions, pullPolicy string) error {
+func ensureImage(ctx context.Context, imageStore oras.GraphTarget, image string, imgOpts *ImageOptions, pullPolicy string) error {
 	switch pullPolicy {
 	case PullImageAlways:
 		_, err := pullGadgetImageToStore(ctx, imageStore, image, &imgOpts.AuthOptions)

--- a/pkg/signature/cosign/verifier.go
+++ b/pkg/signature/cosign/verifier.go
@@ -248,7 +248,7 @@ func checkPayloadImage(payloadBytes []byte, imageDigest string) error {
 	return nil
 }
 
-func (c *Verifier) Verify(ctx context.Context, repo *remote.Repository, imageStore oras.Target, ref reference.Named) error {
+func (c *Verifier) Verify(ctx context.Context, repo *remote.Repository, imageStore oras.GraphTarget, ref reference.Named) error {
 	imageDigest, err := getImageDigest(ctx, imageStore, ref.String())
 	if err != nil {
 		return fmt.Errorf("getting image digest: %w", err)

--- a/pkg/signature/cosign/verifier_test.go
+++ b/pkg/signature/cosign/verifier_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/resources"
 )
 
-func createTestPrerequisities(t *testing.T, image string) (oras.Target, *remote.Repository, reference.Named) {
+func createTestPrerequisities(t *testing.T, image string) (oras.GraphTarget, *remote.Repository, reference.Named) {
 	store, err := oci.New(t.TempDir())
 	require.NoError(t, err)
 

--- a/pkg/signature/notation/verifier.go
+++ b/pkg/signature/notation/verifier.go
@@ -124,7 +124,7 @@ func NewVerifier(opts VerifierOptions) (*Verifier, error) {
 	return &Verifier{verif}, nil
 }
 
-func (n *Verifier) Verify(ctx context.Context, repo *remote.Repository, imageStore oras.Target, ref reference.Named) error {
+func (n *Verifier) Verify(ctx context.Context, _ *remote.Repository, imageStore oras.GraphTarget, ref reference.Named) error {
 	imageDigest, err := getImageDigest(ctx, imageStore, ref.String())
 	if err != nil {
 		return fmt.Errorf("getting image digest: %w", err)
@@ -134,7 +134,7 @@ func (n *Verifier) Verify(ctx context.Context, repo *remote.Repository, imageSto
 		ArtifactReference:    fmt.Sprintf("%s@%s", ref.Name(), imageDigest),
 		MaxSignatureAttempts: maxSignatureAttempts,
 	}
-	_, _, err = notation.Verify(ctx, n.Verifier, registry.NewRepository(repo), verifyOptions)
+	_, _, err = notation.Verify(ctx, n.Verifier, registry.NewRepository(imageStore), verifyOptions)
 
 	return err
 }

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Verifier interface {
-	Verify(ctx context.Context, repo *remote.Repository, imageStore oras.Target, ref reference.Named) error
+	Verify(ctx context.Context, repo *remote.Repository, imageStore oras.GraphTarget, ref reference.Named) error
 }
 
 type SignatureVerifier struct {
@@ -41,7 +41,7 @@ type VerifierOptions struct {
 	NotationVerifierOpts notation.VerifierOptions
 }
 
-func (v *SignatureVerifier) Verify(ctx context.Context, repo *remote.Repository, imageStore oras.Target, ref reference.Named) error {
+func (v *SignatureVerifier) Verify(ctx context.Context, repo *remote.Repository, imageStore oras.GraphTarget, ref reference.Named) error {
 	if len(v.verifiers) == 0 {
 		return errors.New("no verification method available")
 	}


### PR DESCRIPTION
Many uses cases of Inspektor Gadget require it to run without an internet connection. This commit fixes notation to avoid always trying to pull the signature. This is done by passing the local store instead of the remote one as target for the notation.Verify() logic.

Fixes: 7eebaf15a39a ("pkg: signature: Add notation verifying.")

## Testing

0. Build, push and sign a gadget with notation

```bash
$ export IMG=ttl.sh/mauricio-foo:bar
$ sudo -E ig image build ./gadgets/snapshot_process/ -t $IMG
$ sudo -E ig image push $IMG

$ notation cert generate-test foo.io
$ notation sign --key foo.io $IMG

# check image was signed
$ notation list $IMG
Warning: Always list the artifact using digest(@sha256:...) rather than a tag(:bar) because resolved digest may not point to the same signed artifact, as tags are mutable.
ttl.sh/mauricio-foo@sha256:1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d
└── application/vnd.cncf.notary.signature
    └── sha256:86074e183166854eb017f95079b1ae2dc89385393d391a007112d189de91efc9
```

Create a trust policy document:

```bash
$ cat trust-policy.json
{
  "version": "1.0",
  "trustPolicies": [
    {
      "name": "gadgets",
      "registryScopes": [
        "*"
      ],
      "signatureVerification": {
        "level": "strict"
      },
      "trustStores": [
        "ca:foo.io"
      ],
      "trustedIdentities": [
        "x509.subject: CN=foo.io, O=Notary, L=Seattle, ST=WA, C=US"
      ]
    }
  ]
}
```

### Before this PR

Run the image a first time allowing ig to access internet (to pull image, signatures,etc)

```bash
$ sudo -E ig run --notation-certificates="$(cat ~/.config/notation/truststore/x509/ca/foo.io/foo.io.crt)" --notation-policy-document="$(cat trust-policy.json)" $IMG
RUNTIME.CONTAINERNAME                                                                             COMM                    PID        TI                    
```

Now, try to run the image without accessing the nework. It should work as the image is already on our system, right?

```bash
$ sudo -E unshare -n -- ig run --notation-certificates="$(cat ~/.config/notation/truststore/x509/ca/foo.io/foo.io.crt)" --notation-policy-document="$(cat trust-policy.json)" $IMG
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying gadget signature "ttl.sh/mauricio-foo:bar": verifying with cosign: getting signing information: getting signing information for "sha256-1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d.sig": copying index tag "sha256-1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d.sig": failed to perform "FetchReference" on source: Get "https://ttl.sh/v2/mauricio-foo/manifests/sha256-1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d.sig": dial tcp: lookup ttl.sh on 127.0.0.53:53: dial udp 127.0.0.53:53: connect: network is unreachable
getting OCI 1.1 signature tag: signature tag not found for index "sha256-1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d"
verifying with notation: Head "https://ttl.sh/v2/mauricio-foo/manifests/sha256:1a5218bcec108152f6e9492fb3ee5af926084dd7b732d7e0b490d15de417bf3d": dial tcp: lookup ttl.sh on 127.0.0.53:53: dial udp 127.0.0.53:53: connect: network is unreachable
```

Well, it doesn't work as notation tries to pull the image 

### After this PR

Running the gadget without internet works fine.

```bash
$ sudo -E unshare -n -- ig run --notation-certificates="$(cat ~/.config/notation/truststore/x509/ca/foo.io/foo.io.crt)" --notation-policy-document="$(cat trust-policy.json)" $IMG
RUNTIME.CONTAINERNAME                                                                             COMM                    PID        TI                     
```

cc @eiffel-fl 


