### PR TITLE
gadgets/trace_cuda,cuda_metrics: Add CUDA tracing and metrics

### DIFF
--- a/docs/gadgets/cuda_metrics.mdx
+++ b/docs/gadgets/cuda_metrics.mdx
@@ -1,0 +1,1 @@
+../../gadgets/cuda_metrics/README.mdx

--- a/docs/gadgets/trace_cuda.mdx
+++ b/docs/gadgets/trace_cuda.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_cuda/README.mdx

--- a/gadgets/cuda_metrics/LICENSE
+++ b/gadgets/cuda_metrics/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gadgets/cuda_metrics/LICENSE-bpf.txt
+++ b/gadgets/cuda_metrics/LICENSE-bpf.txt
@@ -1,0 +1,366 @@
+The BPF code templates are licensed under the General Public License, Version
+2.0, with the Linux-syscall-note. Copies of the Linux-syscall-note and GPL-2.0
+license text are included below.
+
+= = = = =
+
+Linux-syscall-note:
+
+   NOTE! This copyright does *not* cover user programs that use kernel
+ services by normal system calls - this is merely considered normal use
+ of the kernel, and does *not* fall under the heading of "derived work".
+ Also note that the GPL below is copyrighted by the Free Software
+ Foundation, but the instance of code that it refers to (the Linux
+ kernel) is copyrighted by me and others who actually wrote it.
+
+ Also note that the only valid version of the GPL as far as the kernel
+ is concerned is _this_ particular version of the license (ie v2, not
+ v2.2 or v3.x or whatever), unless explicitly otherwise stated.
+
+Linus Torvalds
+
+= = = = =
+
+GPL-2.0:
+
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/gadgets/cuda_metrics/Makefile
+++ b/gadgets/cuda_metrics/Makefile
@@ -1,0 +1,22 @@
+TAG := $(shell git describe --tags --always --dirty)
+CONTAINER_REPO ?= ghcr.io/inspektor-gadget/gadget/cuda_metrics
+IMAGE_TAG ?= $(TAG)
+CLANG_FORMAT ?= clang-format
+
+.PHONY: build
+build:
+	sudo -E ig image build \
+		-t $(CONTAINER_REPO):$(IMAGE_TAG) \
+		--update-metadata .
+
+PHONY: run
+run:
+	sudo -E ig run $(CONTAINER_REPO):$(IMAGE_TAG) $$PARAMS
+
+.PHONY: push
+push:
+	sudo -E ig image push $(CONTAINER_REPO):$(IMAGE_TAG)
+	
+.PHONY: clang-format
+clang-format:
+	$(CLANG_FORMAT) -i program.bpf.c

