### PR TITLE
gadgets: Use atomic operations when updating values

### DIFF
--- a/gadgets/top_blockio/program.bpf.c
+++ b/gadgets/top_blockio/program.bpf.c
@@ -130,9 +130,9 @@ static __always_inline int trace_done(struct request *req)
 
 	if (valp) {
 		/* save stats */
-		valp->us += delta_us;
-		valp->bytes += startp->data_len;
-		valp->io++;
+		__sync_fetch_and_add(&valp->us, delta_us);
+		__sync_fetch_and_add(&valp->bytes, startp->data_len);
+		__sync_fetch_and_add(&valp->io, 1);
 	}
 
 end:

--- a/gadgets/top_file/program.bpf.c
+++ b/gadgets/top_file/program.bpf.c
@@ -103,11 +103,11 @@ static int probe_entry(struct pt_regs *ctx, struct file *file, size_t count,
 		}
 	}
 	if (op == READ) {
-		valuep->reads++;
-		valuep->rbytes_raw += count;
+		__sync_fetch_and_add(&valuep->reads, 1);
+		__sync_fetch_and_add(&valuep->rbytes_raw, count);
 	} else { /* op == WRITE */
-		valuep->writes++;
-		valuep->wbytes_raw += count;
+		__sync_fetch_and_add(&valuep->writes, 1);
+		__sync_fetch_and_add(&valuep->wbytes_raw, count);
 	}
 	return 0;
 };

--- a/gadgets/top_tcp/program.bpf.c
+++ b/gadgets/top_tcp/program.bpf.c
@@ -115,11 +115,9 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 		bpf_map_update_elem(&ip_map, &ip_key, &zero, BPF_NOEXIST);
 	} else {
 		if (receiving)
-			trafficp->received_raw += size;
+			__sync_fetch_and_add(&trafficp->received_raw, size);
 		else
-			trafficp->sent_raw += size;
-
-		bpf_map_update_elem(&ip_map, &ip_key, trafficp, BPF_EXIST);
+			__sync_fetch_and_add(&trafficp->sent_raw, size);
 	}
 
 	return 0;


### PR DESCRIPTION
Be sure there are not race conditions when updating values on shared maps.

See #4578
