### PR TITLE
deploy: Replace nodes/proxy with nodes/configz

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1304,7 +1304,7 @@ jobs:
             # So, this variables controls whether the last layer of
             # gadget-builder, i.e. the one upgrading the packages to be run
             # without cache.
-            # Changing this value in the repository will force this behaviorn,
+            # Changing this value in the repository will force this behavior,
             # this is particularly useful if trivy reports a CVE in the image
             # and fixed versions exist in debian repository.
             build-args: |

--- a/charts/gadget/templates/clusterrole.yaml
+++ b/charts/gadget/templates/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     k8s-app: {{ include "gadget.fullname" . }}
 rules:
   - apiGroups: [""]
-    resources: ["nodes/proxy"]
+    resources: ["nodes/configz"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["namespaces", "nodes", "pods"]

--- a/docs/reference/install-kubernetes.md
+++ b/docs/reference/install-kubernetes.md
@@ -311,6 +311,42 @@ operator:
 podman-socketpath: /run/podman/podman.sock
 ```
 
+##### Container Runtime Socket Path Detection
+
+Inspektor Gadget automatically detects the container runtime socket path by
+querying the kubelet's `/configz` endpoint on each node. This requires the
+`nodes/configz` RBAC permission, which is granted automatically on clusters
+running Kubernetes v1.33 or later (where fine-grained kubelet API authorization
+is enabled by default, see
+[KEP-2862](https://github.com/kubernetes/enhancements/issues/2862)).
+
+On older clusters (before v1.33), or on distributions where the kubelet API
+authorization feature gate has been explicitly disabled, socket path
+auto-detection is not available. Inspektor Gadget will log a warning and fall
+back to the configured socket path:
+
+```
+time="2026-08-10T14:36:21Z" level=warning msg="Failed to retrieve socket path for runtime client from kubelet: getting /configz: fetching /configz from \"minikube-docker\": kubelet /configz status is 403, expected: 200. Falling back to default container runtime"
+time="2026-08-10T14:36:21Z" level=warning msg="Failed to retrieve socket path for runtime client from kubelet: getting /configz: fetching /configz from \"minikube-docker\": kubelet /configz status is 403, expected: 200. Falling back to default container runtime"
+```
+
+If the default path does not match your setup, you can set it explicitly in a
+daemon configuration file:
+
+```yaml
+# daemon-config.yaml
+containerd-socketpath: /run/containerd/containerd.sock
+crio-socketpath:       /run/crio/crio.sock
+docker-socketpath:     /run/docker.sock
+podman-socketpath:     /run/podman/podman.sock
+```
+
+Then deploy with:
+
+```bash
+$ kubectl gadget deploy --daemon-config=daemon-config.yaml
+```
+
 ##### Other Deploy Options
 
 Please check the following documents to learn more about different options:

--- a/pkg/container-collection/k8s.go
+++ b/pkg/container-collection/k8s.go
@@ -16,12 +16,16 @@ package containercollection
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -49,6 +53,8 @@ type K8sClient struct {
 	runtimeClient runtimeclient.ContainerRuntimeClient
 	RuntimeConfig *containerutilsTypes.RuntimeConfig
 }
+
+const kubeletPort = "10250"
 
 func NewK8sClient(nodeName string, kubeconfigPath string, userAgentComment string) (*K8sClient, error) {
 	clientset, err := k8sutil.NewClientset(kubeconfigPath, userAgentComment)
@@ -257,18 +263,90 @@ func getContainerRuntimeSocketPath(clientset *kubernetes.Clientset, nodeName str
 	return socketPath, nil
 }
 
-// The /configz endpoint isn't officially documented. It was introduced in Kubernetes 1.26 and been around for a long time
-// as stated in https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/configz/OWNERS
+func getNodeInternalIP(node *v1.Node) (string, error) {
+	for _, a := range node.Status.Addresses {
+		if a.Type == v1.NodeInternalIP && a.Address != "" {
+			return a.Address, nil
+		}
+	}
+	return "", fmt.Errorf("no internal IP found for node %q", node.Name)
+}
+
+func getCurrentKubeletConfigThroughNodesConfigz(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) ([]byte, error) {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting node %q: %w", nodeName, err)
+	}
+
+	nodeIP, err := getNodeInternalIP(node)
+	if err != nil {
+		return nil, fmt.Errorf("getting node internal IP: %w", err)
+	}
+
+	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return nil, fmt.Errorf("reading service account token: %w", err)
+	}
+
+	// Let's dialog with the kubelet through HTTPS.
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				// We cannot verify the kubelet serving
+				// certificate: there is no portable way to get
+				// the kubelet CA (it depends on the
+				// distribution), and fetching it from the
+				// kubelet itself would only verify the peer
+				// against the cert it just presented.
+				// Proxy is disabled so the request cannot
+				// leave the node; intercepting it requires
+				// host/CNI level control, at which point the
+				// attacker already owns the kubelet and our
+				// privileged pod.
+				// Same trade-off as node-feature-discovery's
+				// topology-updater:
+				// https://github.com/kubernetes-sigs/node-feature-discovery/blob/b35e1db7e862/pkg/nfd-topology-updater/nfd-topology-updater.go#L561-L573
+				// https://github.com/kubernetes-sigs/node-feature-discovery/blob/76e6cc8cc0d5/pkg/utils/kubeconf/kubelet_configz.go#L82
+				InsecureSkipVerify: true, //nolint:gosec
+				ServerName:         nodeName,
+			},
+			Proxy: nil,
+		},
+		Timeout: 5 * time.Second,
+	}
+	url := fmt.Sprintf("https://%s:%s/configz", nodeIP, kubeletPort)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building http request to kubelet %q: %w", url, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting kubelet /configz at %q: %w", url, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("kubelet /configz status is %d, expected: %d", response.StatusCode, http.StatusOK)
+	}
+
+	return io.ReadAll(io.LimitReader(response.Body, 5<<20 /* 5MiB */))
+}
+
 func getCurrentKubeletConfig(clientset *kubernetes.Clientset, nodeName string) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
-	resp, err := clientset.CoreV1().RESTClient().Get().Resource("nodes").
-		Name(nodeName).Suffix("proxy", "configz").DoRaw(context.TODO())
+	resp, err := getCurrentKubeletConfigThroughNodesConfigz(context.TODO(), clientset, nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("fetching /configz from %q: %w", nodeName, err)
 	}
+
 	kubeCfg, err := decodeConfigz(resp)
 	if err != nil {
 		return nil, err
 	}
+
 	return kubeCfg, nil
 }
 

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -59,7 +59,7 @@ metadata:
     k8s-app: gadget
 rules:
   - apiGroups: [""]
-    resources: ["nodes/proxy"]
+    resources: ["nodes/configz"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["namespaces", "nodes", "pods"]


### PR DESCRIPTION
Since cd40f60ac959 ("container-collection/k8s: auto detect container runtime socket path"), Inspektor Gadget relies on nodes/proxy to access to configz to get the container runtime socket path.
Unfortunately, nodes/proxy, even with the "get" verb permits remote code execution [2].
With k8s 1.36, fine-grained kubelet API authorizations were added to only have access to the configz [3].

This commit modifies the deployment process to check if the target cluster is at least k8s 1.36. If so, the nodes/proxy authorization is replaced by configz.

[1]: https://github.com/inspektor-gadget/inspektor-gadget/commit/cd40f60ac959
[2]: https://kubernetes.io/docs/concepts/security/rbac-good-practices/#access-to-proxy-subresource-of-nodes
[3]: https://github.com/kubernetes/kubernetes/pull/136116
