### PR TITLE
examples: fix trace_dns example, setting socketEnricher parameters

### DIFF
--- a/examples/gadgets/trace_dns/main.go
+++ b/examples/gadgets/trace_dns/main.go
@@ -28,6 +28,7 @@ import (
 	ocihandler "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/oci-handler"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/socketenricher"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 )
 
@@ -67,8 +68,17 @@ func do() error {
 
 	// The socker enricher operator is used to provide information about the
 	// process performing the DNS query.
+	socketEnricherFields := params.ParamDescs{
+		{
+			Key:         "socket-enricher-fields",
+			Description: "Fields to enrich the socket event with",
+			TypeHint:    params.TypeString,
+		},
+	}
 	socketEnricherOp := &socketenricher.SocketEnricher{}
-	if err := socketEnricherOp.Init(nil); err != nil {
+	socketEnricherParams := socketEnricherFields.ToParams()
+	socketEnricherParams.Get("socket-enricher-fields").Set("cwd=512,exepath=512")
+	if err := socketEnricherOp.Init(socketEnricherParams); err != nil {
 		return fmt.Errorf("init socket enricher: %w", err)
 	}
 	defer socketEnricherOp.Close()


### PR DESCRIPTION
# fix trace_dns example, enabling cwd path

The trace_dns example doesn't have cwd path enrichment enabled, and enabling it is currently not working via the "operator.oci.ebpf.paths" annotation.
This PR sets socketEnricher parameters to allow this to work.

## How to use

sudo go run examples/gadgets/trace_dns/main.go

## Testing done

Ran the example on my local machine.