--- a/gadgets/cuda_metrics/README.md
+++ b/gadgets/cuda_metrics/README.md
@@ -1,0 +1,26 @@
+# gadget-template
+
+# cuda-ebpf-poc
+
+cuda_metrics is a [gadget from Inspektor
+Gadget](https://inspektor-gadget.io/). It traces cuda/GPU operation such as LaunchKernel, MemAlloc,Memcpy and generate metrics.
+
+## How to use
+
+```bash
+$ make build
+$ make run PARAMS="--verify-image=false -v --host"
+```
+
+## Requirements
+
+- ig v0.26.0
+- Linux v5.15 
+
+## License 
+
+The user space components are licensed under the [Apache License, Version
+2.0](LICENSE). The BPF code templates are licensed under the [General Public
+License, Version 2.0, with the Linux-syscall-note](LICENSE-bpf.txt).
+
+

--- a/gadgets/cuda_metrics/README.md
+++ b/gadgets/cuda_metrics/README.md
@@ -1,6 +1,6 @@
 # gadget-template
 
-# cuda-ebpf-poc
+# cuda_metrics
 
 cuda_metrics is a [gadget from Inspektor
 Gadget](https://inspektor-gadget.io/). It traces cuda/GPU operation such as LaunchKernel, MemAlloc,Memcpy and generate metrics.

--- a/gadgets/cuda_metrics/README.mdx
+++ b/gadgets/cuda_metrics/README.mdx
@@ -1,0 +1,228 @@
+---
+title: cuda_metrics
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# cuda_metrics
+
+Collect aggregated metrics about CUDA workloads, including kernel launches, execution time, memory allocations, and memory copy operations.
+
+## Requirements
+
+- The CUPTI userspace library must be installed.  
+  Follow the instructions in:
+
+```
+
+inspektor-gadget/gadgets/trace_cuda/cupti/README.md
+
+````
+
+Without the CUPTI library, only memory allocation and memory copy metrics will be available.
+
+- NVIDIA drivers must be installed.
+- CUDA runtime libraries must be available.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/cuda_metrics:%IG_TAG% [flags]
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/cuda_metrics:%IG_TAG% [flags]
+        ```
+    </TabItem>
+</Tabs>
+
+## Flags
+
+### `--host`
+
+Collect metrics from host processes in addition to containers.
+
+## Description
+
+`cuda_metrics` collects aggregated statistics about CUDA activity in running workloads.
+
+It provides visibility into:
+
+### Launch Kernel Metrics
+
+Metrics related to CUDA kernel launches:
+
+* **`kernel_launches`**
+  Total number of kernel launch attempts.
+
+* **`block_threads_hist`**
+  Histogram of threads per block.
+
+* **`grid_blocks_hist`**
+  Histogram of blocks per grid.
+
+* **`total_threads_hist`**
+  Histogram of total threads per kernel launch
+
+* **`kernel_execution_time_hist`**
+  Histogram of kernel execution time (in nanoseconds).
+
+  Requires the CUPTI userspace library.
+
+
+### Memory Allocation Metrics
+
+Metrics related to CUDA device memory allocations:
+
+* **`num_memalloc`**
+  Total number of device memory allocation attempts.
+
+* **`total_mem_alloc`**
+  Total number of bytes successfully allocated on the device.
+
+
+### Memory Copy Metrics
+
+Metrics related to CUDA memory transfers:
+
+* **`num_memcpy_htod`**
+  Number of Host → Device memory copy operations.
+
+* **`num_memcpy_dtoh`**
+  Number of Device → Host memory copy operations.
+
+* **`memcpy_htod_bytes`**
+  Total bytes transferred from Host → Device.
+
+* **`memcpy_dtoh_bytes`**
+  Total bytes transferred from Device → Host.
+
+
+### Error Metrics
+
+Metrics tracking failed CUDA operations:
+
+* **`kernel_launch_errors`**
+  Number of failed kernel launches.
+
+* **`mem_alloc_errors`**
+  Number of failed device memory allocations.
+
+* **`memcpy_htod_errors`**
+  Number of failed Host → Device memory copies.
+
+* **`memcpy_dtoh_errors`**
+  Number of failed Device → Host memory copies.
+
+
+
+## Guide
+### 1. Install the CUPTI library
+
+First, build and install the required CUPTI userspace library by following the instructions in:
+
+````
+
+inspektor-gadget/gadgets/trace_cuda/cupti/README.md
+
+````
+
+### 2. Run the gadget
+
+Start the gadget using one of the commands shown in the *Getting started* section.
+
+### 3. Run a sample CUDA application
+
+You can test the gadget using a simple CUDA program such as the following SAXPY example:
+
+```bash
+cat << EOF > saxpy.cu
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+__global__
+void saxpy(int n, float a, float *x, float *y)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+    y[i] = a * x[i] + y[i];
+}
+
+int main(void)
+{
+  int N = 1<<20;
+  float *x, *y, *d_x, *d_y;
+
+  x = (float*)malloc(N * sizeof(float));
+  y = (float*)malloc(N * sizeof(float));
+
+  cudaMalloc(&d_x, N * sizeof(float));
+  cudaMalloc(&d_y, N * sizeof(float));
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1.0f;
+    y[i] = 2.0f;
+  }
+
+  cudaMemcpy(d_x, x, N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_y, y, N * sizeof(float), cudaMemcpyHostToDevice);
+
+  // Perform SAXPY on 1M elements
+  saxpy<<<(N + 255) / 256, 256>>>(N, 2.0f, d_x, d_y);
+
+  cudaMemcpy(y, d_y, N * sizeof(float), cudaMemcpyDeviceToHost);
+
+  float maxError = 0.0f;
+  for (int i = 0; i < N; i++)
+    maxError = fmax(maxError, fabs(y[i] - 4.0f));
+
+  printf("Max error: %f\n", maxError);
+
+  cudaFree(d_x);
+  cudaFree(d_y);
+  free(x);
+  free(y);
+}
+EOF
+````
+
+Compile and run it:
+
+```bash
+nvcc saxpy.cu -o saxpy
+./saxpy
+```
+
+## Export Prometheus Metrics
+
+To export CUDA metrics via OpenTelemetry:
+
+````
+kubectl gadget run ghcr.io/inspektor-gadget/gadget/cuda_metrics \
+--name cudametrics \
+--annotate=gpu_metrics:metrics.collect=true \
+--otel-metrics-name=gpu_metrics:cuda-metrics
+````
+
+## Retrieving Metrics
+
+After starting the gadget:
+
+````
+POD_NAME=$(kubectl get pods -n gadget -o jsonpath="{.items[0].metadata.name}")
+kubectl -n gadget port-forward $POD_NAME 2224:2224 &
+curl http://localhost:2224/metrics -s | grep cuda
+````
+
+## Notes
+- `cuda_metrics` provides aggregated statistics, while trace_cuda provides per event visibility.
+- Kernel execution time metrics require the CUPTI userspace library.

--- a/gadgets/cuda_metrics/gadget.yaml
+++ b/gadgets/cuda_metrics/gadget.yaml
@@ -1,0 +1,118 @@
+name: cuda_metrics
+description: Traces CUDA driver API operations using eBPF uprobes to generate metrics
+homepageURL: 'TODO: Fill the gadget homepage URL'
+documentationURL: 'TODO: Fill the gadget documentation URL'
+sourceURL: 'TODO: Fill the gadget source code URL'
+datasources:
+  gpu_metrics:
+    annotations:
+      metrics.collect: "true"
+      metrics.print: "true"
+    fields:
+      block_threads_hist:
+        annotations:
+          description: Histogram of the number of threads per CUDA block used in kernel
+            launches
+          metrics.type: histogram
+          metrics.unit: threads
+      grid_blocks_hist:
+        annotations:
+          description: Histogram of the number of blocks per CUDA grid used in kernel
+            launches
+          metrics.type: histogram
+          metrics.unit: blocks
+      kernel_execution_time_hist:
+        annotations:
+          description: Histogram of CUDA kernel execution durations measured in nanoseconds
+          metrics.type: Histogram
+          metrics.unit: ns
+      kernel_launch_errors:
+        annotations:
+          description: Total number of CUDA kernel launch attempts that returned a
+            non-zero error code
+          metrics.type: counter
+          metrics.unit: errors
+      kernel_launches:
+        annotations:
+          description: Total number of CUDA kernel launches observed
+          metrics.type: counter
+          metrics.unit: calls
+      mem_alloc_errors:
+        annotations:
+          description: Total number of CUDA memory allocation calls that returned
+            a non-zero error code
+          metrics.type: counter
+          metrics.unit: errors
+      memcpy_dtoh_bytes:
+        annotations:
+          description: Total number of bytes transferred from device to host via CUDA
+            memory copy operations
+          metrics.type: counter
+          metrics.unit: By
+      memcpy_dtoh_errors:
+        annotations:
+          description: Total number of device to host CUDA memory copy operations
+            that returned a non-zero error code
+          metrics.type: counter
+          metrics.unit: errors
+      memcpy_htod_bytes:
+        annotations:
+          description: Total number of bytes transferred from host to device via CUDA
+            memory copy operations
+          metrics.type: counter
+          metrics.unit: By
+      memcpy_htod_errors:
+        annotations:
+          description: Total number of host to device CUDA memory copy operations
+            that returned a non-zero error code
+          metrics.type: counter
+          metrics.unit: errors
+      mntns_id:
+        annotations:
+          description: Mount namespace inode id
+      num_memalloc:
+        annotations:
+          description: Total number of CUDA device memory allocation calls observed
+          metrics.type: counter
+          metrics.unit: calls
+      num_memcpy_dtoh:
+        annotations:
+          description: Total number of CUDA memory copy operations from device to
+            host
+          metrics.type: counter
+          metrics.unit: calls
+      num_memcpy_htod:
+        annotations:
+          description: Total number of CUDA memory copy operations from host to device
+          metrics.type: counter
+          metrics.unit: calls
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      total_mem_alloc:
+        annotations:
+          description: Total number of bytes allocated on the GPU via CUDA memory
+            allocation calls
+          metrics.type: counter
+          metrics.unit: By
+      total_threads_hist:
+        annotations:
+          description: Histogram of the total number of threads launched per CUDA
+            kernel
+          metrics.type: histogram
+          metrics.unit: threads
+params:
+  ebpf:
+    collect_build_id:
+      key: collect_build_id
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    collect_ustack:
+      key: collect_ustack
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    ig_build_id_max_entries:
+      key: ig_build_id_max_entries
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'

--- a/gadgets/cuda_metrics/gadget.yaml
+++ b/gadgets/cuda_metrics/gadget.yaml
@@ -24,7 +24,7 @@ datasources:
       kernel_execution_time_hist:
         annotations:
           description: Histogram of CUDA kernel execution durations measured in nanoseconds
-          metrics.type: Histogram
+          metrics.type: histogram
           metrics.unit: ns
       kernel_launch_errors:
         annotations:

--- a/gadgets/cuda_metrics/program.bpf.c
+++ b/gadgets/cuda_metrics/program.bpf.c
@@ -1,0 +1,668 @@
+// SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+/* Copyright (c) 2024 Alejandro Salamanca */
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/user_stack_map.h>
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns.h>
+#include <gadget/types.h>
+#include <gadget/bits.bpf.h>
+#include <gadget/core_fixes.bpf.h>
+
+//Type definition
+
+#define MAX_ENTRIES 10240
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+#define GPU_HIST_MAX_SLOTS 48
+#define MAX_GPUKERN_ARGS 16
+#define DIR_HTOD 0
+#define DIR_DTOH 1
+
+typedef __u64 CUdeviceptr;
+typedef __u64 CUstream;
+
+struct gpu_metrics_key {
+	__u32 pid;
+	gadget_mntns_id mntns_id;
+};
+
+struct kernel_key {
+	__u32 pid;
+	__u32 correlation_id;
+};
+
+struct gpu_metrics_value {
+	// LaunchKernel metrics
+	gadget_counter__u64 kernel_launches;
+	gadget_histogram_slot__u64 block_threads_hist[GPU_HIST_MAX_SLOTS];
+	gadget_histogram_slot__u64 grid_blocks_hist[GPU_HIST_MAX_SLOTS];
+	gadget_histogram_slot__u64 total_threads_hist[GPU_HIST_MAX_SLOTS];
+	gadget_histogram_slot__u64
+		kernel_execution_time_hist[GPU_HIST_MAX_SLOTS];
+
+	// MemAlloc metrics
+	gadget_counter__u64 total_mem_alloc;
+	gadget_counter__u64 num_memalloc;
+
+	// Memcpy metrics
+	gadget_counter__u64 num_memcpy_htod;
+	gadget_counter__u64 num_memcpy_dtoh;
+	gadget_counter__u64 memcpy_htod_bytes;
+	gadget_counter__u64 memcpy_dtoh_bytes;
+
+	// Error metrics
+	gadget_counter__u64 kernel_launch_errors;
+	gadget_counter__u64 mem_alloc_errors;
+	gadget_counter__u64 memcpy_htod_errors;
+	gadget_counter__u64 memcpy_dtoh_errors;
+};
+
+struct cupti_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	__u32 grid_x;
+	__u32 grid_y;
+	__u32 grid_z;
+
+	__u32 block_x;
+	__u32 block_y;
+	__u32 block_z;
+
+	__u32 correlation_id;
+
+	__u64 start;
+	__u64 end;
+
+	struct gadget_user_stack ustack;
+	__u32 stream;
+
+	int ret_val;
+};
+
+struct memalloc_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	size_t byte_size;
+	int ret_val;
+};
+
+struct memcpy_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	size_t byte_size;
+	__u8 kind;
+	int ret_val;
+};
+
+static struct gpu_metrics_value zero;
+
+//Map definition
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct gpu_metrics_key);
+	__type(value, struct gpu_metrics_value);
+} gpu_metrics SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct kernel_key);
+	__type(value, struct cupti_event);
+} kernel_event_cupti SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u64);
+	__type(value, struct memalloc_event);
+} memalloc_event SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u64);
+	__type(value, struct memcpy_event);
+} memcpy_event SEC(".maps");
+
+// gadget macros
+
+GADGET_MAPITER(gpu_metrics, gpu_metrics);
+
+//functions impl
+static __always_inline struct gpu_metrics_value *
+get_or_init_gpu_metrics(__u32 pid, gadget_mntns_id mntns_id)
+{
+	struct gpu_metrics_key key = {
+		.pid = pid,
+		.mntns_id = mntns_id,
+	};
+
+	struct gpu_metrics_value *val;
+
+	val = bpf_map_lookup_elem(&gpu_metrics, &key);
+	if (val)
+		return val;
+
+	bpf_map_update_elem(&gpu_metrics, &key, &zero, BPF_NOEXIST);
+
+	return bpf_map_lookup_elem(&gpu_metrics, &key);
+}
+
+static __always_inline int
+handle_cuMemAlloc_impl(void **devptr, size_t bytesize, struct pt_regs *ctx)
+{
+	struct memalloc_event event = {};
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+
+	bpf_map_update_elem(&memalloc_event, &pid_tgid, &event, BPF_ANY);
+
+	return 0;
+}
+
+static __always_inline int handle_cuMemAlloc_exit_impl(int ret,
+						       struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+
+	struct memalloc_event *prev =
+		bpf_map_lookup_elem(&memalloc_event, &pid_tgid);
+	if (!prev)
+		return 0;
+
+	struct gpu_metrics_value *metrics =
+		get_or_init_gpu_metrics(prev->pid, prev->mntns_id);
+
+	if (metrics) {
+		__sync_fetch_and_add(&metrics->total_mem_alloc,
+				     prev->byte_size);
+		__sync_fetch_and_add(&metrics->num_memalloc, 1);
+
+		if (ret != 0) {
+			__sync_fetch_and_add(&metrics->mem_alloc_errors, 1);
+		}
+	}
+
+	bpf_map_delete_elem(&memalloc_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_htod_impl(CUdeviceptr dst,
+						     const void *src,
+						     size_t bytesize,
+						     struct pt_regs *ctx)
+{
+	struct memcpy_event event = {};
+
+	// process info
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+	event.kind = DIR_HTOD;
+
+	bpf_map_update_elem(&memcpy_event, &pid_tgid, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_htod_exit_impl(int ret,
+							  struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct memcpy_event *prev =
+		bpf_map_lookup_elem(&memcpy_event, &pid_tgid);
+
+	if (!prev)
+		return 0;
+
+	struct gpu_metrics_value *metrics =
+		get_or_init_gpu_metrics(prev->pid, prev->mntns_id);
+
+	if (metrics) {
+		__sync_fetch_and_add(&metrics->num_memcpy_htod, 1);
+		__sync_fetch_and_add(&metrics->memcpy_htod_bytes,
+				     prev->byte_size);
+
+		if (ret != 0) {
+			__sync_fetch_and_add(&metrics->memcpy_htod_errors, 1);
+		}
+	}
+
+	bpf_map_delete_elem(&memcpy_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_dtoh_impl(void *dst, CUdeviceptr src,
+						     size_t bytesize,
+						     struct pt_regs *ctx)
+{
+	struct memcpy_event event = {};
+
+	// process info
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+	event.kind = DIR_DTOH;
+
+	bpf_map_update_elem(&memcpy_event, &pid_tgid, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_dtoh_exit_impl(int ret,
+							  struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct memcpy_event *prev =
+		bpf_map_lookup_elem(&memcpy_event, &pid_tgid);
+	if (!prev)
+		return 0;
+
+	struct gpu_metrics_value *metrics =
+		get_or_init_gpu_metrics(prev->pid, prev->mntns_id);
+	if (metrics) {
+		__sync_fetch_and_add(&metrics->num_memcpy_dtoh, 1);
+		__sync_fetch_and_add(&metrics->memcpy_dtoh_bytes,
+				     prev->byte_size);
+
+		if (ret != 0) {
+			__sync_fetch_and_add(&metrics->memcpy_dtoh_errors, 1);
+		}
+	}
+
+	bpf_map_delete_elem(&memcpy_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int
+handle_ig_callback_impl(struct pt_regs *ctx, __u32 correlation_id, __u64 result)
+{
+	struct cupti_event event = {};
+
+	// process info
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.correlation_id = correlation_id;
+	event.ret_val = (int)result;
+
+	struct kernel_key key = {
+		.correlation_id = correlation_id,
+		.pid = pid_tgid >> 32,
+	};
+
+	bpf_map_update_elem(&kernel_event_cupti, &key, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int
+handle_ig_activity_impl(struct pt_regs *ctx, __u32 correlation_id,
+			__u32 device_id, __u32 stream_id, __u32 grid_x,
+			__u32 grid_y, __u32 grid_z, __u32 block_x,
+			__u32 block_y, __u32 block_z, __u64 start, __u64 end)
+{
+	struct cupti_event *prev;
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct kernel_key key = {
+		.correlation_id = correlation_id,
+		.pid = pid_tgid >> 32,
+	};
+
+	prev = bpf_map_lookup_elem(&kernel_event_cupti, &key);
+	if (!prev)
+		return 0;
+
+	struct gpu_metrics_value *metrics =
+		get_or_init_gpu_metrics(prev->pid, prev->mntns_id);
+	__u64 block_threads = block_x * block_y * block_z;
+	__u64 grid_blocks = grid_x * grid_y * grid_z;
+	__u64 total_threads = block_threads * grid_blocks;
+
+	__u64 delta = end - start;
+
+	__u32 slot;
+	if (metrics) {
+		__sync_fetch_and_add(&metrics->kernel_launches, 1);
+
+		slot = get_slot_idx(block_threads);
+		if (slot >= GPU_HIST_MAX_SLOTS)
+			slot = GPU_HIST_MAX_SLOTS - 1;
+		__sync_fetch_and_add(&metrics->block_threads_hist[slot], 1);
+
+		slot = get_slot_idx(grid_blocks);
+		if (slot >= GPU_HIST_MAX_SLOTS)
+			slot = GPU_HIST_MAX_SLOTS - 1;
+		__sync_fetch_and_add(&metrics->grid_blocks_hist[slot], 1);
+
+		slot = get_slot_idx(total_threads);
+		if (slot >= GPU_HIST_MAX_SLOTS)
+			slot = GPU_HIST_MAX_SLOTS - 1;
+		__sync_fetch_and_add(&metrics->total_threads_hist[slot], 1);
+
+		slot = get_slot_idx(delta);
+		if (slot >= GPU_HIST_MAX_SLOTS)
+			slot = GPU_HIST_MAX_SLOTS;
+		__sync_fetch_and_add(&metrics->kernel_execution_time_hist[slot],
+				     1);
+		if (prev->ret_val != 0) {
+			__sync_fetch_and_add(&metrics->kernel_launch_errors, 1);
+		}
+	}
+
+	bpf_map_delete_elem(&kernel_event_cupti, &pid_tgid);
+	return 0;
+}
+// uprobes
+// USDT CUPTI
+
+//  Arguments amd x86: 4@%eax 8@%rdx 8@%rcx 4@%esi 4@%edi 8@-72(%rbp) -4@%r8d 8@-64(%rbp) -4@%r9d
+//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 112] -4@x6 8@[sp, 120] -4@x0
+SEC("usdt/libtrace_cuda_cupti:myprov:ig_activity")
+int handle_ig_activity(struct pt_regs *ctx)
+{
+	__u32 correlation_id = 0, device_id = 0, stream_id = 0;
+	__u64 start = 0, end = 0;
+
+	__u32 grid_z = 0, block_z = 0;
+	__u32 grid_x = 0, grid_y = 0;
+	__u32 block_x = 0, block_y = 0;
+
+#ifdef __TARGET_ARCH_x86
+	__u64 grid_xy = 0, block_xy = 0;
+
+	correlation_id = (__u32)ctx->ax;
+	start = ctx->dx;
+	end = ctx->cx;
+	device_id = ctx->si;
+	stream_id = (__u32)ctx->di;
+	grid_z = (__u32)ctx->r8;
+	block_z = (__u32)ctx->r9;
+
+	__u64 rbp = ctx->bp;
+	if (!rbp)
+		return 0;
+
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), (void *)(rbp - 72)))
+		return 0;
+
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy),
+				(void *)(rbp - 64)))
+		return 0;
+
+	grid_x = grid_xy >> 32;
+	grid_y = grid_xy & 0xffffffff;
+
+	block_x = block_xy >> 32;
+	block_y = block_xy & 0xffffffff;
+
+#endif
+
+#ifdef __TARGET_ARCH_arm64
+	__u64 grid_xy = 0, block_xy = 0;
+
+	void *sp = (void *)ctx->sp;
+	if (!sp)
+		return 0;
+
+	correlation_id = (__u32)ctx->regs[1];
+	start = ctx->regs[2];
+	end = ctx->regs[3];
+	device_id = (__u32)ctx->regs[4];
+	stream_id = (__u32)ctx->regs[5];
+
+	grid_z = (__u32)ctx->regs[6];
+	block_z = (__u32)ctx->regs[0];
+
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 112))
+		return 0;
+
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 120))
+		return 0;
+
+	grid_x = grid_xy >> 32;
+	grid_y = grid_xy & 0xffffffff;
+
+	block_x = block_xy >> 32;
+	block_y = block_xy & 0xffffffff;
+#endif
+
+	handle_ig_activity_impl(ctx, correlation_id, device_id, stream_id,
+				grid_x, grid_y, grid_z, block_x, block_y,
+				block_z, start, end);
+
+	return 0;
+}
+
+// Arguments amd64 x86: 4@-60(%rbp) 4@-80(%rbp) 8@-40(%rbp) 8@-48(%rbp)
+// Arguments arm AArch64: 4@[sp, 60] 4@[sp, 32] 8@[sp, 80] 8@[sp, 72]
+SEC("usdt/libtrace_cuda_cupti:myprov:ig_callback")
+int handle_ig_callback(struct pt_regs *ctx)
+{
+	__u32 correlation_id = 0;
+	__u32 cbid = 0;
+	__u64 result = 0;
+
+#ifdef __TARGET_ARCH_x86
+	__u64 rbp = ctx->bp;
+
+	if (!rbp)
+		return 0;
+
+	/* arg1: 4@-60(%rbp) */
+	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
+				(void *)(rbp - 60)))
+		return 0;
+
+	/* arg2:  4@-80(%rbp) */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 80)))
+		return 0;
+
+	/* arg4: 8@-48(%rbp) */
+	if (bpf_probe_read_user(&result, sizeof(result), (void *)(rbp - 48)))
+		return 0;
+
+#endif
+
+#ifdef __TARGET_ARCH_arm64
+
+	void *sp = (void *)ctx->sp;
+	if (!sp)
+		return 0;
+
+	/* arg1: 4@[sp,60] */
+	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
+				sp + 60))
+		return 0;
+
+	/* arg2: 4@[sp,32] */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), sp + 32))
+		return 0;
+
+	/* arg4: 8@[sp,72] */
+	if (bpf_probe_read_user(&result, sizeof(result), sp + 72))
+		return 0;
+
+#endif
+
+	handle_ig_callback_impl(ctx, correlation_id, result);
+
+	return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exit")
+int trace_sched_process_exit(void *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 pid = pid_tgid >> 32;
+	gadget_mntns_id mntns_id = gadget_get_current_mntns_id();
+
+	struct gpu_metrics_key key = {
+		.pid = pid,
+		.mntns_id = mntns_id,
+	};
+
+	struct gpu_metrics_value *val;
+	val = bpf_map_lookup_elem(&gpu_metrics, &key);
+
+	bpf_map_delete_elem(&gpu_metrics, &key);
+
+	return 0;
+}
+
+//mem alloc
+SEC("uprobe/libcuda:cuMemAlloc")
+int BPF_KPROBE(handle_cuMemAlloc, void **devptr, size_t bytesize)
+{
+	return handle_cuMemAlloc_impl(devptr, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemAlloc")
+int BPF_KRETPROBE(handle_cuMemAlloc_exit, int ret)
+{
+	return handle_cuMemAlloc_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemAlloc_v2")
+int BPF_KPROBE(handle_cuMemAlloc_v2, void **devptr, size_t bytesize)
+{
+	return handle_cuMemAlloc_impl(devptr, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemAlloc_v2")
+int BPF_KRETPROBE(handle_cuMemAlloc_exit_v2, int ret)
+{
+	return handle_cuMemAlloc_exit_impl(ret, ctx);
+}
+
+// memcpy
+SEC("uprobe/libcuda:cuMemcpyHtoD")
+int BPF_KPROBE(handle_cuMemcpy_htod, CUdeviceptr dst, const void *src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoD")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_exit, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_KPROBE(handle_cuMemcpy_htod_v2, CUdeviceptr dst, const void *src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_exit_v2, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoDAsync_v2")
+int BPF_KPROBE(handle_cuMemcpy_htod_async_v2, CUdeviceptr dst, const void *src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoDAsync_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_async_exit_v2, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoDAsync")
+int BPF_KPROBE(handle_cuMemcpy_htod_async, CUdeviceptr dst, const void *src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoDAsync")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_async_exit, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoH")
+int BPF_KPROBE(handle_cuMemcpy_dtoh, void *dst, CUdeviceptr src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoH")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_exit, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_v2, void *dst, CUdeviceptr src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_exit_v2, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoHAsync_v2")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_async_v2, void *dst, CUdeviceptr src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoHAsync_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_async_exit_v2, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoHAsync")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_async, void *dst, CUdeviceptr src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoHAsync")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_async_exit, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/cuda_metrics/program.bpf.c
+++ b/gadgets/cuda_metrics/program.bpf.c
@@ -367,7 +367,7 @@ handle_ig_activity_impl(struct pt_regs *ctx, __u32 correlation_id,
 
 		slot = get_slot_idx(delta);
 		if (slot >= GPU_HIST_MAX_SLOTS)
-			slot = GPU_HIST_MAX_SLOTS;
+			slot = GPU_HIST_MAX_SLOTS - 1;
 		__sync_fetch_and_add(&metrics->kernel_execution_time_hist[slot],
 				     1);
 		if (prev->ret_val != 0) {
@@ -375,14 +375,14 @@ handle_ig_activity_impl(struct pt_regs *ctx, __u32 correlation_id,
 		}
 	}
 
-	bpf_map_delete_elem(&kernel_event_cupti, &pid_tgid);
+	bpf_map_delete_elem(&kernel_event_cupti, &key);
 	return 0;
 }
 // uprobes
 // USDT CUPTI
 
 //  Arguments amd x86: 4@%eax 8@%rdx 8@%rcx 4@%esi 4@%edi 8@-72(%rbp) -4@%r8d 8@-64(%rbp) -4@%r9d
-//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 112] -4@x6 8@[sp, 120] -4@x0
+//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 144] -4@x6 8@[sp, 152] -4@x0
 SEC("usdt/libtrace_cuda_cupti:myprov:ig_activity")
 int handle_ig_activity(struct pt_regs *ctx)
 {
@@ -421,6 +421,15 @@ int handle_ig_activity(struct pt_regs *ctx)
 	block_x = block_xy >> 32;
 	block_y = block_xy & 0xffffffff;
 
+  bpf_printk("ACT corr=%u dev=%u stream=%u",
+           correlation_id, device_id, stream_id);
+
+bpf_printk("ACT time start=%llu end=%llu",
+           start, end);
+
+bpf_printk("ACT grid=(%u,%u,%u) block=(%u,%u,%u)",
+           grid_x, grid_y, grid_z,
+           block_x, block_y, block_z);
 #endif
 
 #ifdef __TARGET_ARCH_arm64
@@ -439,10 +448,10 @@ int handle_ig_activity(struct pt_regs *ctx)
 	grid_z = (__u32)ctx->regs[6];
 	block_z = (__u32)ctx->regs[0];
 
-	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 112))
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 144))
 		return 0;
 
-	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 120))
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 152))
 		return 0;
 
 	grid_x = grid_xy >> 32;
@@ -459,8 +468,8 @@ int handle_ig_activity(struct pt_regs *ctx)
 	return 0;
 }
 
-// Arguments amd64 x86: 4@-60(%rbp) 4@-80(%rbp) 8@-40(%rbp) 8@-48(%rbp)
-// Arguments arm AArch64: 4@[sp, 60] 4@[sp, 32] 8@[sp, 80] 8@[sp, 72]
+// Arguments amd64 x86: 4@-72(%rbp) 4@-96(%rbp) 8@-40(%rbp) 8@-48(%rbp)
+// Arguments arm AArch64: 4@[sp, 64] 4@[sp, 32] 8@[sp, 96] 8@[sp, 88]
 SEC("usdt/libtrace_cuda_cupti:myprov:ig_callback")
 int handle_ig_callback(struct pt_regs *ctx)
 {
@@ -474,19 +483,24 @@ int handle_ig_callback(struct pt_regs *ctx)
 	if (!rbp)
 		return 0;
 
-	/* arg1: 4@-60(%rbp) */
+	/* arg1: 4@-72(%rbp) */
 	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
-				(void *)(rbp - 60)))
+				(void *)(rbp - 72)))
 		return 0;
 
-	/* arg2:  4@-80(%rbp) */
-	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 80)))
+	/* arg2:  4@-96(%rbp) */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 96)))
 		return 0;
 
 	/* arg4: 8@-48(%rbp) */
 	if (bpf_probe_read_user(&result, sizeof(result), (void *)(rbp - 48)))
 		return 0;
 
+  bpf_printk("CB corr=%u cbid=%u",
+           correlation_id, cbid);
+
+bpf_printk("CB result=%llu",
+           result);
 #endif
 
 #ifdef __TARGET_ARCH_arm64
@@ -495,17 +509,17 @@ int handle_ig_callback(struct pt_regs *ctx)
 	if (!sp)
 		return 0;
 
-	/* arg1: 4@[sp,60] */
+	/* arg1: 4@[sp,64] */
 	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
-				sp + 60))
+				sp + 64))
 		return 0;
 
 	/* arg2: 4@[sp,32] */
 	if (bpf_probe_read_user(&cbid, sizeof(cbid), sp + 32))
 		return 0;
 
-	/* arg4: 8@[sp,72] */
-	if (bpf_probe_read_user(&result, sizeof(result), sp + 72))
+	/* arg4: 8@[sp,88] */
+	if (bpf_probe_read_user(&result, sizeof(result), sp + 88))
 		return 0;
 
 #endif
@@ -515,22 +529,22 @@ int handle_ig_callback(struct pt_regs *ctx)
 	return 0;
 }
 
-SEC("tracepoint/sched/sched_process_exit")
-int trace_sched_process_exit(void *ctx)
-{
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	__u32 pid = pid_tgid >> 32;
-	gadget_mntns_id mntns_id = gadget_get_current_mntns_id();
-
-	struct gpu_metrics_key key = {
-		.pid = pid,
-		.mntns_id = mntns_id,
-	};
-
-	bpf_map_delete_elem(&gpu_metrics, &key);
-
-	return 0;
-}
+/*SEC("tracepoint/sched/sched_process_exit")*/
+/*int trace_sched_process_exit(void *ctx)*/
+/*{*/
+/*	__u64 pid_tgid = bpf_get_current_pid_tgid();*/
+/*	__u32 pid = pid_tgid >> 32;*/
+/*	gadget_mntns_id mntns_id = gadget_get_current_mntns_id();*/
+/**/
+/*	struct gpu_metrics_key key = {*/
+/*		.pid = pid,*/
+/*		.mntns_id = mntns_id,*/
+/*	};*/
+/**/
+/*	bpf_map_delete_elem(&gpu_metrics, &key);*/
+/**/
+/*	return 0;*/
+/*}*/
 
 //mem alloc
 SEC("uprobe/libcuda:cuMemAlloc")

--- a/gadgets/cuda_metrics/program.bpf.c
+++ b/gadgets/cuda_metrics/program.bpf.c
@@ -527,9 +527,6 @@ int trace_sched_process_exit(void *ctx)
 		.mntns_id = mntns_id,
 	};
 
-	struct gpu_metrics_value *val;
-	val = bpf_map_lookup_elem(&gpu_metrics, &key);
-
 	bpf_map_delete_elem(&gpu_metrics, &key);
 
 	return 0;

--- a/gadgets/cuda_metrics/test/unit/trace_cuda_test.go
+++ b/gadgets/cuda_metrics/test/unit/trace_cuda_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+
+func TestCudaKernelTrace(t *testing.T) {
+  gadgettesting.DummyGadgetTest(t, "cuda_metrics")
+}
+
+
+
+
+
+
+

--- a/gadgets/trace_cuda/LICENSE
+++ b/gadgets/trace_cuda/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gadgets/trace_cuda/LICENSE-bpf.txt
+++ b/gadgets/trace_cuda/LICENSE-bpf.txt
@@ -1,0 +1,366 @@
+The BPF code templates are licensed under the General Public License, Version
+2.0, with the Linux-syscall-note. Copies of the Linux-syscall-note and GPL-2.0
+license text are included below.
+
+= = = = =
+
+Linux-syscall-note:
+
+   NOTE! This copyright does *not* cover user programs that use kernel
+ services by normal system calls - this is merely considered normal use
+ of the kernel, and does *not* fall under the heading of "derived work".
+ Also note that the GPL below is copyrighted by the Free Software
+ Foundation, but the instance of code that it refers to (the Linux
+ kernel) is copyrighted by me and others who actually wrote it.
+
+ Also note that the only valid version of the GPL as far as the kernel
+ is concerned is _this_ particular version of the license (ie v2, not
+ v2.2 or v3.x or whatever), unless explicitly otherwise stated.
+
+Linus Torvalds
+
+= = = = =
+
+GPL-2.0:
+
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/gadgets/trace_cuda/Makefile
+++ b/gadgets/trace_cuda/Makefile
@@ -1,0 +1,22 @@
+TAG := $(shell git describe --tags --always --dirty)
+CONTAINER_REPO ?= ghcr.io/inspektor-gadget/gadget/trace_cuda
+IMAGE_TAG ?= $(TAG)
+CLANG_FORMAT ?= clang-format
+
+.PHONY: build
+build:
+	sudo -E ig image build \
+		-t $(CONTAINER_REPO):$(IMAGE_TAG) \
+		--update-metadata .
+
+.PHONY: run
+run:
+	sudo -E ig run $(CONTAINER_REPO):$(IMAGE_TAG) $$PARAMS
+
+.PHONY: push
+push:
+	sudo -E ig image push $(CONTAINER_REPO):$(IMAGE_TAG)
+	
+.PHONY: clang-format
+clang-format:
+	$(CLANG_FORMAT) -i program.bpf.c

--- a/gadgets/trace_cuda/README.md
+++ b/gadgets/trace_cuda/README.md
@@ -1,0 +1,24 @@
+# gadget-template
+
+# cuda-ebpf-poc
+
+trace_cuda is a [gadget from Inspektor
+Gadget](https://inspektor-gadget.io/). It traces cuda/GPU operation such as LaunchKernel, MemAlloc,Memcpy.
+
+## How to use
+
+```bash
+$ make build
+$ make run PARAMS="--verify-image=false -o jsonpretty -v --collect_ustack --host"
+```
+
+## Requirements
+
+- ig v0.26.0
+- Linux v5.15 
+
+## License 
+
+The user space components are licensed under the [Apache License, Version
+2.0](LICENSE). The BPF code templates are licensed under the [General Public
+License, Version 2.0, with the Linux-syscall-note](LICENSE-bpf.txt).

--- a/gadgets/trace_cuda/README.md
+++ b/gadgets/trace_cuda/README.md
@@ -1,6 +1,6 @@
 # gadget-template
 
-# cuda-ebpf-poc
+# trace_cuda
 
 trace_cuda is a [gadget from Inspektor
 Gadget](https://inspektor-gadget.io/). It traces cuda/GPU operation such as LaunchKernel, MemAlloc,Memcpy.

--- a/gadgets/trace_cuda/README.mdx
+++ b/gadgets/trace_cuda/README.mdx
@@ -1,0 +1,150 @@
+---
+title: trace_cuda
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# trace_cuda
+
+Trace CUDA Driver API calls such as memory allocations and memory copies, and capture CUDA kernel launch information via a CUPTI based userspace library.
+
+## Requirements
+
+- The CUPTI userspace library must be installed.  
+  Follow the instructions in:
+
+```
+
+inspektor-gadget/gadgets/trace_cuda/cupti/README.md
+
+````
+
+Without the CUPTI library, only memory allocation and memory copy events will be available.
+
+- NVIDIA drivers must be installed.
+- CUDA runtime libraries must be available.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+  <TabItem value="kubectl-gadget" label="kubectl gadget">
+      ```bash
+      $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/trace_cuda:%IG_TAG% [flags]
+      ```
+  </TabItem>
+
+  <TabItem value="ig" label="ig">
+      ```bash
+      $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_cuda:%IG_TAG% [flags]
+      ```
+  </TabItem>
+</Tabs>
+
+## Flags
+
+### `--collect_ustack`
+
+Collect user space stack traces for each kernel launch event.
+Enabling this flag increases overhead and may impact CUDA application performance.
+
+### `--host`
+
+Also trace CUDA activity from processes running on the host.
+
+## Guide
+
+### 1. Install the CUPTI library
+
+First, build and install the required CUPTI userspace library by following the instructions in:
+
+````
+
+inspektor-gadget/gadgets/trace_cuda/cupti/README.md
+
+````
+
+### 2. Run the gadget
+
+Start the gadget using one of the commands shown in the *Getting started* section.
+
+### 3. Run a sample CUDA application
+
+You can test the gadget using a simple CUDA program such as the following SAXPY example:
+
+```bash
+cat << EOF > saxpy.cu
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+__global__
+void saxpy(int n, float a, float *x, float *y)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+    y[i] = a * x[i] + y[i];
+}
+
+int main(void)
+{
+  int N = 1<<20;
+  float *x, *y, *d_x, *d_y;
+
+  x = (float*)malloc(N * sizeof(float));
+  y = (float*)malloc(N * sizeof(float));
+
+  cudaMalloc(&d_x, N * sizeof(float));
+  cudaMalloc(&d_y, N * sizeof(float));
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1.0f;
+    y[i] = 2.0f;
+  }
+
+  cudaMemcpy(d_x, x, N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_y, y, N * sizeof(float), cudaMemcpyHostToDevice);
+
+  // Perform SAXPY on 1M elements
+  saxpy<<<(N + 255) / 256, 256>>>(N, 2.0f, d_x, d_y);
+
+  cudaMemcpy(y, d_y, N * sizeof(float), cudaMemcpyDeviceToHost);
+
+  float maxError = 0.0f;
+  for (int i = 0; i < N; i++)
+    maxError = fmax(maxError, fabs(y[i] - 4.0f));
+
+  printf("Max error: %f\n", maxError);
+
+  cudaFree(d_x);
+  cudaFree(d_y);
+  free(x);
+  free(y);
+}
+EOF
+````
+
+Compile and run it:
+
+```bash
+nvcc saxpy.cu -o saxpy
+./saxpy
+```
+
+While the program is running, `trace_cuda` will report:
+
+* Memory allocation events
+* Memory copy operations
+* Kernel launch information (if the CUPTI library is installed)
+
+## Notes
+
+* `trace_cuda` complements the `cuda_metrics` gadget by providing per event visibility into how GPU metrics are generated.
+* Without the CUPTI userspace library, only memory allocation and memory copy events will be traced.
+* Enabling `--collect_ustack` increases overhead and may affect performance sensitive workloads.
+
+```
+

--- a/gadgets/trace_cuda/cupti/CMakeLists.txt
+++ b/gadgets/trace_cuda/cupti/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.18)
+project(cupti_sandbox LANGUAGES C CXX )
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+# Default to Debug if not specified
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+endif()
+
+find_package(CUDAToolkit REQUIRED)
+
+add_library(trace_cuda_cupti SHARED
+  cupti_tracer.c
+  correlation.cpp
+)
+
+target_link_libraries(trace_cuda_cupti PRIVATE
+    CUDA::cudart
+    CUDA::cuda_driver
+    CUDA::cupti
+    dl
+)
+
+install(TARGETS trace_cuda_cupti
+        EXPORT trace_cuda_cuptiTargets
+        LIBRARY DESTINATION lib)
+
+install(EXPORT trace_cuda_cuptiTargets
+        FILE trace_cuda_cuptiTargets.cmake
+        NAMESPACE trace_cuda_cupti::
+        DESTINATION lib/cmake/trace_cuda_cupti)

--- a/gadgets/trace_cuda/cupti/README.md
+++ b/gadgets/trace_cuda/cupti/README.md
@@ -1,0 +1,93 @@
+
+# trace_cuda – CUPTI Userspace Library
+
+## Overview
+
+This directory contains a **CUPTI-based userspace shared library** used by the `trace_cuda` gadget to instrument CUDA kernel launches.
+
+The purpose of this library is to:
+
+* Subscribe to **CUPTI Runtime and Driver API callbacks**
+* Capture CUDA kernel launch events
+* Correlate runtime and driver API calls using CUPTI correlation IDs
+* Emit **USDT (User Statically Defined Tracing) probes**
+* Provide structured kernel launch data to the eBPF layer
+
+This library acts as the bridge between:
+
+```
+CUDA application
+        ↓
+     CUPTI
+        ↓
+  USDT probes
+        ↓
+   eBPF gadget
+```
+
+
+## Why This Library Exists
+
+CUPTI operates inside the target process and provides access to:
+
+* CUDA Runtime API callbacks
+* CUDA Driver API callbacks
+* Correlation IDs
+* Kernel symbol names
+* Launch results
+
+The library exports USDT probes that allow the `trace_cuda` and `cuda_metrics` eBPF gadget to attach and collect kernel launch information without modifying the CUDA application itself.
+
+
+## Current Build System
+
+For now, the library is built using **CMake**.
+
+
+## Build Instructions
+
+From inside the `trace_cuda/cupti` directory:
+
+```bash
+mkdir -p build
+cd build
+cmake ..
+cmake --build .
+```
+
+This will produce a shared library:
+
+```
+libtrace_cuda_cupti.so
+```
+### Install (Recommended)
+
+To install the library into the default system location (`/usr/local/lib`):
+
+```bash
+sudo cmake --install build
+sudo ldconfig
+```
+
+`ldconfig` updates the dynamic linker cache so the system can discover the library when linking by name.
+
+After installation, you can verify:
+
+```bash
+ldconfig -p | grep trace_cuda
+```
+
+You should see:
+
+```
+libtrace_cuda_cupti.so => /usr/local/lib/libtrace_cuda_cupti.so
+```
+
+## Runtime Usage
+The shared library is injected using CUDA’s built-in injection mechanism via the `CUDA_INJECTION64_PATH` environment variable.
+Example:
+```
+export CUDA_INJECTION64_PATH=/usr/local/lib/libtrace_cuda_cupti.so
+```
+Then run your CUDA application normally
+

--- a/gadgets/trace_cuda/cupti/correlation.cpp
+++ b/gadgets/trace_cuda/cupti/correlation.cpp
@@ -1,0 +1,68 @@
+#include "correlation.h"
+#include <cstddef>
+#include <stdint.h>
+#include <unordered_set>
+#include <mutex>
+
+class Correlator{
+public:
+  void insert(uint32_t correlation_id){
+    std::lock_guard<std::mutex> lock(mutex_);
+    set_.insert(correlation_id);
+  }
+
+  bool check_and_remove(uint32_t correlation_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = set_.find(correlation_id);
+    if (it != set_.end()) {
+        set_.erase(it);
+        return true;
+    }
+    return false;
+  }
+
+  size_t size() const{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return set_.size();
+  }
+private:
+  std::unordered_set<uint32_t> set_;
+  mutable std::mutex mutex_;
+};
+
+extern "C" {
+
+CorrelatorHandle correlator_create(void) {
+    return new Correlator();
+}
+
+void correlator_destroy(CorrelatorHandle filter) {
+    if (filter) {
+        delete static_cast<Correlator*>(filter);
+    }
+}
+
+void correlator_insert(CorrelatorHandle filter,
+                               uint32_t correlation_id) {
+    if (filter) {
+        static_cast<Correlator*>(filter)->insert(correlation_id);
+    }
+}
+
+bool correlator_check_and_remove(CorrelatorHandle filter,
+                                         uint32_t correlation_id) {
+    if (filter) {
+        return static_cast<Correlator*>(filter)
+            ->check_and_remove(correlation_id);
+    }
+    return false;
+}
+
+size_t correlator_size(CorrelatorHandle filter) {
+    if (filter) {
+        return static_cast<Correlator*>(filter)->size();
+    }
+    return 0;
+}
+
+}

--- a/gadgets/trace_cuda/cupti/correlation.cpp
+++ b/gadgets/trace_cuda/cupti/correlation.cpp
@@ -1,6 +1,9 @@
 #include "correlation.h"
 #include <cstddef>
+#include <cstdint>
 #include <stdint.h>
+#include <sys/types.h>
+#include <unordered_map>
 #include <unordered_set>
 #include <mutex>
 
@@ -30,6 +33,96 @@ private:
   mutable std::mutex mutex_;
 };
 
