### PR TITLE
pkg: optimize socket cleanup by discarding iterator output

### DIFF
--- a/pkg/socketenricher/tracer.go
+++ b/pkg/socketenricher/tracer.go
@@ -387,8 +387,7 @@ func (se *SocketEnricher) cleanupDeletedSockets(cleanupIter *link.Iter) {
 func (se *SocketEnricher) cleanupDeletedSocketsNow(cleanupIter *link.Iter) error {
 	// No need to change pidns for this iterator because cleanupIter is an
 	// iterator on a map, not on tasks.
-	_, err := bpfiterns.ReadOnCurrentPidNs(cleanupIter)
-	return err
+	return bpfiterns.DiscardOnCurrentPidNs(cleanupIter)
 }
 
 func (se *SocketEnricher) Close() {


### PR DESCRIPTION
### Description

This PR optimizes the `cleanupDeletedSockets` routine in the socket enricher. 

Previously, `cleanupDeletedSocketsNow` called `ReadOnCurrentPidNs`, which accumulated all iterator output into a `bytes.Buffer` before discarding it. This resulted in unnecessary memory allocations and GC pressure every 2 seconds.

### Changes

- Added `WriteOnCurrentPidNs` and `DiscardOnCurrentPidNs` to the `bpf-iter-ns` package to support streaming or discarding BPF iterator output.
- Updated the socket enricher to use `DiscardOnCurrentPidNs` during its periodic cleanup.

### Impact

Reduces CPU and memory overhead during periodic socket cleanup by avoiding buffer allocations and data copying.