### PR TITLE
operators/kubeipresolver: fix unknown endpoint kind for host-network pods

### DIFF
--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -272,6 +272,14 @@ func (m *KubeIPResolverInstance) PreStart(gadgetCtx operators.GadgetContext) err
 				pod := m.k8sInventory.GetPodByIp(addrStr)
 				if pod != nil {
 					if pod.Spec.HostNetwork {
+						// Host-network pods cannot be selected by pod selectors in
+						// NetworkPolicies, so treat them as raw IP endpoints.
+						a.subK8sKind.Set(data, []byte("raw"))
+						if a.column != nil && a.port != nil {
+							p, _ := a.port.Uint16(data)
+							v := fmt.Sprintf("r/%s:%d", addrStr, p)
+							a.column.Set(data, []byte(v))
+						}
 						continue
 					}
 					a.subK8sName.Set(data, []byte(pod.Name))


### PR DESCRIPTION
When an endpoint IP belongs to a pod with hostNetwork=true, the kubeipresolver
was skipping it without setting the endpoint kind. This left the kind as an
empty string, which caused advise_networkpolicy to crash with "unknown endpoint
kind" when processing network connections.

Since host network pods can't be targeted by pod selectors in network policies,
we now treat them as raw IP endpoints instead.

Fixes #5300

## How to use

Run advise_networkpolicy in a cluster that has pods using hostNetwork=true (e.g.
kube proxy, node exporter). Before this fix it would crash, now it should
generate network policies with IPBlock rules for those connections.

## Testing done

Reproduced the crash by running advise_networkpolicy in a cluster with
host network pods and confirmed the "unknown endpoint kind" error. After the
fix, the gadget runs successfully and generates policies with raw IP entries
for host network connections.