### PR TITLE
Ensure log records have a body if none set

### DIFF
--- a/pkg/datasource/helpers.go
+++ b/pkg/datasource/helpers.go
@@ -86,6 +86,8 @@ func GetKeyValueFunc[S ~string, T any](
 	int64Fn func(int64) T,
 	float64Fn func(float64) T,
 	stringFn func(string) T,
+	boolFn func(bool) T,
+	bytesFn func([]byte) T,
 ) (func(Data) (S, T), error) {
 	emptyVal := *new(T)
 	name := f.FullName()
@@ -99,9 +101,25 @@ func GetKeyValueFunc[S ~string, T any](
 		return func(data Data) (S, T) {
 			val, err := f.String(data)
 			if err != nil {
-				return "", emptyVal
+				return S(name), emptyVal
 			}
 			return S(name), stringFn(val)
+		}, nil
+	case api.Kind_Bool:
+		return func(data Data) (S, T) {
+			val, err := f.Bool(data)
+			if err != nil {
+				return S(name), emptyVal
+			}
+			return S(name), boolFn(val)
+		}, nil
+	case api.Kind_Bytes:
+		return func(data Data) (S, T) {
+			val, err := f.Bytes(data)
+			if err != nil {
+				return S(name), emptyVal
+			}
+			return S(name), bytesFn(val)
 		}, nil
 	case api.Kind_Uint8,
 		api.Kind_Uint16,

--- a/pkg/operators/otel-logs/otel-logs.go
+++ b/pkg/operators/otel-logs/otel-logs.go
@@ -200,6 +200,39 @@ func (o *otelLogsOperatorInstance) init(gadgetCtx operators.GadgetContext) error
 	return nil
 }
 
+// copyBytesToLogValue copies the bytes and returns an otellog.Value.
+// This complies with otellog.BytesValue docs which state that the
+// passed slice must not be modified after the call.
+func copyBytesToLogValue(b []byte) otellog.Value {
+	cp := make([]byte, len(b))
+	copy(cp, b)
+	return otellog.BytesValue(cp)
+}
+
+// makeAttrPrep returns a function that will produce an otellog.KeyValue for the provided field.
+// It handles Bytes (raw string if valid UTF-8, base64 otherwise) and Bool (Int64Value 0/1) specially and falls back
+// to datasource.GetKeyValueFunc for supported scalar kinds.
+func makeAttrPrep(f datasource.FieldAccessor, nameOverride string) (func(data datasource.Data) otellog.KeyValue, error) {
+	name := f.FullName()
+	if nameOverride != "" {
+		name = nameOverride
+	}
+
+	// If the field cannot contain a value or is an empty/container, return nil preparer
+	if f.Type() == api.Kind_Invalid || datasource.FieldFlagEmpty.In(f.Flags()) || datasource.FieldFlagContainer.In(f.Flags()) {
+		return nil, nil
+	}
+
+	kvf, err := datasource.GetKeyValueFunc[string, otellog.Value](f, name, otellog.Int64Value, otellog.Float64Value, otellog.StringValue, otellog.BoolValue, copyBytesToLogValue)
+	if err != nil {
+		return nil, err
+	}
+	return func(data datasource.Data) otellog.KeyValue {
+		key, val := kvf(data)
+		return otellog.KeyValue{Key: key, Value: val}
+	}, nil
+}
+
 func (o *otelLogsOperatorInstance) Name() string {
 	return "otel-logs"
 }
@@ -211,6 +244,8 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 
 		prep := make([]func(data datasource.Data) otellog.KeyValue, 0)
 		kvCount := 0
+
+		var bodySet bool
 
 		fns := make([]func(datasource.Data, *otellog.Record), 0)
 
@@ -238,12 +273,26 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 				}
 				record.SetBody(otellog.StringValue(s.(string)))
 			})
+			bodySet = true
 		}
 
+		// First, collect any explicitly annotated fields (those with `logs.name` per-field).
 		for _, f := range fields {
+			// Skip parent fields that have subfields — their children fully represent the data.
+			if len(f.SubFields()) > 0 {
+				continue
+			}
+
 			fieldAnnotations := f.Annotations()
 			name, ok := fieldAnnotations[AnnotationLogsName]
 			if !ok {
+				continue
+			}
+
+			// Skip fields that don't carry a value (invalid/empty/container)
+			if f.Type() == api.Kind_Invalid ||
+				datasource.FieldFlagEmpty.In(f.Flags()) ||
+				datasource.FieldFlagContainer.In(f.Flags()) {
 				continue
 			}
 
@@ -253,6 +302,8 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 					str, _ := f.String(data)
 					record.SetBody(otellog.StringValue(str))
 				})
