### PR TITLE
automatically builds and push tools/bench(#4904)

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -8,6 +8,7 @@ env:
   AZURE_AKS_CLUSTER_PREFIX: ig-ci-aks-
   DEFAULT_DNSTESTER_IMAGE: ghcr.io/inspektor-gadget/dnstester:main
   DEFAULT_GADGET_BUILDER_IMAGE: ghcr.io/inspektor-gadget/gadget-builder:main
+  DEFAULT_TOOLS_BENCH_IMAGE: ghcr.io/inspektor-gadget/benchmark:main
   # With the recent update of docker/build-push-action to v6, this action
   # started creating docker build summary files (i.e. .dockerbuild).
   # Sadly, these files create troubles when trying to download artifact in the
@@ -989,6 +990,11 @@ jobs:
               include/**
               Dockerfiles/gadget-builder.Dockerfile
               cmd/common/image/Makefile.build
+          - name: "tools-bench"
+            context: "tools/bench"
+            dockerfile: "tools/bench/Dockerfile"
+            platform: "linux/amd64,linux/arm64"
+            key-files: "tools/bench/*"
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
     - name: Set up Docker Buildx
@@ -1039,6 +1045,8 @@ jobs:
             image=${{ env.DEFAULT_DNSTESTER_IMAGE }}
           elif [ ${{ matrix.image.name }} == "gadget-builder" ]; then
             image=${{ env.DEFAULT_GADGET_BUILDER_IMAGE }}
+          elif [ ${{ matrix.image.name }} == "tools-bench" ]; then
+            image=${{ env.DEFAULT_TOOLS_BENCH_IMAGE }}
           else
             >&2 echo "No default image for ${{ matrix.image.name }}!"
             exit 1

--- a/integration/benchmarks/benchmarks.yaml
+++ b/integration/benchmarks/benchmarks.yaml
@@ -16,23 +16,23 @@ tests:
     # trace only the client container
     gadgetParams: ["--containername=test-trace_dns-client"]
     server:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=dns-server
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=dns:server={{.ServerIP}}:5353 --events-per-second={{.EventsPerSecond}}
     # at 8192 IG starts to drop packets
     eventsPerSecond: [ 256, 512, 1024, 2048, 4096 ]
   - name: trace_exec
     gadgetName: trace_exec:v0.43.0
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=exec --events-per-second={{.EventsPerSecond}}
     eventsPerSecond: [ 1024, 2048, 4096, 8192 ]
   - name: trace_open
     gadgetName: trace_open:v0.43.0
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=open --events-per-second={{.EventsPerSecond}}
     eventsPerSecond: [ 1024, 2048, 4096, 8192, 16384 ]
   - name: trace_tcp
@@ -40,7 +40,7 @@ tests:
     # trace only the client container
     gadgetParams: ["--containername=test-trace_tcp-client"]
     server:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=tcp-server
       sysctls:
         "net.ipv4.ip_local_port_range": "10000 65535"
@@ -48,7 +48,7 @@ tests:
         "net.ipv4.tcp_fin_timeout":     "10"
         "net.ipv4.tcp_timestamps":      "0"
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=tcp:server={{.ServerIP}}:8080 --events-per-second={{.EventsPerSecond}}
       sysctls:
         "net.ipv4.ip_local_port_range": "10000 65535"
@@ -62,7 +62,7 @@ tests:
     # trace only the client container
     gadgetParams: ["--containername=test-top_tcp-client"]
     server:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=tcp-server
       sysctls:
         "net.ipv4.ip_local_port_range": "10000 65535"
@@ -70,7 +70,7 @@ tests:
         "net.ipv4.tcp_fin_timeout":     "10"
         "net.ipv4.tcp_timestamps":      "0"
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=tcp:server={{.ServerIP}}:8080 --events-per-second={{.EventsPerSecond}}
       sysctls:
         "net.ipv4.ip_local_port_range": "10000 65535"
@@ -82,7 +82,7 @@ tests:
   - name: top_process
     gadgetName: top_process:v0.43.0
     generator:
-      image: ghcr.io/mauriciovasquezbernal/bench
+      image: ghcr.io/inspektor-gadget/benchmark:main
       cmd: /bench --events=processes --events-per-second={{.EventsPerSecond}}
     # limit to 32768 as 32GB of memory aren't enough to run more processes
     eventsPerSecond: [ 2048, 4096, 8192, 16384, 32768 ]

--- a/tools/bench/Dockerfile
+++ b/tools/bench/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/bench/
 RUN GOARCH=${TARGETARCH} go build -o /bench /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/bench
 
 # Final image
-FROM alpine:3.18@sha256:1875c923b73448b558132e7d4a44b815d078779ed7a73f76209c6372de95ea8d
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0
 COPY --from=builder /bench /bench
 
 CMD ["/bench"]


### PR DESCRIPTION
**Automatically build and push tools/bench Docker image(#4904 )**

This PR adds support for building and publishing the tools/bench Docker image as part of the helper image build workflow.
The new image enables benchmarking tools to be built and distributed automatically through the existing CI pipeline.

**Changes:**

Added tools-bench entry to the build-helper-images workflow matrix, similar to dnstester and gadget-builder.

**Verified local build of tools/bench using:**

`docker run --rm bench-test /bench`

Updated workflow YAML to include tools-bench in matrix and caching logic.

_Notes:

The first CI run might fail because the tools-bench image is not yet published to GHCR.

@mauriciovasquezbernal has confirmed that they will push the image once this PR is open._

## How to use

Once merged, the tools/bench image will be automatically built and pushed to GitHub Container Registry (GHCR) along with the other helper images.

```
docker pull ghcr.io/inspektor-gadget/tools-bench:main
docker run --rm ghcr.io/inspektor-gadget/tools-bench:main /bench --help
```


[ describe what reviewers need to do in order to validate this PR ]

1 . **Checkout the branch**
    ```
    git fetch origin Add-tools-bench
    git checkout Add-tools-bench
    ```

2. **Build the image locally**
    ```
    make -C tools/bench docker-build
    docker run --rm bench-test /bench --help
    ```
3. **Check the workflow on GitHub**

    Go to Actions → Build Helper Images
    
    Manually trigger the workflow on this branch.
    
    Confirm that it builds and pushes the tools/bench image to GHCR (workflow may fail for first push, expected).
    
    Verify the image in GHCR
    After the workflow finishes (or after the maintainer pushes), ensure that the image
    ghcr.io/inspektor-gadget/tools-bench:main appears in Packages.

**## Testing done**
Verified that the Docker image builds locally and runs /bench --help successfully.

Workflow syntax validated and CI triggered successfully up to the point of GHCR push (failure expected for first run).
