### PR TITLE
Set host network flag when not used

### DIFF
--- a/pkg/datasource/compat/wrapper.go
+++ b/pkg/datasource/compat/wrapper.go
@@ -378,6 +378,8 @@ func (ev *EventWrapper) SetPodMetadata(container types.Container) {
 		if ev.hostNetworkAccessor.IsRequested() {
 			if container.UsesHostNetwork() {
 				ev.hostNetworkAccessor.PutInt8(ev.Data, 1)
+			} else {
+				ev.hostNetworkAccessor.PutInt8(ev.Data, 0)
 			}
 		}
 		ownerKindRequest := ev.ownerKindAccessor.IsRequested()


### PR DESCRIPTION
Write explicit 0 to hostNetworkAccessor when container doesn't use the host network to avoid leaving a stale non-zero value