+class GraphCorrelatorEnter{
+public:
+  uint8_t state[2];
+  bool seen;
+  uint32_t enter_cycle;
+
+  GraphCorrelatorEnter(uint32_t c)
+    : state{GRAPH_UNINITIALIZED, GRAPH_UNINITIALIZED}
+    , seen(false)
+    , enter_cycle(c) {}
+};
+
+
+class GraphMap{
+public:
+  GraphMap() : current_cycle(0){}
+  void insert(uint32_t cid){
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_.emplace(cid,GraphCorrelatorEnter(current_cycle));
+  }
+  void cycle_start(uint32_t cycle){
+    std::lock_guard<std::mutex> lock(mutex_);
+    current_cycle = cycle;
+    uint32_t slot = cycle %2;
+    for(auto& pair: map_){
+      pair.second.state[slot] = GRAPH_CYCLE_CLEARED;
+    }
+  }
+  bool mark_seen_cycle(uint32_t cycle, uint32_t cid){
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = map_.find(cid);
+    if (it != map_.end()){
+      uint32_t slot = cycle % 2;
+      it->second.state[slot] = GRAPH_KERNEL_SEEN;
+      it->second.seen = true;
+      return true;
+    }
+    return false;
+  }
+  size_t size(){
+    std::lock_guard<std::mutex> lock(mutex_);
+    return map_.size();
+  }
+
+  void finish_cycle(){
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t remove = 0;
+    size_t remove_fallback = 0;
+    for(auto it = map_.begin();it != map_.end();){
+      bool should_remove = false;
+      bool is_fallback = false;
+      if(it->second.state[0] == GRAPH_CYCLE_CLEARED && it->second.state[1] == GRAPH_CYCLE_CLEARED){
+        if(it->second.seen){
+          should_remove = true;
+          remove++;
+        }
+        else if((current_cycle - it->second.enter_cycle)>100){
+          should_remove = true;
+          is_fallback = true;
+          remove_fallback ++;
+        }
+      }
+      
+
+      if(should_remove){
+        it = map_.erase(it);
+      }
+      else {
+        ++it;
+      }
+      
+    }
+  }
+
+  void get_stat(size_t& size, size_t& oldest_age)const{
+    std::lock_guard<std::mutex> lock(mutex_);
+    size = map_.size();
+    oldest_age = 0;
+    for(const auto& pair: map_){
+      uint32_t age = current_cycle - pair.second.enter_cycle;
+      if(age > oldest_age){
+        oldest_age = age;
+      }
+    }
+  }
+private:
+  std::unordered_map<uint32_t, GraphCorrelatorEnter> map_;
+  uint32_t current_cycle;
+  mutable std::mutex mutex_;
+};
 extern "C" {
 
 CorrelatorHandle correlator_create(void) {
@@ -63,6 +156,50 @@ size_t correlator_size(CorrelatorHandle filter) {
         return static_cast<Correlator*>(filter)->size();
     }
     return 0;
+}
+
+GraphMapHandle graph_map_create(void){
+  return new GraphMap();
+}
+
+void graph_map_destroy(GraphMapHandle map){
+  if(map){
+    delete static_cast<GraphMap*>(map);
+  }
+}
+
+void graph_map_insert(GraphMapHandle map, uint32_t cid){
+  if(map){
+    static_cast<GraphMap*>(map)->insert(cid);
+  }
+}
+void graph_map_cycle_start(GraphMapHandle map, uint32_t cycle){
+  if (map) {
+    static_cast<GraphMap*>(map)->cycle_start(cycle);
+  }
+}
+bool graph_map_mark_seen_cycle(GraphMapHandle map,uint32_t cid, uint32_t cycle){
+  if(map){
+    return static_cast<GraphMap*>(map)->mark_seen_cycle(cycle, cid);
+  }
+  return false;
+}
+
+void graph_map_finish_cycle(GraphMapHandle map){
+  if (map) {
+    static_cast<GraphMap*>(map)->finish_cycle();
+  }
+}
+void graph_map_get_stat(GraphMapHandle map, size_t* size, size_t* old_age){
+  if (map){
+    static_cast<GraphMap*>(map)->get_stat(*size, *old_age);
+  }
+}
+size_t graph_map_size(GraphMapHandle map){
+  if(map){
+    return static_cast<GraphMap*>(map)->size();
+  }
+  return 0;
 }
 
 }

