### PR TITLE
added new function to recursively call GetAuthConfig

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -708,7 +708,12 @@ func newAuthClient(repository string, authOptions *AuthOptions) (*oras_auth.Clie
 	if err != nil {
 		return nil, fmt.Errorf("getting host string: %w", err)
 	}
-	authConfig, err := cfg.GetAuthConfig(hostString)
+	authKey := hostString
+	// Special case for docker.io
+	if authKey == "docker.io" {
+		authKey = "index.docker.io"
+	}
+	authConfig, err := cfg.GetAuthConfig(authKey)
 	if err != nil {
 		return nil, fmt.Errorf("getting auth config: %w", err)
 	}


### PR DESCRIPTION
# added new function to recursively call GetAuthConfig

so basically i added a new function  which in tern takes the host string and checks for aliases, as the possible number of names are very few we are brute forcing it via a for loop
also we are checkign the DOCKER_CONFIG  as docker by default stores the credentials there

## How to use

first run the command 
`sudo ./ig image pull [IMAGE_NAME]`

then push it to docker with ig even when you haven't logged in explicitly with ig but have logged in with docker
`sudo -E HOME=$HOME ./ig image push [IMAGE_NAME]`

## Testing done

<img width="1103" height="372" alt="image" src="https://github.com/user-attachments/assets/b00dd361-94d9-4537-b017-47d6aae3944b" />


Fixes #2299
