### PR TITLE
Fix(`oci`): Harmless "ErrNotFound" Error During `ig` Gadget Image Removal

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -688,7 +688,13 @@ func deleteGadgetImage(ctx context.Context, image string) error {
 	}
 
 	// TODO: GC() could race with other processes calling it a the same time.
-	return ociStore.GC(ctx)
+	if err := ociStore.GC(ctx); err != nil {
+		if !errors.Is(err, errdef.ErrNotFound) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // SplitIGDomain splits a repository name to domain and remote-name.


### PR DESCRIPTION
# `OCI`: Modified the image removal logic to suppress harmless `ErrNotFound` errors during garbage collection

When removing a gadget image, the garbage collection (`GC()`) operation triggers a reload of the index. In some scenarios, it attempts to access the manifest that was just deleted in the previous step. This results in the error: 
```
Error: removing gadget image: unable to reload index: sha256:ab1e07bb9fddfefad91c19dde82255151a5277e8b5edf0a334a3610a6ea84074: application/vnd.oci.image.index.v1+json: not found
```

I modified `pkg/oci/oci.go::deleteGadgetImage()` to explicitly check for and ignore `ErrNotFound` returned by the `GC` operation.

+ If `GC` returns `ErrNotFound`, it implies the resource is already gone, which is the desired state during removal.
+ All other `GC` errors are still propagated to the user.

## Testing done

Command:
```zsh
sudo ./ig image rm <gadget-name>
Successfully removed <gadget-name>
```
Now, the error is not being emitted and Gadget Image gets deleted successfully.

## Checklist
+ [x] Fixes #4761 
+ [x] Commits are signed-off
+ [x] Unit & Integration Tests pass locally