### PR TITLE
ci: Have the CVE scanning for helper images being informational only.

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1051,7 +1051,7 @@ jobs:
       with:
         input: /tmp/${{ matrix.image.name }}
         format: 'table'
-        exit-code: 1
+        exit-code: 0
         severity: CRITICAL,HIGH
         # uncomment to ignore vulnerabilities
         ignore-unfixed: true


### PR DESCRIPTION
This job had been breaking the CI quite often recently. While this is good to scan the CVEs in these images, particularly gadget-builder, let's have this as informational only.

Fixes: 1a89486dacab ("ci: Scan helper images for CVEs.")