### PR TITLE
Testing: Wait for the Pod to be created before kubectl wait

### DIFF
--- a/integration/command.go
+++ b/integration/command.go
@@ -652,8 +652,8 @@ func WaitUntilJobCompleteCommand(namespace string, jobname string) *Command {
 // the given as parameter namespace is ready.
 func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 	return &Command{
-		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname),
+		Name:           "WaitForReadyTestPod",
+		Cmd:            fmt.Sprintf("timeout 10 bash -c 'until kubectl get pod -n %s %s > /dev/null 2>&1; do sleep 1; done' && kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname, namespace, podname),
 		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
 	}
 }
@@ -663,7 +663,7 @@ func WaitUntilPodReadyCommand(namespace string, podname string) *Command {
 func WaitUntilPodReadyOrOOMKilledCommand(namespace string, podname string) *Command {
 	return &Command{
 		Name:           "WaitForTestPod",
-		Cmd:            fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname),
+		Cmd:            fmt.Sprintf("timeout 10 bash -c 'until kubectl get pod -n %s %s > /dev/null 2>&1; do sleep 1; done' && (kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s)", namespace, podname, namespace, podname, namespace, podname),
 		ExpectedString: fmt.Sprintf("pod/%s condition met\n", podname),
 	}
 }

--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -80,7 +80,6 @@ func (c *K8sContainer) Start(t *testing.T) {
 
 	testSteps := []igtesting.TestStep{
 		podCommand(t, c.name, c.options.image, c.options.namespace, `["/bin/sh", "-c"]`, c.cmd, c.options.limits),
-		sleepForSecondsCommand(2),
 		waitCommand,
 	}
 	if !c.options.useExistingNamespace {
@@ -235,7 +234,7 @@ func deleteK8sNamespace(t *testing.T, namespace string) {
 func waitUntilPodReadyCommand(t *testing.T, namespace string, podname string) *command.Command {
 	return &command.Command{
 		Name:           "WaitForTestPod",
-		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname)),
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("timeout 10 bash -c 'until kubectl get pod -n %s %s > /dev/null 2>&1; do sleep 1; done' && kubectl wait pod --for condition=ready --timeout=60s -n %s %s", namespace, podname, namespace, podname)),
 		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod/%s condition met\n", podname)),
 	}
 }
@@ -245,7 +244,7 @@ func waitUntilPodReadyCommand(t *testing.T, namespace string, podname string) *c
 func waitUntilPodReadyOrOOMKilledCommand(t *testing.T, namespace string, podname string) *command.Command {
 	return &command.Command{
 		Name:           "WaitForTestPod",
-		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s", namespace, podname, namespace, podname)),
+		Cmd:            exec.Command("/bin/sh", "-c", fmt.Sprintf("timeout 10 bash -c 'until kubectl get pod -n %s %s > /dev/null 2>&1; do sleep 1; done' && (kubectl wait pod --for condition=ready --timeout=60s -n %s %s || kubectl wait pod --for jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled -n %s %s)", namespace, podname, namespace, podname, namespace, podname)),
 		ValidateOutput: match.EqualString(t, fmt.Sprintf("pod/%s condition met\n", podname)),
 	}
 }


### PR DESCRIPTION
`kubectl wait` will error out when the pod is not yet created.

There is a `kubectl wait --for=create` but that has 2 problems:
1. It times out when the pod is already created in that moment
2. It doesn't seem to work with pods. So we still get an error like "pod not found"

With this PR we try to check if a pod is known to `kubectl get pods` and then we call `kubectl wait` for it to become ready.
The first step has a timeout of 10s (~10 tries * sleep 1)