### PR TITLE
Update finder.go

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -45,6 +45,7 @@ var RuntimePaths = []string{
 	"/var/lib/k0s/bin/runc",                      // Used in k0s
 	"/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/runc", // Used in Bottlerocket OS
 	"/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/runc",  // Used in Bottlerocket OS
+	"/snap/microk8s/current/bin/runc",
 }
 
 // Notify marks the runtime path given as argument if it exists.


### PR DESCRIPTION
# Adding the path for microk8s

Microk8s runs its own runc which is deployed in a path containing the snap revision number.
Fortunately there's a symlink we can use to point to the current one:
```bash
$ realpath /snap/microk8s/current/bin/runc 
/snap/microk8s/8507/bin/runc
```

## How to use

Install microk8s and run IG with `kubectl gadget...`

## Testing done

Tested on various versions of microk8s (1.34, 1.33, 1.31).