+				bodySet = true
+				continue
 			case FieldNameTimestamp:
 				ts, err := datasource.AsInt64(f)
 				if err != nil {
@@ -261,6 +312,7 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 				fns = append(fns, func(data datasource.Data, record *otellog.Record) {
 					record.SetObservedTimestamp(time.Unix(0, ts(data)*int64(time.Microsecond)))
 				})
+				continue
 			case FieldNameSeverity:
 				severity, err := datasource.AsInt64(f)
 				if err != nil {
@@ -272,18 +324,39 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 				continue
 			}
 
-			kvf, err := datasource.GetKeyValueFunc[string, otellog.Value](f, name, otellog.Int64Value, otellog.Float64Value, otellog.StringValue)
+			// Build attribute prep function via helper.
+			p, err := makeAttrPrep(f, name)
 			if err != nil {
 				return fmt.Errorf("getting key/val func for %s.%s: %w", ds.Name(), f.FullName(), err)
 			}
-			prep = append(prep, func(data datasource.Data) otellog.KeyValue {
-				key, val := kvf(data)
-				return otellog.KeyValue{
-					Key:   key,
-					Value: val,
-				}
-			})
+			if p == nil {
+				continue
+			}
+			prep = append(prep, p)
 			kvCount++
+		}
+
+		// If there were no annotated fields producing attributes and no body setter,
+		// fall back to encoding the entire event as attributes by adding all fields.
+		// This ensures the event is represented via attributes even when `logs.body`
+		// isn't set and no per-field annotations exist.
+		if kvCount == 0 && !bodySet {
+			for _, f := range fields {
+				// Skip parent fields that have subfields — their children fully represent the data.
+				if len(f.SubFields()) > 0 {
+					continue
+				}
+				// Build attr prep using full field name
+				p, err := makeAttrPrep(f, "")
+				if err != nil {
+					return fmt.Errorf("getting key/val func for %s.%s: %w", ds.Name(), f.FullName(), err)
+				}
+				if p == nil {
+					continue
+				}
+				prep = append(prep, p)
+				kvCount++
+			}
 		}
 
 		ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
@@ -300,6 +373,14 @@ func (o *otelLogsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) e
 			for _, f := range fns {
 				f(data, &rec)
 			}
+
+			// If no body setter was provided, ensure the record still has a body
+			// (empty string). This makes the exporter emit the event encoded via
+			// attributes even when `logs.body` isn't set.
+			if !bodySet {
+				rec.SetBody(otellog.StringValue(""))
+			}
+
 			rec.SetTimestamp(time.Now())
 
 			logger.Emit(gadgetCtx.Context(), rec)