--- a/gadgets/trace_cuda/cupti/correlation.h
+++ b/gadgets/trace_cuda/cupti/correlation.h
@@ -1,0 +1,34 @@
+#ifndef CORRELATION_FILTER_H
+#define CORRELATION_FILTER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* CorrelatorHandle;
+
+// Create / destroy
+CorrelatorHandle correlator_create(void);
+void correlator_destroy(CorrelatorHandle filter);
+
+// Insert correlation ID
+void correlator_insert(CorrelatorHandle filter,
+                               uint32_t correlation_id);
+
+// Check and remove (atomic)
+bool correlator_check_and_remove(CorrelatorHandle filter,
+                                         uint32_t correlation_id);
+
+// Size (optional, useful for debugging)
+size_t correlator_size(CorrelatorHandle filter);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/gadgets/trace_cuda/cupti/correlation.h
+++ b/gadgets/trace_cuda/cupti/correlation.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 typedef void* CorrelatorHandle;
+typedef void* GraphMapHandle;
 
 // Create / destroy
 CorrelatorHandle correlator_create(void);
@@ -26,6 +27,20 @@ bool correlator_check_and_remove(CorrelatorHandle filter,
 // Size (optional, useful for debugging)
 size_t correlator_size(CorrelatorHandle filter);
 
+enum GraphState {
+  GRAPH_UNINITIALIZED = 0, // Entry just created, slot not yet processed
+  GRAPH_CYCLE_CLEARED = 1, // Cycle started, no kernels seen yet
+  GRAPH_KERNEL_SEEN = 2    // At least one kernel seen this cycle
+};
+
+GraphMapHandle graph_map_create(void);
+void graph_map_destroy(GraphMapHandle map);
+void graph_map_insert(GraphMapHandle map, uint32_t cid);
+void graph_map_cycle_start(GraphMapHandle map, uint32_t cycle);
+bool graph_map_mark_seen_cycle(GraphMapHandle map,uint32_t cid, uint32_t cycle);
+void graph_map_finish_cycle(GraphMapHandle map);
+void graph_map_get_stat(GraphMapHandle map, size_t* size, size_t* old_age);
+size_t graph_map_size(GraphMapHandle map);
 #ifdef __cplusplus
 }
 #endif

