### PR TITLE
add support for pyroscope profiling to ig daemons

### DIFF
--- a/cmd/common/profile/pyroscope.go
+++ b/cmd/common/profile/pyroscope.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"os"
+
+	"github.com/grafana/pyroscope-go"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+func init() {
+	logger := logger.DefaultLogger()
+	if serverAddress, ok := os.LookupEnv("PYROSCOPE_SERVER_ADDRESS"); ok {
+		_, err := pyroscope.Start(pyroscope.Config{
+			ApplicationName: "ig",
+			ServerAddress:   serverAddress,
+			Logger:          logger,
+		})
+		if err != nil {
+			logger.Warnf("initializing pyroscope: %v", err)
+		}
+	}
+}

--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The Inspektor Gadget authors
+// Copyright 2023-2025 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
+	_ "github.com/inspektor-gadget/inspektor-gadget/cmd/common/profile"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -70,6 +70,7 @@ import (
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/symbolizer/debuginfod"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/symbolizer/symtab"
 
+	_ "github.com/inspektor-gadget/inspektor-gadget/cmd/common/profile"
 	gadgetservice "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	kubemanagertypes "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/types"

--- a/go.mod
+++ b/go.mod
@@ -203,11 +203,14 @@ require (
 	sigs.k8s.io/release-utils v0.11.1 // indirect
 )
 
+require github.com/grafana/pyroscope-go v1.2.7
+
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.7 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.10 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/notaryproject/notation-core-go v1.3.0 // indirect
 	github.com/notaryproject/notation-plugin-framework-go v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,10 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/grafana/pyroscope-go v1.2.7 h1:VWBBlqxjyR0Cwk2W6UrE8CdcdD80GOFNutj0Kb1T8ac=
+github.com/grafana/pyroscope-go v1.2.7/go.mod h1:o/bpSLiJYYP6HQtvcoVKiE9s5RiNgjYTj1DhiddP2Pc=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasnuOY813tbMN8i/a3Og=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=


### PR DESCRIPTION
Profiling will be enabled when the `PYROSCOPE_SERVER_ADDRESS` environment variable is set and pointing to a pyroscope instance.

This way we can utilize Grafana for diving into Go profiles, which can help with debugging & optimizing IG.

Setting up a pyroscope server with docker compose could be done like this:
```
services:
  pyroscope:
    image: grafana/pyroscope:latest
    command: ["-self-profiling.disable-push=true"]
    ports:
      - "4040:4040"
```

Then set `PYROSCOPE_SERVER_ADDRESS` to http://yourip:4040. 

Just register pyroscope as a source for Grafana and you should be able to browse the profiles.