### PR TITLE
[v0.41] Update docker images and CI to Go 1.24.6 

### DIFF
--- a/.github/workflows/cloud-cleanup.yml
+++ b/.github/workflows/cloud-cleanup.yml
@@ -1,6 +1,6 @@
 name: Cleanup Cloud Resources
 env:
-  GO_VERSION: 1.24.2
+  GO_VERSION: 1.24.6
 on:
   schedule:
     - cron: "0 */3 * * *"

--- a/.github/workflows/dockerhub-mirror.yml
+++ b/.github/workflows/dockerhub-mirror.yml
@@ -7,7 +7,7 @@ name: Mirror Dockerhub
 env:
   REGISTRY: ghcr.io
   CONTAINER_REPO: ${{ github.repository_owner }}
-  GO_VERSION: 1.24.2
+  GO_VERSION: 1.24.6
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2,7 +2,7 @@ name: Inspektor Gadget CI
 env:
   REGISTRY: ghcr.io
   CONTAINER_REPO: ${{ github.repository }}
-  GO_VERSION: 1.24.2
+  GO_VERSION: 1.24.6
   # controller-gen with go >1.21 panics, but we can't update controller-gen itself
   GO_VERSION_DOC_CHECK: 1.21.3
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.24.2
+  go: 1.24.6
   build-tags:
     - docs
 linters:

--- a/Dockerfiles/gadget-builder.Dockerfile
+++ b/Dockerfiles/gadget-builder.Dockerfile
@@ -1,7 +1,7 @@
 ARG CLANG_LLVM_VERSION=18
 ARG BPFTOOL_VERSION=v7.3.0
 ARG LIBBPF_VERSION=v1.3.0
-ARG GOLANG_VERSION=1.24.2
+ARG GOLANG_VERSION=1.24.6
 
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

--- a/Dockerfiles/gadget.Dockerfile
+++ b/Dockerfiles/gadget.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for Inspektor Gadget.
 
-ARG BUILDER_IMAGE=golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2
+ARG BUILDER_IMAGE=golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12@sha256:ce46866b3a5170db3b49364900fb3168dc0833dfb46c26da5c77f22abb01d8c3
 
 # Prepare and build gadget artifacts in a container

--- a/Dockerfiles/ig-tests.Dockerfile
+++ b/Dockerfiles/ig-tests.Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2
+ARG BUILDER_IMAGE=golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:latest@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfiles/ig.Dockerfile
+++ b/Dockerfiles/ig.Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2
+ARG BUILDER_IMAGE=golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:latest@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfiles/kubectl-gadget.Dockerfile
+++ b/Dockerfiles/kubectl-gadget.Dockerfile
@@ -6,7 +6,7 @@
 # image is valid, even scratch. Alpine is used by default as a tradeoff
 # between size and tools available in the image.
 
-ARG BUILDER_IMAGE=golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2
+ARG BUILDER_IMAGE=golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:latest@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/examples/builtin-gadgets/withfilter/trace/network/Dockerfile
+++ b/examples/builtin-gadgets/withfilter/trace/network/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a AS builder
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 WORKDIR /src

--- a/examples/container-hook/Dockerfile
+++ b/examples/container-hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2 AS builder
+FROM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a AS builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/

--- a/examples/kube-container-collection/Dockerfile
+++ b/examples/kube-container-collection/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bullseye@sha256:f0fe88a509ede4f792cbd42056e939c210a1b2be282cfe89c57a654ef8707cd2 AS builder
+FROM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a AS builder
 
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.2-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.6-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS builder
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Compiling with older Golang versions results in a failed scan image CI step:

```
bin/gadgettracermanager (gobinary)
==================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                        Title                         │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy │
│         │                │          │        │                   │                 │ validation in crypto/x509                            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874           │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────┤
│         │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition           │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907           │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────┘

cleanup (gobinary)
==================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                        Title                         │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy │
│         │                │          │        │                   │                 │ validation in crypto/x509                            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874           │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────┤
│         │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition           │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907           │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────┘

opt/hooks/nri/nrigadget (gobinary)
==================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                        Title                         │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy │
│         │                │          │        │                   │                 │ validation in crypto/x509                            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874           │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────┤
│         │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition           │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907           │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────┘

opt/hooks/oci/ocihookgadget (gobinary)
======================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                        Title                         │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy │
│         │                │          │        │                   │                 │ validation in crypto/x509                            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874           │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────┤
│         │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition           │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907           │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────┘
```