### PR TITLE
pkg/testing: Add timestamp for start/stop

### DIFF
--- a/pkg/testing/command/command.go
+++ b/pkg/testing/command/command.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -110,10 +111,10 @@ func (c *Command) verifyStderrOutput(t *testing.T) {
 func (c *Command) Run(t *testing.T) {
 	c.initExecCmd()
 
-	t.Logf("Run command(%s):\n", c.Name)
+	t.Logf("[%s] Run command(%s):\n", time.Now().UTC(), c.Name)
 	err := c.Cmd.Run()
-	t.Logf("Command returned(%s):\n%s\n%s\n",
-		c.Name, c.stderr.String(), c.stdout.String())
+	t.Logf("[%s] Command returned(%s):\n%s\n%s\n",
+		time.Now().UTC(), c.Name, c.stderr.String(), c.stdout.String())
 	require.NoError(t, err, "failed to run command(%s)", c.Name)
 
 	c.verifyStderrOutput(t)
@@ -130,7 +131,7 @@ func (c *Command) Start(t *testing.T) {
 
 	c.initExecCmd()
 
-	t.Logf("Start command(%s)", c.Name)
+	t.Logf("[%s] Start command(%s)", time.Now().UTC(), c.Name)
 	err := c.Cmd.Start()
 	require.NoError(t, err, "failed to start command(%s)", c.Name)
 
@@ -147,10 +148,10 @@ func (c *Command) Stop(t *testing.T) {
 		return
 	}
 
-	t.Logf("Stop command(%s)\n", c.Name)
+	t.Logf("[%s] Stop command(%s)\n", time.Now().UTC(), c.Name)
 	err := c.kill()
-	t.Logf("Command returned(%s):\n%s\n%s\n",
-		c.Name, c.stderr.String(), c.stdout.String())
+	t.Logf("[%s] Command returned(%s):\n%s\n%s\n",
+		time.Now().UTC(), c.Name, c.stderr.String(), c.stdout.String())
 	require.NoError(t, err, "failed to kill command(%s)", c.Name)
 
 	c.verifyOutput(t)


### PR DESCRIPTION
The timestamps we see in the CI output is tied to the command that had written something to the log. This PR adds a timestamp directly in the log message itself

[Example](https://productionresultssa16.blob.core.windows.net/actions-results/1cb5f410-9d92-442b-946f-4ede458765cd/workflow-job-run-e5a476af-8fcb-5615-9036-ba8c6fb06732/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-10-14T13%3A36%3A01Z&sig=TfiLTRiEXCohC1PHyYGQwR3dAoDnd5JqlNPU7gZ69Uc%3D&ske=2025-10-14T22%3A52%3A13Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-10-14T10%3A52%3A13Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-10-14T13%3A25%3A56Z&sv=2025-11-05) where Sleeps were instant and ns+pod creation aswell:
```
2025-10-14T12:31:47.3314700Z === RUN   TestSchedCLS
2025-10-14T12:31:47.3315206Z     utils.go:250: Seed used: 1760445014561125172
2025-10-14T12:31:47.3315916Z     command.go:113: Run command(Create test namespace):
2025-10-14T12:31:47.3316698Z     command.go:115: Command returned(Create test namespace):
2025-10-14T12:31:47.3317220Z         
2025-10-14T12:31:47.3317808Z         namespace/schedcls-test-3422692525181471847 created
2025-10-14T12:31:47.3318430Z         NAME      SECRETS   AGE
2025-10-14T12:31:47.3318908Z         default   0         0s
2025-10-14T12:31:47.3319309Z         
2025-10-14T12:31:47.3319986Z     command.go:133: Start command(Run schedcls-server)
2025-10-14T12:31:47.3320671Z     command.go:113: Run command(SleepForSeconds):
2025-10-14T12:31:47.3321373Z     command.go:115: Command returned(SleepForSeconds):
2025-10-14T12:31:47.3321866Z         
2025-10-14T12:31:47.3322165Z         
2025-10-14T12:31:47.3322632Z     command.go:113: Run command(WaitForTestPod):
2025-10-14T12:31:47.3323300Z     command.go:115: Command returned(WaitForTestPod):
2025-10-14T12:31:47.3323788Z         
2025-10-14T12:31:47.3324255Z         pod/schedcls-server condition met
2025-10-14T12:31:47.3324721Z         
2025-10-14T12:31:47.3325224Z     command.go:150: Stop command(Run schedcls-server)
2025-10-14T12:31:47.3325948Z     command.go:152: Command returned(Run schedcls-server):
2025-10-14T12:31:47.3326461Z         
2025-10-14T12:31:47.3326882Z         pod/schedcls-server created
2025-10-14T12:31:47.3327296Z         
2025-10-14T12:31:47.3327795Z     command.go:133: Start command(Run schedcls-client)
2025-10-14T12:31:47.3328460Z     command.go:113: Run command(SleepForSeconds):
2025-10-14T12:31:47.3329146Z     command.go:115: Command returned(SleepForSeconds):
2025-10-14T12:31:47.3329777Z         
2025-10-14T12:31:47.3330081Z         
2025-10-14T12:31:47.3330523Z     command.go:113: Run command(WaitForTestPod):
2025-10-14T12:31:47.3331134Z     command.go:115: Command returned(WaitForTestPod):
2025-10-14T12:31:47.3331616Z         
2025-10-14T12:31:47.3332075Z         pod/schedcls-client condition met
2025-10-14T12:31:47.3332518Z         
2025-10-14T12:31:47.3333003Z     command.go:150: Stop command(Run schedcls-client)
2025-10-14T12:31:47.3333698Z     command.go:152: Command returned(Run schedcls-client):
```