### PR TITLE
fix(trace_fsslower): unify latency threshold and duration units to µs

### DIFF
--- a/gadgets/trace_fsslower/README.mdx
+++ b/gadgets/trace_fsslower/README.mdx
@@ -37,9 +37,9 @@ $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_fsslower:%IG_TAG% [flags]
 
 ### `--min`
 
-Minimum latency in ms to trace
+Minimum latency in µs to trace
 
-Default value: "10"
+Default value: "10000"
 
 ### `--pid`
 
@@ -67,7 +67,7 @@ TODO
 
   <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run trace_fsslower:%IG_TAG%  --verify-image=false --filesystem ext4 --min 1 -c test-trace-fsslower
+$ sudo ig run trace_fsslower:%IG_TAG%  --verify-image=false --filesystem ext4 --min 1000 -c test-trace-fsslower
 RUNTIME.CONTAINERNAME     COMM                 PID        TID DELTA_… OFFSET   SIZE FILE         OP
 ```
   </TabItem>
@@ -103,7 +103,7 @@ TODO
 
   <TabItem value="ig" label="ig">
 ```bash
-$ sudo ig run trace_fsslower%IG_TAG% --verify-image=false --filesystem ext4 --min 1 -c test-trace-fsslower
+$ sudo ig run trace_fsslower%IG_TAG% --verify-image=false --filesystem ext4 --min 1000 -c test-trace-fsslower
 RUNTIME.CONTAINERNAME     COMM                 PID        TID DELTA_… OFFSET   SIZE FILE         OP
 test-trace-fsslower       dpkg-preconf…     204239     204239    1008      0 92233… #38586681    F_FSYNC
 test-trace-fsslower       dpkg-preconf…     204239     204239    1878      0 92233… #38586683    F_FSYNC

--- a/gadgets/trace_fsslower/gadget.yaml
+++ b/gadgets/trace_fsslower/gadget.yaml
@@ -36,12 +36,12 @@ datasources:
           columns.width: 10
 params:
   ebpf:
-    min_lat_ms:
+    min_lat_us:
       key: min
       alias: m
       title: Minimum Latency
-      defaultValue: "10"
-      description: Minimum latency in ms to trace
+      defaultValue: "10000"
+      description: Minimum latency in µs to trace
   wasm:
     filesystem:
       key: filesystem

--- a/gadgets/trace_fsslower/program.bpf.c
+++ b/gadgets/trace_fsslower/program.bpf.c
@@ -36,8 +36,8 @@ struct event {
 
 #define MAX_ENTRIES 8192
 
-const volatile __u64 min_lat_ms = 0;
-GADGET_PARAM(min_lat_ms);
+const volatile __u64 min_lat_us = 0;
+GADGET_PARAM(min_lat_us);
 
 GADGET_TRACER_MAP(events, 1024 * 256);
 GADGET_TRACER(malloc, events, event);
@@ -108,7 +108,7 @@ static int probe_exit(void *ctx, enum fs_file_op op, ssize_t size)
 
 	end_ns = bpf_ktime_get_ns();
 	delta_ns = end_ns - datap->ts;
-	if (delta_ns <= 1000 * 1000 * min_lat_ms)
+	if (delta_ns <= 1000 * min_lat_us)
 		return 0;
 
 	event = gadget_reserve_buf(&events, sizeof(*event));


### PR DESCRIPTION
## fix: #5044 
Changed all latency-related parameters in trace_fsslower from milliseconds (ms) to microseconds (µs) for consistency with operation duration units. Updated README.mdx, gadget.yaml, and program.bpf.c accordingly to maintain uniform measurement and preserve previous default behavior (10 ms → 10000 µs).