### PR TITLE
Add top_cpu_throttle gadget to detect CFS bandwidth throttling

### DIFF
--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -39,6 +39,7 @@ import (
 
 	// Another blank import for the used operator
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cgroup"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/env"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"

--- a/docs/gadgets/top_cpu_throttle.mdx
+++ b/docs/gadgets/top_cpu_throttle.mdx
@@ -1,0 +1,1 @@
+../../gadgets/top_cpu_throttle/README.mdx

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/gadget-container/entrypoint"
 	// Blank import for some operators
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/btfgen"
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cgroup"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/env"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -58,6 +58,7 @@ GADGETS ?= \
 	trace_tcpdrop \
 	trace_tcpretrans \
 	top_blockio \
+	top_cpu_throttle \
 	top_file \
 	top_process \
 	top_tcp \

--- a/gadgets/top_cpu_throttle/README.md
+++ b/gadgets/top_cpu_throttle/README.md
@@ -1,0 +1,5 @@
+# top_cpu_throttle
+
+The `top_cpu_throttle` gadget periodically reports CFS CPU bandwidth throttling statistics per cgroup, helping identify containers suffering from tight CPU limits rather than actual CPU overutilization.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/top_cpu_throttle

--- a/gadgets/top_cpu_throttle/README.mdx
+++ b/gadgets/top_cpu_throttle/README.mdx
@@ -1,0 +1,110 @@
+---
+title: top_cpu_throttle
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# top_cpu_throttle
+
+The top_cpu_throttle gadget periodically reports cgroup v2 CPU throttling
+statistics, making it easy to identify which containers, pods, or namespaces
+are the worst CFS (Completely Fair Scheduler) throttle offenders.
+
+This is particularly useful when PSI (Pressure Stall Information) shows high
+CPU pressure on a node but `top`/`htop` shows available CPU time — the
+pressure is likely caused by too-tight cgroup CPU limits rather than genuine
+CPU overutilization.
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_cpu_throttle:%IG_TAG%
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run ghcr.io/inspektor-gadget/gadget/top_cpu_throttle:%IG_TAG%
+        ```
+    </TabItem>
+</Tabs>
+
+## Guide
+
+The gadget reads the following cgroup v2 files for every cgroup that has a
+CPU bandwidth limit:
+
+| File | Data |
+|---|---|
+| `cpu.max` | Quota and period (the CPU limit) |
+| `cpu.stat` | `nr_periods`, `nr_throttled`, `throttled_usec` (cumulative throttle counters) |
+| `cpu.pressure` | PSI averages (optional — gracefully skipped if unavailable) |
+
+### Reported fields
+
+| Column | Description |
+|---|---|
+| `CGROUP` | Cgroup v2 path (hidden by default) |
+| `PERIODS` | Number of CFS enforcement intervals elapsed in the reporting period |
+| `THROTTLED` | Number of times the cgroup was throttled |
+| `THROTTLED_TIME` | Total time spent throttled (human-readable duration) |
+| `%THROT` | Throttle percentage (`THROTTLED / PERIODS × 100`, 0–100) |
+| `QUOTA` | CPU quota per CFS period (human-readable duration) |
+| `LIMIT` | Effective CPU core limit (`quota / period`) |
+| `%PSI10` | CPU pressure % over 10 s (PSI "some" avg) |
+| `%PSI60` | CPU pressure % over 60 s (PSI "some" avg) |
+
+Only cgroups with an explicit CPU bandwidth limit are shown — cgroups
+without a `cpu.max` quota (i.e., unlimited) are filtered out.
+
+PSI "full" is omitted because CFS throttling is all-or-nothing at the cgroup
+level — "full" is always identical to "some" for CPU pressure.
+
+All throttle counters are **per-interval deltas**, not cumulative totals —
+they reflect what happened since the last report.
+
+### Sorting by worst offenders
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+        ```bash
+        $ kubectl gadget run ghcr.io/inspektor-gadget/gadget/top_cpu_throttle:%IG_TAG% --sort -throttleRatio
+        K8S.NODE     K8S.NAMESPACE K8S.PODNAME     K8S.CONTAINER  PERIODS THROTTLED THROTTLED_TIME %THROT   QUOTA  LIMIT %PSI10 %PSI60
+        minikube     default       heavy-web       heavy-web           50        50       7.24511s 100.00  5.00ms   0.05  79.43  29.55
+        minikube     default       api-server      api-server          50        50       2.87386s 100.00 20.00ms   0.20  60.54  24.27
+        minikube     default       light-load      light-load          50         8       62.72ms   16.00 10.00ms   0.10   0.27   0.08
+        minikube     default       batch-job       batch-job           50         0           0ns    0.00 100.00m   1.00   0.00   0.00
+        ```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+        ```bash
+        $ sudo ig run top_cpu_throttle --sort -throttleRatio
+        RUNTIME.CONTAINERNAME  PERIODS THROTTLED THROTTLED_TIME %THROT   QUOTA  LIMIT %PSI10 %PSI60
+        heavy-web                   50        50       7.24511s 100.00  5.00ms   0.05  79.43  29.55
+        api-server                  50        50       2.87386s 100.00 20.00ms   0.20  60.54  24.27
+        light-load                  50         8       62.72ms   16.00 10.00ms   0.10   0.27   0.08
+        batch-job                   50         0           0ns    0.00 100.00m   1.00   0.00   0.00
+        ```
+    </TabItem>
+</Tabs>
+
+### Adjusting the interval
+
+```bash
+$ sudo ig run top_cpu_throttle --interval 3s
+```
+
+## Requirements
+
+* **cgroup v2** — the host must use cgroup v2 (unified hierarchy). Cgroup v1
+  is not supported.
+* **PSI** — PSI metrics require `CONFIG_PSI=y` in the kernel (Linux 4.20+).
+  If PSI is not available, the PSI columns will report 0 and the gadget will
+  continue to work normally.

--- a/gadgets/top_cpu_throttle/artifacthub-pkg.yml
+++ b/gadgets/top_cpu_throttle/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+# Artifact Hub package metadata file
+version: 0.50.0
+name: "top cpu throttle"
+category: monitoring-logging
+displayName: "top cpu throttle"
+createdAt: "2026-03-05T22:00:00Z"
+digest: "2026-03-05T22:00:00Z"
+description: "Periodically report CFS CPU bandwidth throttling per cgroup"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: ""
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/top_cpu_throttle"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/top_cpu_throttle:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+    - cpu
+    - throttle
+    - cgroup
+    - monitoring
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_cpu_throttle"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/top_cpu_throttle:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/top_cpu_throttle/gadget.yaml
+++ b/gadgets/top_cpu_throttle/gadget.yaml
@@ -1,0 +1,64 @@
+name: top cpu throttle
+description: Periodically report cgroup CPU throttling statistics to identify containers under CFS bandwidth pressure
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/top_cpu_throttle
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/top_cpu_throttle
+operator:
+  cgroup:
+    emitstats: true
+    interval: 5s
+    first-interval: 500ms
+datasources:
+  cgroups:
+    annotations:
+      cli.clear-screen-before: "true"
+    fields:
+      cgroupPath:
+        annotations:
+          columns.alias: 'CGROUP'
+          columns.hidden: 'true'
+      nrPeriods:
+        annotations:
+          columns.alias: 'PERIODS'
+      nrThrottled:
+        annotations:
+          columns.alias: 'THROTTLED'
+      throttledTime:
+        annotations:
+          columns.alias: 'THROTTLED_TIME'
+      throttleRatio:
+        annotations:
+          columns.alias: '%THROT'
+      cpuQuota:
+        annotations:
+          columns.alias: 'QUOTA'
+      cpuPeriod:
+        annotations:
+          columns.alias: 'PERIOD'
+      cpuLimitCores:
+        annotations:
+          columns.alias: 'LIMIT'
+      psiSomeAvg10:
+        annotations:
+          columns.alias: '%PSI10'
+      psiSomeAvg60:
+        annotations:
+          columns.alias: '%PSI60'
+params:
+  custom:
+    interval:
+      description: "interval to re-read statistics"
+      defaultValue: 5s
+      patch:
+        operator:
+          cgroup:
+            interval: >-
+              {{call .getParamValue "custom.interval"}}
+    count:
+      description: "number of reports (0 = unlimited)"
+      defaultValue: 0
+      patch:
+        operator:
+          cgroup:
+            count: >-
+              {{call .getParamValue "custom.count"}}

--- a/gadgets/top_cpu_throttle/test/unit/top_cpu_throttle_test.go
+++ b/gadgets/top_cpu_throttle/test/unit/top_cpu_throttle_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+)
+
+func TestTopCPUThrottle(t *testing.T) {
+	// TODO: This is a dummy test to check that the gadget runs without errors.
+	// It should be extended to check that the gadget produces correct data.
+	gadgettesting.DummyGadgetTest(t, "top_cpu_throttle")
+}

--- a/pkg/operators/cgroup/cgroup.go
+++ b/pkg/operators/cgroup/cgroup.go
@@ -1,0 +1,672 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cgroup implements an operator that periodically emits cgroup v2 CPU
+// throttling statistics. It reads cpu.stat, cpu.max, and (optionally)
+// cpu.pressure for every cgroup that has a CPU bandwidth limit, making it
+// straightforward to identify which containers/pods are the worst CFS
+// throttle offenders.
+package cgroup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/viper"
+
+	containerutils "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/cgroups"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	metadatav1 "github.com/inspektor-gadget/inspektor-gadget/pkg/metadata/v1"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
+)
+
+const (
+	Name     = "cgroup"
+	Priority = -900
+
+	// Configuration keys
+	configKeyEnabled       = "operator.cgroup.emitstats"
+	configKeyInterval      = "operator.cgroup.interval"
+	configKeyFirstInterval = "operator.cgroup.first-interval"
+	configKeyCount         = "operator.cgroup.count"
+
+	defaultInterval = 5 * time.Second
+
+	// Field names
+	fieldCgroupPath    = "cgroupPath"
+	fieldNrPeriods     = "nrPeriods"
+	fieldNrThrottled   = "nrThrottled"
+	fieldThrottledTime = "throttledTime"
+	fieldThrottleRatio = "throttleRatio"
+	fieldCPUQuota      = "cpuQuota"
+	fieldCPUPeriod     = "cpuPeriod"
+	fieldCPULimitCores = "cpuLimitCores"
+	fieldPSISomeAvg10  = "psiSomeAvg10"
+	fieldPSISomeAvg60  = "psiSomeAvg60"
+	fieldMountNsID     = "mountnsid"
+)
+
+// cpuStat holds parsed cumulative values from cgroup v2 cpu.stat.
+type cpuStat struct {
+	nrPeriods     uint64
+	nrThrottled   uint64
+	throttledUsec uint64
+}
+
+// cpuMax holds parsed values from cgroup v2 cpu.max.
+type cpuMax struct {
+	quota  int64  // -1 means unlimited ("max")
+	period uint64 // CFS period in microseconds
+}
+
+// psiMetrics holds parsed values from cgroup v2 cpu.pressure.
+// Only "some" metrics are included — for CPU cgroups, PSI "full" is always
+// identical to "some" because CFS throttling is all-or-nothing.
+type psiMetrics struct {
+	someAvg10 float64
+	someAvg60 float64
+	available bool
+}
+
+// cgroupInfo holds all collected data for a single cgroup.
+type cgroupInfo struct {
+	cgroupPath string
+	stat       cpuStat
+	max        cpuMax
+	psi        psiMetrics
+	mountNsID  uint64
+}
+
+type cgroupOperator struct{}
+
+func (o *cgroupOperator) Name() string                { return Name }
+func (o *cgroupOperator) Init(_ *params.Params) error { return nil }
+func (o *cgroupOperator) GlobalParams() api.Params    { return api.Params{} }
+func (o *cgroupOperator) InstanceParams() api.Params  { return api.Params{} }
+func (o *cgroupOperator) Priority() int               { return Priority }
+
+func (o *cgroupOperator) InstantiateDataOperator(
+	gadgetCtx operators.GadgetContext,
+	instanceParamValues api.ParamValues,
+) (operators.DataOperatorInstance, error) {
+	config, ok := gadgetCtx.GetVar("config")
+	if !ok {
+		return nil, fmt.Errorf("config not found in gadget context")
+	}
+
+	viperConfig, ok := config.(*viper.Viper)
+	if !ok {
+		return nil, fmt.Errorf("config is not a viper instance")
+	}
+
+	if !viperConfig.GetBool(configKeyEnabled) {
+		gadgetCtx.Logger().Debug("Cgroup CPU throttle monitoring is disabled")
+		return nil, nil
+	}
+
+	interval := viperConfig.GetDuration(configKeyInterval)
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+
+	count := viperConfig.GetInt(configKeyCount)
+	firstInterval := viperConfig.GetDuration(configKeyFirstInterval)
+
+	ds, err := gadgetCtx.RegisterDataSource(datasource.TypeArray, "cgroups")
+	if err != nil {
+		return nil, fmt.Errorf("registering cgroups data source: %w", err)
+	}
+	ds.AddAnnotation(api.FetchIntervalAnnotation, interval.String())
+
+	inst := &cgroupOperatorInstance{
+		interval:      interval,
+		count:         count,
+		firstInterval: firstInterval,
+		done:          make(chan struct{}),
+		dataSource:    ds,
+		prevStats:     make(map[string]cpuStat),
+	}
+
+	if err := inst.registerFields(ds); err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// cgroupOperatorInstance is the per-run state.
+type cgroupOperatorInstance struct {
+	interval      time.Duration
+	count         int
+	firstInterval time.Duration
+	dataSource    datasource.DataSource
+	done          chan struct{}
+	wg            sync.WaitGroup
+
+	// Field accessors
+	cgroupPathField    datasource.FieldAccessor
+	nrPeriodsField     datasource.FieldAccessor
+	nrThrottledField   datasource.FieldAccessor
+	throttledTimeField datasource.FieldAccessor
+	throttleRatioField datasource.FieldAccessor
+	cpuQuotaField      datasource.FieldAccessor
+	cpuPeriodField     datasource.FieldAccessor
+	cpuLimitCoresField datasource.FieldAccessor
+	psiSomeAvg10Field  datasource.FieldAccessor
+	psiSomeAvg60Field  datasource.FieldAccessor
+	mountNsIDField     datasource.FieldAccessor
+
+	// Delta tracking: previous cumulative cpu.stat values keyed by cgroup path
+	prevStats map[string]cpuStat
+}
+
+func (inst *cgroupOperatorInstance) registerFields(ds datasource.DataSource) error {
+	var err error
+
+	inst.cgroupPathField, err = ds.AddField(fieldCgroupPath, api.Kind_String, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:     "The cgroup v2 path.",
+		metadatav1.ColumnsMaxWidthAnnotation: "60",
+		metadatav1.ColumnsEllipsisAnnotation: "start",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding cgroupPath field: %w", err)
+	}
+
+	inst.nrPeriodsField, err = ds.AddField(fieldNrPeriods, api.Kind_Uint64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "Number of CFS enforcement intervals elapsed in this reporting period.",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsMaxWidthAnnotation:  "10",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding nrPeriods field: %w", err)
+	}
+
+	inst.nrThrottledField, err = ds.AddField(fieldNrThrottled, api.Kind_Uint64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "Number of times the cgroup was throttled in this reporting period.",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsMaxWidthAnnotation:  "12",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding nrThrottled field: %w", err)
+	}
+
+	inst.throttledTimeField, err = ds.AddField(fieldThrottledTime+"_raw", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.DescriptionAnnotation:      "Total time spent throttled in this reporting period.",
+			metadatav1.ColumnsAlignmentAnnotation: "right",
+			metadatav1.ColumnsMaxWidthAnnotation:  "14",
+		}),
+		datasource.WithTags("type:gadget_duration"),
+	)
+	if err != nil {
+		return fmt.Errorf("adding throttledTime field: %w", err)
+	}
+
+	inst.throttleRatioField, err = ds.AddField(fieldThrottleRatio, api.Kind_Float64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "Percentage of periods where the cgroup was throttled (0-100) in this reporting period.",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsPrecisionAnnotation: "2",
+		metadatav1.ColumnsMaxWidthAnnotation:  "8",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding throttleRatio field: %w", err)
+	}
+
+	inst.cpuQuotaField, err = ds.AddField(fieldCPUQuota+"_raw", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.DescriptionAnnotation:      "CPU quota per CFS period.",
+			metadatav1.ColumnsAlignmentAnnotation: "right",
+			metadatav1.ColumnsMaxWidthAnnotation:  "10",
+		}),
+		datasource.WithTags("type:gadget_duration"),
+	)
+	if err != nil {
+		return fmt.Errorf("adding cpuQuota field: %w", err)
+	}
+
+	inst.cpuPeriodField, err = ds.AddField(fieldCPUPeriod+"_raw", api.Kind_Uint64,
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.DescriptionAnnotation:      "CFS period length.",
+			metadatav1.ColumnsAlignmentAnnotation: "right",
+			metadatav1.ColumnsMaxWidthAnnotation:  "10",
+			metadatav1.ColumnsHiddenAnnotation:    "true",
+		}),
+		datasource.WithTags("type:gadget_duration"),
+	)
+	if err != nil {
+		return fmt.Errorf("adding cpuPeriod field: %w", err)
+	}
+
+	inst.cpuLimitCoresField, err = ds.AddField(fieldCPULimitCores, api.Kind_Float64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "Effective CPU core limit (quota / period).",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsPrecisionAnnotation: "2",
+		metadatav1.ColumnsMaxWidthAnnotation:  "8",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding cpuLimitCores field: %w", err)
+	}
+
+	// PSI fields
+	inst.psiSomeAvg10Field, err = ds.AddField(fieldPSISomeAvg10, api.Kind_Float64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "PSI 'some' CPU pressure average over 10 seconds.",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsPrecisionAnnotation: "2",
+		metadatav1.ColumnsMaxWidthAnnotation:  "8",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding psiSomeAvg10 field: %w", err)
+	}
+
+	inst.psiSomeAvg60Field, err = ds.AddField(fieldPSISomeAvg60, api.Kind_Float64, datasource.WithAnnotations(map[string]string{
+		metadatav1.DescriptionAnnotation:      "PSI 'some' CPU pressure average over 60 seconds.",
+		metadatav1.ColumnsAlignmentAnnotation: "right",
+		metadatav1.ColumnsPrecisionAnnotation: "2",
+		metadatav1.ColumnsMaxWidthAnnotation:  "8",
+	}))
+	if err != nil {
+		return fmt.Errorf("adding psiSomeAvg60 field: %w", err)
+	}
+
+	// Mount namespace ID for container/pod enrichment
+	inst.mountNsIDField, err = ds.AddField(fieldMountNsID, api.Kind_Uint64,
+		datasource.WithTags("type:gadget_mntns_id"),
+		datasource.WithAnnotations(map[string]string{
+			metadatav1.TemplateAnnotation: "mntns_id",
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("adding mountnsid field: %w", err)
+	}
+
+	return nil
+}
+
+func (inst *cgroupOperatorInstance) Name() string { return Name }
+
+func (inst *cgroupOperatorInstance) Start(gadgetCtx operators.GadgetContext) error {
+	inst.wg.Go(func() { inst.monitor(gadgetCtx) })
+	return nil
+}
+
+func (inst *cgroupOperatorInstance) Stop(gadgetCtx operators.GadgetContext) error {
+	close(inst.done)
+	inst.wg.Wait()
+	return nil
+}
+
+func (inst *cgroupOperatorInstance) Close(gadgetCtx operators.GadgetContext) error {
+	return nil
+}
+
+func (inst *cgroupOperatorInstance) monitor(gadgetCtx operators.GadgetContext) {
+	// First collection establishes baseline for delta computation.
+	if err := inst.collectAndEmit(gadgetCtx, false); err != nil {
+		gadgetCtx.Logger().Errorf("Error collecting cgroup stats: %v", err)
+	}
+
+	if inst.firstInterval > 0 {
+		timer := time.NewTimer(inst.firstInterval)
+		defer timer.Stop()
+		select {
+		case <-inst.done:
+			return
+		case <-timer.C:
+			if err := inst.collectAndEmit(gadgetCtx, true); err != nil {
+				gadgetCtx.Logger().Errorf("Error collecting cgroup stats: %v", err)
+			}
+		}
+	}
+
+	ticker := time.NewTicker(inst.interval)
+	defer ticker.Stop()
+
+	count := 0
+	for {
+		select {
+		case <-inst.done:
+			return
+		case <-ticker.C:
+			if err := inst.collectAndEmit(gadgetCtx, true); err != nil {
+				gadgetCtx.Logger().Errorf("Error collecting cgroup stats: %v", err)
+			}
+			count++
+			if inst.count > 0 && count >= inst.count {
+				return
+			}
+		}
+	}
+}
+
+// discoverCgroupsFn is the function used to discover cgroups. It defaults to
+// discoverCgroups and can be replaced in tests.
+var discoverCgroupsFn = discoverCgroups
+
+// collectAndEmit discovers cgroups with CPU bandwidth limits, reads their
+// throttling stats, computes per-interval deltas, and emits the results.
+// When emit is false (baseline collection), only prevStats is updated —
+// no packets are allocated or emitted.
+func (inst *cgroupOperatorInstance) collectAndEmit(gadgetCtx operators.GadgetContext, emit bool) error {
+	infos, err := discoverCgroupsFn(gadgetCtx)
+	if err != nil {
+		return fmt.Errorf("discovering cgroups: %w", err)
+	}
+
+	newPrevStats := make(map[string]cpuStat, len(infos))
+
+	if !emit {
+		for _, info := range infos {
+			newPrevStats[info.cgroupPath] = info.stat
+		}
+		inst.prevStats = newPrevStats
+		return nil
+	}
+
+	packetArray, err := inst.dataSource.NewPacketArray()
+	if err != nil {
+		return fmt.Errorf("creating packet array: %w", err)
+	}
+
+	for _, info := range infos {
+		newPrevStats[info.cgroupPath] = info.stat
+
+		// Compute deltas from the previous interval
+		var deltaPeriods, deltaThrottled, deltaThrottledUsec uint64
+		if prev, ok := inst.prevStats[info.cgroupPath]; ok {
+			// Guard against counter resets (e.g. cgroup destroyed and recreated)
+			if info.stat.nrPeriods >= prev.nrPeriods {
+				deltaPeriods = info.stat.nrPeriods - prev.nrPeriods
+			}
+			if info.stat.nrThrottled >= prev.nrThrottled {
+				deltaThrottled = info.stat.nrThrottled - prev.nrThrottled
+			}
+			if info.stat.throttledUsec >= prev.throttledUsec {
+				deltaThrottledUsec = info.stat.throttledUsec - prev.throttledUsec
+			}
+		} else {
+			// First time seeing this cgroup: record baseline, skip emission.
+			continue
+		}
+
+		// Skip cgroups with no CFS activity in this interval
+		if deltaPeriods == 0 && deltaThrottled == 0 {
+			continue
+		}
+
+		var throttleRatio float64
+		if deltaPeriods > 0 {
+			throttleRatio = float64(deltaThrottled) / float64(deltaPeriods) * 100
+		}
+
+		var cpuLimitCores float64
+		if info.max.quota > 0 && info.max.period > 0 {
+			cpuLimitCores = float64(info.max.quota) / float64(info.max.period)
+		}
+
+		packet := packetArray.New()
+
+		inst.cgroupPathField.PutString(packet, info.cgroupPath)
+		inst.nrPeriodsField.PutUint64(packet, deltaPeriods)
+		inst.nrThrottledField.PutUint64(packet, deltaThrottled)
+		inst.throttledTimeField.PutUint64(packet, deltaThrottledUsec*1000) // µs → ns for gadget_duration
+		inst.throttleRatioField.PutFloat64(packet, throttleRatio)
+		inst.cpuQuotaField.PutUint64(packet, uint64(info.max.quota)*1000) // µs → ns for gadget_duration
+		inst.cpuPeriodField.PutUint64(packet, info.max.period*1000)       // µs → ns for gadget_duration
+		inst.cpuLimitCoresField.PutFloat64(packet, cpuLimitCores)
+
+		if info.psi.available {
+			inst.psiSomeAvg10Field.PutFloat64(packet, info.psi.someAvg10)
+			inst.psiSomeAvg60Field.PutFloat64(packet, info.psi.someAvg60)
+		}
+
+		inst.mountNsIDField.PutUint64(packet, info.mountNsID)
+		packetArray.Append(packet)
+	}
+
+	inst.prevStats = newPrevStats
+	return inst.dataSource.EmitAndRelease(packetArray)
+}
+
+// ---------------------------------------------------------------------------
+// Cgroup discovery
+// ---------------------------------------------------------------------------
+
+// discoverCgroups iterates /proc to find all unique cgroup v2 paths, then
+// reads CPU throttling data for those that have a bandwidth limit (non-"max"
+// quota in cpu.max).
+func discoverCgroups(gadgetCtx operators.GadgetContext) ([]cgroupInfo, error) {
+	entries, err := os.ReadDir(host.HostProcFs)
+	if err != nil {
+		return nil, fmt.Errorf("reading proc directory: %w", err)
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	cgroupMap := make(map[string]int) // cgroup path → representative PID
+	pidQueue := make(chan int, 64)
+
+	workers := runtime.NumCPU()
+	for range workers {
+		wg.Go(func() {
+			for pid := range pidQueue {
+				_, v2Path, err := cgroups.GetCgroupPaths(pid)
+				if err != nil || v2Path == "" {
+					continue
+				}
+				mu.Lock()
+				if _, exists := cgroupMap[v2Path]; !exists {
+					cgroupMap[v2Path] = pid
+				}
+				mu.Unlock()
+			}
+		})
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		pidQueue <- pid
+	}
+	close(pidQueue)
+	wg.Wait()
+
+	// Read stats for each unique cgroup that has a CPU bandwidth limit.
+	var infos []cgroupInfo
+	for cgPath, pid := range cgroupMap {
+		fullPath, err := cgroups.CgroupPathV2AddMountpoint(cgPath)
+		if err != nil {
+			gadgetCtx.Logger().Debugf("Skipping cgroup %s: %v", cgPath, err)
+			continue
+		}
+
+		cpuMax, err := readCPUMax(fullPath)
+		if err != nil {
+			gadgetCtx.Logger().Debugf("Skipping cgroup %s: cannot read cpu.max: %v", cgPath, err)
+			continue
+		}
+
+		// Skip cgroups without an explicit CPU limit.
+		if cpuMax.quota == -1 {
+			continue
+		}
+
+		stat, err := readCPUStat(fullPath)
+		if err != nil {
+			gadgetCtx.Logger().Debugf("Skipping cgroup %s: cannot read cpu.stat: %v", cgPath, err)
+			continue
+		}
+
+		psi := readCPUPressure(fullPath)
+		mntNsID, _ := containerutils.GetMntNs(pid)
+
+		infos = append(infos, cgroupInfo{
+			cgroupPath: cgPath,
+			stat:       stat,
+			max:        cpuMax,
+			psi:        psi,
+			mountNsID:  mntNsID,
+		})
+	}
+
+	return infos, nil
+}
+
+// ---------------------------------------------------------------------------
+// Cgroup v2 file parsers
+// ---------------------------------------------------------------------------
+
+// readCPUStat parses the cpu.stat file.
+//
+// Example content:
+//
+//	usage_usec 123456
+//	user_usec 100000
+//	system_usec 23456
+//	nr_periods 1000
+//	nr_throttled 50
+//	throttled_usec 500000
+func readCPUStat(cgroupFullPath string) (cpuStat, error) {
+	var stat cpuStat
+
+	data, err := os.ReadFile(filepath.Join(cgroupFullPath, "cpu.stat"))
+	if err != nil {
+		return stat, err
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		val, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "nr_periods":
+			stat.nrPeriods = val
+		case "nr_throttled":
+			stat.nrThrottled = val
+		case "throttled_usec":
+			stat.throttledUsec = val
+		}
+	}
+
+	return stat, nil
+}
+
+// readCPUMax parses the cpu.max file.
+//
+// Format: "<quota> <period>" or "max <period>"
+func readCPUMax(cgroupFullPath string) (cpuMax, error) {
+	var result cpuMax
+
+	data, err := os.ReadFile(filepath.Join(cgroupFullPath, "cpu.max"))
+	if err != nil {
+		return result, err
+	}
+
+	fields := strings.Fields(strings.TrimSpace(string(data)))
+	if len(fields) != 2 {
+		return result, fmt.Errorf("unexpected cpu.max format: %q", string(data))
+	}
+
+	if fields[0] == "max" {
+		result.quota = -1
+	} else {
+		quota, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			return result, fmt.Errorf("parsing quota: %w", err)
+		}
+		result.quota = quota
+	}
+
+	period, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return result, fmt.Errorf("parsing period: %w", err)
+	}
+	result.period = period
+
+	return result, nil
+}
+
+// readCPUPressure parses the cpu.pressure file. Returns a zero-value
+// psiMetrics (with available=false) if the file cannot be read, so
+// callers never need to treat a missing PSI file as an error.
+//
+// Example content:
+//
+//	some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+//	full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+func readCPUPressure(cgroupFullPath string) psiMetrics {
+	var psi psiMetrics
+
+	data, err := os.ReadFile(filepath.Join(cgroupFullPath, "cpu.pressure"))
+	if err != nil {
+		return psi
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "some ") {
+			psi.someAvg10, psi.someAvg60 = parsePSILine(line)
+			psi.available = true
+		}
+	}
+
+	return psi
+}
+
+// parsePSILine extracts avg10 and avg60 from a PSI line such as:
+//
+//	some avg10=0.50 avg60=1.20 avg300=0.80 total=12345
+func parsePSILine(line string) (avg10, avg60 float64) {
+	for field := range strings.FieldsSeq(line) {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			continue
+		}
+		switch parts[0] {
+		case "avg10":
+			avg10 = val
+		case "avg60":
+			avg60 = val
+		}
+	}
+	return
+}
+
+// Operator is the global instance registered via init().
+var Operator = &cgroupOperator{}
+
+func init() {
+	operators.RegisterDataOperator(Operator)
+}

--- a/pkg/operators/cgroup/cgroup_test.go
+++ b/pkg/operators/cgroup/cgroup_test.go
@@ -1,0 +1,810 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
+)
+
+// ---------------------------------------------------------------------------
+// Parser tests: readCPUStat
+// ---------------------------------------------------------------------------
+
+func TestReadCPUStat(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `usage_usec 1234567
+user_usec 1000000
+system_usec 234567
+nr_periods 5000
+nr_throttled 150
+throttled_usec 750000
+nr_bursts 0
+burst_usec 0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.stat"), []byte(content), 0o644))
+
+	stat, err := readCPUStat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5000), stat.nrPeriods)
+	assert.Equal(t, uint64(150), stat.nrThrottled)
+	assert.Equal(t, uint64(750000), stat.throttledUsec)
+}
+
+func TestReadCPUStatMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readCPUStat(dir)
+	require.Error(t, err)
+}
+
+func TestReadCPUStatPartialFields(t *testing.T) {
+	dir := t.TempDir()
+	// File exists but only has some of the fields we care about
+	content := `usage_usec 100
+nr_throttled 42
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.stat"), []byte(content), 0o644))
+
+	stat, err := readCPUStat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), stat.nrPeriods)
+	assert.Equal(t, uint64(42), stat.nrThrottled)
+	assert.Equal(t, uint64(0), stat.throttledUsec)
+}
+
+func TestReadCPUStatMalformedValues(t *testing.T) {
+	dir := t.TempDir()
+	// Non-numeric values should be silently skipped
+	content := `nr_periods notanumber
+nr_throttled 10
+throttled_usec -5
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.stat"), []byte(content), 0o644))
+
+	stat, err := readCPUStat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), stat.nrPeriods)
+	assert.Equal(t, uint64(10), stat.nrThrottled)
+	assert.Equal(t, uint64(0), stat.throttledUsec) // -5 fails ParseUint
+}
+
+func TestReadCPUStatEmpty(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.stat"), []byte(""), 0o644))
+
+	stat, err := readCPUStat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), stat.nrPeriods)
+	assert.Equal(t, uint64(0), stat.nrThrottled)
+	assert.Equal(t, uint64(0), stat.throttledUsec)
+}
+
+// ---------------------------------------------------------------------------
+// Parser tests: readCPUMax
+// ---------------------------------------------------------------------------
+
+func TestReadCPUMax(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantQuota  int64
+		wantPeriod uint64
+		wantErr    bool
+	}{
+		{
+			name:       "limited",
+			content:    "50000 100000\n",
+			wantQuota:  50000,
+			wantPeriod: 100000,
+		},
+		{
+			name:       "unlimited",
+			content:    "max 100000\n",
+			wantQuota:  -1,
+			wantPeriod: 100000,
+		},
+		{
+			name:    "malformed_single_field",
+			content: "garbage",
+			wantErr: true,
+		},
+		{
+			name:    "malformed_quota_not_number",
+			content: "abc 100000\n",
+			wantErr: true,
+		},
+		{
+			name:    "malformed_period_not_number",
+			content: "50000 xyz\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			content: "",
+			wantErr: true,
+		},
+		{
+			name:    "three_fields",
+			content: "50000 100000 extra\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.max"), []byte(tt.content), 0o644))
+
+			result, err := readCPUMax(dir)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantQuota, result.quota)
+			assert.Equal(t, tt.wantPeriod, result.period)
+		})
+	}
+}
+
+func TestReadCPUMaxMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readCPUMax(dir)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Parser tests: readCPUPressure
+// ---------------------------------------------------------------------------
+
+func TestReadCPUPressure(t *testing.T) {
+	t.Run("available", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `some avg10=1.50 avg60=2.30 avg300=0.80 total=12345
+full avg10=0.10 avg60=0.20 avg300=0.05 total=678
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.pressure"), []byte(content), 0o644))
+
+		psi := readCPUPressure(dir)
+		assert.True(t, psi.available)
+		assert.InDelta(t, 1.50, psi.someAvg10, 0.001)
+		assert.InDelta(t, 2.30, psi.someAvg60, 0.001)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		dir := t.TempDir()
+		psi := readCPUPressure(dir)
+		assert.False(t, psi.available)
+	})
+
+	t.Run("no_some_line", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `full avg10=0.10 avg60=0.20 avg300=0.05 total=678
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.pressure"), []byte(content), 0o644))
+
+		psi := readCPUPressure(dir)
+		assert.False(t, psi.available)
+		assert.Equal(t, float64(0), psi.someAvg10)
+		assert.Equal(t, float64(0), psi.someAvg60)
+	})
+
+	t.Run("empty_file", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cpu.pressure"), []byte(""), 0o644))
+
+		psi := readCPUPressure(dir)
+		assert.False(t, psi.available)
+		assert.Equal(t, float64(0), psi.someAvg10)
+		assert.Equal(t, float64(0), psi.someAvg60)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Parser tests: parsePSILine
+// ---------------------------------------------------------------------------
+
+func TestParsePSILine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantAvg10 float64
+		wantAvg60 float64
+	}{
+		{
+			name:      "normal",
+			line:      "some avg10=5.25 avg60=3.10 avg300=1.00 total=999",
+			wantAvg10: 5.25,
+			wantAvg60: 3.10,
+		},
+		{
+			name:      "zeroes",
+			line:      "some avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+			wantAvg10: 0.0,
+			wantAvg60: 0.0,
+		},
+		{
+			name:      "high_values",
+			line:      "some avg10=99.99 avg60=50.00 avg300=25.00 total=123456789",
+			wantAvg10: 99.99,
+			wantAvg60: 50.00,
+		},
+		{
+			name:      "empty_line",
+			line:      "",
+			wantAvg10: 0,
+			wantAvg60: 0,
+		},
+		{
+			name:      "no_equals",
+			line:      "some avg10 avg60 avg300 total",
+			wantAvg10: 0,
+			wantAvg60: 0,
+		},
+		{
+			name:      "malformed_values",
+			line:      "some avg10=abc avg60=def avg300=ghi total=jkl",
+			wantAvg10: 0,
+			wantAvg60: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			avg10, avg60 := parsePSILine(tt.line)
+			assert.InDelta(t, tt.wantAvg10, avg10, 0.001)
+			assert.InDelta(t, tt.wantAvg60, avg60, 0.001)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Operator lifecycle tests
+// ---------------------------------------------------------------------------
+
+func TestCgroupOperatorDisabled(t *testing.T) {
+	config := viper.New()
+	config.Set(configKeyEnabled, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	setupOp := simple.New("setup",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			gadgetCtx.SetVar("config", config)
+			return nil
+		}),
+		simple.OnStart(func(gadgetCtx operators.GadgetContext) error {
+			ds := gadgetCtx.GetDataSources()["cgroups"]
+			assert.Nil(t, ds)
+			return nil
+		}),
+	)
+
+	op := &cgroupOperator{}
+	gadgetCtx := gadgetcontext.New(ctx, "test", gadgetcontext.WithDataOperators(op, setupOp))
+
+	err := gadgetCtx.Run(api.ParamValues{})
+	require.NoError(t, err)
+}
+
+type testSubscriber struct {
+	mu     sync.Mutex
+	events []datasource.Data
+}
+
+func (s *testSubscriber) handleEvent(ds datasource.DataSource, data datasource.Data) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, data)
+	return nil
+}
+
+func (s *testSubscriber) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.events)
+}
+
+// ---------------------------------------------------------------------------
+// Delta computation and emission tests using a fake discoverer
+// ---------------------------------------------------------------------------
+
+// fakeDiscoverer returns a sequence of cgroupInfo slices, one per call.
+type fakeDiscoverer struct {
+	mu       sync.Mutex
+	calls    int
+	sequence [][]cgroupInfo
+}
+
+func (f *fakeDiscoverer) discover(_ operators.GadgetContext) ([]cgroupInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	idx := f.calls
+	f.calls++
+	if idx >= len(f.sequence) {
+		return nil, nil
+	}
+	return f.sequence[idx], nil
+}
+
+func (f *fakeDiscoverer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// runWithFakeDiscoverer creates a gadget context with the cgroup operator
+// configured to use a fake discover function, subscribes to events, and
+// runs until the context expires. Returns the collected events.
+func runWithFakeDiscoverer(t *testing.T, fake *fakeDiscoverer, interval time.Duration, count int, timeout time.Duration) *testSubscriber {
+	t.Helper()
+
+	config := viper.New()
+	config.Set(configKeyEnabled, true)
+	config.Set(configKeyInterval, interval.String())
+	if count > 0 {
+		config.Set(configKeyCount, count)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	subscriber := &testSubscriber{events: make([]datasource.Data, 0)}
+
+	setupOp := simple.New("setup",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			gadgetCtx.SetVar("config", config)
+			return nil
+		}),
+		simple.OnStart(func(gadgetCtx operators.GadgetContext) error {
+			ds := gadgetCtx.GetDataSources()["cgroups"]
+			require.NotNil(t, ds)
+			return ds.Subscribe(subscriber.handleEvent, Priority+1)
+		}),
+	)
+
+	// Swap the package-level discover function for the fake, restore after test.
+	old := discoverCgroupsFn
+	discoverCgroupsFn = fake.discover
+	t.Cleanup(func() { discoverCgroupsFn = old })
+
+	op := &cgroupOperator{}
+	gadgetCtx := gadgetcontext.New(ctx, "test", gadgetcontext.WithDataOperators(op, setupOp))
+	err := gadgetCtx.Run(api.ParamValues{})
+	require.NoError(t, err)
+
+	return subscriber
+}
+
+func TestDeltaComputationBasic(t *testing.T) {
+	// Two collection rounds: first establishes baseline (no emit), second emits deltas.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/test",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 5000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+			},
+			// Round 1: cumulative values increased
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/test",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 30, throttledUsec: 15000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+
+	// We should have received exactly 1 emission (count=1 means 1 tick after baseline).
+	require.Equal(t, 1, subscriber.count())
+}
+
+func TestDeltaComputationInactiveCgroupsFiltered(t *testing.T) {
+	// Cgroups with zero delta in both nrPeriods and nrThrottled should be filtered out.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/active",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 5000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/inactive",
+					stat:       cpuStat{nrPeriods: 50, nrThrottled: 0, throttledUsec: 0},
+					max:        cpuMax{quota: 30000, period: 100000},
+				},
+			},
+			// Round 1: only "active" has new activity; "inactive" is unchanged
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/active",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 20, throttledUsec: 10000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/inactive",
+					stat:       cpuStat{nrPeriods: 50, nrThrottled: 0, throttledUsec: 0},
+					max:        cpuMax{quota: 30000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// Only the active cgroup should produce a row in the emitted packet.
+	require.Equal(t, 1, subscriber.count())
+}
+
+func TestCountLimitsEmissions(t *testing.T) {
+	// With count=3 and constant activity, we should get exactly 3 emissions.
+	makeCgroups := func() []cgroupInfo {
+		return []cgroupInfo{
+			{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 5000},
+				max:        cpuMax{quota: 50000, period: 100000},
+			},
+		}
+	}
+
+	fake := &fakeDiscoverer{
+		sequence: func() [][]cgroupInfo {
+			// Generate enough rounds: 1 baseline + 3 counted ticks + extra
+			rounds := make([][]cgroupInfo, 10)
+			for i := range rounds {
+				infos := makeCgroups()
+				// Make counters increase each round so delta > 0
+				infos[0].stat.nrPeriods = uint64(100 * (i + 1))
+				infos[0].stat.nrThrottled = uint64(10 * (i + 1))
+				infos[0].stat.throttledUsec = uint64(5000 * (i + 1))
+				rounds[i] = infos
+			}
+			return rounds
+		}(),
+	}
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 3, 50*time.Millisecond)
+
+	// Should get exactly 3 emissions (count=3 stops the monitor loop after 3 ticks).
+	require.Equal(t, 3, subscriber.count())
+}
+
+func TestNoBaselineEmission(t *testing.T) {
+	// First call to collectAndEmit should NOT emit (emit=false). Even with
+	// active cgroups, the baseline collection is silent.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline — active cgroup, but should not emit
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/test",
+					stat:       cpuStat{nrPeriods: 500, nrThrottled: 100, throttledUsec: 99999},
+					max:        cpuMax{quota: 10000, period: 100000},
+				},
+			},
+			// Round 1: same values as baseline — delta is 0, so nothing emitted
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/test",
+					stat:       cpuStat{nrPeriods: 500, nrThrottled: 100, throttledUsec: 99999},
+					max:        cpuMax{quota: 10000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// Delta is zero between rounds, so the subscriber receives no data rows.
+	require.Equal(t, 0, subscriber.count())
+}
+
+func TestEmptyDiscovery(t *testing.T) {
+	// If no cgroups are discovered, the operator should run without errors.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			{}, // empty
+			{}, // empty
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// No cgroups discovered, so subscriber receives no data rows.
+	require.Equal(t, 0, subscriber.count())
+}
+
+func TestMultipleCgroupsDeltaComputation(t *testing.T) {
+	// Test that deltas are computed independently per cgroup path.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline with two cgroups
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/web",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/worker",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 50, throttledUsec: 8000},
+					max:        cpuMax{quota: 25000, period: 100000},
+				},
+			},
+			// Round 1: both advance by different amounts
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/web",
+					stat:       cpuStat{nrPeriods: 150, nrThrottled: 15, throttledUsec: 2000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/worker",
+					stat:       cpuStat{nrPeriods: 400, nrThrottled: 150, throttledUsec: 30000},
+					max:        cpuMax{quota: 25000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// Both cgroups had activity, so the subscriber receives 2 data rows.
+	require.Equal(t, 2, subscriber.count())
+}
+
+func TestNewCgroupAppearsAfterBaseline(t *testing.T) {
+	// A cgroup that wasn't in the baseline is recorded as a new baseline on
+	// first sight (no emission). It only emits on the *next* interval once
+	// a proper delta can be computed.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: only cgroup A
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/a",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+			},
+			// Round 1: cgroup A advances; new cgroup B appears (baseline recorded, not emitted)
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/a",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 20, throttledUsec: 2000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/b",
+					stat:       cpuStat{nrPeriods: 50, nrThrottled: 5, throttledUsec: 500},
+					max:        cpuMax{quota: 30000, period: 100000},
+				},
+			},
+			// Round 2: both advance — now B has a baseline and can emit
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/a",
+					stat:       cpuStat{nrPeriods: 300, nrThrottled: 30, throttledUsec: 3000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/b",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+					max:        cpuMax{quota: 30000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 2, 50*time.Millisecond)
+	// Round 1: only cgroup A emits (B is new, baseline only) → 1 row.
+	// Round 2: both A and B emit (B now has a previous baseline) → 2 rows.
+	// Total data rows = 3.
+	require.Equal(t, 3, subscriber.count())
+}
+
+func TestCgroupDisappearsCleanly(t *testing.T) {
+	// A cgroup present in baseline but gone in the next round should not cause errors.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: two cgroups
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/a",
+					stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+				{
+					cgroupPath: "/sys/fs/cgroup/b",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 20, throttledUsec: 2000},
+					max:        cpuMax{quota: 30000, period: 100000},
+				},
+			},
+			// Round 1: only cgroup A remains, B disappeared
+			{
+				{
+					cgroupPath: "/sys/fs/cgroup/a",
+					stat:       cpuStat{nrPeriods: 200, nrThrottled: 20, throttledUsec: 2000},
+					max:        cpuMax{quota: 50000, period: 100000},
+				},
+			},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// Should succeed without panics or errors, with only cgroup A in the emission.
+	require.Equal(t, 1, subscriber.count())
+}
+
+func TestPSIFieldsIncludedWhenAvailable(t *testing.T) {
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Baseline
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+				max:        cpuMax{quota: 50000, period: 100000},
+				psi:        psiMetrics{available: true, someAvg10: 5.5, someAvg60: 3.2},
+			}},
+			// Round 1
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 200, nrThrottled: 30, throttledUsec: 5000},
+				max:        cpuMax{quota: 50000, period: 100000},
+				psi:        psiMetrics{available: true, someAvg10: 8.1, someAvg60: 6.0},
+			}},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	require.Equal(t, 1, subscriber.count())
+}
+
+func TestCounterResetDeltaClampedToZero(t *testing.T) {
+	// When a cgroup is destroyed and recreated, cumulative counters may
+	// decrease. The operator should clamp each delta to zero rather than
+	// wrapping around as a huge uint64.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline with high cumulative values
+			{{
+				cgroupPath: "/sys/fs/cgroup/reset",
+				stat:       cpuStat{nrPeriods: 5000, nrThrottled: 500, throttledUsec: 100000},
+				max:        cpuMax{quota: 50000, period: 100000},
+			}},
+			// Round 1: counters are lower than baseline (cgroup was recycled)
+			{{
+				cgroupPath: "/sys/fs/cgroup/reset",
+				stat:       cpuStat{nrPeriods: 10, nrThrottled: 2, throttledUsec: 300},
+				max:        cpuMax{quota: 50000, period: 100000},
+			}},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// All deltas are clamped to zero (new < old), so nrPeriods=0 and
+	// nrThrottled=0 → the cgroup is filtered as inactive.
+	require.Equal(t, 0, subscriber.count())
+}
+
+func TestFirstIntervalEmission(t *testing.T) {
+	// When firstInterval is set, the operator should emit once after the
+	// first-interval timer and then continue with the regular ticker.
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Round 0: baseline
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+				max:        cpuMax{quota: 50000, period: 100000},
+			}},
+			// Round 1: first-interval emission
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 150, nrThrottled: 20, throttledUsec: 3000},
+				max:        cpuMax{quota: 50000, period: 100000},
+			}},
+			// Round 2: regular ticker emission
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 250, nrThrottled: 40, throttledUsec: 7000},
+				max:        cpuMax{quota: 50000, period: 100000},
+			}},
+		},
+	}
+
+	config := viper.New()
+	config.Set(configKeyEnabled, true)
+	config.Set(configKeyInterval, (10 * time.Millisecond).String())
+	config.Set(configKeyFirstInterval, (5 * time.Millisecond).String())
+	config.Set(configKeyCount, 1) // 1 regular tick after the first-interval
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	subscriber := &testSubscriber{events: make([]datasource.Data, 0)}
+
+	setupOp := simple.New("setup",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			gadgetCtx.SetVar("config", config)
+			return nil
+		}),
+		simple.OnStart(func(gadgetCtx operators.GadgetContext) error {
+			ds := gadgetCtx.GetDataSources()["cgroups"]
+			require.NotNil(t, ds)
+			return ds.Subscribe(subscriber.handleEvent, Priority+1)
+		}),
+	)
+
+	old := discoverCgroupsFn
+	discoverCgroupsFn = fake.discover
+	t.Cleanup(func() { discoverCgroupsFn = old })
+
+	op := &cgroupOperator{}
+	gadgetCtx := gadgetcontext.New(ctx, "test", gadgetcontext.WithDataOperators(op, setupOp))
+	err := gadgetCtx.Run(api.ParamValues{})
+	require.NoError(t, err)
+
+	// Expect 2 emissions: one from first-interval, one from the regular ticker (count=1).
+	require.Equal(t, 2, subscriber.count())
+}
+
+func TestPSIFieldsGracefulWhenUnavailable(t *testing.T) {
+	fake := &fakeDiscoverer{
+		sequence: [][]cgroupInfo{
+			// Baseline — PSI unavailable
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 100, nrThrottled: 10, throttledUsec: 1000},
+				max:        cpuMax{quota: 50000, period: 100000},
+				psi:        psiMetrics{available: false},
+			}},
+			// Round 1 — PSI still unavailable
+			{{
+				cgroupPath: "/sys/fs/cgroup/test",
+				stat:       cpuStat{nrPeriods: 200, nrThrottled: 30, throttledUsec: 5000},
+				max:        cpuMax{quota: 50000, period: 100000},
+				psi:        psiMetrics{available: false},
+			}},
+		},
+	}
+
+	subscriber := runWithFakeDiscoverer(t, fake, 5*time.Millisecond, 1, 50*time.Millisecond)
+	// Should work fine even without PSI data.
+	require.Equal(t, 1, subscriber.count())
+}