--- a/gadgets/trace_cuda/cupti/cupti_tracer.c
+++ b/gadgets/trace_cuda/cupti/cupti_tracer.c
@@ -1,0 +1,343 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cupti.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/sdt.h>
+#include "correlation.h"
+#include <time.h>
+
+#define CUPTI_CALL(call)                                                \
+  do {                                                                  \
+    CUptiResult _status = call;                                         \
+    if (_status != CUPTI_SUCCESS) {                                     \
+      const char *errstr;                                               \
+      cuptiGetResultString(_status, &errstr);                           \
+      fprintf(stderr, "%s:%d: error: function %s failed with error %s.\n", \
+              __FILE__, __LINE__, #call, errstr);                       \
+    }                                                                   \
+  } while (0)
+
+#define CUPTI_CALL_ABORT_RET(call, ret)                                 \
+  do {                                                                   \
+    CUptiResult _status = (call);                                        \
+    if (_status != CUPTI_SUCCESS) {                                      \
+      const char *errstr = NULL;                                          \
+      cuptiGetResultString(_status, &errstr);                            \
+      fprintf(stderr, "[CUPTI:FATAL] %s:%d: %s failed: %s\n",            \
+              __FILE__, __LINE__, #call,                                  \
+              errstr ? errstr : "unknown");                              \
+      return (ret);                                                      \
+    }                                                                    \
+  } while (0)
+
+
+#define BUF_SIZE (128 * 1024)
+#define ALIGN_SIZE (8)
+
+static uint64_t startTimestamp = 0;
+static CUpti_SubscriberHandle subscriber = 0;
+
+static CorrelatorHandle filter = NULL;
+
+static __thread uint32_t runtimeEnterCorrelationId = 0;
+
+static bool debug_enabled = false;
+static bool debug_initialized = false;
+
+static void init_debug(void) {
+  if (!debug_initialized) {
+    debug_enabled = getenv("CUPTI_TRACER_DEBUG") != NULL;
+    debug_initialized = true;
+  }
+}
+
+#define DEBUG_PRINTF(...)                                                     \
+  do {                                                                        \
+    init_debug();                                                             \
+    if (debug_enabled) {                                                      \
+      struct timespec ts;                                                     \
+      clock_gettime(CLOCK_REALTIME, &ts);                                     \
+      fprintf(stderr, "[%ld.%09ld] ", ts.tv_sec, ts.tv_nsec);                 \
+      fprintf(stderr, __VA_ARGS__);                                           \
+    }                                                                         \
+  } while (0)
+
+static inline uint64_t cpu_time_ns() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
+}
+
+static void CUPTIAPI bufferRequested(uint8_t **buffer , size_t *size,size_t *maxNumRecords){
+  *buffer = (uint8_t *)aligned_alloc(ALIGN_SIZE,BUF_SIZE);
+  *size = BUF_SIZE;
+  *maxNumRecords = 0;
+}
+
+static void CUPTIAPI  bufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t *buffer, size_t size, size_t validSize){
+  CUptiResult result;
+  CUpti_Activity *record = NULL;
+
+  if(validSize >0){
+    do{
+      result = cuptiActivityGetNextRecord(buffer, validSize,&record);
+      if (result == CUPTI_SUCCESS){
+        if(record->kind == CUPTI_ACTIVITY_KIND_KERNEL || record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL){
+          CUpti_ActivityKernel9 *kernel = (CUpti_ActivityKernel9 *) record;
+          
+          bool send = true;
+          if(filter){
+            send = correlator_check_and_remove(filter, kernel->correlationId);
+          }
+
+
+          if (send){
+            uint64_t grid_xy =
+                ((uint64_t)kernel->gridX << 32) |
+                 (uint64_t)kernel->gridY;
+
+            uint64_t block_xy =
+                ((uint64_t)kernel->blockX << 32) |
+                 (uint64_t)kernel->blockY;
+
+            double start = (kernel->start - startTimestamp) / 1e6;
+            double end   = (kernel->end   - startTimestamp) / 1e6;
+            double dur   = (kernel->end - kernel->start) / 1e6;
+
+            DEBUG_PRINTF("\n=== Kernel Launch ===\n");
+            DEBUG_PRINTF("Name: %s\n", kernel->name);
+            DEBUG_PRINTF("Grid: %u x %u x %u\n",
+                   kernel->gridX, kernel->gridY, kernel->gridZ);
+            DEBUG_PRINTF("Block: %u x %u x %u\n",
+                   kernel->blockX, kernel->blockY, kernel->blockZ);
+            DEBUG_PRINTF("Start (ms): %.3f\n", start);
+            DEBUG_PRINTF("End   (ms): %.3f\n", end);
+            DEBUG_PRINTF("Duration (ms): %.3f\n", dur);
+
+            
+            DEBUG_PRINTF("\n=== Correlated Kernel ===\n");
+            DEBUG_PRINTF("Correlation ID: %u\n", kernel->correlationId);
+          
+            DEBUG_PRINTF("Stream ID: %u\n", kernel->streamId);
+
+            DTRACE_PROBE9(myprov, ig_activity, kernel->correlationId,
+                           kernel->start,
+                           kernel->end,
+                           kernel->deviceId,
+                           kernel->streamId,
+                           grid_xy,
+                           kernel->gridZ,
+                           block_xy,
+                           kernel->blockZ);
+          }
+          
+        }
+      }
+      else if(result == CUPTI_ERROR_MAX_LIMIT_REACHED){
+        break;
+      }
+      else{
+        DEBUG_PRINTF("Error reading activity record\n");
+        break;
+      }
+    }while (1);
+  }
+
+  free(buffer);
+
+  size_t dropped;
+  CUPTI_CALL(cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped));
+  if (dropped != 0) {
+    DEBUG_PRINTF("Dropped %zu activity records\n", dropped);
+  }
+}
+
+static void CUPTIAPI cuptiCallback(void *userdata, CUpti_CallbackDomain domain,
+                                    CUpti_CallbackId cbid, const CUpti_CallbackData *cbInfo){
+
+  uint32_t correlationId = cbInfo->correlationId;
+
+  const char *name = cbInfo->symbolName ? cbInfo->symbolName : cbInfo->functionName;
+
+  bool emit = false;
+  uint64_t result_value = 0;
+
+  if( domain == CUPTI_CB_DOMAIN_RUNTIME_API && cbInfo->callbackSite == CUPTI_API_ENTER){
+    runtimeEnterCorrelationId = correlationId;
+    return;
+  }
+
+  if(cbInfo->callbackSite != CUPTI_API_EXIT){
+    return;
+  }
+
+  if( domain == CUPTI_CB_DOMAIN_DRIVER_API){
+    if (correlationId == runtimeEnterCorrelationId)
+      return;
+
+    switch (cbid) {
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunch:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchGrid:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchGridAsync:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz:
+      case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice:
+      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch:
+      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz:
+      {
+        CUresult result = cbInfo->functionReturnValue? *(CUresult *)cbInfo->functionReturnValue: CUDA_SUCCESS;
+
+        DEBUG_PRINTF("\n[Driver EXIT] cuLaunchKernel\n");
+        DEBUG_PRINTF("Correlation ID: %u\n", correlationId);
+        DEBUG_PRINTF("Kernel: %s\n", name);
+        DEBUG_PRINTF("Return value: %d\n", result);
+        DEBUG_PRINTF("cbid: %u\n", cbid);
+
+        result_value = (uint64_t)result;
+        emit = true;
+        if(filter)
+          correlator_insert(filter, correlationId);
+
+        break;
+      }
+    }
+      
+
+  }
+  else if( domain == CUPTI_CB_DOMAIN_RUNTIME_API){
+
+    switch (cbid){
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_v3020:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_ptsz_v7000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000:
+      {
+        cudaError_t result = cbInfo->functionReturnValue? *(cudaError_t *)cbInfo->functionReturnValue: cudaSuccess;
+
+        DEBUG_PRINTF("\n[Runtime EXIT] cudaLaunchKernel\n");
+        DEBUG_PRINTF("Correlation ID: %u\n", correlationId);
+        DEBUG_PRINTF("Kernel: %s\n", name);
+        DEBUG_PRINTF("Return value: %d\n", result);
+        DEBUG_PRINTF("cbid: %u\n", cbid);
+
+        result_value = (uint64_t)result;
+        emit = true;
+        if (filter)
+          correlator_insert(filter, correlationId);
+        
+        break;
+      }
+    }
+
+    runtimeEnterCorrelationId = 0;
+
+  }
+
+  if(emit){
+     DTRACE_PROBE4(myprov, ig_callback,
+      correlationId,
+      (uint32_t)cbid,
+      name,
+      result_value);
+  }
+}
+
+void cleanup(void){
+  static bool cleanup_done = false;
+
+  // Make cleanup idempotent - safe to call multiple times
+  if (cleanup_done) {
+    return;
+  }
+  cleanup_done = true;
+
+  cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED);
+
+  if (subscriber) {
+    cuptiUnsubscribe(subscriber);
+    subscriber = 0;
+  }
+
+  if(filter){
+     size_t remaining = correlator_size(filter);
+    if (remaining > 0) {
+      DEBUG_PRINTF("[CUPTI] Warning: %zu correlation IDs still in filter at cleanup\n", remaining);
+    }
+    correlator_destroy(filter);
+    filter= NULL;
+  }
+
+  DEBUG_PRINTF("Cleanup complet \n");
+}
+
+int InitializeInjection(void){
+
+  CUPTI_CALL(cuptiActivityFlushAll(1000));
+
+  CUPTI_CALL_ABORT_RET(cuptiSubscribe(&subscriber, (CUpti_CallbackFunc)cuptiCallback, NULL),1);
+
+  CUpti_CallbackId runtimeCallbacks[] = {
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_v3020,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_ptsz_v7000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,
+    CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000,
+  };
+
+  for (size_t i = 0; i < sizeof(runtimeCallbacks)/sizeof(runtimeCallbacks[0]); i++){
+    CUPTI_CALL(cuptiEnableCallback(1, subscriber, CUPTI_CB_DOMAIN_RUNTIME_API, runtimeCallbacks[i]));
+  }
+
+  CUpti_CallbackId driverCallbacks[] = {
+    CUPTI_DRIVER_TRACE_CBID_cuLaunch,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchGrid,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchGridAsync,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz,
+  };
+
+  for (size_t i = 0 ; i< sizeof(driverCallbacks)/sizeof(driverCallbacks[0]);i++){
+    CUPTI_CALL(cuptiEnableCallback(1, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,driverCallbacks[i] ));
+  }
+
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL));
+
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+
+  CUPTI_CALL_ABORT_RET(cuptiActivityRegisterCallbacks(bufferRequested,bufferCompleted ),1);
+
+  CUPTI_CALL(cuptiGetTimestamp(&startTimestamp));
+
+  filter = correlator_create();
+
+  atexit(cleanup);
+  return 1;
+}
+

