### PR TITLE
ci: Force using legacy .sig format when signing with cosign.

### DIFF
--- a/.github/actions/sign-container-image/action.yml
+++ b/.github/actions/sign-container-image/action.yml
@@ -23,4 +23,6 @@ runs:
         COSIGN_PRIVATE_KEY: '${{ inputs.private_key }}'
       shell: bash
       run: |
-        cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive "${{ inputs.image }}"
+        # Force using legacy .sig format.
+        # TODO Switch to bundle format.
+        cosign sign --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes --recursive "${{ inputs.image }}"

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1461,8 +1461,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-        with:
-          cosign-release: 'v2.6.0'
       - name: Check if public key is up-to-date.
         env:
           COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
@@ -1569,8 +1567,6 @@ jobs:
       - name: Install Cosign
         if: needs.check-secrets.outputs.cosign == 'true'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-        with:
-          cosign-release: 'v2.6.0'
       - name: Verify gadget builder image
         if: needs.check-secrets.outputs.cosign == 'true'
         run: |
@@ -2359,8 +2355,6 @@ jobs:
     - name: Install Cosign
       if: needs.check-secrets.outputs.cosign == 'true'
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      with:
-        cosign-release: 'v2.6.0'
     - name: Sign checksums file
       if: needs.check-secrets.outputs.cosign == 'true'
       shell: bash
@@ -2370,9 +2364,11 @@ jobs:
       run: |
         checksums_file=SHA256SUMS
 
-        cosign sign-blob --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
+        # Force using legacy .sig format.
+        # TODO Switch to bundle format.
+        cosign sign-blob --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
 
-        # Derivate public key from private key to publish it as release
+        # Derive public key from private key to publish it as release
         # artifact, so people can verify our signature.
         cosign public-key --key env://COSIGN_PRIVATE_KEY > inspektor-gadget.pub
     - name: Login to Container Registry

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -12,6 +12,9 @@ IG_RUNTIME ?= docker
 IG_FLAGS ?=
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
+# Force using legacy .sig format.
+# TODO Switch to bundle format.
+COSIGN_FLAGS ?= --new-bundle-format=false --use-signing-config=false
 CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
@@ -148,14 +151,14 @@ push-existing: $(addsuffix -push-existing,$(GADGETS))
 %-sign: %-push
 	@echo "Signing $*"
 	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
 	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
-	cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 


### PR DESCRIPTION
We had a problem when cosign installer was bumped and installed cosign v3, as this new version was using bundle as default format [1]. To circumvent this problem we fixed cosign release to using 2.6.0 [2]. But, we can still use legacy .sig format with cosign v3 by using corresponding flags.

In the future, we should switch to using bundle format, as we already support it [3].


[1]: 12699c4809b7 ("Revert "ci: bump sigstore/cosign-installer from 3.10.0 to 4.0.0")
[2]: c6268950caa5 ("ci: bump sigstore/cosign-installer from 3.10.0 to 4.0.0")
[3]: 01cf64de8fbe (" pkg: signature: Add support for cosign bundle format")