### PR TITLE
op/generate_networkpolicy: Use podSelector for Services

### DIFF
--- a/pkg/operators/common/kubeinventorycache.go
+++ b/pkg/operators/common/kubeinventorycache.go
@@ -87,7 +87,8 @@ type SlimService struct {
 }
 
 type SlimServiceSpec struct {
-	ClusterIP string `json:"clusterIP"`
+	ClusterIP string            `json:"clusterIP"`
+	Selector  map[string]string `json:"selector,omitempty"`
 }
 
 func NewSlimService(s *v1.Service) *SlimService {
@@ -102,6 +103,7 @@ func NewSlimService(s *v1.Service) *SlimService {
 		},
 		Spec: SlimServiceSpec{
 			ClusterIP: s.Spec.ClusterIP,
+			Selector:  s.Spec.Selector,
 		},
 	}
 }
@@ -190,6 +192,7 @@ func transformObject(obj any) (any, error) {
 			},
 			Spec: v1.ServiceSpec{
 				ClusterIP: t.Spec.ClusterIP,
+				Selector:  t.Spec.Selector,
 			},
 		}
 		return s, nil

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy.go
@@ -100,7 +100,7 @@ func networkPeerKey(e NetworkEvent) (string, error) {
 	case types.EndpointKindPod:
 		ret = string(e.endpoint.Kind) + ":" + e.endpoint.Namespace + ":" + labelKeyString(e.endpoint.PodLabels)
 	case types.EndpointKindService:
-		ret = string(e.endpoint.Kind) + ":" + e.endpoint.Namespace + ":" + labelKeyString(e.endpoint.PodLabels)
+		ret = string(e.endpoint.Kind) + ":" + e.endpoint.Namespace + ":" + labelKeyString(e.endpoint.PodSelector)
 	case types.EndpointKindRaw:
 		ret = string(e.endpoint.Kind) + ":" + e.endpoint.Addr
 	default:
@@ -140,7 +140,7 @@ func eventToRule(e NetworkEvent) ([]networkingv1.NetworkPolicyPort, []networking
 	case types.EndpointKindService:
 		peers = []networkingv1.NetworkPolicyPeer{
 			{
-				PodSelector: &metav1.LabelSelector{MatchLabels: e.endpoint.PodLabels},
+				PodSelector: &metav1.LabelSelector{MatchLabels: e.endpoint.PodSelector},
 			},
 		}
 		if e.K8s.Namespace != e.endpoint.Namespace {

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
@@ -52,20 +52,21 @@ func (s *gnpOperator) InstanceParams() api.Params {
 }
 
 type k8sAccesors struct {
-	k8sHostNetwork       datasource.FieldAccessor
-	k8sNamespace         datasource.FieldAccessor
-	k8sPodLabels         datasource.FieldAccessor
-	k8sPodIP             datasource.FieldAccessor
-	k8sPodName           datasource.FieldAccessor
-	k8sOwnerName         datasource.FieldAccessor
-	endpointAddr         datasource.FieldAccessor
-	endpointPort         datasource.FieldAccessor
-	endpointK8sKind      datasource.FieldAccessor
-	endpointK8sName      datasource.FieldAccessor
-	endpointK8sNamespace datasource.FieldAccessor
-	endpointK8sLabels    datasource.FieldAccessor
-	endpointProto        datasource.FieldAccessor
-	egress               datasource.FieldAccessor
+	k8sHostNetwork         datasource.FieldAccessor
+	k8sNamespace           datasource.FieldAccessor
+	k8sPodLabels           datasource.FieldAccessor
+	k8sPodIP               datasource.FieldAccessor
+	k8sPodName             datasource.FieldAccessor
+	k8sOwnerName           datasource.FieldAccessor
+	endpointAddr           datasource.FieldAccessor
+	endpointPort           datasource.FieldAccessor
+	endpointK8sKind        datasource.FieldAccessor
+	endpointK8sName        datasource.FieldAccessor
+	endpointK8sNamespace   datasource.FieldAccessor
+	endpointK8sLabels      datasource.FieldAccessor
+	endpointK8sPodSelector datasource.FieldAccessor
+	endpointProto          datasource.FieldAccessor
+	egress                 datasource.FieldAccessor
 
 	adviseDS    datasource.DataSource
 	adviseField datasource.FieldAccessor
@@ -132,6 +133,8 @@ func (s *gnpOperator) getAccessors(gadgetCtx operators.GadgetContext) (map[datas
 		if acc.endpointK8sLabels == nil {
 			return nil, fmt.Errorf("no endpoint.k8s.labels field found")
 		}
+		// podSelector is optional: it is only set for service endpoints
+		acc.endpointK8sPodSelector = ds.GetField("endpoint.k8s.podSelector")
 		acc.endpointProto = ds.GetField("endpoint.proto")
 		if acc.endpointProto == nil {
 			return nil, fmt.Errorf("no endpoint.proto field found")
@@ -239,6 +242,21 @@ func (s *gnpOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 						continue
 					}
 					e.endpoint.PodLabels[kv[0]] = kv[1]
+				}
+
+				// Parse the service's pod selector if available
+				if acc.endpointK8sPodSelector != nil {
+					podSelectorRaw, _ := acc.endpointK8sPodSelector.String(data)
+					if podSelectorRaw != "" {
+						e.endpoint.PodSelector = map[string]string{}
+						for _, pair := range strings.Split(podSelectorRaw, ",") {
+							kv := strings.Split(pair, "=")
+							if len(kv) != 2 {
+								continue
+							}
+							e.endpoint.PodSelector[kv[0]] = kv[1]
+						}
+					}
 				}
 
 				e.K8s.PodName, _ = acc.k8sPodName.String(data)

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -107,6 +107,7 @@ func (m *KubeIPResolverInstance) enrich(ev any) {
 			endpoint.Name = svc.Name
 			endpoint.Namespace = svc.Namespace
 			endpoint.PodLabels = svc.Labels
+			endpoint.PodSelector = svc.Spec.Selector
 		}
 	}
 }
@@ -125,11 +126,12 @@ func (k *KubeIPResolver) InstanceParams() api.Params {
 }
 
 type endpointAccessors struct {
-	root            datasource.FieldAccessor
-	subK8sKind      datasource.FieldAccessor
-	subK8sName      datasource.FieldAccessor
-	subK8sNamespace datasource.FieldAccessor
-	subK8sLabels    datasource.FieldAccessor
+	root              datasource.FieldAccessor
+	subK8sKind        datasource.FieldAccessor
+	subK8sName        datasource.FieldAccessor
+	subK8sNamespace   datasource.FieldAccessor
+	subK8sLabels      datasource.FieldAccessor
+	subK8sPodSelector datasource.FieldAccessor
 
 	column datasource.FieldAccessor
 	port   datasource.FieldAccessor
@@ -202,6 +204,10 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			if err != nil {
 				return nil, fmt.Errorf("adding field %q: %w", "labels", err)
 			}
+			k8sPodSelectorAcc, err := k8sSubAcc.AddSubField("podSelector", api.Kind_String, datasource.WithFlags(datasource.FieldFlagHidden))
+			if err != nil {
+				return nil, fmt.Errorf("adding field %q: %w", "podSelector", err)
+			}
 
 			// control how the field is displayed
 			var endpointColAcc datasource.FieldAccessor
@@ -214,13 +220,14 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 			}
 
 			ea := endpointAccessors{
-				root:            ep,
-				subK8sKind:      k8sKindAcc,
-				subK8sName:      k8sNameAcc,
-				subK8sNamespace: k8sNamespaceAcc,
-				subK8sLabels:    k8sLabelsAcc,
-				column:          endpointColAcc,
-				port:            portAcc,
+				root:              ep,
+				subK8sKind:        k8sKindAcc,
+				subK8sName:        k8sNameAcc,
+				subK8sNamespace:   k8sNamespaceAcc,
+				subK8sLabels:      k8sLabelsAcc,
+				subK8sPodSelector: k8sPodSelectorAcc,
+				column:            endpointColAcc,
+				port:              portAcc,
 			}
 			epAccessors[ds] = append(epAccessors[ds], ea)
 		}
@@ -302,6 +309,14 @@ func (m *KubeIPResolverInstance) PreStart(gadgetCtx operators.GadgetContext) err
 						labels = append(labels, fmt.Sprintf("%s=%s", key, val))
 					}
 					a.subK8sLabels.Set(data, []byte(strings.Join(labels, ",")))
+
+					// Store the service's pod selector so downstream consumers
+					// (e.g. network policy generation) can select the backing pods.
+					var selectorLabels []string
+					for key, val := range svc.Spec.Selector {
+						selectorLabels = append(selectorLabels, fmt.Sprintf("%s=%s", key, val))
+					}
+					a.subK8sPodSelector.Set(data, []byte(strings.Join(selectorLabels, ",")))
 
 					if a.column != nil && a.port != nil {
 						p, _ := a.port.Uint16(data)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -245,6 +245,10 @@ type L3Endpoint struct {
 	Name      string            `json:"podname,omitempty" column:"name,hide"`
 	Kind      EndpointKind      `json:"kind,omitempty" column:"kind,hide"`
 	PodLabels map[string]string `json:"podlabels,omitempty" column:"podLabels,hide"`
+
+	// PodSelector contains the service's spec.selector when Kind is
+	// EndpointKindService. It holds the labels that select the backing pods
+	PodSelector map[string]string `json:"podSelector,omitempty" column:"podSelector,hide"`
 }
 
 type L4Endpoint struct {


### PR DESCRIPTION
As mentioned in https://github.com/inspektor-gadget/inspektor-gadget/issues/5338#issuecomment-4030243236, we need to use the service' `spec.selector` (not service labels) when generating network policies. This change adds `PodSelector` field t `L3Endpoint` so the service's pod selector is available for `generate_networkpoliy` to generate correct network policies. 

Fixes: #5338 

Also, it isn't possible to refer services by name in Network Policies and using pod selector is viable workaround:

> Targeting of services by name (you can, however, target pods or namespaces by their [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels), which is often a viable workaround).

ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#what-you-can-t-do-with-network-policies-at-least-not-yet