### PR TITLE
`top_process`: Rename `cpuUsageRelative` Field to `cpuRelative`

### DIFF
--- a/gadgets/top_process/gadget.yaml
+++ b/gadgets/top_process/gadget.yaml
@@ -28,7 +28,7 @@ datasources:
       cpuUsage:
         annotations:
           columns.alias: '%CPU'
-      cpuUsageRelative:
+      cpuRelative:
         annotations:
           columns.alias: '%RELCPU'
       memoryRelative:

--- a/pkg/operators/process/process.go
+++ b/pkg/operators/process/process.go
@@ -65,7 +65,7 @@ const (
 	fieldCPUTime          = "cpuTime"
 	fieldCPUTimeStr       = "cpuTimeStr"
 	fieldCPUUsage         = "cpuUsage"
-	fieldCPUUsageRelative = "cpuUsageRelative"
+	fieldCPUUsageRelative = "cpuRelative"
 	fieldMemoryRSS        = "memoryRSS"
 	fieldMemoryVirtual    = "memoryVirtual"
 	fieldMemoryRelative   = "memoryRelative"
@@ -247,7 +247,7 @@ func (p *processOperator) InstantiateDataOperator(gadgetCtx operators.GadgetCont
 				metadatav1.ColumnsMaxWidthAnnotation:  "8",
 			}))
 			if err != nil {
-				return nil, fmt.Errorf("adding cpuUsageRelative field: %w", err)
+				return nil, fmt.Errorf("adding cpuRelative field: %w", err)
 			}
 			requireCPUInfo = true
 		case fieldMemoryRSS:

--- a/pkg/process-helpers/processhelpers.go
+++ b/pkg/process-helpers/processhelpers.go
@@ -43,21 +43,21 @@ type ProcessInfo struct {
 	PID              int       `json:"pid"`
 	PPID             int       `json:"ppid"`
 	Comm             string    `json:"comm"`
-	CPUUsage         float64   `json:"cpuUsage"`         // CPU usage in percentage
-	CPUUsageRelative float64   `json:"cpuUsageRelative"` // CPU usage in percentage, relative to number of cores
-	CPUTime          uint64    `json:"cpuTime"`          // Total CPU time
-	Priority         int64     `json:"priority"`         // Process priority
-	Nice             int64     `json:"nice"`             // Nice Value
-	MemoryRSS        uint64    `json:"memoryRSS"`        // Resident Set Size in bytes
-	MemoryVirtual    uint64    `json:"memoryVirtual"`    // Virtual memory size in bytes
-	MemoryShared     uint64    `json:"memoryShared"`     // Shared memory size in bytes
-	MemoryRelative   float64   `json:"memoryRelative"`   // Percentage of memory usage of the system
-	ThreadCount      int       `json:"threadCount"`      // Number of threads
-	State            string    `json:"state"`            // Process state (R: running, S: sleeping, etc.)
-	Uid              uint32    `json:"uid"`              // UID of the process owner
-	StartTime        uint64    `json:"startTime"`        // Process start time (clock ticks since system boot)
-	StartTimeStr     time.Time `json:"startTimeStr"`     // Process start time as a formatted string
-	MountNsID        uint64    `json:"mountnsid"`        // Mount namespace ID
+	CPUUsage         float64   `json:"cpuUsage"`       // CPU usage in percentage
+	CPUUsageRelative float64   `json:"cpuRelative"`    // CPU usage in percentage, relative to number of cores
+	CPUTime          uint64    `json:"cpuTime"`        // Total CPU time
+	Priority         int64     `json:"priority"`       // Process priority
+	Nice             int64     `json:"nice"`           // Nice Value
+	MemoryRSS        uint64    `json:"memoryRSS"`      // Resident Set Size in bytes
+	MemoryVirtual    uint64    `json:"memoryVirtual"`  // Virtual memory size in bytes
+	MemoryShared     uint64    `json:"memoryShared"`   // Shared memory size in bytes
+	MemoryRelative   float64   `json:"memoryRelative"` // Percentage of memory usage of the system
+	ThreadCount      int       `json:"threadCount"`    // Number of threads
+	State            string    `json:"state"`          // Process state (R: running, S: sleeping, etc.)
+	Uid              uint32    `json:"uid"`            // UID of the process owner
+	StartTime        uint64    `json:"startTime"`      // Process start time (clock ticks since system boot)
+	StartTimeStr     time.Time `json:"startTimeStr"`   // Process start time as a formatted string
+	MountNsID        uint64    `json:"mountnsid"`      // Mount namespace ID
 }
 
 type Options interface {


### PR DESCRIPTION
# Align CPU and Memory Fields

Renames the `cpuUsageRelative` field to `cpuRelative` to align it with the existing `memoryRelative` field naming pattern.

## Implementation Details

+ `gadgets/top_process/gadget.yaml`: renamed field key from `cpuUsageRelative` to `cpuRelative`
+ `pkg/operators/process/process.go`: updated constant value and error message string
+ `pkg/process-helpers/processhelpers.go`: updated JSON tag

## Note

This is a **Breaking Change**. Users relying on `--sort -cpuUsageRelative` or referencing this field by name in scripts/tooling will need to update to `cpuRelative`.

## Checklist

+ [x] Fixes #4594 
+ [x] Commits are signed-off
+ [x] Unit & Integration Tests pass locally