--- a/pkg/testing/gadgetrunner/gadgetrunner.go
+++ b/pkg/testing/gadgetrunner/gadgetrunner.go
@@ -43,6 +43,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/local"
 
 	// TODO: create a common package with all operators
+	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cgroup"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/ebpf"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/filter"
 	_ "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/formatters"


### PR DESCRIPTION
## Add `top_cpu_throttle` gadget to detect CFS bandwidth throttling

This PR adds a new gadget that helps identify containers suffering from CPU pressure due to tight cgroup CPU limits (CFS throttling), rather than actual CPU overutilization.

### Problem

When a container is under CPU pressure, `top`/`htop` may show plenty of available CPU — the issue is the cgroup's CFS bandwidth limit being too tight. Today there is no easy way to rank which pods are the worst throttle offenders across a cluster.

### Solution

A new `top_cpu_throttle` gadget implemented as a pure userspace operator (no eBPF) that periodically reads cgroup v2 files and reports per-container throttling metrics:

| File | Data |
|---|---|
| `cpu.stat` | `nr_periods`, `nr_throttled`, `throttled_usec` (cumulative counters) |
| `cpu.max` | Quota and period (the CPU bandwidth limit) |
| `cpu.pressure` | PSI "some" averages (optional, gracefully skipped if unavailable) |

