### PR TITLE
ebpf: clean up partially initialized resources when Start() fails

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -896,6 +896,30 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		}
 	}
 
+	// startSucceeded tracks whether Start() completed successfully. If it
+	// didn't, the deferred cleanup below stops tracer goroutines, closes
+	// attached links, and releases perf FDs so that no resources are leaked
+	// when the caller skips calling Stop() on a failed instance.
+	startSucceeded := false
+	defer func() {
+		if startSucceeded {
+			return
+		}
+		for _, t := range i.tracers {
+			t.close()
+		}
+		for _, l := range i.links {
+			gadgets.CloseLink(l)
+		}
+		i.links = nil
+		for _, fd := range i.perfFds {
+			unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
+			unix.Close(fd)
+		}
+		i.perfFds = nil
+		i.wg.Wait()
+	}()
+
 	for _, tracer := range i.tracers {
 		i.logger.Debugf("starting tracer %q", tracer.mapName)
 		err := i.runTracer(gadgetCtx, tracer)
@@ -951,6 +975,7 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		return fmt.Errorf("running map iterators: %w", err)
 	}
 
+	startSucceeded = true
 	return nil
 }
 


### PR DESCRIPTION
## What's the problem?

While digging into the eBPF operator initialization flow, I found that `ebpfInstance.Start()` doesn't clean up if it fails partway through.

`Start()` runs in phases, it first spawns tracer goroutines, then attaches eBPF programs, then runs iterators. If any later phase fails, it returns an error but leaves the already-started tracers running. Since the caller only calls `Stop()` on operators that started *successfully*, the partially initialized instance never gets cleaned up.

Over time, especially on nodes where gadgets repeatedly fail due to kernel mismatches or BTF issues,  this causes goroutine and file descriptor leaks.

## Fix

I added a deferred rollback at the top of `Start()` that only fires if initialization doesn't complete successfully:

```go
startSucceeded := false

defer func() {
    if startSucceeded {
        return
    }
    for _, t := range i.tracers {
        t.close()
    }
    for _, l := range i.links {
        gadgets.CloseLink(l)
    }
    for _, fd := range i.perfFds {
        unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
        unix.Close(fd)
    }
    i.wg.Wait()
}()
```

At the end of a successful init, I set `startSucceeded = true` so the cleanup is skipped on the happy path.

This makes sure tracer goroutines exit, attached links are released, and perf FDs are closed before `Start()` returns an error.