### PR TITLE
tools/Dockerfile: Update final images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,10 @@ updates:
         patterns:
           - "github.com/containers/*"
   - package-ecosystem: "docker"
+    directories:
+      - "/Dockerfiles"
+      - "/tools/dnstester"
+      - "/tools/bench"
     directory: "/Dockerfiles"
     schedule:
       interval: "daily"

--- a/tools/bench/Dockerfile
+++ b/tools/bench/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/bench/
 RUN GOARCH=${TARGETARCH} go build -o /bench /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/bench
 
 # Final image
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:cba10d7abd3e203428e86f5b2d7fd5eb7d8987c387864ae4996cf97191b33764
 COPY --from=builder /bench /bench
 
 CMD ["/bench"]

--- a/tools/dnstester/Dockerfile
+++ b/tools/dnstester/Dockerfile
@@ -7,7 +7,7 @@ COPY go.mod go.sum dnstester.go /go/src/github.com/inspektor-gadget/inspektor-ga
 RUN GOARCH=${TARGETARCH} go build -o /dnstester /go/src/github.com/inspektor-gadget/inspektor-gadget/tools/dnstester
 
 # Final image
-FROM alpine:3.18@sha256:1875c923b73448b558132e7d4a44b815d078779ed7a73f76209c6372de95ea8d
+FROM alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 COPY --from=builder /dnstester /dnstester
 RUN apk --no-cache upgrade -a && apk --no-cache add bind-tools
 


### PR DESCRIPTION
The job to build helper images is failing on [image scanning](https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/20907893270/job/60064976348), this PR updates the images to fix the issue! 
