### PR TITLE
localmanager: fix memory leak on container detach

### DIFF
--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
@@ -317,6 +318,7 @@ type localManagerTrace struct {
 	subscriptionKey string
 
 	// Keep a map to attached containers, so we can clean up properly
+	containerMutex     sync.Mutex
 	attachedContainers map[*containercollection.Container]struct{}
 	attacher           Attacher
 	params             *params.Params
@@ -405,7 +407,9 @@ func (l *localManagerTrace) handleGadgetInstance(log logger.Logger) error {
 				return
 			}
 
+			l.containerMutex.Lock()
 			l.attachedContainers[container] = struct{}{}
+			l.containerMutex.Unlock()
 
 			log.Debugf("tracer attached: container %q pid %d mntns %d netns %d",
 				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
@@ -413,6 +417,10 @@ func (l *localManagerTrace) handleGadgetInstance(log logger.Logger) error {
 
 		detachContainerFunc := func(container *containercollection.Container) {
 			log.Debugf("calling gadget.DetachContainer()")
+			l.containerMutex.Lock()
+			delete(l.attachedContainers, container)
+			l.containerMutex.Unlock()
+
 			err := attacher.DetachContainer(container)
 			if err != nil {
 				log.Warnf("stop tracing container %q: %s", container.K8s.ContainerName, err)


### PR DESCRIPTION
Remove containers from attachedContainers map in detachContainerFunc. Without this cleanup, memory grows until the gadget stops, particularly due to container.OciConfig which can be large.

Add mutex protection for attachedContainers since container creation and deletion can occur concurrently.

Note: KubeManager already handles cleanup correctly.

Reported by: @chsomati