### PR TITLE
containers: Avoid blocking creation of new containers

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -79,14 +79,18 @@ type Container struct {
 
 // close releases any resources (like  file descriptors) the container is using.
 func (c *Container) close() {
-	if c.mntNsFd != 0 {
-		unix.Close(c.mntNsFd)
-		c.mntNsFd = 0
-	}
-	if c.netNsFd != 0 {
-		unix.Close(c.netNsFd)
-		c.netNsFd = 0
-	}
+	// we run this in a goroutine to avoid blocking the caller as it can happen
+	// if the container has an NFS mount
+	go func() {
+		if c.mntNsFd != 0 {
+			unix.Close(c.mntNsFd)
+			c.mntNsFd = 0
+		}
+		if c.netNsFd != 0 {
+			unix.Close(c.netNsFd)
+			c.netNsFd = 0
+		}
+	}()
 }
 
 type RuntimeMetadata struct {


### PR DESCRIPTION
Inspektor Gadget keeps a reference of the mount namespace few seconds after a container has been terminated in order to avoid its inode to be reused by newer containers which causes a race condition when enriching events [0].

This reference is closed few seconds after the container is terminated, however, if the container had a nfs mount when terminated, this call gets blocked (up to 6mins in our testing), which causes the whole container creation logic to get stuck, i.e. not new containers can be created on the system.

In order to avoid this issue, this commits moves this logic into an independent goroutine.

[0]: 4dedafc8565d ("Fix race condition on enrichers")

Fixes: 4dedafc8565d ("Fix race condition on enrichers")

Suggested-by:  Alban Crequy <alban.crequy@gmail.com

---

## Reproducer

### 1. create an nfs server

```bash
mkdir data
cd data
echo foobaryes > file.txt

docker run -it --rm --name nfs --privileged -v $(pwd):/data \
    -e SHARED_DIRECTORY=/data -p 2049:2049 \
    itsthenetwork/nfs-server-alpine:latest
```

Get the IP of the nfs server container, we'll need it in the next step:

```bash
docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nfs
```

### 2. run ig

```bash
sudo ig run trace_exec
```

### 3. mount the folder from another container

```bash
docker run -it --privileged ghcr.io/mauriciovasquezbernal/ubuntu-nfs-client:latest bash
# inside the container:
mkdir /foo && mount -t nfs 172.17.0.2:/ /foo && exit

# terminate the container
exit
```

### 4. try to create more containers

```bash
# Wait for few seconds before running this, if it's run too quickly it works...
sleep 10

# this command gets stuck
docker run --rm -it ubuntu bash
```

### 5. kill ig

Kill `ig` and the command above finished creating the container

After this fix, the container can be created without having to kill `ig`
