### PR TITLE
node field verified during the integration tests

### DIFF
--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
@@ -19,6 +19,7 @@ package generate_networkpolicy
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
@@ -206,7 +207,7 @@ func (s *gnpOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 				if hostNetwork {
 					continue
 				}
-
+				node := os.Getenv("NODE_NAME")
 				e := NetworkEvent{
 					endpoint: types.L4Endpoint{
 						L3Endpoint: types.L3Endpoint{
@@ -214,6 +215,7 @@ func (s *gnpOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 						},
 					},
 					K8s: types.K8sMetadata{
+						Node: node,
 						BasicK8sMetadata: types.BasicK8sMetadata{
 							PodLabels: map[string]string{},
 						},


### PR DESCRIPTION
# verify node field in integration tests

This change improves CI coverage by verifying that generated gadget events contain the correct Kubernetes node name.


## Testing done

 I manually verified runtime behavior by running a gadget and inspecting emitted events:
running this particular gadget 
`./kubectl-gadget run trace_exec -o json`

and received the following result 
`"k8s": {
  "namespace": "default",
  "podName": "test",
  "containerName": "test",
  "podLabels": "run=test",
  "node": "kind-control-plane"
}
` 
Fixes #967 