### PR TITLE
operators/ebpf: reuse records of readers

### DIFF
--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -123,13 +123,15 @@ func (t *Tracer) receiveEvents(gadgetCtx operators.GadgetContext, wg *sync.WaitG
 
 	switch t.mapType {
 	case ebpf.RingBuf:
+		var rec ringbuf.Record
 		readCb = func() ([]byte, uint64, error) {
-			rec, err := t.ringbufReader.Read()
+			err := t.ringbufReader.ReadInto(&rec)
 			return rec.RawSample, 0, err
 		}
 	case ebpf.PerfEventArray:
+		var rec perf.Record
 		readCb = func() ([]byte, uint64, error) {
-			rec, err := t.perfReader.Read()
+			err := t.perfReader.ReadInto(&rec)
 			return rec.RawSample, rec.LostSamples, err
 		}
 	default:


### PR DESCRIPTION
Since we're guaranteeing that data coming from subscriptions cannot be used after processing synchronously, we can reuse the underlying Record structs as well.

This should reduce overhead a bit and reduce stress on the GC.