### PR TITLE
vex: Fix PURL for trivy

### DIFF
--- a/.vex/v0.41.0.vex.json
+++ b/.vex/v0.41.0.vex.json
@@ -2,21 +2,22 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v0.41.0/v0.41.0.vex.json",
   "author": "Inspektor Gadget Security Team <security@inspektor-gadget.io>",
-  "timestamp": "2025-08-21T08:52:32.416055456+02:00",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2025-54388"
       },
-      "timestamp": "2025-08-21T08:52:32.416057292+02:00",
       "products": [
         {
-          "@id": "pkg:github/inspektor-gadget/inspektor-gadget@v0.41.0"
+          "@id": "pkg:golang/github.com/inspektor-gadget/inspektor-gadget@v0.41.0"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2025-10-29T15:15:40.47857836Z"
     }
-  ]
+  ],
+  "timestamp": "2025-08-21T06:52:32Z",
+  "last_updated": "2025-10-29T15:15:40Z"
 }

--- a/.vex/v0.42.0.vex.json
+++ b/.vex/v0.42.0.vex.json
@@ -2,21 +2,22 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v0.42.0/v0.42.0.vex.json",
   "author": "Inspektor Gadget Security Team <security@inspektor-gadget.io>",
-  "timestamp": "2025-08-21T08:52:50.431237874+02:00",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2025-54388"
       },
-      "timestamp": "2025-08-21T08:52:50.431242261+02:00",
       "products": [
         {
-          "@id": "pkg:github/inspektor-gadget/inspektor-gadget@v0.42.0"
+          "@id": "pkg:golang/github.com/inspektor-gadget/inspektor-gadget@v0.42.0"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2025-10-29T15:15:48.10457314Z"
     }
-  ]
+  ],
+  "timestamp": "2025-10-29T07:41:43Z",
+  "last_updated": "2025-10-29T15:15:48Z"
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,7 +65,7 @@ To add a VEX document when none exists for a specific version yet, use the
 ```bash
 VER=v0.41.0
 vexctl create --file .vex/$VER.vex.json \
---product "pkg:github/inspektor-gadget/inspektor-gadget@$VER" \
+--product "pkg:golang/github.com/inspektor-gadget/inspektor-gadget@$VER" \
 --vuln "CVE-2025-54388" \
 --status "not_affected" \
 --justification "vulnerable_code_not_in_execute_path" \
@@ -86,7 +86,7 @@ instead of `vexctl create`. For example:
 ```bash
 VER=v0.41.0
 vexctl add --in-place .vex/$VER.vex.json \
---product "pkg:github/inspektor-gadget/inspektor-gadget@$VER" \
+--product "pkg:golang/github.com/inspektor-gadget/inspektor-gadget@$VER" \
 --vuln "CVE-2099-12345" \
 --status "not_affected" \
 --justification "vulnerable_code_not_in_execute_path"


### PR DESCRIPTION
Scanning the image with trivy still resulted in the CVE being shown. With this PURL it successfully is supressed

To test one can use
```
$ trivy clean --scan-cache && trivy image ghcr.io/inspektor-gadget/ig:v0.41.0 --vex ./.vex/v0.41.0.vex.json
```

To keep a log I just used `vexctl add`, but I could also just manually modify the vex file and fix the URL there, keeping the revision and all the same

Ref https://github.com/aquasecurity/vexhub-crawler/pull/43#issuecomment-3459687464