**Reported columns:**

| Column | Description |
|---|---|
| `PERIODS` | CFS enforcement intervals elapsed per reporting window |
| `THROTTLED` | Times the cgroup was throttled per reporting window |
| `THROTTLED_TIME` | Time spent throttled (human-readable duration) |
| `%THROT` | Throttle percentage (0–100) |
| `QUOTA` | CPU quota per CFS period (human-readable duration) |
| `LIMIT` | Effective CPU core limit (quota / period) |
| `%PSI10` / `%PSI60` | PSI "some" CPU pressure over 10s / 60s |

**Design decisions:**
- **cgroup v2 only** — the modern standard
- **Delta computation** — `cpu.stat` counters are cumulative; the operator tracks previous values per cgroup and reports per-interval deltas
- **Unlimited cgroups filtered out** — only cgroups with an explicit CPU bandwidth limit are shown
- **PSI "full" omitted** — CFS throttling is all-or-nothing at the cgroup level, so "full" is always identical to "some"
- **Duration formatting** — `throttledTime`, `cpuQuota`, and `cpuPeriod` use the built-in `gadget_duration` formatter for human-readable output
- Follows the existing `top_process` operator pattern (per-instance monitor loop, no eBPF)

### Testing

**Unit tests:**
```bash
go test ./pkg/operators/cgroup/ -v
```

