### PR TITLE
feature(cli): allow “-f -” to apply gadget manifest from stdin

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -319,7 +319,10 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		if inFile != "" {
 			var f io.ReadCloser
 			var err error
-			if strings.HasPrefix(inFile, "http://") || strings.HasPrefix(inFile, "https://") {
+
+			if inFile == "-" {
+				f = os.Stdin
+			} else if strings.HasPrefix(inFile, "http://") || strings.HasPrefix(inFile, "https://") {
 				f, err = utils.DownloadFile(inFile)
 				if err != nil {
 					return fmt.Errorf("downloading gadget runtime manifest file %s: %w", inFile, err)
@@ -332,7 +335,9 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			}
 
 			specs, err := gadgetmanifest.InstanceSpecsFromReader(f)
-			f.Close()
+			if inFile != "-" {
+				f.Close()
+			}
 			if err != nil {
 				return fmt.Errorf("reading gadget runtime manifest file %s: %w", inFile, err)
 			}


### PR DESCRIPTION
# Title: Can now use -f - flag to pass in a yaml 

in oci.go and build.go i have added the logic of detecting a - in the args
when found we take the input from the stdin

## How to use

cat gadget.yaml | sudo ./ig run -f -    
i ran this command and checked locally and it gave the same output as when 
sudo ./ig run -f - gadget.yaml
 
## Testing done

<img width="1398" height="827" alt="ig_tested" src="https://github.com/user-attachments/assets/877ff6ba-fb88-4070-897f-533f5ebc019d" />

Fixes #4905 