--- a/pkg/operators/otel-logs/otel-logs_test.go
+++ b/pkg/operators/otel-logs/otel-logs_test.go
@@ -1,0 +1,461 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otellogs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"oras.land/oras-go/v2"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+type mockExporter struct {
+	records []sdklog.Record
+}
+
+func (m *mockExporter) Export(ctx context.Context, records []sdklog.Record) error {
+	// sdklog.Record is a struct, copy by value
+	m.records = append(m.records, records...)
+	return nil
+}
+
+func (m *mockExporter) Shutdown(ctx context.Context) error   { return nil }
+func (m *mockExporter) ForceFlush(ctx context.Context) error { return nil }
+
+type mockGadgetContext struct {
+	ctx         context.Context
+	dataSources map[string]datasource.DataSource
+}
+
+func (m *mockGadgetContext) ID() string               { return "test-id" }
+func (m *mockGadgetContext) Name() string             { return "test-gadget" }
+func (m *mockGadgetContext) Context() context.Context { return m.ctx }
+func (m *mockGadgetContext) Logger() logger.Logger    { return logger.DefaultLogger() }
+func (m *mockGadgetContext) ExtraInfo() bool          { return false }
+func (m *mockGadgetContext) Cancel()                  {}
+func (m *mockGadgetContext) SerializeGadgetInfo(requestExtraInfo bool) (*api.GadgetInfo, error) {
+	return nil, nil
+}
+func (m *mockGadgetContext) ImageName() string { return "test-image" }
+func (m *mockGadgetContext) RegisterDataSource(t datasource.Type, name string) (datasource.DataSource, error) {
+	return nil, nil
+}
+func (m *mockGadgetContext) GetDataSources() map[string]datasource.DataSource { return m.dataSources }
+func (m *mockGadgetContext) SetVar(name string, value any)                    {}
+func (m *mockGadgetContext) GetVar(name string) (any, bool)                   { return nil, false }
+func (m *mockGadgetContext) Params() []*api.Param                             { return nil }
+func (m *mockGadgetContext) SetParams(params []*api.Param)                    {}
+func (m *mockGadgetContext) SetMetadata(metadata []byte) error                { return nil }
+func (m *mockGadgetContext) OrasTarget() oras.ReadOnlyTarget                  { return nil }
+func (m *mockGadgetContext) IsRemoteCall() bool                               { return false }
+func (m *mockGadgetContext) IsClient() bool                                   { return false }
+
+func TestPreStart_NoAnnotations(t *testing.T) {
+	// Create a datasource with no annotations
+	ds, err := datasource.New(datasource.TypeSingle, "test-ds")
+	require.NoError(t, err)
+
+	fooField, err := ds.AddField("foo", api.Kind_String)
+	require.NoError(t, err)
+
+	barField, err := ds.AddField("bar", api.Kind_Int32)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	logger := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: logger,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-ds": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	err = fooField.PutString(packet, "hello")
+	require.NoError(t, err)
+	err = barField.PutInt32(packet, 42)
+	require.NoError(t, err)
+
+	err = ds.EmitAndRelease(packet)
+	require.NoError(t, err)
+
+	// Verify
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	// Check body is empty (fallback behavior)
+	assert.Equal(t, otellog.StringValue(""), rec.Body())
+
+	// Check attributes (fallback behavior: all fields as attributes)
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	require.Contains(t, attrMap, "foo")
+	assert.Equal(t, otellog.StringValue("hello"), attrMap["foo"])
+
+	require.Contains(t, attrMap, "bar")
+	// Int32 is converted to Int64Value
+	assert.Equal(t, otellog.Int64Value(42), attrMap["bar"])
+}
+
+func TestPreStart_WithAnnotations(t *testing.T) {
+	// Create a datasource with annotations
+	ds, err := datasource.New(datasource.TypeSingle, "test-ds")
+	require.NoError(t, err)
+
+	// Field with logs.name annotation
+	fooField, err := ds.AddField("foo", api.Kind_String)
+	require.NoError(t, err)
+	fooField.AddAnnotation("logs.name", "custom.foo")
+
+	// Field without annotation should be ignored when other fields are explicitly annotated.
+	// The fallback mechanism (adding all fields) is disabled when at least one field is annotated.
+	barField, err := ds.AddField("bar", api.Kind_Int32)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	logger := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: logger,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-ds": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	err = fooField.PutString(packet, "hello")
+	require.NoError(t, err)
+	err = barField.PutInt32(packet, 42)
+	require.NoError(t, err)
+
+	err = ds.EmitAndRelease(packet)
+	require.NoError(t, err)
+
+	// Verify
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	// Check body is empty (default if not set)
+	assert.Equal(t, otellog.StringValue(""), rec.Body())
+
+	// Check attributes
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	// "custom.foo" should be present
+	require.Contains(t, attrMap, "custom.foo")
+	assert.Equal(t, otellog.StringValue("hello"), attrMap["custom.foo"])
+
+	// "bar" should NOT be present because we have at least one annotated field, so fallback is disabled.
+	require.NotContains(t, attrMap, "bar")
+}
+
+func TestPreStart_BodyAnnotation(t *testing.T) {
+	// Create a datasource with logs.body annotation
+	ds, err := datasource.New(datasource.TypeSingle, "test-ds")
+	require.NoError(t, err)
+	ds.AddAnnotation("logs.body", "foo") // Use field 'foo' as body
+
+	fooField, err := ds.AddField("foo", api.Kind_String)
+	require.NoError(t, err)
+
+	barField, err := ds.AddField("bar", api.Kind_Int32)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	logger := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: logger,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-ds": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	err = fooField.PutString(packet, "body-content")
+	require.NoError(t, err)
+	err = barField.PutInt32(packet, 42)
+	require.NoError(t, err)
+
+	err = ds.EmitAndRelease(packet)
+	require.NoError(t, err)
+
+	// Verify
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	// Check body is set
+	assert.Equal(t, otellog.StringValue("body-content"), rec.Body())
+
+	// Check attributes
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	// No fields are annotated with logs.name, but logs.body is set.
+	// The fallback mechanism (adding all fields) is disabled when the body is explicitly set.
+	// Therefore, no attributes should be present.
+
+	require.Empty(t, attrMap)
+}
+
+func TestPreStart_BytesField(t *testing.T) {
+	// Create a datasource with a bytes field and no annotations
+	ds, err := datasource.New(datasource.TypeSingle, "test-ds-bytes")
+	require.NoError(t, err)
+
+	fooField, err := ds.AddField("foo", api.Kind_Bytes)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	logger := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: logger,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-ds-bytes": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	err = fooField.PutBytes(packet, []byte("hello-bytes"))
+	require.NoError(t, err)
+
+	err = ds.EmitAndRelease(packet)
+	require.NoError(t, err)
+
+	// Verify
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	// Check body is empty (fallback behavior)
+	assert.Equal(t, otellog.StringValue(""), rec.Body())
+
+	// Check attributes (fallback behavior: all fields as attributes)
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	require.Contains(t, attrMap, "foo")
+	// Bytes are preserved as BytesValue
+	assert.Equal(t, otellog.BytesValue([]byte("hello-bytes")), attrMap["foo"])
+}
+
+func TestPreStart_BoolField(t *testing.T) {
+	// Create a datasource with a bool field and no annotations
+	ds, err := datasource.New(datasource.TypeSingle, "test-ds-bool")
+	require.NoError(t, err)
+
+	flagField, err := ds.AddField("flag", api.Kind_Bool)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	logger := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: logger,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-ds-bool": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	err = flagField.PutBool(packet, true)
+	require.NoError(t, err)
+
+	err = ds.EmitAndRelease(packet)
+	require.NoError(t, err)
+
+	// Verify
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	// Check body is empty (fallback behavior)
+	assert.Equal(t, otellog.StringValue(""), rec.Body())
+
+	// Check attributes (fallback behavior: all fields as attributes)
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	require.Contains(t, attrMap, "flag")
+	assert.Equal(t, otellog.BoolValue(true), attrMap["flag"])
+}
+
+func TestPreStart_ParentWithChildren_NotEmitted(t *testing.T) {
+	// Create a datasource where `parent` is a container with children.
+	ds, err := datasource.New(datasource.TypeSingle, "test-parent")
+	require.NoError(t, err)
+
+	parent, err := ds.AddField("proc", api.Kind_Invalid, datasource.WithFlags(datasource.FieldFlagContainer|datasource.FieldFlagEmpty))
+	require.NoError(t, err)
+
+	_, err = parent.AddSubField("comm", api.Kind_String)
+	require.NoError(t, err)
+	_, err = parent.AddSubField("pid", api.Kind_Int32)
+	require.NoError(t, err)
+
+	// Also add a sibling field to ensure fallback still works for unrelated fields.
+	other, err := ds.AddField("other", api.Kind_String)
+	require.NoError(t, err)
+
+	exporter := &mockExporter{}
+	processor := sdklog.NewSimpleProcessor(exporter)
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(processor))
+	l := provider.Logger("test-logger")
+
+	inst := &otelLogsOperatorInstance{
+		loggers: map[datasource.DataSource]otellog.Logger{
+			ds: l,
+		},
+	}
+
+	gadgetCtx := &mockGadgetContext{
+		ctx: context.Background(),
+		dataSources: map[string]datasource.DataSource{
+			"test-parent": ds,
+		},
+	}
+
+	err = inst.PreStart(gadgetCtx)
+	require.NoError(t, err)
+
+	// Emit data: set child fields and the sibling field
+	packet, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+
+	// Set children via parent accessor
+	commAcc := ds.GetField("proc.comm")
+	require.NotNil(t, commAcc)
+	pidAcc := ds.GetField("proc.pid")
+	require.NotNil(t, pidAcc)
+
+	require.NoError(t, commAcc.PutString(packet, "sh"))
+	require.NoError(t, pidAcc.PutInt32(packet, 1234))
+	require.NoError(t, other.PutString(packet, "hello"))
+
+	require.NoError(t, ds.EmitAndRelease(packet))
+
+	// Verify: exporter should contain a record with attributes for children and sibling, but not the parent 'proc'
+	require.Len(t, exporter.records, 1)
+	rec := exporter.records[0]
+
+	attrMap := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrMap[kv.Key] = kv.Value
+		return true
+	})
+
+	// children should be present
+	require.Contains(t, attrMap, "proc.comm")
+	require.Contains(t, attrMap, "proc.pid")
+	// parent should NOT be present
+	require.NotContains(t, attrMap, "proc")
+	// sibling should be present
+	require.Contains(t, attrMap, "other")
+}

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -17,6 +17,7 @@ package otelmetrics
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -372,9 +373,13 @@ type metricsCollector struct {
 	useGlobalProvider bool
 }
 
+func bytesToAttributeValue(b []byte) attribute.Value {
+	return attribute.StringValue(base64.StdEncoding.EncodeToString(b))
+}
+
 func (mc *metricsCollector) addKeyFunc(f datasource.FieldAccessor) error {
 	nameOverride := f.Annotations()[AnnotationMetricsName]
-	vf, err := datasource.GetKeyValueFunc[attribute.Key, attribute.Value](f, nameOverride, attribute.Int64Value, attribute.Float64Value, attribute.StringValue)
+	vf, err := datasource.GetKeyValueFunc[attribute.Key, attribute.Value](f, nameOverride, attribute.Int64Value, attribute.Float64Value, attribute.StringValue, attribute.BoolValue, bytesToAttributeValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Ensure log records have a body if none set and encode the entire event as attributes

Add a counter for body setter functions and set an empty-string body when no field writes the log body. This ensures exporters still emit records represented via attributes even if logs.body is not present.

fixes #5106 

## How to use

Not quite sure how to test this...

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
