### PR TITLE
Dockerfiles: Run apt-get upgrade in gadget-builder.

### DIFF
--- a/Dockerfiles/gadget-builder.Dockerfile
+++ b/Dockerfiles/gadget-builder.Dockerfile
@@ -40,6 +40,7 @@ ARG RUST_VERSION
 # make and git is needed for make ebpf-objects and make clang-format
 # clang-format is needed for make clang-format
 RUN apt-get update \
+	&& apt-get upgrade -y --with-new-pkgs \
 	&& apt-get install -y --no-install-recommends libc-dev lsb-release wget xz-utils software-properties-common make git
 
 # Install clang


### PR DESCRIPTION
This permits upgrading the existing package in the base images in order to avoid having outdated packages with CVEs.

Fixes: https://productionresultssa18.blob.core.windows.net/actions-results/227a96d6-2836-4d0c-98e4-c90b673faf9e/workflow-job-run-dc4135a2-86bd-559a-a9a3-c4dda990401b/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-28T10%3A10%3A31Z&sig=7qSHVmPbNs8teTJQX8btKpCmGmZwJMD0yNYs0X0l8sg%3D&ske=2026-01-28T18%3A34%3A13Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-28T06%3A34%3A13Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-28T10%3A00%3A26Z&sv=2025-11-05