### PR TITLE
types: add ECS metadata types for container and event enrichment

### DIFF
--- a/pkg/container-collection/containers.go
+++ b/pkg/container-collection/containers.go
@@ -37,6 +37,9 @@ type Container struct {
 	// K8s contains the Kubernetes metadata of the container.
 	K8s K8sMetadata `json:"k8s,omitempty" column:"k8s" columnTags:"kubernetes"`
 
+	// Ecs contains the ECS metadata of the container.
+	Ecs EcsMetadata `json:"ecs,omitempty" column:"ecs" columnTags:"ecs"`
+
 	// Container's configuration is the config.json from the OCI runtime
 	// spec
 	OciConfig string `json:"ociConfig,omitempty"`
@@ -102,6 +105,17 @@ type K8sMetadata struct {
 	PodUID                 string `json:"podUID,omitempty"`
 
 	ownerReference *metav1.OwnerReference
+}
+
+type EcsMetadata struct {
+	types.BasicEcsMetadata `json:",inline"`
+
+	ClusterARN        string `json:"clusterArn,omitempty"`
+	TaskARN           string `json:"taskArn,omitempty"`
+	TaskDefinitionARN string `json:"taskDefinitionArn,omitempty"`
+	ContainerARN      string `json:"containerArn,omitempty"`
+	AvailabilityZone  string `json:"availabilityZone,omitempty"`
+	ContainerInstance string `json:"containerInstance,omitempty"`
 }
 
 type K8sSelector struct {
@@ -225,6 +239,10 @@ func (c *Container) K8sMetadata() *types.BasicK8sMetadata {
 
 func (c *Container) RuntimeMetadata() *types.BasicRuntimeMetadata {
 	return &c.Runtime.BasicRuntimeMetadata
+}
+
+func (c *Container) EcsMetadata() *types.BasicEcsMetadata {
+	return &c.Ecs.BasicEcsMetadata
 }
 
 func (c *Container) UsesHostNetwork() bool {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -63,3 +63,131 @@ func TestK8sMetadataUnmarshalBadFormat2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected.PodLabels, actual.PodLabels)
 }
+
+func TestBasicEcsMetadataIsEnriched(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata BasicEcsMetadata
+		expected bool
+	}{
+		{
+			name: "fully enriched",
+			metadata: BasicEcsMetadata{
+				ClusterName:   "my-cluster",
+				TaskFamily:    "my-task",
+				ContainerName: "my-container",
+			},
+			expected: true,
+		},
+		{
+			name: "missing cluster name",
+			metadata: BasicEcsMetadata{
+				TaskFamily:    "my-task",
+				ContainerName: "my-container",
+			},
+			expected: false,
+		},
+		{
+			name: "missing task family",
+			metadata: BasicEcsMetadata{
+				ClusterName:   "my-cluster",
+				ContainerName: "my-container",
+			},
+			expected: false,
+		},
+		{
+			name: "missing container name",
+			metadata: BasicEcsMetadata{
+				ClusterName: "my-cluster",
+				TaskFamily:  "my-task",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty metadata",
+			metadata: BasicEcsMetadata{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.metadata.IsEnriched())
+		})
+	}
+}
+
+func TestEcsMetadataJSON(t *testing.T) {
+	input := `{
+		"clusterName": "production-cluster",
+		"taskFamily": "web-app",
+		"taskRevision": "5",
+		"serviceName": "web-service",
+		"containerName": "nginx",
+		"launchType": "FARGATE",
+		"clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/production-cluster",
+		"taskArn": "arn:aws:ecs:us-east-1:123456789012:task/production-cluster/abc123",
+		"taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/web-app:5",
+		"containerArn": "arn:aws:ecs:us-east-1:123456789012:container/xyz789",
+		"availabilityZone": "us-east-1a",
+		"containerInstance": "arn:aws:ecs:us-east-1:123456789012:container-instance/abc"
+	}`
+
+	expected := &EcsMetadata{
+		BasicEcsMetadata: BasicEcsMetadata{
+			ClusterName:   "production-cluster",
+			TaskFamily:    "web-app",
+			TaskRevision:  "5",
+			ServiceName:   "web-service",
+			ContainerName: "nginx",
+			LaunchType:    "FARGATE",
+		},
+		ClusterARN:        "arn:aws:ecs:us-east-1:123456789012:cluster/production-cluster",
+		TaskARN:           "arn:aws:ecs:us-east-1:123456789012:task/production-cluster/abc123",
+		TaskDefinitionARN: "arn:aws:ecs:us-east-1:123456789012:task-definition/web-app:5",
+		ContainerARN:      "arn:aws:ecs:us-east-1:123456789012:container/xyz789",
+		AvailabilityZone:  "us-east-1a",
+		ContainerInstance: "arn:aws:ecs:us-east-1:123456789012:container-instance/abc",
+	}
+
+	var actual EcsMetadata
+	err := json.Unmarshal([]byte(input), &actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected.ClusterName, actual.ClusterName)
+	assert.Equal(t, expected.TaskFamily, actual.TaskFamily)
+	assert.Equal(t, expected.TaskRevision, actual.TaskRevision)
+	assert.Equal(t, expected.ServiceName, actual.ServiceName)
+	assert.Equal(t, expected.ContainerName, actual.ContainerName)
+	assert.Equal(t, expected.LaunchType, actual.LaunchType)
+	assert.Equal(t, expected.ClusterARN, actual.ClusterARN)
+	assert.Equal(t, expected.TaskARN, actual.TaskARN)
+	assert.Equal(t, expected.TaskDefinitionARN, actual.TaskDefinitionARN)
+	assert.Equal(t, expected.ContainerARN, actual.ContainerARN)
+	assert.Equal(t, expected.AvailabilityZone, actual.AvailabilityZone)
+	assert.Equal(t, expected.ContainerInstance, actual.ContainerInstance)
+}
+
+func TestCommonDataWithEcs(t *testing.T) {
+	input := `{
+		"runtime": {
+			"runtimeName": "containerd",
+			"containerId": "abc123",
+			"containerName": "nginx"
+		},
+		"ecs": {
+			"clusterName": "prod-cluster",
+			"taskFamily": "web-task",
+			"containerName": "nginx"
+		}
+	}`
+
+	var actual CommonData
+	err := json.Unmarshal([]byte(input), &actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "containerd", string(actual.Runtime.RuntimeName))
+	assert.Equal(t, "prod-cluster", actual.Ecs.ClusterName)
+	assert.Equal(t, "web-task", actual.Ecs.TaskFamily)
+	assert.True(t, actual.Ecs.IsEnriched())
+}


### PR DESCRIPTION
## Summary

Add ECS (Elastic Container Service) metadata types to support AWS ECS workloads in inspektor-gadget. This change mirrors the existing Kubernetes metadata pattern and enables ECS-specific container discovery and eBPF event enrichment.

## Motivation

Inspektor Gadget currently supports Kubernetes environments via the `KubeManager` operator and K8s metadata types. This PR extends support to AWS ECS environments by adding equivalent ECS metadata types, enabling the future implementation of an `ECSManager` operator.

## Changes

### New Types

1. **`BasicEcsMetadata`** - Basic ECS metadata for events (similar to `BasicK8sMetadata`)
   - Fields: `ClusterName`, `TaskFamily`, `TaskRevision`, `ServiceName`, `ContainerName`, `LaunchType`
   - Includes `IsEnriched()` method

2. **`EcsMetadata`** - Extended ECS metadata with full ARNs (similar to `K8sMetadata`)
   - Embeds `BasicEcsMetadata`
   - Additional fields: `ClusterARN`, `TaskARN`, `TaskDefinitionARN`, `ContainerARN`, `AvailabilityZone`, `ContainerInstance`

### Modified Types

- **`Container` interface**: Added `EcsMetadata()` method
- **`CommonData`**: Added `Ecs EcsMetadata` field
- **Container struct** (pkg/container-collection): Added `Ecs EcsMetadata` field and accessor method

### Column Templates

Registered new column templates for ECS fields:
- `ecsCluster` (width: 30)
- `taskFamily` (width: 30)
- `ecsService` (width: 30)

## Testing

Added comprehensive unit tests:
- `TestBasicEcsMetadataIsEnriched` - Tests enrichment validation
- `TestEcsMetadataJSON` - Tests JSON serialization/deserialization
- `TestCommonDataWithEcs` - Tests integration with CommonData

All tests pass successfully.

## Design Decisions

1. **Inline JSON pattern**: Uses `json:",inline"` for `BasicEcsMetadata` to flatten JSON output, matching K8s pattern
2. **ARN visibility**: Full ARNs are hidden in column output by default (too long) but available in JSON
3. **LaunchType as string**: Supports future launch types beyond EC2/FARGATE
4. **Backward compatibility**: All ECS fields use `omitempty`, ensuring no impact on existing K8s workflows

## Future Work

This PR lays the foundation for:
- `ECSManager` operator (similar to `KubeManager`)
- ECS metadata client (Task Metadata Endpoint v4)
- Container filtering by ECS concepts (`--ecs-service`, `--ecs-task-family`, `--ecs-cluster`)

## Related Issues

Part of the broader effort to support AWS ECS environments in inspektor-gadget.