**Manual test on Kubernetes (minikube):**

1. Deploy Inspektor Gadget:
   ```bash
   make minikube-deploy
   ```

2. Build and push the gadget image:
   ```bash
   ig image build -t ghcr.io/<your-registry>/test:top_cpu_throttle ./gadgets/top_cpu_throttle/
   ig image push ghcr.io/<your-registry>/test:top_cpu_throttle
   ```

3. Create test pods with different CPU limits and workloads:
   ```bash
   # 100% throttled — busy loop with tight limit
   kubectl run full-throttle --image=busybox --restart=Never --overrides='
   {"spec":{"containers":[{"name":"full-throttle","image":"busybox",
     "command":["sh","-c","while true; do :; done"],
     "resources":{"limits":{"cpu":"100m"}}}]}}'

   # Partially throttled — intermittent CPU bursts
   kubectl run light-load --image=busybox --restart=Never --overrides='
   {"spec":{"containers":[{"name":"light-load","image":"busybox",
     "command":["sh","-c","while true; do i=0; while [ $i -lt 2000 ]; do i=$((i+1)); done; sleep 0.08; done"],
     "resources":{"limits":{"cpu":"100m"}}}]}}'

   # Not throttled — generous limit
   kubectl run batch-job --image=busybox --restart=Never --overrides='
   {"spec":{"containers":[{"name":"batch-job","image":"busybox",
     "command":["sh","-c","while true; do :; done"],
     "resources":{"limits":{"cpu":"1000m"}}}]}}'
   ```

4. Run the gadget:
   ```bash
   kubectl-gadget run ghcr.io/<your-registry>/test:top_cpu_throttle --pull=always
   ```

**Expected output** (three distinct throttle levels):
```
K8S.NODE     K8S.NAMESPACE K8S.PODNAME     K8S.CONTAINER  PERIODS THROTTLED THROTTLED_TIME %THROT   QUOTA  LIMIT %PSI10 %PSI60
minikube     default       full-throttle   full-throttle       50        50       4.36049s 100.00 10.00ms   0.10  75.45  30.31
minikube     default       light-load      light-load          50         5       32.68ms   10.00 10.00ms   0.10   0.15   0.07
minikube     default       batch-job       batch-job           50         0           0ns    0.00 100.00m   1.00   0.00   0.00
```