### PR TITLE
testing: Increase kubectl wait timeout to 60s

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -643,7 +643,7 @@ func DeleteRemainingNamespacesCommand() *Command {
 func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
 	return &Command{
 		Name:           fmt.Sprintf("WaitForJob: %s", jobname),
-		Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete -n %s %s", namespace, jobname),
+		Cmd:            fmt.Sprintf("kubectl wait job --for condition=complete --timeout=60s -n %s %s", namespace, jobname),
 		ExpectedString: fmt.Sprintf("job.batch/%s condition met\n", jobname),
 	}
 }
@@ -653,7 +653,7 @@ func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
 func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 	return &Command{
 		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", namespace, podname),
+		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname),
 		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
 	}
 }
@@ -663,7 +663,7 @@ func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 func WaitUntilPodReadyOrOOMKilledCommand(namespace string, podname string) *Command {
 	return &Command{
 		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname),
+		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname),
 		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
 	}
 }

--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -235,7 +235,7 @@ func deleteK8sNamespace(t *testing.T, namespace string) {
 func waitUntilPodReadyCommand(t *testing.T, namespace string, podname string) *command.Command {
 	return &command.Command{
 		Name:           "WaitForTestPod",
-		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s", namespace, podname)),
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname)),
 		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod/%s condition met\n", podname)),
 	}
 }
@@ -245,7 +245,7 @@ func waitUntilPodReadyCommand(t *testing.T, namespace string, podname string) *c
 func waitUntilPodReadyOrOOMKilledCommand(t *testing.T, namespace string, podname string) *command.Command {
 	return &command.Command{
 		Name:           "WaitForTestPod",
-		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname)),
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname)),
 		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod/%s condition met\n", podname)),
 	}
 }


### PR DESCRIPTION
I have seen multiple CI runs where the `kubectl wait` has timed out. IMO we can be sure that this is just slow network/cpu and we can double the default timeout from 30s to 60s for these.

https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18556266312/job/52896818159#step:11:1295
https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18556266312/job/52896818272#step:9:1608