### PR TITLE
operators: Support pre-provided container and tracer collections

### DIFF
--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -69,6 +69,18 @@ type Attacher interface {
 type KubeManager struct {
 	containerCollection *containercollection.ContainerCollection
 	tracerCollection    *tracercollection.TracerCollection
+	externalCollections bool
+}
+
+// NewKubeManager creates a new KubeManager operator skipping the Init() method.
+// This can be used when the operator is used as a library and the caller wants to manage the lifecycle of the collections.
+// It also means that all initialization steps in Init() are skipped, so the caller is responsible for initializing the collections.
+func NewKubeManager(containerCollection *containercollection.ContainerCollection, tracerCollection *tracercollection.TracerCollection) *KubeManager {
+	return &KubeManager{
+		containerCollection: containerCollection,
+		tracerCollection:    tracerCollection,
+		externalCollections: true,
+	}
 }
 
 func (k *KubeManager) Name() string {
@@ -115,6 +127,10 @@ func (k *KubeManager) ParamDescs() params.ParamDescs {
 }
 
 func (k *KubeManager) Init(params *params.Params) error {
+	if k.externalCollections {
+		return nil
+	}
+
 	hookMode := params.Get(ParamHookMode).AsString()
 	fallbackPodInformer := params.Get(ParamFallbackPodInformer).AsBool()
 	socketPath := params.Get(ParamHookLivenessSocketFile).AsString()

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -75,8 +75,20 @@ type Attacher interface {
 type localManager struct {
 	containerCollection *containercollection.ContainerCollection
 	tracerCollection    *tracercollection.TracerCollection
+	externalCollections bool
 
 	fakeContainer *containercollection.Container
+}
+
+// NewLocalManager creates a new LocalManager operator skipping the Init() method.
+// This can be used when the operator is used as a library and the caller wants to manage the lifecycle of the collections.
+// It also means that all initialization steps in Init() are skipped, so the caller is responsible for initializing the collections.
+func NewLocalManager(containerCollection *containercollection.ContainerCollection, tracerCollection *tracercollection.TracerCollection) *localManager {
+	return &localManager{
+		containerCollection: containerCollection,
+		tracerCollection:    tracerCollection,
+		externalCollections: true,
+	}
 }
 
 func (l *localManager) Name() string {
@@ -154,6 +166,10 @@ func (l *localManager) ParamDescs() params.ParamDescs {
 }
 
 func (l *localManager) Init(operatorParams *params.Params) error {
+	if l.externalCollections {
+		return nil
+	}
+
 	rc := make([]*containerutilsTypes.RuntimeConfig, 0)
 
 	runtimesParam := operatorParams.Get(Runtimes)


### PR DESCRIPTION
Add NewKubeManager() and NewLocalManager() constructors that accept pre-initialized containerCollection and tracerCollection. When collections are provided via constructor, Init() skips initialization and collection creation. This allows external users to provide their own collections while maintaining backward compatibility with existing init()-based registration.

Both operators now track externally provided collections via the externalCollections field, which defaults to false for zero-value operators (including those registered via init()).