### PR TITLE
[v0.41] Backport: deletePodCommand: Add regex to optionally include ns

### DIFF
--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -176,7 +176,7 @@ func deletePodCommand(t *testing.T, podname, namespace string) *command.Command 
 	return &command.Command{
 		Name:           fmt.Sprintf("Delete %s", podname),
 		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl delete -n=%s pod %s", namespace, podname)),
-		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod \"%s\" deleted\n", podname)),
+		ValidateOutput: match.MatchRegexp(t, fmt.Sprintf("pod \"%s\" deleted( from %s namespace)?\n", podname, namespace)),
 	}
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/inspektor-gadget/inspektor-gadget/pull/4861 to make the CI happy in case a `v0.41` release is needed in the future