### PR TITLE
charts: Use gadget.namespace for configmap config.yaml.

### DIFF
--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
       crio-socketpath: {{ .Values.config.crioSocketPath }}
       docker-socketpath: {{ .Values.config.dockerSocketPath }}
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
-      gadget-namespace: {{ .Values.config.gadgetNamespace }}
+      gadget-namespace: {{ include "gadget.namespace" . }}
       daemon-log-level: {{ .Values.config.daemonLogLevel }}
       operator:
         {{- include "gadget.operatorConfig" . | nindent 8 -}}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -22,9 +22,6 @@ config:
   # -- Daemon Log Level. Valid values are: "trace", "debug", "info", "warning", "error", "fatal", "panic"
   daemonLogLevel: "info"
 
-  # -- Namespace where Inspektor Gadget is running
-  gadgetNamespace: "gadget"
-
   # -- Operator configuration, this will only be used if deprecated values are not set.
   operator:
     kubemanager:


### PR DESCRIPTION
gadget-namespace was set by using config.gadgetNamespace, unfortunately this forces setting this value in values.yaml instead of inheriting the one when the chart is created.