### PR TITLE
Improve `bpfstats` Gadget: default to showing all `eBPF` programs and add new flag `--gadgets-only` to show only gadget programs

### DIFF
--- a/gadgets/bpfstats/test/unit/bpfstats_test.go
+++ b/gadgets/bpfstats/test/unit/bpfstats_test.go
@@ -46,7 +46,7 @@ type ExpectedBpfstatsEvent struct {
 
 type testDef struct {
 	runnerConfig   *utils.RunnerConfig
-	allPrograms    bool
+	gadgetsOnly    bool
 	generateEvent  func(t *testing.T)
 	expectedEvents []ExpectedBpfstatsEvent
 }
@@ -69,6 +69,7 @@ func TestBpfstatsGadget(t *testing.T) {
 		"by_gadget": {
 			runnerConfig:  runnerConfig,
 			generateEvent: generateEvent,
+			gadgetsOnly:   true,
 			expectedEvents: []ExpectedBpfstatsEvent{
 				{
 					GadgetImage: gadgetrunner.GetGadgetImageName(testGadgetImage),
@@ -79,7 +80,7 @@ func TestBpfstatsGadget(t *testing.T) {
 		"by_programs": {
 			runnerConfig:  runnerConfig,
 			generateEvent: generateEvent,
-			allPrograms:   true,
+			gadgetsOnly:   false,
 			expectedEvents: []ExpectedBpfstatsEvent{
 				// programs from trace_open gadget. This introduces a dependency
 				// on the trace_open gadget, but it's almost guaranteed that this
@@ -129,8 +130,8 @@ func TestBpfstatsGadget(t *testing.T) {
 			}
 
 			var paramValues map[string]string
-			if testCase.allPrograms {
-				paramValues = map[string]string{"operator.ebpf.all": "true"}
+			if testCase.gadgetsOnly {
+				paramValues = map[string]string{"operator.ebpf.gadgets-only": "true"}
 			}
 
 			opts := gadgetrunner.GadgetRunnerOpts[ExpectedBpfstatsEvent]{

--- a/pkg/operators/ebpf/stats.go
+++ b/pkg/operators/ebpf/stats.go
@@ -37,7 +37,7 @@ import (
 const (
 	ParamGadgetStatisticsInterval = "statistics-interval"
 	EmitStatsAnn                  = "emitstats"
-	ParamAllProgramsStats         = "all"
+	ParamGadgetsOnly              = "gadgets-only"
 	StatsDSName                   = "bpfstats"
 )
 
@@ -71,10 +71,11 @@ func (o *ebpfOperator) InstantiateDataOperator(
 		return nil, fmt.Errorf("creating processMap: %w", err)
 	}
 
+	gadgetsOnly := paramValues[ParamGadgetsOnly] == "true"
 	instance := &ebpfOperatorDataInstance{
 		bpfOperator:      o,
 		done:             make(chan struct{}),
-		allProgramsStats: paramValues[ParamAllProgramsStats] == "true",
+		allProgramsStats: !gadgetsOnly,
 		processMap:       processMap,
 	}
 
@@ -253,11 +254,11 @@ func (o *ebpfOperator) InstanceParams() api.Params {
 			Title:        "Gadget statistics interval",
 		},
 		{
-			Key:          ParamAllProgramsStats,
-			Description:  "Collect statistics for all eBPF programs",
+			Key:          ParamGadgetsOnly,
+			Description:  "Show only gadget-related eBPF programs",
 			DefaultValue: "false",
 			TypeHint:     api.TypeBool,
-			Title:        "All programs statistics",
+			Title:        "Gadgets only",
 		},
 	}
 }


### PR DESCRIPTION
# `feat(bpfstats)`: default to showing all `eBPF` programs and add `--gadgets-only` flag
This PR improves the usability of the `bpfstats` gadget by changing its default behavior to display statistics for all `eBPF` programs on the system, rather than just those attached to `Inspektor Gadget` instances.

Currently, users must know to pass the `--all` flag to see system-wide `eBPF` stats. Without it, the output is often empty if no other gadgets are running, leading users to believe the tool is broken or not working as intended. This change makes `bpfstats` a more effective general-purpose `eBPF` monitoring tool out of the box.

## Checklist
+ [x] Inverted Default Logic: The operator now defaults to collecting stats for all programs (`allProgramsStats = true`).
+ [x] New Parameter: Introduced `--gadgets-only` (`default: false`) to allow users to opt-in to the old behavior of filtering for only Inspektor Gadget programs.
+ [x] Removed Parameter: Removed the `--all` parameter since it is now the implicit default.
+ [x] This PR fixes #5185
+ [x] Yes, I've signed my commits

## Technical Implementation:
`pkg/gadgets/bpfstats/stats.go`:
+ Replaced `ParamAllProgramsStats` constant with `ParamGadgetsOnly`.
+ Updated `InstanceParams` to register the new flag `--gadgets-only` with a default of `false`.
+ Updated `InstantiateDataOperator` to invert the logic: `instance.allProgramsStats = !gadgetsOnly`.

## Testing done

### Before the Changes
Command Executed:
```bash
kubectl gadget run bpfstats \
                --max-entries 10 \
                --sort -runcount \
                --timeout 10
```
Output:
<img width="1920" height="79" alt="image" src="https://github.com/user-attachments/assets/24ed18d4-1a23-4b4c-9abb-9618049e8bcd" />
Command Executed:
```bash
kubectl gadget run bpfstats --all \
                --max-entries 10 \
                --sort -runcount \
                --timeout 10
```
Output:
<img width="1920" height="234" alt="image" src="https://github.com/user-attachments/assets/2bb24d18-7ba5-4cdf-a071-bee8001b6d23" />

### After the Changes
Command Executed:
```bash
kubectl gadget run bpfstats \
                --max-entries 10 \
                --sort -runcount \
                --timeout 10
```
Output:
<img width="1920" height="242" alt="image" src="https://github.com/user-attachments/assets/c6dd35c8-cde5-48df-ac36-7e2bac7fc95e" />
Command Executed:
```bash
kubectl gadget run bpfstats --gadgets-only \
                --max-entries 10 \
                --sort -runcount \
                --timeout 10
```
Output:
<img width="1920" height="78" alt="image" src="https://github.com/user-attachments/assets/2cf9b85a-81df-4b81-951d-b8d6a3b33b52" />

This is a breaking change in CLI behavior, but it aligns the default output with user expectations and the gadget’s name.
