### PR TITLE
trace_open: add file path after symlink resolution

### DIFF
--- a/gadgets/trace_open/gadget.yaml
+++ b/gadgets/trace_open/gadget.yaml
@@ -30,6 +30,12 @@ datasources:
           columns.alignment: right
       fname:
         annotations:
+          description: File name as given in the open syscall
+          columns.width: 32
+          columns.minwidth: 24
+      fpath:
+        annotations:
+          description: Full file path after symlink resolution (require --paths flag)
           columns.width: 32
           columns.minwidth: 24
 params:
@@ -38,3 +44,7 @@ params:
       key: failed
       defaultValue: "false"
       description: Show only failed events
+    paths:
+      key: paths
+      defaultValue: "false"
+      description: Show file path after symlink resolution


### PR DESCRIPTION
Example of workload:
```
docker run -ti --rm --workdir /usr busybox cat ../etc/mtab
```

Output:
```
sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open --paths --fields=comm,fd,fname,fpath,error
COMM      FD FNAME               FPATH               ERROR
cat        3 ../etc/mtab         /proc/1/mounts
```

The builtin gadget used to have this field:
https://github.com/inspektor-gadget/inspektor-gadget/blob/14d447c35c092c38ea596eb752e630ef098bbd71/pkg/gadgets/trace/open/tracer/bpf/opensnoop.bpf.c#L219

cc @matthyx 