### PR TITLE
`ci`: switch to cosign bundle format for signing

### DIFF
--- a/.github/actions/sign-container-image/action.yml
+++ b/.github/actions/sign-container-image/action.yml
@@ -24,6 +24,4 @@ runs:
         IMAGE: '${{ inputs.image }}'
       shell: bash
       run: |
-        # Force using legacy .sig format.
-        # TODO Switch to bundle format.
-        cosign sign --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes --recursive "${IMAGE}"
+        cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive "${IMAGE}"

--- a/.github/actions/sign-oci-artifact/action.yml
+++ b/.github/actions/sign-oci-artifact/action.yml
@@ -24,6 +24,4 @@ runs:
         OCI_ARTIFACT: '${{ inputs.oci_artifact }}'
       shell: bash
       run: |
-        # Force using legacy .sig format.
-        # TODO Switch to bundle format.
-        cosign sign --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes --recursive "${OCI_ARTIFACT}"
+        cosign sign --key env://COSIGN_PRIVATE_KEY --yes --recursive "${OCI_ARTIFACT}"

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2487,10 +2487,7 @@ jobs:
         COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
       run: |
         checksums_file=SHA256SUMS
-
-        # Force using legacy .sig format.
-        # TODO Switch to bundle format.
-        cosign sign-blob --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
+        cosign sign-blob --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
 
         # Derive public key from private key to publish it as release
         # artifact, so people can verify our signature.

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -2810,10 +2810,7 @@ jobs:
         COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
       run: |
         checksums_file=SHA256SUMS
-
-        # Force using legacy .sig format.
-        # TODO Switch to bundle format.
-        cosign sign-blob --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
+        cosign sign-blob --key env://COSIGN_PRIVATE_KEY --yes $checksums_file --output-signature="${checksums_file}.sig" --bundle="${checksums_file}.bundle"
 
         # Derive public key from private key to publish it as release
         # artifact, so people can verify our signature.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -12,9 +12,7 @@ IG_RUNTIME ?= docker
 IG_FLAGS ?=
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
-# Force using legacy .sig format.
-# TODO Switch to bundle format.
-COSIGN_FLAGS ?= --new-bundle-format=false --use-signing-config=false
+COSIGN_FLAGS ?=
 CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -21,9 +21,7 @@ IG_FLAGS ?=
 GADGET_PUSH_RETRIES ?= 0
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
-# Force using legacy .sig format.
-# TODO Switch to bundle format.
-COSIGN_FLAGS ?= --new-bundle-format=false --use-signing-config=false
+COSIGN_FLAGS ?=
 CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M


### PR DESCRIPTION
# Sign Gadgets, Images and Release Assets with `cosign-v3` Bundle

Remove flags that forced the legacy `.sig` format, allowing `cosign v3+` to use bundle as the default format.
Both .sig and .bundle files are still uploaded as release assets for backward compatibility.

## Implementation Details

Remove legacy cosign flags from:
+ `gadgets/Makefile`
+ `.github/actions/sign-container-image/action.yml`
+ `.github/workflows/inspektor-gadget.yml`

The `cosign sign-blob` command still outputs both `--output-signature` (`.sig`) and `--bundle` (`.bundle`) files, both of which continue to be uploaded as release assets. Users on older cosign can still verify using the `.sig` file.

## Checklist

+ [x] Fixes #5154  
+ [x] Commits are signed-off
+ [x] Unit & Integration Tests pass locally