### PR TITLE
dependabot: Revert weekly scanning, but add grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
   - package-ecosystem: "gomod"
     directories:
       - "**/*"
-    exclude-paths:
-      - "tools/eks-cleanup/**"
     schedule:
       interval: "daily"
       time: "05:00"
@@ -38,16 +36,6 @@ updates:
       containers:
         patterns:
           - "github.com/containers/*"
-  # Weekly only for /tools/eks-cleanup
-  - package-ecosystem: "gomod"
-    directory: "/tools/eks-cleanup"
-    schedule:
-      interval: "weekly"
-      time: "05:00"
-      timezone: "Europe/Paris"
-    commit-message:
-      prefix: "go:"
-    groups:
       aws-sdk:
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"


### PR DESCRIPTION
The glob overlaps with the second gomod ecosystem, even though an exclude pattern was given.

This broke dependabot https://github.com/inspektor-gadget/inspektor-gadget/network/updates:
`Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'gomod' has overlapping directories.`

Fixes: d5432fdd4ccc491df68e8b39a025617f62879c2b