### PR TITLE
docs: add instructions for publishing gadgets to Artifact Hub

### DIFF
--- a/docs/gadget-devel/publishing.md
+++ b/docs/gadget-devel/publishing.md
@@ -82,10 +82,10 @@ authenticated) and that the image was pushed successfully.
 After publishing a gadget, consider:
 
 * [Signing the gadget image][signing]
-* Providing usage examples for end users
 
 [artifacthub]: https://artifacthub.io/
 [building]: ./building.md
 [signing]: ./signing.md
+
 
 


### PR DESCRIPTION
# Title: Publishing Gadgets to Artifact Hub
This PR adds documentation describing how Inspektor Gadget developers can publish gadgets to Artifact Hub.

While the existing docs cover building, testing, and signing gadgets, there was no guidance on how gadget images are expected to be distributed and made discoverable.

## How to use

This document explains:

Publishing gadget images as OCI artifacts

Using Artifact Hub for discovery

How users consume published gadgets

The scope is intentionally limited to Inspektor Gadget–specific behavior and links out to Artifact Hub documentation where appropriate.
