### PR TITLE
gadgets/tcpdump: fix packet length output

### DIFF
--- a/gadgets/tcpdump/gadget.yaml
+++ b/gadgets/tcpdump/gadget.yaml
@@ -18,7 +18,7 @@ datasources:
       cli.raw.fields: payload
       pcap.payload: payload
       pcap.timestamp: timestamp
-      pcap.packet-length: payload_len
+      pcap.packet-length: packet_size
     fields:
       ifindex:
         annotations:


### PR DESCRIPTION
Before this patch, the tcpdump gadget would falsely use the captured packet length (affected by snap-len) as the on-wire packet length.