### PR TITLE
makefile/gadgets: Support testing for local registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pkg/btfgen/btfs/arm64/*
 !pkg/kfilefields/**/*.o
 !pkg/gadgets/**/*.o
 !pkg/socketenricher/*.o
+.daemon-config.yaml
 
 !gadgets/*.o
 !testdata/*.o

--- a/docs/devel/contributing.md
+++ b/docs/devel/contributing.md
@@ -124,6 +124,17 @@ $ export KUBECONFIG=... # not needed if valid config in $HOME/.kube/config
 $ make integration-tests
 ```
 
+### Testing gadgets from a local registry
+
+You can use minikube to test gadgets from a local registry. Once [Inspektor Gadget is deployed](#development-environment-on-minikube) you can run a gadget using:
+
+```bash
+# build and run the gadget, in this case trace_dns
+GADGETS=trace_dns make -C gadgets minikube-gadget-run
+# run the gadget with a timeout of 10 seconds
+GADGETS=trace_dns GADGET_PARAMS="--timeout 10" make -C gadgets minikube-gadget-run
+```
+
 ### Integration tests for `ig`
 
 #### Kubernetes

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -20,6 +20,8 @@ DOCKER ?= docker
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
 
+include minikube.mk
+
 GADGETS ?= \
 	advise_networkpolicy \
 	advise_seccomp \
@@ -137,7 +139,7 @@ push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))

--- a/gadgets/minikube.mk
+++ b/gadgets/minikube.mk
@@ -1,0 +1,26 @@
+MINIKUBE_IP = $(shell $(MINIKUBE) ip)
+MINIKUBE_REGISTRY = $(MINIKUBE_IP):5000
+
+include ../minikube.mk
+
+.PHONY: minikube-registry-enable
+minikube-registry-enable:
+	@echo "Enabling minikube registry addon"
+	$(MINIKUBE) addons enable registry
+
+.PHONY: minikube-registry-disable
+minikube-registry-disable:
+	@echo "Disabling minikube registry addon"
+	$(MINIKUBE) addons disable registry
+
+.PHONY: minikube-registry-enable
+minikube-registry-prepare: minikube-registry-enable
+	@echo "Pushing gadget images to minikube registry"
+	$(MAKE) GADGET_REPOSITORY=$(MINIKUBE_REGISTRY) IG_FLAGS="--insecure-registries $(MINIKUBE_REGISTRY)" push-existing
+
+# GADGET_PARAMS can be used to pass extra parameters to the gadget run command
+# GADGET_PARAMS="--timeout 10" make -C gadgets GADGETS=trace_dns minikube-gadget-run
+.PHONY:
+minikube-gadget-run: minikube-registry-prepare
+	@echo "Running gadgets on minikube"
+	../kubectl-gadget run $(MINIKUBE_REGISTRY)/$(firstword $(GADGETS)):$(GADGET_TAG) --pull always $$GADGET_PARAMS


### PR DESCRIPTION
This adds few targets to allow testing gadgets via minikube registry using:

```
GADGETS=trace_dns make -C gadgets  minikube-gadget-run
```

Also, this PR disable image verification when deploying in minikube since normally signature aren't pushed in that case!  

Hopefully it will help with testing in-tree gadgets in Kubernetes easily! 