### PR TITLE
fix(`params`): make parameter names case-insensitive

### DIFF
--- a/pkg/gadget-service/api/helpers.go
+++ b/pkg/gadget-service/api/helpers.go
@@ -86,10 +86,15 @@ func (pv Params) AddPrefix(prefix string) Params {
 
 func (pv ParamValues) ExtractPrefixedValues(prefix string) ParamValues {
 	prefix = prefix + "."
+	lowerPrefix := strings.ToLower(prefix)
 	res := make(ParamValues)
 	for k, v := range pv {
 		if strings.HasPrefix(k, prefix) {
 			res[strings.TrimPrefix(k, prefix)] = v
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(k), lowerPrefix) {
+			res[k[len(lowerPrefix):]] = v
 		}
 	}
 	return res

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -179,6 +179,11 @@ func (p *ParamDescs) Get(key string) *ParamDesc {
 			return param
 		}
 	}
+	for _, param := range *p {
+		if strings.EqualFold(key, param.Key) || (param.AlternativeKey != "" && strings.EqualFold(key, param.AlternativeKey)) {
+			return param
+		}
+	}
 	return nil
 }
 
@@ -212,12 +217,22 @@ func (p *Params) Get(key string) *Param {
 			return param
 		}
 	}
+	for _, param := range *p {
+		if strings.EqualFold(key, param.Key) || (param.AlternativeKey != "" && strings.EqualFold(key, param.AlternativeKey)) {
+			return param
+		}
+	}
 	return nil
 }
 
 func (p *Params) Set(key, val string) error {
 	for _, e := range *p {
 		if e.Key == key || e.AlternativeKey == key {
+			return e.Set(val)
+		}
+	}
+	for _, e := range *p {
+		if strings.EqualFold(e.Key, key) || (e.AlternativeKey != "" && strings.EqualFold(e.AlternativeKey, key)) {
 			return e.Set(val)
 		}
 	}
@@ -235,6 +250,14 @@ func (p *Params) ParamMap() (res map[string]string) {
 func (p *Params) ValidateStringMap(cfg map[string]string) error {
 	for _, param := range *p {
 		value, ok := cfg[param.Key]
+		if !ok {
+			for k, v := range cfg {
+				if strings.EqualFold(k, param.Key) || (param.AlternativeKey != "" && strings.EqualFold(k, param.AlternativeKey)) {
+					value, ok = v, true
+					break
+				}
+			}
+		}
 		if !ok && param.IsMandatory {
 			return fmt.Errorf("expected value for %q", param.Key)
 		}
@@ -310,9 +333,11 @@ func (p *Params) CopyToMapExt(target map[string]any, prefix string) {
 }
 
 func (p *Params) CopyFromMap(source map[string]string, prefix string) error {
+	lowerPrefix := strings.ToLower(prefix)
 	for k, v := range source {
-		if strings.HasPrefix(k, prefix) {
-			param := p.Get(strings.TrimPrefix(k, prefix))
+		lowerK := strings.ToLower(k)
+		if strings.HasPrefix(lowerK, lowerPrefix) {
+			param := p.Get(strings.TrimPrefix(lowerK, lowerPrefix))
 			if param == nil || param.value == v {
 				continue
 			}
@@ -333,10 +358,15 @@ func (p *Params) CopyFromMap(source map[string]string, prefix string) error {
 }
 
 func (p Collection) Set(entry, key, val string) error {
-	if _, ok := p[entry]; !ok {
-		return fmt.Errorf("%q is not part of the collection", entry)
+	if params, ok := p[entry]; ok {
+		return params.Set(key, val)
 	}
-	return p[entry].Set(key, val)
+	for collectionKey, params := range p {
+		if strings.EqualFold(collectionKey, entry) {
+			return params.Set(key, val)
+		}
+	}
+	return fmt.Errorf("%q is not part of the collection", entry)
 }
 
 func (p Collection) CopyToMap(target map[string]string, prefix string) {


### PR DESCRIPTION
# Make Parameter Names Case-Insensitive

Parameter names passed via the Go API (and other interfaces) were matched case-sensitively against registered operator param keys. This caused silent failures e.g., passing `"operator.localmanager.containername"` instead of `"operator.LocalManager.containername"` would silently ignore the filter, causing gadgets to behave as if no parameter was set at all.

## Implementation Details

+ **`pkg/gadget-service/api/helpers.go`**: Made `ExtractPrefixedValues()` case-insensitive by computing a lowercased prefix once and adding a fallback `HasPrefix` check against the lowercased incoming key. The fast path (exact match) is preserved with a `continue` to avoid double-matching.
+ **`pkg/params/params.go`**: Added `strings.EqualFold` fallback loops to `(*ParamDescs).Get()`, `(*Params).Get()`, and `(*Params).Set()` this fixes case sensitivity at the primitive lookup level so all callers benefit automatically. Made `CopyFromMap()` case-insensitive by lowercasing both the incoming key and the prefix before `HasPrefix` and `TrimPrefix`.

## Checklist

+ [x] Fixes #4580 
+ [x] Commits are signed-off
+ [x] Unit & Integration Tests pass locally