### PR TITLE
oci: Warn if operator for layer is not found

### DIFF
--- a/pkg/operators/oci-handler/oci.go
+++ b/pkg/operators/oci-handler/oci.go
@@ -477,6 +477,7 @@ func (o *OciHandlerInstance) init(gadgetCtx operators.GadgetContext) error {
 		log.Debugf("layer > %+v", layer)
 		op, ok := operators.GetImageOperatorForMediaType(layer.MediaType)
 		if !ok {
+			log.Warnf("no operator found for media type %q, skipping layer", layer.MediaType)
 			continue
 		}
 


### PR DESCRIPTION
Log a warning in case the gadget contains an image that doesn't have an operator. This will avoid confusion when a program using the API doesn't work because it forgot to import one of the operators.

Fixes #5103
