### PR TITLE
rfc: treewide: Replace filepath-securejoin.SecureJoin() by pathrs-lite.OpenInRoot().

### DIFF
--- a/cmd/ig/utils/flags.go
+++ b/cmd/ig/utils/flags.go
@@ -19,13 +19,11 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/pkg/cri/constants"
-	securejoin "github.com/cyphar/filepath-securejoin"
 
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
 	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
 	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
-	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -90,25 +88,20 @@ func AddCommonFlags(command *cobra.Command, commonFlags *CommonFlags) {
 			runtimeName := types.String2RuntimeName(strings.TrimSpace(p))
 			socketPath := ""
 			namespace := ""
-			var err error
 
 			switch runtimeName {
 			case types.RuntimeNameDocker:
-				socketPath, err = securejoin.SecureJoin(host.HostRoot, commonFlags.Docker)
+				socketPath = commonFlags.Docker
 			case types.RuntimeNameContainerd:
-				socketPath, err = securejoin.SecureJoin(host.HostRoot, commonFlags.Containerd)
+				socketPath = commonFlags.Containerd
 				namespace = commonFlags.ContainerdNamespace
 			case types.RuntimeNameCrio:
-				socketPath, err = securejoin.SecureJoin(host.HostRoot, commonFlags.Crio)
+				socketPath = commonFlags.Crio
 			case types.RuntimeNamePodman:
-				socketPath, err = securejoin.SecureJoin(host.HostRoot, commonFlags.Podman)
+				socketPath = commonFlags.Podman
 			default:
 				return commonutils.WrapInErrInvalidArg("--runtime / -r",
 					fmt.Errorf("runtime %q is not supported", p))
-			}
-
-			if err != nil {
-				return fmt.Errorf("securejoining %v to %v socket path: %w", host.HostRoot, runtimeName, err)
 			}
 
 			for _, r := range commonFlags.RuntimeConfigs {

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -25,7 +25,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	securejoin "github.com/cyphar/filepath-securejoin"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -61,11 +60,6 @@ func NewK8sClient(nodeName string, kubeconfigPath string, userAgentComment strin
 	socketPath, err := getContainerRuntimeSocketPath(clientset, nodeName)
 	if err != nil {
 		log.Warnf("Failed to retrieve socket path for runtime client from kubelet: %v. Falling back to default container runtime", err)
-	} else {
-		socketPath, err = securejoin.SecureJoin(host.HostRoot, socketPath)
-		if err != nil {
-			log.Warnf("securejoin failed: %s. Falling back to default container runtime", err)
-		}
 	}
 
 	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -45,7 +45,6 @@ var podLabelFilter = map[string]struct{}{
 // plugin interface to communicate with the different container runtimes.
 type CRIClient struct {
 	Name        types.RuntimeName
-	SocketPath  string
 	ConnTimeout time.Duration
 
 	conn   *grpc.ClientConn
@@ -68,7 +67,6 @@ func NewCRIClient(name types.RuntimeName, socketPath string, timeout time.Durati
 
 	return &CRIClient{
 		Name:        name,
-		SocketPath:  socketPath,
 		ConnTimeout: timeout,
 		conn:        conn,
 		client:      runtime.NewRuntimeServiceClient(conn),

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -18,13 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/containerd/containerd/pkg/cri/constants"
-	securejoin "github.com/cyphar/filepath-securejoin"
+	pathrslite "github.com/cyphar/filepath-securejoin/pathrs-lite"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -184,14 +185,8 @@ func (l *localManager) Init(operatorParams *params.Params) error {
 
 		socketPath := socketPathParam.AsString()
 		socketPathIsSet := socketPathParam.IsSet()
-
-		cleanSocketPath, err := securejoin.SecureJoin(host.HostRoot, socketPath)
+		socketFile, err := pathrslite.OpenInRoot(host.HostRoot, socketPath)
 		if err != nil {
-			log.Debugf("securejoin failed: %s", err)
-			continue
-		}
-
-		if _, err := os.Stat(cleanSocketPath); err != nil {
 			if socketPathIsSet || runtimesIsSet {
 				return fmt.Errorf("runtime %q with non-existent socketPath %q", runtimeName, socketPath)
 			}
@@ -201,7 +196,7 @@ func (l *localManager) Init(operatorParams *params.Params) error {
 
 		r := &containerutilsTypes.RuntimeConfig{
 			Name:            runtimeName,
-			SocketPath:      cleanSocketPath,
+			SocketPath:      filepath.Join("/proc", "self", "fd", fmt.Sprint(socketFile.Fd())),
 			RuntimeProtocol: operatorParams.Get(RuntimeProtocol).AsString(),
 			Extra: containerutilsTypes.ExtraConfig{
 				Namespace: namespace,


### PR DESCRIPTION
filepath-securejoin.SecureJoin() does not prevent TOCTOU attacks, therefore it is now recommended to
use pathrs-lite.OpenInRoot() [1,2].
By first opening the socket file with OpenInRoot() and using its
/proc/self/fd/socket-fd for the socket operations, we avoid TOCTOU issues.
    
    [1]: https://github.com/cyphar/filepath-securejoin/?tab=readme-ov-file#old-api
    [2]: https://github.com/cyphar/filepath-securejoin/?tab=readme-ov-file#-new-api