### PR TITLE
Removing os.exit in case of filesystem is not set 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "inspektor-gadget",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pkg/utils/host/host.go
+++ b/pkg/utils/host/host.go
@@ -106,12 +106,12 @@ func Init(config Config) error {
 	} else {
 		mountsSuggested, err := autoMountFilesystems(true)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+			// Continue execution instead of crashing
 		}
 		if len(mountsSuggested) != 0 {
-			fmt.Fprintf(os.Stderr, "error: filesystems %s not mounted (did you try --auto-mount-filesystems?)\n", strings.Join(mountsSuggested, ", "))
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "warning: filesystems %s not mounted (try --auto-mount-filesystems if needed)\n", strings.Join(mountsSuggested, ", "))
+			// Continue execution instead of crashing
 		}
 	}
 
@@ -124,8 +124,8 @@ func Init(config Config) error {
 	} else {
 		err = suggestWSLWorkaround()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+			// Continue execution instead of crashing
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the `Init` function in `pkg/utils/host/host.go` to improve error handling during initialization. Instead of terminating the program on certain errors, the code now logs warnings and continues execution, making the initialization process more resilient.

Error handling improvements:

* Errors from `autoMountFilesystems` and missing filesystem mounts are now logged as warnings instead of causing the process to exit, allowing the application to continue running even if some mounts fail.
* Errors from `suggestWSLWorkaround` are also logged as warnings, preventing the application from crashing in these scenarios.# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
