### PR TITLE
Validate parent TID belongs to same process in test

### DIFF
--- a/gadgets/fdpass/test/unit/fdpass_test.go
+++ b/gadgets/fdpass/test/unit/fdpass_test.go
@@ -52,7 +52,7 @@ func TestFdpassGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, inodeNum uint64, sockfd int, fd int, events []ExpectedFdpassEvent) {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, fd int) *ExpectedFdpassEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedFdpassEvent{
 						Proc:      proc,
 						SocketIno: inodeNum,
@@ -88,7 +88,7 @@ func TestFdpassGadget(t *testing.T) {
 				return nil
 			}
 			normalizeEvent := func(event *ExpectedFdpassEvent) {
-				utils.NormalizeProc(&event.Proc)
+				utils.NormalizeParentTid(&event.Proc)
 			}
 			opts := gadgetrunner.GadgetRunnerOpts[ExpectedFdpassEvent]{
 				Image:          "fdpass",

--- a/gadgets/top_file/test/unit/top_file_test.go
+++ b/gadgets/top_file/test/unit/top_file_test.go
@@ -64,7 +64,7 @@ func TestTopFileGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, filepath string, events []ExpectedTopFileEvent) {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedTopFileEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTopFileEvent{
 						Proc: proc,
 						T:    "R",
@@ -99,7 +99,7 @@ func TestTopFileGadget(t *testing.T) {
 			}
 			normalizeEvent := func(event *ExpectedTopFileEvent) {
 				utils.NormalizeInt(&event.Writes)
-				utils.NormalizeProc(&event.Proc)
+				utils.NormalizeParentTid(&event.Proc)
 			}
 			onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
 				utils.RunWithRunner(t, runner, func() error {

--- a/gadgets/trace_bind/test/unit/trace_bind_test.go
+++ b/gadgets/trace_bind/test/unit/trace_bind_test.go
@@ -138,11 +138,15 @@ func TestTraceBind(t *testing.T) {
 				return nil
 			}
 
+			normalizeEvent := func(event *ExpectedTraceBindEvent) {
+				utils.NormalizeParentTid(&event.Proc)
+			}
 			opts := gadgetrunner.GadgetRunnerOpts[ExpectedTraceBindEvent]{
 				Image:          "trace_bind",
 				Timeout:        5 * time.Second,
 				MntnsFilterMap: utils.CreateMntNsFilterMap(t, runner.Info.MountNsID),
 				OnGadgetRun:    onGadgetRun,
+				NormalizeEvent: normalizeEvent,
 				ParamValues: api.ParamValues{
 					"operator.oci.ebpf.ignore-errors": "false",
 				},
@@ -153,6 +157,8 @@ func TestTraceBind(t *testing.T) {
 
 			utils.ExpectOneEvent(
 				func(info *utils.RunnerInfo, fd int) *ExpectedTraceBindEvent {
+					proc := info.Proc
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceBindEvent{
 						Addr: utils.L4Endpoint{
 							Addr:    tc.addr,
@@ -160,7 +166,7 @@ func TestTraceBind(t *testing.T) {
 							Port:    tc.port,
 							Proto:   tc.network,
 						},
-						Proc:  info.Proc,
+						Proc:  proc,
 						Error: "",
 					}
 				},

--- a/gadgets/trace_open/test/unit/trace_open_test.go
+++ b/gadgets/trace_open/test/unit/trace_open_test.go
@@ -55,8 +55,10 @@ func TestTraceOpenGadget(t *testing.T) {
 			generateEvent: generateEvent,
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, events []ExpectedTraceOpenEvent) {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, fd int) *ExpectedTraceOpenEvent {
+					proc := info.Proc
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceOpenEvent{
-						Proc:  info.Proc,
+						Proc:  proc,
 						Fd:    uint32(fd),
 						FName: "/dev/null",
 					}
@@ -81,8 +83,10 @@ func TestTraceOpenGadget(t *testing.T) {
 			generateEvent: generateEvent,
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, events []ExpectedTraceOpenEvent) {
 				utils.ExpectOneEvent(func(info *utils.RunnerInfo, fd int) *ExpectedTraceOpenEvent {
+					proc := info.Proc
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceOpenEvent{
-						Proc:  info.Proc,
+						Proc:  proc,
 						Fd:    uint32(fd),
 						FName: "/dev/null",
 					}
@@ -192,8 +196,10 @@ func TestTraceOpenGadget(t *testing.T) {
 			},
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, events []ExpectedTraceOpenEvent) {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, fd int) *ExpectedTraceOpenEvent {
+					proc := info.Proc
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceOpenEvent{
-						Proc:     info.Proc,
+						Proc:     proc,
 						Fd:       uint32(fd),
 						FName:    "/tmp/foo/bar.test",
 						ErrRaw:   0,
@@ -239,11 +245,15 @@ func TestTraceOpenGadget(t *testing.T) {
 				})
 				return nil
 			}
+			normalizeEvent := func(event *ExpectedTraceOpenEvent) {
+				utils.NormalizeParentTid(&event.Proc)
+			}
 			opts := gadgetrunner.GadgetRunnerOpts[ExpectedTraceOpenEvent]{
 				Image:          "trace_open",
 				Timeout:        5 * time.Second,
 				MntnsFilterMap: mntnsFilterMap,
 				OnGadgetRun:    onGadgetRun,
+				NormalizeEvent: normalizeEvent,
 			}
 			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
 

--- a/gadgets/trace_signal/test/unit/trace_signal_test.go
+++ b/gadgets/trace_signal/test/unit/trace_signal_test.go
@@ -82,20 +82,26 @@ func TestTraceSignalGadget(t *testing.T) {
 				})
 				return nil
 			}
+			normalizeEvent := func(event *traceSignalEvent) {
+				utils.NormalizeParentTid(&event.Proc)
+			}
 			opts := gadgetrunner.GadgetRunnerOpts[traceSignalEvent]{
 				Image:          "trace_signal",
 				Timeout:        5 * time.Second,
 				ParamValues:    api.ParamValues{},
 				OnGadgetRun:    onGadgetRun,
 				MntnsFilterMap: utils.CreateMntNsFilterMap(t, runner.Info.MountNsID),
+				NormalizeEvent: normalizeEvent,
 			}
 			gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
 
 			gadgetRunner.RunGadget()
 
 			utils.ExpectOneEvent(func(info *utils.RunnerInfo, fd int) *traceSignalEvent {
+				proc := info.Proc
+				utils.NormalizeParentTid(&proc)
 				return &traceSignalEvent{
-					Proc:      info.Proc,
+					Proc:      proc,
 					Signal:    signalName(testCase.signal),
 					SignalRaw: int(testCase.signal),
 					Error:     "",

--- a/gadgets/trace_tcp/test/unit/trace_tcp_test.go
+++ b/gadgets/trace_tcp/test/unit/trace_tcp_test.go
@@ -67,7 +67,7 @@ func TestTraceTcpGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, _ int, events []ExpectedTraceTcpEvent) error {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedTraceTcpEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceTcpEvent{
 						Proc:    proc,
 						Type:    "close",
@@ -102,7 +102,7 @@ func TestTraceTcpGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, _ int, events []ExpectedTraceTcpEvent) error {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedTraceTcpEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceTcpEvent{
 						Proc:    proc,
 						Type:    "connect",
@@ -137,7 +137,7 @@ func TestTraceTcpGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, _ int, events []ExpectedTraceTcpEvent) error {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedTraceTcpEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceTcpEvent{
 						Proc:    proc,
 						Type:    "connect",
@@ -170,7 +170,7 @@ func TestTraceTcpGadget(t *testing.T) {
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, fd int, acceptFd int, events []ExpectedTraceTcpEvent) error {
 				utils.ExpectAtLeastOneEvent(func(info *utils.RunnerInfo, pid int) *ExpectedTraceTcpEvent {
 					proc := info.Proc
-					utils.NormalizeProc(&proc)
+					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceTcpEvent{
 						Proc:    proc,
 						Type:    "accept",
@@ -207,7 +207,7 @@ func TestTraceTcpGadget(t *testing.T) {
 				} else {
 					utils.NormalizeInt(&event.Src.Port)
 				}
-				utils.NormalizeProc(&event.Proc)
+				utils.NormalizeParentTid(&event.Proc)
 			}
 			fd := -1
 			acceptFd := -1

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -154,6 +154,11 @@ func BuildProc(comm string, uid, gid uint32) Process {
 	}
 }
 
+// NormalizeParentTid normalizes the parent TID on p.
+func NormalizeParentTid(p *Process) {
+	NormalizeInt(&p.Parent.Tid)
+}
+
 // NormalizeProc normalizes the pid, tid, parent pid and parent comm fields on
 // p.
 func NormalizeProc(p *Process) {


### PR DESCRIPTION
# Validate parent TID belongs to same process in test

Replace strict parent.tid equality in trace_signal_test with a same-process check for parent threads to accommodate multi-threaded parent processes.

Fixes #5068

## How to use

Run tests.

## Testing done

Multiple runs with multithreading.
