### PR TITLE
include: add gadget_socket_lookup_with_direction

### DIFF
--- a/gadgets/tcpdump/program.bpf.c
+++ b/gadgets/tcpdump/program.bpf.c
@@ -56,9 +56,9 @@ static __always_inline int handle(struct __sk_buff *skb, __u8 packet_type)
 			       (void *)(long)skb->data_end))
 		return 0;
 
-	struct gadget_socket_value *skb_val = gadget_socket_lookup(skb);
-	if (gadget_should_discard_data_by_skb(skb_val))
-		return 0;
+	__u8 is_ingress = (packet_type == PACKET_TYPE_INGRESS);
+	struct gadget_socket_value *skb_val =
+		gadget_socket_lookup_with_direction(skb, is_ingress);
 
 	struct packet_event_t *event;
 

--- a/gadgets/tcpdump/test/integration/tcpdump_test.go
+++ b/gadgets/tcpdump/test/integration/tcpdump_test.go
@@ -34,7 +34,8 @@ import (
 type tcpdumpEvent struct {
 	utils.CommonData
 
-	Timestamp string `json:"timestamp"`
+	Timestamp  string `json:"timestamp"`
+	PacketType int    `json:"packet_type"`
 }
 
 const (
@@ -103,11 +104,19 @@ func newTCPDumpStep(t *testing.T, tc testCase) (igtesting.TestStep, []igtesting.
 	runnerOpts = append(runnerOpts, igrunner.WithValidateOutput(
 		func(t *testing.T, output string) {
 			expectedEntries := []*tcpdumpEvent{
-				// A DNS packet
+				// A DNS request
 				{
 					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
 
-					Timestamp: utils.NormalizedStr,
+					Timestamp:  utils.NormalizedStr,
+					PacketType: 0,
+				},
+				// A DNS response
+				{
+					CommonData: utils.BuildCommonData(clientContainerName, commonDataOpts...),
+
+					Timestamp:  utils.NormalizedStr,
+					PacketType: 1,
 				},
 			}
 


### PR DESCRIPTION
It seems in certain cases (e.g CNIs) certain information like `skb->pkt_type` is [scrapped](https://elixir.bootlin.com/linux/v6.17.5/source/net/core/skbuff.c#L6168) from the packets so [port calculations](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/include/gadget/sockets-map.h#L172) can be incorrect resulting in failure to lookup the sockets resulting in [packets being dropped](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/tcpdump/program.bpf.c#L60). This change won't rely on `skb->pkt_type` for TC programs and will use correct direction provided in the gadget.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/5022


## TODO:

- [x] Update the tcpdump test to check if it can see both egress/ingress packets.

## Testing:

- [CI runs on main](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18905983092/job/53965133434#step:8:1066) only captures the ingress traffic. Events with `"packet_type":1` only! 
- [CI runs for this change](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/18936492621/job/54065586177?pr=5025#step:8:1039) captures both traffic. Both packet_type events! 
