### PR TITLE
socket-enricher: Use bpf_core_field_exists() for new fields

### DIFF
--- a/include/gadget/sockets-map.h
+++ b/include/gadget/sockets-map.h
@@ -12,6 +12,7 @@
 
 // Necessary for the SEC() definition
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
 #include <gadget/types.h>
 
 // This file is shared between the networking and tracing programs.
@@ -264,7 +265,11 @@ gadget_process_populate_from_socket(const struct gadget_socket_value *skb_val,
 	__builtin_memcpy(p->parent.comm, skb_val->ptask,
 			 sizeof(p->parent.comm));
 	p->parent.pid = skb_val->ppid;
-	p->parent.tid = skb_val->ptid;
+
+	if (bpf_core_field_exists(skb_val->ptid))
+		p->parent.tid = skb_val->ptid;
+	else
+		p->parent.tid = 0;
 }
 
 #endif


### PR DESCRIPTION
Use bpf_core_field_exists() when accessing new fields added to the socket enricher to ensure they are present and avoid CO-RE failures when running a newer gadget with an older IG version.

All fields added after aaa2ffd7bebd ("socketenricher: Use CO-RE to make it resilient against changes") should include this conditional.

Fixes: 509e83be4a85 ("Adding ptid for socket enricher and defining gadget_ptid type")

### Testing

0. Grab or compile IG v0.46.0

```bash
$ git checkout v0.46.0
$ go build ./cmd/ig/
```

### Before this PR 

Try to run a newer version of tcpdump with IG v0.46.0

```bash
$ sudo ig run tcpdump:main
RUNTIME.CONTAINERNAME     PA… IFINDEX    PAYLOAD_L… PACKET_SI… COMM                 PID        TID TID        PAYLOAD
Error: starting operators: starting operator "oci": starting operator "ebpf": creating eBPF collection: program ingress_main: load program: bad CO-RE relocation: invalid func unknown#195896080 (241 line(s) omitted)
```

(using `latest`, `v0.47.0` produces the same result)


### After this PR 

Compile the gadget

```bash
$ export IG_SOURCE_PATH=$(pwd)
$ sudo -E ig image build gadgets/tcpdump/ -t mytcpdump
```

Run the gadget

```bash
$ sudo ig run mytcpdump --verify-image=false
WARN[0000] gadget signature verification is disabled due to using corresponding option
WARN[0000] gadget signature verification is disabled due to using corresponding option
RUNTIME.CONTAINERNAME     PA… IFINDEX    PAYLOAD_L… PACKET_SI… COMM                 PID        TID TID        PAYLOAD
```

The gadget now works. The Parent TID is always 0 as it's not provided by the socket enricher running. I think this is better than failing the gadget.

Reported by: @flyth 

@flyth @alban any thoughts on this one?


