### PR TITLE
Support exclusion and multiple values in container selector

### DIFF
--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -84,13 +84,12 @@ Inspektor Gadget supports to efficiently filter events directly on eBPF for some
 common fields:
 
  * `--node string`, show only data from pods running in that node
- * `-n string`, `--namespace string`, show data from pods in that namespace
+ * `-n string`, `--namespace string`, Kubernetes namespaces to filter on. Supports comma-separated list and exclusion using `!`.
  * `-A`, `--all-namespaces`, show data from pods in all namespaces
- * `-p string`, `--podname string`, `--k8s-podname` show only data from pods with that name
- * `-c string`, `--containername string`, `--k8s-containername`, show only data from containers with the name defined in the pod spec
- * `--runtime-containername string`, show only data from containers with the runtime-assigned name (not the name defined in the pod spec)
- * `-l string`, `--selector string`, `--k8s-selector`, show only data that matches the given
-   Kubernetes label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
+ * `-p string`, `--podname string`, `--k8s-podname` Kubernetes pods to filter on. Supports comma-separated list and exclusion using `!`.
+ * `-c string`, `--containername string`, `--k8s-containername`, Kubernetes container names to filter on. Supports comma-separated list and exclusion using `!`.
+ * `--runtime-containername string`, runtime-assigned name container names to filter on (not the name defined in the pod spec). Supports comma-separated list and exclusion using `!`.
+ * `-l string`, `--selector string`, `--k8s-selector`, Kubernetes Labels selector to filter on.  Supports comma-separated list and exclusion using '!' (e.g. `!key=value` or `key=!value`).
 
 We can use one or more of these parameters to choose which pods or
 containers will be inspected by our gadgets. For example:
@@ -115,13 +114,13 @@ The current supported fields to filter in kernel are:
 
  * `-c string`, `--containername string`, `--runtime-containername`, show only data from containers with
    that name. Notice that this container name is the one set by the runtime, and
-   it may be different from the one set by Kubernetes (defined in the pod spec) depending on the runtime.
+   it may be different from the one set by Kubernetes (defined in the pod spec) depending on the runtime. Supports comma-separated list and exclusion using `!`.
 * `--k8s-containername string`, show only data from containers with the name
-   defined in the pod spec.
-* `--k8s-namespace string`, show data from pods in that Kubernetes namespace.
-* `--k8s-podname`, show only data from containers with the name defined in the pod spec
+   defined in the pod spec. Supports comma-separated list and exclusion using `!`.
+* `--k8s-namespace string`, show data from pods in that Kubernetes namespace. Supports comma-separated list and exclusion using `!`.
+* `--k8s-podname`, show only data from containers with the name defined in the pod spec. Supports comma-separated list and exclusion using `!`.
 * `--k8s-selector string`, show only data that matches the given
