### PR TITLE
tools/eks-cleanup: fix early return skipping remaining internet gateways

### DIFF
--- a/tools/eks-cleanup/main.go
+++ b/tools/eks-cleanup/main.go
@@ -171,7 +171,7 @@ func detachAndDeleteInternetGateways(svc *ec2.EC2, vpcId string) error {
 		for _, attachment := range gateway.Attachments {
 			if aws.StringValue(attachment.VpcId) != vpcId {
 				// not attached to this vpc
-				return nil
+				continue
 			}
 			fmt.Printf("detaching internet gateway: %s\n", aws.StringValue(gateway.InternetGatewayId))
 			input := &ec2.DetachInternetGatewayInput{


### PR DESCRIPTION
In detachAndDeleteInternetGateways, when an attachment's VPC ID didn't
match the current VPC, the code was doing `return nil` inside the inner
loop. This exited the entire function early, so any remaining gateways
never got processed and were left behind silently.

Changed it to `continue` so it just skips that attachment and moves on
to the next one.

## How to use

Run the eks cleanup tool against a VPC that has multiple internet
gateways tagged with ig ci. Before this fix, only the first gateway
would be evaluated. After the fix, all of them get detached and deleted.

## Testing done

Code inspection. The change is a one liner replacing `return nil` with
`continue` in the attachment loop inside detachAndDeleteInternetGateways.