### PR TITLE
helm: Allow configuring hostPID and hostNetwork

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -35,8 +35,8 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       serviceAccount: {{ include "gadget.fullname" . }}
-      hostPID: false
-      hostNetwork: false
+      hostPID: {{ .Values.hostPID }}
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -75,6 +75,12 @@ skipLabels: false
 additionalLabels:
   labels: {}
 
+# -- Use the host PID namespace
+hostPID: false
+
+# -- Use the host network namespace
+hostNetwork: false
+
 # -- RuntimeClassName used by daemonset
 runtimeClassName: ""
 


### PR DESCRIPTION
In some cases IG needs to be deployed on those namespaces. Allow controlling that from helm as well.