--- a/gadgets/trace_cuda/cupti/cupti_tracer.c
+++ b/gadgets/trace_cuda/cupti/cupti_tracer.c
@@ -40,7 +40,12 @@
 static uint64_t startTimestamp = 0;
 static CUpti_SubscriberHandle subscriber = 0;
 
+static size_t outstandingEvents = 0;
+
 static CorrelatorHandle filter = NULL;
+static GraphMapHandle graphMap = NULL;
+
+uint32_t buffer_cycle = 0;
 
 static __thread uint32_t runtimeEnterCorrelationId = 0;
 
@@ -80,19 +85,53 @@ static void CUPTIAPI bufferRequested(uint8_t **buffer , size_t *size,size_t *max
 static void CUPTIAPI  bufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t *buffer, size_t size, size_t validSize){
   CUptiResult result;
   CUpti_Activity *record = NULL;
-
+  uint32_t currentCycle = buffer_cycle++;
+  if(graphMap){
+    graph_map_cycle_start(graphMap, currentCycle);
+  }
   if(validSize >0){
+    
     do{
       result = cuptiActivityGetNextRecord(buffer, validSize,&record);
       if (result == CUPTI_SUCCESS){
         if(record->kind == CUPTI_ACTIVITY_KIND_KERNEL || record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL){
           CUpti_ActivityKernel9 *kernel = (CUpti_ActivityKernel9 *) record;
+          DEBUG_PRINTF(
+            "[kernel] correlation=%u graphId=%u cycle=%u\n",
+            kernel->correlationId,
+            kernel->graphId,
+            currentCycle
+          );
           
           bool send = true;
-          if(filter){
-            send = correlator_check_and_remove(filter, kernel->correlationId);
-          }
 
+          if(kernel->graphId != 0){
+            if(graphMap){
+              send = graph_map_mark_seen_cycle(graphMap, kernel->correlationId, currentCycle);
+              if(!send){
+                 DEBUG_PRINTF(
+                  "[graph_map] MISS: correlation_id=%u graph_id=%u cycle=%u (entry not found)\n",
+                  kernel->correlationId,
+                  kernel->graphId,
+                  currentCycle
+                );
+              }
+              else{
+                DEBUG_PRINTF(
+                  "[graph_map] HIT: correlation_id=%u graph_id=%u cycle=%u map_size=%zu (sending kernel)\n",
+                  kernel->correlationId,
+                  kernel->graphId,
+                  currentCycle,
+                  graph_map_size(graphMap)
+                );
+              }
+            }
+          }
+          else{
+            if(filter){
+              send = correlator_check_and_remove(filter, kernel->correlationId);
+            }
+          }
 
           if (send){
             uint64_t grid_xy =
@@ -146,6 +185,28 @@ static void CUPTIAPI  bufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t 
     }while (1);
   }
 
+  if(graphMap){
+    graph_map_finish_cycle(graphMap);
+    size_t map_size = 0;
+    size_t oldest_age = 0;
+    graph_map_get_stat(graphMap, &map_size, &oldest_age);
+    DEBUG_PRINTF(
+      "[graph_map] FINISH_CYCLE: cycle=%u map_size=%zu oldest_age=%zu\n",
+      currentCycle,
+      map_size,
+      oldest_age
+    );
+    if(oldest_age >50 && currentCycle%10 ==0){
+      DEBUG_PRINTF(
+        "[graph_map] WARNING: aged entries detected (oldest_age=%zu > 50) cycle=%u map_size=%zu\n",
+        oldest_age,
+        currentCycle,
+        map_size
+      );
+    }
+  }
+  outstandingEvents = 0;
+
   free(buffer);
 
   size_t dropped;
@@ -189,8 +250,6 @@ static void CUPTIAPI cuptiCallback(void *userdata, CUpti_CallbackDomain domain,
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz:
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice:
-      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch:
-      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz:
       {
         CUresult result = cbInfo->functionReturnValue? *(CUresult *)cbInfo->functionReturnValue: CUDA_SUCCESS;
 
@@ -205,6 +264,16 @@ static void CUPTIAPI cuptiCallback(void *userdata, CUpti_CallbackDomain domain,
         if(filter)
           correlator_insert(filter, correlationId);
 
+        break;
+      }
+      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch:
+      case CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz:
+      {
+        CUresult result = cbInfo->functionReturnValue? *(CUresult *)cbInfo->functionReturnValue: CUDA_SUCCESS;
+        result_value = (uint64_t)result;
+        emit = true;
+        if(graphMap)
+          graph_map_insert(graphMap, correlationId);
         break;
       }
     }
@@ -223,8 +292,6 @@ static void CUPTIAPI cuptiCallback(void *userdata, CUpti_CallbackDomain domain,
       case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000:
       case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000:
       case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000:
-      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000:
-      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000:
       {
         cudaError_t result = cbInfo->functionReturnValue? *(cudaError_t *)cbInfo->functionReturnValue: cudaSuccess;
 
@@ -241,19 +308,36 @@ static void CUPTIAPI cuptiCallback(void *userdata, CUpti_CallbackDomain domain,
         
         break;
       }
+      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000:
+      case CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000:
+      {
+        cudaError_t result = cbInfo->functionReturnValue? *(cudaError_t *)cbInfo->functionReturnValue: cudaSuccess;
+        result_value = (uint64_t)result;
+        emit = true;
+        if(graphMap){
+          graph_map_insert(graphMap, correlationId);
+        }
+        break;
+      }
+
     }
-
     runtimeEnterCorrelationId = 0;
-
   }
 
   if(emit){
-     DTRACE_PROBE4(myprov, ig_callback,
+    outstandingEvents ++;
+    DTRACE_PROBE4(myprov, ig_callback,
       correlationId,
       (uint32_t)cbid,
       name,
       result_value);
+    if(outstandingEvents > 3000){
+      CUPTI_CALL(cuptiActivityFlushAll(0));
+      outstandingEvents = 0;
+    }
   }
+
+  
 }
 
 void cleanup(void){
@@ -273,7 +357,7 @@ void cleanup(void){
   }
 
   if(filter){
-     size_t remaining = correlator_size(filter);
+    size_t remaining = correlator_size(filter);
     if (remaining > 0) {
       DEBUG_PRINTF("[CUPTI] Warning: %zu correlation IDs still in filter at cleanup\n", remaining);
     }
@@ -281,12 +365,21 @@ void cleanup(void){
     filter= NULL;
   }
 
+  if(graphMap){
+    size_t remaining = graph_map_size(graphMap);
+    if(remaining > 0){
+      DEBUG_PRINTF("[CUPTI] Warning: %zu correlation IDs still in graph map at cleanup\n", remaining);
+    }
+    graph_map_destroy(graphMap);
+    graphMap = NULL;
+  }
+
   DEBUG_PRINTF("Cleanup complet \n");
 }
 
 int InitializeInjection(void){
 
-  CUPTI_CALL(cuptiActivityFlushAll(1000));
+  CUPTI_CALL(cuptiActivityFlushPeriod(1000));
 
   CUPTI_CALL_ABORT_RET(cuptiSubscribe(&subscriber, (CUpti_CallbackFunc)cuptiCallback, NULL),1);
 
@@ -336,6 +429,8 @@ int InitializeInjection(void){
   CUPTI_CALL(cuptiGetTimestamp(&startTimestamp));
 
   filter = correlator_create();
+
+  graphMap = graph_map_create();
 
   atexit(cleanup);
   return 1;

--- a/gadgets/trace_cuda/cupti/toolchain-arm64.cmake
+++ b/gadgets/trace_cuda/cupti/toolchain-arm64.cmake
@@ -1,0 +1,7 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/gadgets/trace_cuda/gadget.yaml
+++ b/gadgets/trace_cuda/gadget.yaml
@@ -1,0 +1,129 @@
+name: trace_cuda
+description: Traces CUDA driver API operations using eBPF uprobes
+homepageURL: 'TODO: Fill the gadget homepage URL'
+documentationURL: 'TODO: Fill the gadget documentation URL'
+sourceURL: 'TODO: Fill the gadget source code URL'
+datasources:
+  cuda_mytracer:
+    annotations:
+      cli.default-output-mode: jsonpretty
+    fields:
+      block_x:
+        annotations:
+          description: CUDA block dimension in X axis
+      block_y:
+        annotations:
+          description: CUDA block dimension in Y axis
+      block_z:
+        annotations:
+          description: CUDA block dimension in Z axis
+      comm:
+        annotations:
+          description: Name of the process invoking the CUDA kernel
+          template: comm
+      correlation_id:
+        annotations:
+          description: Unique CUDA correlation identifier used to match kernel launch
+            and completion events
+      end:
+        annotations:
+          description: Kernel completion timestamp in nanoseconds
+      grid_x:
+        annotations:
+          description: CUDA grid dimension in X axis
+      grid_y:
+        annotations:
+          description: CUDA grid dimension in Y axis
+      grid_z:
+        annotations:
+          description: CUDA grid dimension in Z axis
+      mntns_id:
+        annotations:
+          columns.hidden: "true"
+          description: Mount namespace inode id
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      ret_val:
+        annotations:
+          description: CUDA return value for the kernel launch (CUresult)
+      start:
+        annotations:
+          description: Kernel start timestamp in nanoseconds
+      stream:
+        annotations:
+          description: CUDA stream identifier used for kernel launch
+      timestamp:
+        annotations:
+          description: Timestamp when the kernel launch was observed
+      ustack:
+        annotations:
+          description: User-space stack trace at kernel launch
+  memalloc_tracer:
+    annotations:
+      cli.default-output-mode: jsonpretty
+    fields:
+      byte_size:
+        annotations:
+          description: Number of bytes requested for GPU memory allocation
+      comm:
+        annotations:
+          description: Process name
+          template: comm
+      mntns_id:
+        annotations:
+          columns.hidden: "true"
+          description: Mount namespace inode id
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      ret_val:
+        annotations:
+          description: 'TODO: Fill field description'
+      timestamp:
+        annotations:
+          description: Timestamp when the memory allocation occurred
+  memcpy_tracer:
+    annotations:
+      cli.default-output-mode: jsonpretty
+    fields:
+      byte_size:
+        annotations:
+          description: Number of bytes transferred in the memory copy
+      comm:
+        annotations:
+          description: Process name
+          template: comm
+      kind:
+        annotations:
+          description: Direction of the memory transfer (HtoD or DtoH)
+      mntns_id:
+        annotations:
+          columns.hidden: "true"
+          description: Mount namespace inode id
+      pid:
+        annotations:
+          description: Process ID
+          template: pid
+      ret_val:
+        annotations:
+          description: 'TODO: Fill field description'
+      timestamp:
+        annotations:
+          description: Timestamp when the memory copy occurred
+params:
+  ebpf:
+    collect_build_id:
+      key: collect_build_id
+      defaultValue: ""
+      description: Enable collection of build IDs for user-space symbol resolution
+    collect_ustack:
+      key: collect_ustack
+      defaultValue: ""
+      description: Enable collection of user-space stack traces
+    ig_build_id_max_entries:
+      key: ig_build_id_max_entries
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'

--- a/gadgets/trace_cuda/program.bpf.c
+++ b/gadgets/trace_cuda/program.bpf.c
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+/* Copyright (c) 2024 Alejandro Salamanca */
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/user_stack_map.h>
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns.h>
+#include <gadget/types.h>
+#include <gadget/bits.bpf.h>
+#include <gadget/core_fixes.bpf.h>
+
+//Type definition
+
+#define MAX_ENTRIES 10240
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+#define GPU_HIST_MAX_SLOTS 48
+#define MAX_GPUKERN_ARGS 16
+#define DIR_HTOD 0
+#define DIR_DTOH 1
+
+typedef __u64 CUdeviceptr;
+typedef __u64 CUstream;
+
+struct kernel_key {
+	__u32 pid;
+	__u32 correlation_id;
+};
+
+struct cupti_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	__u32 grid_x;
+	__u32 grid_y;
+	__u32 grid_z;
+
+	__u32 block_x;
+	__u32 block_y;
+	__u32 block_z;
+
+	__u32 correlation_id;
+
+	__u64 start;
+	__u64 end;
+
+	struct gadget_user_stack ustack;
+	__u32 stream;
+
+	int ret_val;
+};
+
+struct memalloc_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	size_t byte_size;
+	int ret_val;
+};
+
+struct memcpy_event {
+	gadget_timestamp timestamp;
+	gadget_mntns_id mntns_id;
+	gadget_pid pid;
+	gadget_comm comm[TASK_COMM_LEN];
+	size_t byte_size;
+	__u8 kind;
+	int ret_val;
+};
+
+//Map definition
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct kernel_key);
+	__type(value, struct cupti_event);
+} kernel_event_cupti SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u64);
+	__type(value, struct memalloc_event);
+} memalloc_event SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u64);
+	__type(value, struct memcpy_event);
+} memcpy_event SEC(".maps");
+
+// gadget macros
+GADGET_PARAM(collect_ustack);
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER_MAP(memalloc_events, 1024 * 256);
+GADGET_TRACER_MAP(memcpy_events, 1024 * 256);
+
+GADGET_TRACER(cuda_mytracer, events, cupti_event);
+GADGET_TRACER(memalloc_tracer, memalloc_events, memalloc_event);
+GADGET_TRACER(memcpy_tracer, memcpy_events, memcpy_event);
+
+//functions impl
+
+static __always_inline int
+handle_cuMemAlloc_impl(void **devptr, size_t bytesize, struct pt_regs *ctx)
+{
+	struct memalloc_event event = {};
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+
+	bpf_map_update_elem(&memalloc_event, &pid_tgid, &event, BPF_ANY);
+
+	return 0;
+}
+
+static __always_inline int handle_cuMemAlloc_exit_impl(int ret,
+						       struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+
+	struct memalloc_event *prev =
+		bpf_map_lookup_elem(&memalloc_event, &pid_tgid);
+	if (!prev)
+		return 0;
+
+	struct memalloc_event *event;
+	event = gadget_reserve_buf(&memalloc_events, sizeof(*event));
+	if (!event)
+		goto clean;
+
+	event->mntns_id = prev->mntns_id;
+	event->timestamp = prev->timestamp;
+	event->byte_size = prev->byte_size;
+	event->pid = prev->pid;
+	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+	event->ret_val = ret;
+
+	gadget_submit_buf(ctx, &memalloc_events, event, sizeof(*event));
+
+clean:
+	bpf_map_delete_elem(&memalloc_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_htod_impl(CUdeviceptr dst,
+						     const void *src,
+						     size_t bytesize,
+						     struct pt_regs *ctx)
+{
+	struct memcpy_event event = {};
+
+	// process info
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+	event.kind = DIR_HTOD;
+
+	bpf_map_update_elem(&memcpy_event, &pid_tgid, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_htod_exit_impl(int ret,
+							  struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct memcpy_event *prev =
+		bpf_map_lookup_elem(&memcpy_event, &pid_tgid);
+
+	if (!prev)
+		return 0;
+
+	struct memcpy_event *event;
+	event = gadget_reserve_buf(&memcpy_events, sizeof(*event));
+
+	if (!event)
+		goto clean;
+
+	event->byte_size = prev->byte_size;
+	event->pid = prev->pid;
+	event->timestamp = prev->timestamp;
+	event->mntns_id = prev->mntns_id;
+	event->kind = prev->kind;
+	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+	event->ret_val = ret;
+
+	gadget_submit_buf(ctx, &memcpy_events, event, sizeof(*event));
+
+clean:
+	bpf_map_delete_elem(&memcpy_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_dtoh_impl(void *dst, CUdeviceptr src,
+						     size_t bytesize,
+						     struct pt_regs *ctx)
+{
+	struct memcpy_event event = {};
+
+	// process info
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.byte_size = bytesize;
+	event.kind = DIR_DTOH;
+
+	bpf_map_update_elem(&memcpy_event, &pid_tgid, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int handle_cuMemcpy_dtoh_exit_impl(int ret,
+							  struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct memcpy_event *prev =
+		bpf_map_lookup_elem(&memcpy_event, &pid_tgid);
+	if (!prev)
+		return 0;
+
+	struct memcpy_event *event;
+
+	event = gadget_reserve_buf(&memcpy_events, sizeof(*event));
+	if (!event)
+		goto clean;
+
+	event->timestamp = prev->timestamp;
+	event->pid = prev->pid;
+	event->mntns_id = prev->mntns_id;
+	event->kind = prev->kind;
+	event->byte_size = prev->byte_size;
+	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+
+	event->ret_val = ret;
+
+	gadget_submit_buf(ctx, &memcpy_events, event, sizeof(*event));
+
+clean:
+	bpf_map_delete_elem(&memcpy_event, &pid_tgid);
+	return 0;
+}
+
+static __always_inline int
+handle_ig_callback_impl(struct pt_regs *ctx, __u32 correlation_id, __u64 result)
+{
+	if (result != 0)
+		return 0;
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct cupti_event event = {};
+	event.timestamp = bpf_ktime_get_boot_ns();
+	event.mntns_id = gadget_get_current_mntns_id();
+	event.pid = pid_tgid >> 32;
+
+	event.correlation_id = correlation_id;
+	event.ret_val = (int)result;
+
+	if (collect_ustack)
+		gadget_get_user_stack(ctx, &event.ustack);
+
+	struct kernel_key key = {
+		.correlation_id = correlation_id,
+		.pid = pid_tgid >> 32,
+	};
+	bpf_map_update_elem(&kernel_event_cupti, &key, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int
+handle_ig_activity_impl(struct pt_regs *ctx, __u32 correlation_id,
+			__u32 device_id, __u32 stream_id, __u32 grid_x,
+			__u32 grid_y, __u32 grid_z, __u32 block_x,
+			__u32 block_y, __u32 block_z, __u64 start, __u64 end)
+{
+	struct cupti_event *prev;
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct kernel_key key = {
+		.correlation_id = correlation_id,
+		.pid = pid_tgid >> 32,
+	};
+
+	prev = bpf_map_lookup_elem(&kernel_event_cupti, &key);
+	if (!prev)
+		return 0;
+
+	struct cupti_event *event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		goto clean;
+
+	event->timestamp = prev->timestamp;
+	event->mntns_id = prev->mntns_id;
+	event->pid = prev->pid;
+	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+
+	event->correlation_id = correlation_id;
+	event->ret_val = prev->ret_val;
+
+	event->block_x = block_x;
+	event->block_y = block_y;
+	event->block_z = block_z;
+
+	event->grid_x = grid_x;
+	event->grid_y = grid_y;
+	event->grid_z = grid_z;
+
+	event->stream = stream_id;
+
+	event->start = start;
+	event->end = end;
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+clean:
+	bpf_map_delete_elem(&kernel_event_cupti, &key);
+	return 0;
+}
+// uprobes
+
+// USDT cupti
+
+//  Arguments amd x86: 4@%eax 8@%rdx 8@%rcx 4@%esi 4@%edi 8@-72(%rbp) -4@%r8d 8@-64(%rbp) -4@%r9d
+//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 112] -4@x6 8@[sp, 120] -4@x0
+SEC("usdt/libtrace_cuda_cupti:myprov:ig_activity")
+int handle_ig_activity(struct pt_regs *ctx)
+{
+	__u32 correlation_id = 0, device_id = 0, stream_id = 0;
+	__u64 start = 0, end = 0;
+
+	__u32 grid_z = 0, block_z = 0;
+	__u32 grid_x = 0, grid_y = 0;
+	__u32 block_x = 0, block_y = 0;
+
+#ifdef __TARGET_ARCH_x86
+	__u64 grid_xy = 0, block_xy = 0;
+
+	correlation_id = (__u32)ctx->ax;
+	start = ctx->dx;
+	end = ctx->cx;
+	device_id = ctx->si;
+	stream_id = (__u32)ctx->di;
+	grid_z = (__u32)ctx->r8;
+	block_z = (__u32)ctx->r9;
+
+	__u64 rbp = ctx->bp;
+	if (!rbp)
+		return 0;
+
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), (void *)(rbp - 72)))
+		return 0;
+
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy),
+				(void *)(rbp - 64)))
+		return 0;
+
+	grid_x = grid_xy >> 32;
+	grid_y = grid_xy & 0xffffffff;
+
+	block_x = block_xy >> 32;
+	block_y = block_xy & 0xffffffff;
+
+#endif
+
+#ifdef __TARGET_ARCH_arm64
+	__u64 grid_xy = 0, block_xy = 0;
+
+	void *sp = (void *)ctx->sp;
+	if (!sp)
+		return 0;
+
+	correlation_id = (__u32)ctx->regs[1];
+	start = ctx->regs[2];
+	end = ctx->regs[3];
+	device_id = (__u32)ctx->regs[4];
+	stream_id = (__u32)ctx->regs[5];
+
+	grid_z = (__u32)ctx->regs[6];
+	block_z = (__u32)ctx->regs[0];
+
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 112))
+		return 0;
+
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 120))
+		return 0;
+
+	grid_x = grid_xy >> 32;
+	grid_y = grid_xy & 0xffffffff;
+
+	block_x = block_xy >> 32;
+	block_y = block_xy & 0xffffffff;
+#endif
+
+	handle_ig_activity_impl(ctx, correlation_id, device_id, stream_id,
+				grid_x, grid_y, grid_z, block_x, block_y,
+				block_z, start, end);
+
+	return 0;
+}
+
+// Arguments amd64 x86: 4@-60(%rbp) 4@-80(%rbp) 8@-40(%rbp) 8@-48(%rbp)
+// Arguments arm AArch64: 4@[sp, 60] 4@[sp, 32] 8@[sp, 80] 8@[sp, 72]
+SEC("usdt/libtrace_cuda_cupti:myprov:ig_callback")
+int handle_ig_callback(struct pt_regs *ctx)
+{
+	__u32 correlation_id = 0;
+	__u32 cbid = 0;
+	__u64 result = 0;
+
+#ifdef __TARGET_ARCH_x86
+	__u64 rbp = ctx->bp;
+
+	if (!rbp)
+		return 0;
+
+	/* arg1: 4@-60(%rbp) */
+	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
+				(void *)(rbp - 60)))
+		return 0;
+
+	/* arg2:  4@-80(%rbp) */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 80)))
+		return 0;
+
+	/* arg4: 8@-48(%rbp) */
+	if (bpf_probe_read_user(&result, sizeof(result), (void *)(rbp - 48)))
+		return 0;
+
+#endif
+
+#ifdef __TARGET_ARCH_arm64
+
+	void *sp = (void *)ctx->sp;
+	if (!sp)
+		return 0;
+
+	/* arg1: 4@[sp,60] */
+	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
+				sp + 60))
+		return 0;
+
+	/* arg2: 4@[sp,32] */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), sp + 32))
+		return 0;
+
+	/* arg4: 8@[sp,72] */
+	if (bpf_probe_read_user(&result, sizeof(result), sp + 72))
+		return 0;
+
+#endif
+
+	handle_ig_callback_impl(ctx, correlation_id, result);
+
+	return 0;
+}
+
+//mem alloc
+SEC("uprobe/libcuda:cuMemAlloc")
+int BPF_KPROBE(handle_cuMemAlloc, void **devptr, size_t bytesize)
+{
+	return handle_cuMemAlloc_impl(devptr, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemAlloc")
+int BPF_KRETPROBE(handle_cuMemAlloc_exit, int ret)
+{
+	return handle_cuMemAlloc_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemAlloc_v2")
+int BPF_KPROBE(handle_cuMemAlloc_v2, void **devptr, size_t bytesize)
+{
+	return handle_cuMemAlloc_impl(devptr, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemAlloc_v2")
+int BPF_KRETPROBE(handle_cuMemAlloc_exit_v2, int ret)
+{
+	return handle_cuMemAlloc_exit_impl(ret, ctx);
+}
+
+// memcpy
+SEC("uprobe/libcuda:cuMemcpyHtoD")
+int BPF_KPROBE(handle_cuMemcpy_htod, CUdeviceptr dst, const void *src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoD")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_exit, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_KPROBE(handle_cuMemcpy_htod_v2, CUdeviceptr dst, const void *src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_exit_v2, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoDAsync_v2")
+int BPF_KPROBE(handle_cuMemcpy_htod_async_v2, CUdeviceptr dst, const void *src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoDAsync_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_async_exit_v2, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoDAsync")
+int BPF_KPROBE(handle_cuMemcpy_htod_async, CUdeviceptr dst, const void *src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_htod_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyHtoDAsync")
+int BPF_KRETPROBE(handle_cuMemcpy_htod_async_exit, int ret)
+{
+	return handle_cuMemcpy_htod_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoH")
+int BPF_KPROBE(handle_cuMemcpy_dtoh, void *dst, CUdeviceptr src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoH")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_exit, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_v2, void *dst, CUdeviceptr src,
+	       size_t bytesize)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_exit_v2, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoHAsync_v2")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_async_v2, void *dst, CUdeviceptr src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoHAsync_v2")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_async_exit_v2, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoHAsync")
+int BPF_KPROBE(handle_cuMemcpy_dtoh_async, void *dst, CUdeviceptr src,
+	       size_t bytesize, u64 stream)
+{
+	return handle_cuMemcpy_dtoh_impl(dst, src, bytesize, ctx);
+}
+
+SEC("uretprobe/libcuda:cuMemcpyDtoHAsync")
+int BPF_KRETPROBE(handle_cuMemcpy_dtoh_async_exit, int ret)
+{
+	return handle_cuMemcpy_dtoh_exit_impl(ret, ctx);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/trace_cuda/program.bpf.c
+++ b/gadgets/trace_cuda/program.bpf.c
@@ -338,7 +338,7 @@ clean:
 // USDT cupti
 
 //  Arguments amd x86: 4@%eax 8@%rdx 8@%rcx 4@%esi 4@%edi 8@-72(%rbp) -4@%r8d 8@-64(%rbp) -4@%r9d
-//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 112] -4@x6 8@[sp, 120] -4@x0
+//  Arguments arm archh: 4@x1 8@x2 8@x3 4@x4 4@x5 8@[sp, 144] -4@x6 8@[sp, 152] -4@x0
 SEC("usdt/libtrace_cuda_cupti:myprov:ig_activity")
 int handle_ig_activity(struct pt_regs *ctx)
 {
@@ -395,10 +395,10 @@ int handle_ig_activity(struct pt_regs *ctx)
 	grid_z = (__u32)ctx->regs[6];
 	block_z = (__u32)ctx->regs[0];
 
-	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 112))
+	if (bpf_probe_read_user(&grid_xy, sizeof(grid_xy), sp + 144))
 		return 0;
 
-	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 120))
+	if (bpf_probe_read_user(&block_xy, sizeof(block_xy), sp + 152))
 		return 0;
 
 	grid_x = grid_xy >> 32;
@@ -415,8 +415,8 @@ int handle_ig_activity(struct pt_regs *ctx)
 	return 0;
 }
 
-// Arguments amd64 x86: 4@-60(%rbp) 4@-80(%rbp) 8@-40(%rbp) 8@-48(%rbp)
-// Arguments arm AArch64: 4@[sp, 60] 4@[sp, 32] 8@[sp, 80] 8@[sp, 72]
+// Arguments amd64 x86: 4@-72(%rbp) 4@-96(%rbp) 8@-40(%rbp) 8@-48(%rbp)
+// Arguments arm AArch64: 4@[sp, 64] 4@[sp, 32] 8@[sp, 96] 8@[sp, 88]
 SEC("usdt/libtrace_cuda_cupti:myprov:ig_callback")
 int handle_ig_callback(struct pt_regs *ctx)
 {
@@ -430,13 +430,13 @@ int handle_ig_callback(struct pt_regs *ctx)
 	if (!rbp)
 		return 0;
 
-	/* arg1: 4@-60(%rbp) */
+	/* arg1: 4@-72(%rbp) */
 	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
-				(void *)(rbp - 60)))
+				(void *)(rbp - 72)))
 		return 0;
 
-	/* arg2:  4@-80(%rbp) */
-	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 80)))
+	/* arg2:  4@-96(%rbp) */
+	if (bpf_probe_read_user(&cbid, sizeof(cbid), (void *)(rbp - 96)))
 		return 0;
 
 	/* arg4: 8@-48(%rbp) */
