### PR TITLE
Revert "ci: bump sigstore/cosign-installer from 3.10.0 to 4.0.0"

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1452,7 +1452,7 @@ jobs:
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
       - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
       - name: Check if public key is up-to-date.
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -1558,7 +1558,7 @@ jobs:
           sudo mv ig /usr/bin/ig
       - name: Install Cosign
         if: needs.check-secrets.outputs.cosign == 'true'
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
       - name: Verify gadget builder image
         if: needs.check-secrets.outputs.cosign == 'true'
         run: |
@@ -2346,7 +2346,7 @@ jobs:
         done
     - name: Install Cosign
       if: needs.check-secrets.outputs.cosign == 'true'
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
     - name: Sign checksums file
       if: needs.check-secrets.outputs.cosign == 'true'
       shell: bash


### PR DESCRIPTION
This reverts commit 2e1075568fb01b6b25541d397f81fd12edf7427f. This commit broke the CI, as the gadgets are not signed but the failure is not notified [1,2].

Let revert it to have more time to investigate the root cause and change the invocation of signing.

[1]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18678704075/job/53255123822#step:10:1 The whole text to answer "yes" to cosign pushing something is not printed with the new version, thus the gadgets are not signed and CI fails later. [2]: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18596598596/job/53028651000#step:10:32 The whole text is printed, which ensures the gadget are signed.