### PR TITLE
Fix `datasource`: Add case-insensitive fallback to `GetField`

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -558,11 +558,17 @@ func (ds *dataSource) GetField(name string) FieldAccessor {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()
 
-	f, ok := ds.fieldMap[name]
-	if !ok {
-		return nil
+	if f, ok := ds.fieldMap[name]; ok {
+		return &fieldAccessor{ds: ds, f: f}
 	}
-	return &fieldAccessor{ds: ds, f: f}
+
+	for existingName, f := range ds.fieldMap {
+		if strings.EqualFold(existingName, name) {
+			return &fieldAccessor{ds: ds, f: f}
+		}
+	}
+
+	return nil
 }
 
 func (ds *dataSource) GetFieldsWithTag(tag ...string) []FieldAccessor {


### PR DESCRIPTION
# `datasource`: Make GetField case-insensitive

This PR updates `ds.GetField()` to handle field names case-insensitively. This centrally resolves issues where operators (like `--sort`) rejected valid fields due to casing mismatches (e.g., `-mapmemory` vs `-mapMemory`).

## Technical Implementation
Modified `GetField` in `pkg/datasource/data.go`:

+ Fast Path: Retained optimized direct lookup (`ds.fieldMap[name]`) for exact matches.
+ Fallback: If not found, iterates through existing fields using `strings.EqualFold` to find a case-insensitive match.

This approach ensures `O(1)` performance for correct usage while automatically enabling case-insensitive lookups for sort, filter, and other operators.

## Testing Done
### Before:
Command:
```
sudo ig run bpfstats --all \
                --max-entries 10 \
                --sort -runcount \
                --timeout 3
```
Output:
<img width="1918" height="237" alt="image" src="https://github.com/user-attachments/assets/7615da6a-6b2a-41de-bf01-13aca6edc963" />

Issue:
<img width="819" height="119" alt="image" src="https://github.com/user-attachments/assets/39741b5e-f5c8-4641-9f0c-a0ee375b2707" />

### After:
Command:
```
sudo ig run bpfstats --all \
                --max-entries 10 \
                --sort -RuNCount \
                --timeout 3
```
Output:
<img width="1918" height="237" alt="image" src="https://github.com/user-attachments/assets/211ab421-b073-4bd9-881e-49e1ae818fdb" />

Command:
```
sudo ig run bpfstats \
                --max-entries 10 \
                --sort -RuNCoUnT \
                --filter 'maPMEmorY>2' \
                --timeout 3
```
Output:
<img width="1920" height="141" alt="image" src="https://github.com/user-attachments/assets/6209fef7-b1e9-44c0-9a95-4faafb95de00" />

+ [x] This PR fixes #4632
+ [x] I have signed my commits

@burak-ok, kindly review this PR whenever you get time. Thanks!