### PR TITLE
Datasource deep copy clean v2

### DIFF
--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -854,7 +854,7 @@ func (ds *dataSource) Release(item interface{}) {
 		if v.Data != nil {
 			elem := (*dataElement)(v.Data)
 			// Keep payload slices for reuse - don't set to nil to reduce GC pressure
-			elem.Payload = nil
+			elem.Payload = elem.Payload[:0]
 			ds.dataElementPool.Put(elem)
 			v.Data = nil
 		}
@@ -863,7 +863,7 @@ func (ds *dataSource) Release(item interface{}) {
 		ds.dataPool.Put(v)
 	case *dataElement:
 		// Keep payload slices for reuse - don't set to nil to reduce GC pressure
-		v.Payload = nil
+		v.Payload = v.Payload[:0]
 		ds.dataElementPool.Put(v)
 	case *dataArray:
 		// Release all elements in the array

--- a/pkg/datasource/data.go
+++ b/pkg/datasource/data.go
@@ -355,7 +355,17 @@ func (ds *dataSource) newDataElement() *dataElement {
 		d.Payload = make([][]byte, int(ds.payloadCount))
 	} else {
 		d.Payload = d.Payload[:int(ds.payloadCount)]
-		// Keep existing payload slices for reuse, don't set to nil
+	}
+
+	// Reset every payload slot to zero length so that fields which are not
+	// explicitly written by the gadget read back as their zero value (e.g. an
+	// empty string), exactly as for a freshly allocated element. The backing
+	// arrays are kept (length 0, capacity preserved) so they can be reused by
+	// the Put* helpers without re-allocating. Without this reset, a pooled
+	// element reused from a previous emission would leak stale data into any
+	// field the gadget leaves untouched.
+	for i := range d.Payload {
+		d.Payload[i] = d.Payload[i][:0]
 	}
 
 	// Allocate or reuse memory for fixed size fields
@@ -379,7 +389,11 @@ func (ds *dataSource) newDataElement() *dataElement {
 		if cap(slot) < size {
 			slot = make([]byte, size)
 		} else {
+			// Reuse the existing buffer but clear it: a fixed size field that
+			// the gadget does not write must read back as zero, not as stale
+			// data from a previous use of this pooled element.
 			slot = slot[:size]
+			clear(slot)
 		}
 		d.payload()[f.PayloadIndex] = slot
 	}

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -51,13 +51,16 @@ type Data interface {
 }
 
 type DataArray interface {
-	// New returns a newly allocated data element. Use Append to add it to the array
+	// New returns a newly allocated data element from the pool. Use Append to add it to the array.
+	// The returned Data MUST be released via DataSource.Release() or DataArray.Release() when no longer needed.
 	New() Data
 
 	// Append appends Data to the array
 	Append(Data)
 
-	// Release releases the memory of Data; Data may not be used after calling this
+	// Release returns a Data item to the pool for reuse.
+	// The Data instance MUST NOT be used after calling Release.
+	// This delegates to the underlying DataSource's Release method.
 	Release(Data)
 
 	// Len returns the number of elements in the array
@@ -121,26 +124,37 @@ type DataSource interface {
 	// AddField adds a field as a new payload
 	AddField(fieldName string, kind api.Kind, options ...FieldOption) (FieldAccessor, error)
 
-	// NewPacketSingle builds a new PacketSingle that can be written to
+	// NewPacketSingle builds a new PacketSingle that can be written to.
+	// The returned packet uses pooled memory and MUST be released via Release() when done.
 	NewPacketSingle() (PacketSingle, error)
 	// NewPacketSingleFromRaw builds a new PacketSingle from a raw bytes slice coming from protobuf
 	NewPacketSingleFromRaw(b []byte) (PacketSingle, error)
 
 	// NewPacketArray and NewPacketArrayFromRaw are analogous to NewPacketSingle and NewPacketSingleFromRaw, but for
-	// PacketArray
+	// PacketArray. The returned packet uses pooled memory and MUST be released via Release() when done.
 	NewPacketArray() (PacketArray, error)
 	NewPacketArrayFromRaw(b []byte) (PacketArray, error)
 
 	GetField(fieldName string) FieldAccessor
 	GetFieldsWithTag(tag ...string) []FieldAccessor
 
+	// DeepCopy creates a deep copy of the Data using a pooled instance from this DataSource.
+	// WARNING: The returned Data MUST be released by calling DataSource.Release() when no longer needed.
+	// Failure to release will prevent the instance from being returned to the pool, leading to
+	// increased memory usage in high-throughput scenarios.
+	DeepCopy(Data) Data
+
 	// EmitAndRelease sends Packet through the operator chain and releases it afterward;
 	// Packet may not be used after calling this. This should only be used in the running phase of the gadget, not
 	// in the initialization phase.
 	EmitAndRelease(Packet) error
 
-	// Release releases the memory of Packet; Packet may not be used after calling this
-	Release(Packet)
+	// Release returns a Packet or Data to the pool for reuse, reducing allocations.
+	// The instance MUST NOT be used after calling Release.
+	// This must be called for all packets/data created via NewPacketSingle(), NewPacketArray(),
+	// NewPacketSingleFromRaw(), NewPacketArrayFromRaw(), or obtained via DeepCopy().
+	// Alternatively, use EmitAndRelease() for packets.
+	Release(interface{})
 
 	// ReportLostData reports a number of lost data cases
 	ReportLostData(lostSampleCount uint64)

--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -1029,3 +1029,45 @@ func TestClientServerRoundTrip(t *testing.T) {
 		}
 	})
 }
+
+// TestDataSourcePooledElementReset ensures that a data element reused from the
+// per-DataSource pool does not leak stale data into fields that the producer
+// leaves unwritten. This reproduces the trace_dns regression where a DNS query
+// (which never sets "rcode") inherited the "rcode" value of a previously
+// emitted DNS response because the pooled payload buffers were not reset.
+func TestDataSourcePooledElementReset(t *testing.T) {
+	t.Parallel()
+
+	ds, err := New(TypeSingle, "event")
+	require.NoError(t, err)
+
+	strAcc, err := ds.AddField("str", api.Kind_String)
+	require.NoError(t, err)
+
+	numAcc, err := ds.AddField("num", api.Kind_Uint32)
+	require.NoError(t, err)
+
+	// First packet: write both fields, then release it back to the pool.
+	first, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+	require.NoError(t, strAcc.PutString(first, "Success"))
+	require.NoError(t, numAcc.PutUint32(first, 42))
+	ds.Release(first)
+
+	// Subsequent packets reuse the pooled element. Fields left unwritten must
+	// read back as their zero value, not the value set on a previous packet.
+	for i := 0; i < 8; i++ {
+		d, err := ds.NewPacketSingle()
+		require.NoError(t, err)
+
+		str, err := strAcc.String(d)
+		require.NoError(t, err)
+		assert.Equal(t, "", str, "string field leaked stale data from a pooled element")
+
+		num, err := numAcc.Uint32(d)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(0), num, "fixed-size field leaked stale data from a pooled element")
+
+		ds.Release(d)
+	}
+}


### PR DESCRIPTION
supersedes #5019

# datasource: Add deep copy to Data

DataSource.Subscribe doc says:
> Data sent to dataFn has to be consumed synchronously and must not be accessed after returning.

In order to allow deferring data consumption, I'm adding a DeepCopy() method to the interface.

## How to use

We are thinking about ways to incorporate a Sync.Pool somewhere to avoid overloading the GC... Maybe it would make sense to provide a pointer to a buffer for DeepCopyInto(*buf)?

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
