### PR TITLE
gadgets/tests: Increase sleep to minimum 1 second

### DIFF
--- a/gadgets/advise_networkpolicy/test/integration/advise_networkpolicy_test.go
+++ b/gadgets/advise_networkpolicy/test/integration/advise_networkpolicy_test.go
@@ -115,7 +115,7 @@ func TestAdviseNetworkpolicyGadget(t *testing.T) {
 	}
 	testClientContainer := containerFactory.NewContainer(
 		clientContainerName,
-		fmt.Sprintf("while true; do sleep 0.5 && wget %s; done", testServerContainer.IP()),
+		fmt.Sprintf("while true; do sleep 1 && wget %s; done", testServerContainer.IP()),
 		clientContainerOpts...,
 	)
 

--- a/gadgets/top_blockio/test/integration/top_blockio_test.go
+++ b/gadgets/top_blockio/test/integration/top_blockio_test.go
@@ -65,7 +65,7 @@ func TestTopBlockio(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do dd if=/dev/zero of=/tmp/test count=4096; sleep 0.2; done",
+		"while true; do dd if=/dev/zero of=/tmp/test count=4096; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/top_tcp/test/integration/top_tcp_test.go
+++ b/gadgets/top_tcp/test/integration/top_tcp_test.go
@@ -68,7 +68,7 @@ func TestTopTcp(t *testing.T) {
 	// TODO: can't use setuidgid because it's not available on the nginx image
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"nginx && while true; do curl 127.0.0.1; sleep 0.1; done",
+		"nginx && while true; do curl 127.0.0.1; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/trace_fsslower/test/integration/trace_fsslower_test.go
+++ b/gadgets/trace_fsslower/test/integration/trace_fsslower_test.go
@@ -67,7 +67,7 @@ func TestTraceFSSlower(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"echo 'this is foo' > foo && while true; do cat foo && sleep 0.1; done",
+		"echo 'this is foo' > foo && while true; do cat foo && sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/trace_mount/test/integration/trace_mount_test.go
+++ b/gadgets/trace_mount/test/integration/trace_mount_test.go
@@ -68,7 +68,7 @@ func TestTraceMount(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do mount /mnt /mnt; sleep 0.1; done",
+		"while true; do mount /mnt /mnt; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/trace_open/test/integration/trace_open_test.go
+++ b/gadgets/trace_open/test/integration/trace_open_test.go
@@ -60,7 +60,7 @@ func TestTraceOpen(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do setuidgid 1000:1111 cat /dev/null; sleep 0.1; done",
+		"while true; do setuidgid 1000:1111 cat /dev/null; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/trace_sni/test/integration/trace_sni_test.go
+++ b/gadgets/trace_sni/test/integration/trace_sni_test.go
@@ -61,7 +61,7 @@ func TestTraceSNI(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do setuidgid 1000:1111 wget --no-check-certificate -T 2 -q -O /dev/null https://inspektor-gadget.io; sleep 0.1; done",
+		"while true; do setuidgid 1000:1111 wget --no-check-certificate -T 2 -q -O /dev/null https://inspektor-gadget.io; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/trace_tcp/test/integration/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/integration/trace_tcp_test.go
@@ -66,7 +66,7 @@ func TestTraceTCP(t *testing.T) {
 	// TODO: can't use setuidgid because it's not available on the nginx image
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"nginx && while true; do curl 127.0.0.1; sleep 0.1; done",
+		"nginx && while true; do curl 127.0.0.1; sleep 1; done",
 		containerOpts...,
 	)
 

--- a/gadgets/traceloop/test/integration/traceloop_test.go
+++ b/gadgets/traceloop/test/integration/traceloop_test.go
@@ -62,7 +62,7 @@ func TestTraceloop(t *testing.T) {
 
 	testContainer := containerFactory.NewContainer(
 		containerName,
-		"while true; do ls > /dev/null; sleep 0.1; done",
+		"while true; do ls > /dev/null; sleep 1; done",
 		containerOpts...,
 	)
 


### PR DESCRIPTION
The console/CI output gets spammed with the output of these commands and executing these that many times is not needed. This also reduces the load of the CI nodes, which can counteract the CI flakyness.

There is still another sleep which is under 1 sec, but I think that is needed to be sure that we hit a retrans there.
https://github.com/inspektor-gadget/inspektor-gadget/blob/07a515c76eb3700c0addee6804463e7cd9cab10b/gadgets/trace_tcpretrans/test/integration/trace_tcpretrans_test.go#L66-L67