### PR TITLE
fix(`kubectl-gadget`): Show Correct Output for `runtime.containerName` on `Docker` Runtime

### DIFF
--- a/integration/k8s/enrichment_pod_label_test.go
+++ b/integration/k8s/enrichment_pod_label_test.go
@@ -52,9 +52,9 @@ func TestEnrichmentPodLabelExistingPod(t *testing.T) {
 	podUID := GetPodUID(t, ns, pod)
 
 	// Containerd and docker shim name the container with the Kubernetes container
-	// name, while CRI-O use a composed name.
+	// name, while CRI-O and Docker use a composed name.
 	runtimeContainerName := cn
-	if containerRuntime == ContainerRuntimeCRIO {
+	if containerRuntime == ContainerRuntimeCRIO || containerRuntime == ContainerRuntimeDocker {
 		// Test container shouldn't have been restarted, so append "0".
 		runtimeContainerName = "k8s_" + cn + "_" + pod + "_" + ns + "_" + podUID + "_" + "0"
 	}
@@ -180,13 +180,13 @@ func TestEnrichmentPodLabelNewPod(t *testing.T) {
 				e.Container.Runtime.ContainerImageDigest = ""
 				e.Container.Runtime.ContainerStartedAt = 0
 
-				// CRI-O uses a custom container name composed, among
+				// CRI-O and Docker use a custom container name composed, among
 				// other things, by the pod UID. We don't know the pod UID in
 				// advance, so we can't match the expected container name.
 				// TODO: Create a test for this once we support filtering by k8s
 				// container name. See
 				// https://github.com/inspektor-gadget/inspektor-gadget/issues/1403.
-				if e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO {
+				if e.Container.Runtime.RuntimeName == ContainerRuntimeCRIO || e.Container.Runtime.RuntimeName == ContainerRuntimeDocker {
 					e.Container.Runtime.ContainerName = cn
 				}
 

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -443,10 +443,10 @@ func buildContainerData(runtimeName types.RuntimeName, container CRIContainer, p
 	// Initial labels are stored in the pod sandbox
 	containerData.K8s.PodLabels = getFilteredPodLabels(podSandbox)
 
-	// CRI-O does not use the same container name of Kubernetes as containerd.
+	// Docker and CRI-O use composed container names with pod metadata (unlike containerd).
 	// Instead, it uses a composed name as Docker does, but such name is not
 	// available in the container metadata.
-	if runtimeName == types.RuntimeNameCrio {
+	if runtimeName == types.RuntimeNameCrio || runtimeName == types.RuntimeNameDocker {
 		containerData.Runtime.ContainerName = fmt.Sprintf("k8s_%s_%s_%s_%s_%d",
 			containerData.K8s.ContainerName,
 			containerData.K8s.PodName,


### PR DESCRIPTION
# Add `Docker` runtime support for composed container names

In the file `pkg/container-utils/cri/cri.go`, the `buildContainerData()` function constructs container metadata from the `CRI`. It had special handling to construct the full composed name format: `k8s_<container>_<pod>_<namespace>_<uid>_<attempt>` but this was only applied to `CRI-O`.
I've added `types.RuntimeNameDocker` to the condition so the `Docker` runtime also gets the composed container name format.

## Testing done

**Before**

Command:
```zsh
kubectl gadget run trace_tcp -n kube-system --fields k8s.podname,k8s.namespace,k8s.containerName,runtime.runtimeName,runtime.containerName
```
Output:
```
K8S.PODNAME                                                                                       K8S.NAMESPACE                                                                                     K8S.CONTAINERNAME                                                                                RUNTIME.RUNTIMENAME RUNTIME.CONTAINERNAME                                                                           
coredns-7db6d8ff4d-llt66                                                                          kube-system                                                                                       coredns                                                                                          docker              coredns                                                                                         
coredns-7db6d8ff4d-llt66                                                                          kube-system                                                                                       coredns                                                                                          docker              coredns                                                                                         
coredns-7db6d8ff4d-llt66                                                                          kube-system                                                                                       coredns                                                                                          docker              coredns                           
```

**After**

Command:
```zsh
kubectl gadget run trace_tcp -n kube-system --fields k8s.podname,k8s.namespace,k8s.containerName,runtime.runtimeName,runtime.containerName
```
Output:
```
K8S.PODNAME                                      K8S.NAMESPACE                                   K8S.CONTAINERNAME                               RUNTIME.RUNTIMENAME RUNTIME.CONTAINERNAME                          
etcd-minikube-docker                             kube-system                                     etcd                                            docker              k8s_etcd_etcd-minikube-docker_kube-system_02ca1
etcd-minikube-docker                             kube-system                                     etcd                                            docker              k8s_etcd_etcd-minikube-docker_kube-system_02ca1
etcd-minikube-docker                             kube-system                                     etcd                                            docker              k8s_etcd_etcd-minikube-docker_kube-system_02ca1
etcd-minikube-docker                             kube-system                                     etcd                                            docker              k8s_etcd_etcd-minikube-docker_kube-system_02ca1
coredns-66bc5c9577-dwmcr                         kube-system                                     coredns                                         docker              k8s_coredns_coredns-66bc5c9577-dwmcr_kube-syste
coredns-66bc5c9577-dwmcr                         kube-system                                     coredns                                         docker              k8s_coredns_coredns-66bc5c9577-dwmcr_kube-syste
coredns-66bc5c9577-dwmcr                         kube-system                                     coredns                                         docker              k8s_coredns_coredns-66bc5c9577-dwmcr_kube-syste
```

## Checklist
+ [x] Aligns `kubectl-gadget` `runtime.containerName` output with that of `ig`
+ [x] Adds runtime check for `Docker` identical to `CRI-O`
+ [x] Fixes #4844 
+ [x] Commits are signed-off