### PR TITLE
pkg: signature: Add CopySigningInformation() helper.

### DIFF
--- a/pkg/signature/cosign/exporter.go
+++ b/pkg/signature/cosign/exporter.go
@@ -16,20 +16,15 @@ package cosign
 
 import (
 	"context"
-	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/signature/helpers"
 )
 
 type Exporter struct{} // Empty type only to respect the interface.
 
 func (e *Exporter) ExportSigningInformation(ctx context.Context, src oras.ReadOnlyTarget, dst oras.Target, desc ocispec.Descriptor) error {
-	signatureTag, err := craftCosignSignatureTag(desc.Digest.String())
-	if err != nil {
-		return fmt.Errorf("crafting signature tag: %w", err)
-	}
-
-	_, err = oras.Copy(ctx, src, signatureTag, dst, signatureTag, oras.DefaultCopyOptions)
-	return err
+	return helpers.CopySigningInformation(ctx, src, dst, desc.Digest.String(), craftCosignSignatureTag)
 }

--- a/pkg/signature/cosign/puller.go
+++ b/pkg/signature/cosign/puller.go
@@ -20,6 +20,8 @@ import (
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/signature/helpers"
 )
 
 type Puller struct{} // Empty type only to respect the interface.
@@ -33,10 +35,5 @@ func pullCosignSigningInformation(ctx context.Context, repo *remote.Repository, 
 }
 
 func (c *Puller) PullSigningInformation(ctx context.Context, repo *remote.Repository, imageStore oras.Target, digest string) error {
-	signingInfoTag, err := craftCosignSignatureTag(digest)
-	if err != nil {
-		return fmt.Errorf("crafting cosign signature tag: %w", err)
-	}
-
-	return pullCosignSigningInformation(ctx, repo, signingInfoTag, imageStore)
+	return helpers.CopySigningInformation(ctx, repo, imageStore, digest, craftCosignSignatureTag)
 }

--- a/pkg/signature/helpers/helpers.go
+++ b/pkg/signature/helpers/helpers.go
@@ -46,3 +46,13 @@ func CraftSignatureIndexTag(digest string) (string, error) {
 
 	return fmt.Sprintf("%s-%s", parts[0], parts[1]), nil
 }
+
+func CopySigningInformation(ctx context.Context, src oras.ReadOnlyTarget, dst oras.Target, digest string, craftSigningInfoTag func(digest string) (string, error)) error {
+	signingInfoTag, err := craftSigningInfoTag(digest)
+	if err != nil {
+		return fmt.Errorf("crafting signing information tag: %w", err)
+	}
+
+	_, err = oras.Copy(ctx, src, signingInfoTag, dst, signingInfoTag, oras.DefaultCopyOptions)
+	return err
+}

--- a/pkg/signature/oci11/exporter.go
+++ b/pkg/signature/oci11/exporter.go
@@ -16,7 +16,6 @@ package oci11
 
 import (
 	"context"
-	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -27,11 +26,5 @@ import (
 type Exporter struct{} // Empty type only to respect the interface.
 
 func (e *Exporter) ExportSigningInformation(ctx context.Context, src oras.ReadOnlyTarget, dst oras.Target, desc ocispec.Descriptor) error {
-	signatureTag, err := helpers.CraftSignatureIndexTag(desc.Digest.String())
-	if err != nil {
-		return fmt.Errorf("crafting index tag: %w", err)
-	}
-
-	_, err = oras.Copy(ctx, src, signatureTag, dst, signatureTag, oras.DefaultCopyOptions)
-	return err
+	return helpers.CopySigningInformation(ctx, src, dst, desc.Digest.String(), helpers.CraftSignatureIndexTag)
 }

--- a/pkg/signature/oci11/puller.go
+++ b/pkg/signature/oci11/puller.go
@@ -16,7 +16,6 @@ package oci11
 
 import (
 	"context"
-	"fmt"
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
@@ -27,14 +26,5 @@ import (
 type Puller struct{} // Empty type only to respect the interface.
 
 func (c *Puller) PullSigningInformation(ctx context.Context, repo *remote.Repository, imageStore oras.Target, digest string) error {
-	signingInfoTag, err := helpers.CraftSignatureIndexTag(digest)
-	if err != nil {
-		return fmt.Errorf("crafting cosign signature tag: %w", err)
-	}
-
-	if _, err := oras.Copy(ctx, repo, signingInfoTag, imageStore, signingInfoTag, oras.DefaultCopyOptions); err != nil {
-		return fmt.Errorf("copying index tag %q: %w", signingInfoTag, err)
-	}
-
-	return nil
+	return helpers.CopySigningInformation(ctx, repo, imageStore, digest, helpers.CraftSignatureIndexTag)
 }


### PR DESCRIPTION
This helper is used in Puller and Exporter interfaces to ease the task and reduce code duplication.