-Kubernetes label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`).
+Kubernetes label or selector. Only `=` is currently supported (e.g. `key1=value1,key2=value2`). Supports exclusion using `!` (e.g. `!key=value` or `key=!value`).
 
 For example, the following command will show only data from the container named
 `mycontainer`:

--- a/pkg/container-collection/match.go
+++ b/pkg/container-collection/match.go
@@ -15,29 +15,67 @@
 package containercollection
 
 import (
-	"slices"
 	"strings"
 )
+
+// matchFilterString checks if a value matches a filter string. The filter string can
+// contain multiple comma-separated values. A value can be excluded by prefixing
+// it with a '!'. If the filter is empty, it matches any value.
+func matchFilterString(filter, value string) bool {
+	if filter == "" {
+		return true
+	}
+	parts := strings.Split(filter, ",")
+	matched := false
+	hasInclusion := false
+	for _, part := range parts {
+		if strings.HasPrefix(part, "!") {
+			if value == part[1:] {
+				return false // Explicit exclusion
+			}
+		} else {
+			hasInclusion = true
+			if value == part {
+				matched = true
+			}
+		}
+	}
+	if hasInclusion && !matched {
+		return false
+	}
+	return true
+}
 
 // ContainerSelectorMatches tells if a container matches the criteria in a
 // container selector.
 func ContainerSelectorMatches(s *ContainerSelector, c *Container) bool {
-	if s.K8s.Namespace != "" && !slices.Contains(strings.Split(s.K8s.Namespace, ","), c.K8s.Namespace) {
+	if !matchFilterString(s.K8s.Namespace, c.K8s.Namespace) {
 		return false
 	}
-	if s.K8s.PodName != "" && s.K8s.PodName != c.K8s.PodName {
+
+	if !matchFilterString(s.K8s.PodName, c.K8s.PodName) {
 		return false
 	}
-	if s.K8s.ContainerName != "" && s.K8s.ContainerName != c.K8s.ContainerName {
+
+	if !matchFilterString(s.K8s.ContainerName, c.K8s.ContainerName) {
 		return false
 	}
-	if s.Runtime.ContainerName != "" && s.Runtime.ContainerName != c.Runtime.ContainerName {
+
+	if !matchFilterString(s.Runtime.ContainerName, c.Runtime.ContainerName) {
 		return false
 	}
+
 	for sk, sv := range s.K8s.PodLabels {
-		if cv, ok := c.K8s.PodLabels[sk]; !ok || cv != sv {
-			return false
+		if strings.HasPrefix(sk, "!") {
+			if cv, ok := c.K8s.PodLabels[sk[1:]]; ok && matchFilterString(sv, cv) {
+				return false
+			}
+		} else {
+			if cv, ok := c.K8s.PodLabels[sk]; !ok || !matchFilterString(sv, cv) {
+				return false
+			}
 		}
 	}
+
 	return true
 }

--- a/pkg/container-collection/match_test.go
+++ b/pkg/container-collection/match_test.go
@@ -170,6 +170,397 @@ func TestSelector(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "Exclude container by name shouldn't return a result with the excluded container name",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "!this-container",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by name returns a result without the excluded container name",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "!other-container",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by namespace shouldn't return a result with the excluded namespace",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace: "!this-namespace",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by namespace returns a result without the excluded namespace",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace: "!this-namespace",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "other-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod name shouldn't return a result with the excluded pod name",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodName: "!this-pod",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod name returns a result without the excluded pod name",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodName: "!this-pod",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "other-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod label shouldn't return a result with the excluded pod label",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodLabels: map[string]string{
+							"!key1": "value1",
+						},
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+						PodLabels: map[string]string{
+							"key1": "value1",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod label should return a result without the excluded pod label",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodLabels: map[string]string{
+							"!key1": "value1",
+						},
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+						PodLabels: map[string]string{
+							"key1": "value2",
+							"key2": "value2",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod label value shouldn't return a result with the excluded value",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodLabels: map[string]string{
+							"key1": "!value1",
+						},
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+						PodLabels: map[string]string{
+							"key1": "value1",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by pod label value should return a result without the excluded value",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						PodLabels: map[string]string{
+							"key1": "!value1",
+						},
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+						PodLabels: map[string]string{
+							"key1": "value2",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude container by runtime container name shouldn't return a result with the excluded container name",
+			match:       false,
+			selector: &ContainerSelector{
+				Runtime: RuntimeSelector{
+					ContainerName: "!runtime-container",
+				},
+			},
+			container: &Container{
+				Runtime: RuntimeMetadata{
+					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+						ContainerName: "runtime-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Mixed inclusion and exclusion should return a match",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace: "this-namespace",
+						PodName:   "!other-pod",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Mixed inclusion and exclusion shouldn't return a match",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace: "this-namespace",
+						PodName:   "!this-pod",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "this-container",
+					},
+				},
+			},
+		},
+		{
+			description: "Several container names with match",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "c1,c2,c3",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "c2",
+					},
+				},
+			},
+		},
+		{
+			description: "Several container names without match",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "c1,c2,c3",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "c4",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude multiple container names retuns a result without the excluded container names",
+			match:       true,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "!c1,!c2",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "c3",
+					},
+				},
+			},
+		},
+		{
+			description: "Exclude multiple container names shouldn't return a result with the excluded container names",
+			match:       false,
+			selector: &ContainerSelector{
+				K8s: K8sSelector{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						ContainerName: "!c1,!c2",
+					},
+				},
+			},
+			container: &Container{
+				K8s: K8sMetadata{
+					BasicK8sMetadata: types.BasicK8sMetadata{
+						Namespace:     "this-namespace",
+						PodName:       "this-pod",
+						ContainerName: "c1",
+					},
+				},
+			},
+		},
+		{
+			description: "Several runtime container names with match",
+			match:       true,
+			selector: &ContainerSelector{
+				Runtime: RuntimeSelector{
+					ContainerName: "rc1,rc2,rc3",
+				},
+			},
+			container: &Container{
+				Runtime: RuntimeMetadata{
+					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+						ContainerName: "rc2",
+					},
+				},
+			},
+		},
+		{
+			description: "Several runtime container names without match",
+			match:       false,
+			selector: &ContainerSelector{
+				Runtime: RuntimeSelector{
+					ContainerName: "rc1,rc2,rc3",
+				},
+			},
+			container: &Container{
+				Runtime: RuntimeMetadata{
+					BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+						ContainerName: "rc4",
+					},
+				},
+			},
+		},
 	}
 
 	for i, entry := range table {

--- a/pkg/operators/common/container-selector.go
+++ b/pkg/operators/common/container-selector.go
@@ -73,21 +73,21 @@ func GetContainerSelectorParams(isKubeManager bool) params.ParamDescs {
 	k8sPodName := params.ParamDesc{
 		Key:         ParamK8sPodName,
 		Title:       "K8s Pod Name",
-		Description: "Show only data from Kubernetes pods with that name",
+		Description: "Kubernetes pods to filter on. Supports comma-separated list and exclusion using '!'.",
 		ValueHint:   gadgets.K8SPodName,
 		Tags:        []string{api.TagGroupDataFiltering},
 	}
 	k8sNamespace := params.ParamDesc{
 		Key:         ParamK8sNamespace,
 		Title:       "K8s Namespace",
-		Description: "Show only data from pods in a given Kubernetes namespace",
+		Description: "Kubernetes namespaces to filter on. Supports comma-separated list and exclusion using '!'.",
 		ValueHint:   gadgets.K8SNamespace,
 		Tags:        []string{api.TagGroupDataFiltering},
 	}
 	k8sSelector := params.ParamDesc{
 		Key:         ParamK8sSelector,
 		Title:       "K8s Label Selector",
-		Description: "Kubernetes Labels selector to filter on. Only '=' is supported (e.g. key1=value1,key2=value2).",
+		Description: "Kubernetes Labels selector to filter on. Supports comma-separated list and exclusion using '!' (e.g. '!key=value' or 'key=!value').",
 		ValueHint:   gadgets.K8SLabels,
 		Validator:   labelSelectorValidator,
 		Tags:        []string{api.TagGroupDataFiltering},
@@ -95,14 +95,14 @@ func GetContainerSelectorParams(isKubeManager bool) params.ParamDescs {
 	k8sContainerNameParam := params.ParamDesc{
 		Key:         ParamK8sContainerName,
 		Title:       "K8s Container Name",
-		Description: "Show data only from containers with the name defined in the pod spec",
+		Description: "Kubernetes container names to filter on. Supports comma-separated list and exclusion using '!'.",
 		ValueHint:   gadgets.K8SContainerName,
 		Tags:        []string{api.TagGroupDataFiltering},
 	}
 	runtimeContainerParam := params.ParamDesc{
 		Key:         ParamRuntimeContainerName,
 		Title:       "Runtime Container Name",
-		Description: "Show data only from containers with the runtime-assigned name (not the name defined in the pod spec)",
+		Description: "runtime-assigned name container names to filter on (not the name defined in the pod spec). Supports comma-separated list and exclusion using '!'.",
 		ValueHint:   gadgets.LocalContainer,
 		Tags:        []string{api.TagGroupDataFiltering},
 	}


### PR DESCRIPTION
# Support exclusion and multiple values in container selector

This PR enhances the container selection mechanism by adding support for exclusion and multiple values in various fields. Specifically, it introduces the ! prefix to negate matches for Namespace, Pod Name, Container Name, and Pod Labels. This allows users to filter out specific containers or pods (e.g., excluding the kube-system namespace).

Additionally, it extends the `ContainerName` field (both Kubernetes and Runtime) to support comma-separated lists, aligning it with the existing behavior of the `Namespace` field. This enables selecting multiple specific containers in a single query.

## How to use

Reviewers can verify this by using the `ig` CLI with the new syntax:

* Exclusion: Prefix the value with ! to exclude it.
`--namespace !kube-system` (Matches everything except kube-system)
`--podname !my-pod`
`--containername !sidecar`
* Multiple Values: Use commas to separate values.
`--containername nginx,redis` (Matches containers named nginx OR redis)
* Combined:
`--namespace default,!kube-system`

## Testing done

I have updated the unit tests in `match_test.go`. 
```
$ go test ./pkg/container-collection/...
ok      github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection   0.018s
```

I also built the `ig` cli and tried it:
```
make ig
sudo ./ig trace_exec:latest --containername \!gadget
```