@@ -451,17 +451,17 @@ int handle_ig_callback(struct pt_regs *ctx)
 	if (!sp)
 		return 0;
 
-	/* arg1: 4@[sp,60] */
+	/* arg1: 4@[sp,64] */
 	if (bpf_probe_read_user(&correlation_id, sizeof(correlation_id),
-				sp + 60))
+				sp + 64))
 		return 0;
 
 	/* arg2: 4@[sp,32] */
 	if (bpf_probe_read_user(&cbid, sizeof(cbid), sp + 32))
 		return 0;
 
-	/* arg4: 8@[sp,72] */
-	if (bpf_probe_read_user(&result, sizeof(result), sp + 72))
+	/* arg4: 8@[sp,88] */
+	if (bpf_probe_read_user(&result, sizeof(result), sp + 88))
 		return 0;
 
 #endif

--- a/gadgets/trace_cuda/test/unit/trace_cuda_test.go
+++ b/gadgets/trace_cuda/test/unit/trace_cuda_test.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestCudaKernelTrace(t *testing.T) {
+  gadgettesting.DummyGadgetTest(t, "trace_cuda")
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
Introduce CUDA tracing support through a new trace_cuda gadget and a dedicated cuda_metrics gadget.

The trace_cuda gadget instruments CUDA Runtime and Driver API calls using eBPF uprobes and a CUPTI-based userspace shim library. It captures kernel launches, CUDA Graph launches, memory allocations, and memory copy operations, and emits events one by one for observability and debugging purposes.


The cuda_metrics gadget exposes metrics including kernel launch counts, memory allocation counts, memcpy statistics, error codes and histograms for launch dimensions and GPU processing time.

# Add CUDA tracing and metrics gadgets for GPU applications

The trace_cuda gadget instruments CUDA Driver API calls using eBPF uprobes and a CUPTI based userspace shim library. It captures kernel launches, memory allocations, and memory copy operations, and emits events one by one for observability and debugging purposes.

The cuda_metrics gadget exposes Prometheus metrics derived from CUDA activity. The following metrics are currently exported:

### LaunchKernel

* Total number of kernel launches
* Histogram of threads per block
* Histogram of blocks per grid
* Histogram of total threads per kernel
* Histogram of GPU kernel execution time
* Support for CUDA Graph launch events

### MemAlloc

* Total memory allocated
* Number of memory allocation calls

### Memcpy

* Number of host → device copies
* Number of device → host copies
* Bytes transferred host → device
* Bytes transferred device → host

### Errors

* Kernel launch errors
* Memory allocation errors
* Memcpy HtoD errors
* Memcpy DtoH errors

Both gadgets depend on a CUPTI-based shim library located under the `trace_cuda/cupti` directory. This library enables access to accurate GPU kernel execution time directly from CUPTI, including kernels launched through CUDA Graph APIs. The library communicates with eBPF through USDT probes.

At the moment, users need to follow the steps described in the README to ensure the shim library can be found by the gadgets. In the future, this could be improved by providing a cleaner distribution mechanism (for example, packaging it as a `.deb` or defining a more transparent deployment method, especially for containerized environments).


## How to use

Detailed usage instructions can be found in the corresponding documentation:

[https://github.com/ALEYI17/inspektor-gadget/tree/gpu-cuda-gadget/gadgets/trace_cuda](https://github.com/ALEYI17/inspektor-gadget/tree/gpu-cuda-gadget/gadgets/cuda_metrics)

[https://github.com/ALEYI17/inspektor-gadget/tree/gpu-cuda-gadget/gadgets/trace_cuda](https://github.com/ALEYI17/inspektor-gadget/tree/gpu-cuda-gadget/gadgets/trace_cuda)

* `gadgets/cuda_metrics/README.md` and `README.mdx`
* `gadgets/trace_cuda/README.md` and `README.mdx`

These documents describe how to build, deploy, and validate the gadgets.


### Using prebuilt Docker images

Prebuilt container images are also available:

* **cuda_metrics**:
  [https://github.com/users/ALEYI17/packages/container/package/cuda-metrics](https://github.com/users/ALEYI17/packages/container/package/cuda-metrics)

* **trace_cuda**:
  [https://github.com/users/ALEYI17/packages/container/package/trace_cuda](https://github.com/users/ALEYI17/packages/container/package/trace_cuda)

For testing CUDA workloads, a sample CUDA application image is available:

* **saxpy test application**(already with cupti lib):
  [https://github.com/users/ALEYI17/packages/container/package/saxpy](https://github.com/users/ALEYI17/packages/container/package/saxpy)
  
* **graph test application (CUDA Graph API)**:  
[https://github.com/users/ALEYI17/packages/container/package/graph]
(https://github.com/users/ALEYI17/packages/container/package/graph)

When running the container saxpy, make sure to enable GPU access:

```bash
docker run --gpus all <image>
```
For example:

```bash
docker run --gpus all ghcr.io/aleyi17/saxpy:latest
docker run --gpus all ghcr.io/aleyi17/graph:latest
```


## Design notes

* **MemAlloc and Memcpy** are instrumented using eBPF uprobes attached to the CUDA Driver API (`libcuda.so`). Each operation type maintains dedicated maps to correlate requests and results.
* **LaunchKernel** is handled through a CUPTI based shim library. CUPTI provides accurate GPU processing time for each kernel. The shim library emits this information via USDT probes, which are then consumed from eBPF.