### PR TITLE
dependabot: Weekly scanning for /tools/eks-cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
   - package-ecosystem: "gomod"
     directories:
       - "**/*"
+    exclude-paths:
+      - "tools/eks-cleanup/**"
     schedule:
       interval: "daily"
       time: "05:00"
@@ -36,6 +38,19 @@ updates:
       containers:
         patterns:
           - "github.com/containers/*"
+  # Weekly only for /tools/eks-cleanup
+  - package-ecosystem: "gomod"
+    directory: "/tools/eks-cleanup"
+    schedule:
+      interval: "weekly"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    commit-message:
+      prefix: "go:"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
   - package-ecosystem: "docker"
     directory: "/Dockerfiles"
     schedule:


### PR DESCRIPTION
The aws-sdk packages are changing very often and since the eks-cleanup code is only used in the CI for cleaning up the malfunctioning containers and not in Inspektor Gadget itself we can slow dependabot for that path