### PR TITLE
Update guide for trace_signal and trace_fsslower

### DIFF
--- a/gadgets/trace_fsslower/README.mdx
+++ b/gadgets/trace_fsslower/README.mdx
@@ -62,7 +62,10 @@ Let's start the gadget before running our workload:
 
 <Tabs groupId="env">
   <TabItem value="kubectl-gadget" label="kubectl gadget">
-TODO
+```bash
+$ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_fsslower:%IG_TAG% -- --filesystem ext4 --min 1 -c test-trace-fsslower
+K8S.NODE          K8S.NAMESPACE        K8S.PODNAME          K8S.CONTAINERNAME    COMM             PID        TID DELTA_… OFFSET   SIZE FILE         OP
+```
   </TabItem>
 
   <TabItem value="ig" label="ig">
@@ -78,7 +81,9 @@ Launch a container that will perform input/output operations:
 
 <Tabs groupId="env">
   <TabItem value="kubectl-gadget" label="kubectl gadget">
-TODO
+```bash
+$ kubectl run test-trace-fsslower --image=debian --restart=Never -- /bin/sh -c "apt-get update && apt-get install -y git"
+```
   </TabItem>
 
   <TabItem value="ig" label="ig">
@@ -98,7 +103,25 @@ The tool will list the I/O operations that were slower than 1ms:
 
 <Tabs groupId="env">
   <TabItem value="kubectl-gadget" label="kubectl gadget">
-TODO
+```bash
+$ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_fsslower:%IG_TAG% -- --filesystem ext4 --min 1 -c test-trace-fsslower
+K8S.NODE          K8S.NAMESPACE        K8S.PODNAME          K8S.CONTAINERNAME    COMM             PID        TID DELTA_… OFFSET   SIZE FILE         OP
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg-preconf…     204239     204239    1008      0 92233… #38586681    F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg-preconf…     204239     204239    1878      0 92233… #38586683    F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    3245      0 92233… perl-module… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1517      0 92233… libperl5.36… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1273      0 92233… symbols      F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1285      0 92233… openssl.lis… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1110      0 92233… ca-certific… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1310      0 92233… tmp.i        F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    6302      0 92233… triggers     F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1435      0 92233… tmp.i        F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1042      0 92233… libkrb5supp… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1318      0 92233… md5sums      F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1032      0 92233… openssh-cli… F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    1063      0 92233… symbols      F_FSYNC
+minikube          default              test-trace-fsslower  test-trace-fsslower  dpkg              204242     204242    2532      0 92233… git.list-new F_FSYNC
+```
   </TabItem>
 
   <TabItem value="ig" label="ig">

--- a/gadgets/trace_signal/README.mdx
+++ b/gadgets/trace_signal/README.mdx
@@ -60,4 +60,86 @@ Default value: ""
 
 ## Guide
 
-TODO
+In this guide, we will use the `trace_signal` gadget to monitor signals sent to processes.
+
+First, let's start the gadget. We will filter for signals sent to a specific container to reduce noise.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_signal:%IG_TAG% -- -c test-trace-signal
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_signal:%IG_TAG% -c test-trace-signal
+        ```
+    </TabItem>
+</Tabs>
+
+Now, let's start a container that we can send signals to.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl run test-trace-signal --image=busybox --restart=Never -- /bin/sh -c "sleep infinity"
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker run --name test-trace-signal --rm -d busybox /bin/sh -c "sleep infinity"
+        ```
+    </TabItem>
+</Tabs>
+
+Now, let's send a signal to the container.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl exec test-trace-signal -- kill -SIGUSR1 1
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker kill -s SIGUSR1 test-trace-signal
+        ```
+    </TabItem>
+</Tabs>
+
+The gadget should show the signal event.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        K8S.NODE          K8S.NAMESPACE        K8S.PODNAME          K8S.CONTAINERNAME    COMM             PID        TID        TPID       SIG        ERROR
+        minikube          default              test-trace-signal    test-trace-signal    kill             147026     147026     146864     SIGUSR1    0
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        RUNTIME.CONTAINERNAME     COMM             PID        TID        TPID       SIG        ERROR
+        test-trace-signal         kill             146387     146387     146227     SIGUSR1    0
+        ```
+    </TabItem>
+</Tabs>
+
+Finally, clean up the container.
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl delete pod test-trace-signal
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ docker rm -f test-trace-signal
+        ```
+    </TabItem>
+</Tabs>


### PR DESCRIPTION
This PR updates the documentation for the trace_signal and trace_fsslower gadgets to fill in missing "TODO" sections.

Changes:

trace_signal: Added a complete "Guide" section with examples for both kubectl gadget and ig , showing how to run the gadget, generate signals, and observe events.
trace_fsslower: Added the missing kubectl gadget examples to the "Guide" section, including example output.