### PR TITLE
Enable CLI clear-screen-before for profile gadgets

### DIFF
--- a/gadgets/profile_blockio/gadget.yaml
+++ b/gadgets/profile_blockio/gadget.yaml
@@ -7,6 +7,7 @@ dataSources:
   blockio:
     annotations:
       metrics.print: "true"
+      cli.clear-screen-before: "true"
     fields:
       latency:
         annotations:

--- a/gadgets/profile_cpu/gadget.yaml
+++ b/gadgets/profile_cpu/gadget.yaml
@@ -17,6 +17,7 @@ datasources:
       views.modes.flamegraph: true
       views.defaults.mode: flamegraph
       ebpf.map.flush-on-stop: true
+      cli.clear-screen-before: "true"
     fields:
       runtime.containerName:
         annotations:

--- a/gadgets/profile_qdisc_latency/gadget.yaml
+++ b/gadgets/profile_qdisc_latency/gadget.yaml
@@ -7,6 +7,7 @@ datasources:
   qdisc:
     annotations:
       metrics.print: "true"
+      cli.clear-screen-before: "true"
     fields:
       latency:
         annotations:
@@ -16,7 +17,7 @@ params:
     ifindex:
       key: ifindex
       defaultValue: "-1"
-      description: 'Interface index to collect metrics for. To collect metric for all interfaces, set to -1.'
+      description: "Interface index to collect metrics for. To collect metric for all interfaces, set to -1."
     targ_ms:
       key: ms
       defaultValue: "false"

--- a/gadgets/profile_tcprtt/gadget.yaml
+++ b/gadgets/profile_tcprtt/gadget.yaml
@@ -7,6 +7,7 @@ dataSources:
   tcprtt:
     annotations:
       metrics.print: "true"
+      cli.clear-screen-before: "true"
     fields:
       latency:
         annotations:


### PR DESCRIPTION
## Add `cli.clear-screen-before` to all profile gadgets so CLI prints headers immediately

This change adds the `cli.clear-screen-before: "true"` annotation to the datasources of all profile gadgets. The CLI operator prints column headers for array-style data sources only when that annotation is present (it's used to determine whether to clear/print the header immediately). Without it, headers could be delayed until the first array event/map flush — causing the header to appear only after a map fetch interval (what you observed with `ig run profile_cpu`).

fixes #5113 

## How to use

Rebuild the modified gadgets and run them with `ig`.

## Testing done

```
$ cd gadgets/profile_cpu/
$ sudo ig image build . -t profile_cpu
$ sudo ig run profile_cpu --verify-image=false --map-fetch-interval=10s
```
The column headers are printed immediately.