### PR TITLE
[BACKPORT] include: Add maps dedicated to count ring buffer lost samples.

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -530,7 +530,7 @@ GADGET_TRACER_MAP(events, 1024 * 256);
 
 Then, you can interact with the buffer using these functions:
 
-1. `void *gadget_reserve_buf(void *map, __u64 size)`: Reserves memory in the corresponding buffer.
+1. `void *gadget_reserve_buf(void *map, __u64 size)`: Reserves memory in the corresponding buffer. This is actually a macro and you must call it by taking the address of the map, like `gadget_reserve_buf(&events, 256)`.
 1. `long gadget_submit_buf(void *ctx, void *map, void *buf, __u64 size)`: Writes the previously reserved memory in the corresponding buffer.
 1. `void gadget_discard_buf(void *buf)`: Discards the previously reserved buffer. This is needed to avoid wasting memory.
 1. `long gadget_output_buf(void *ctx, void *map, void *buf, __u64 size)`: Reserves and writes the buffer in the corresponding map. This is equivalent to calling `gadget_reserve_buf()` and `gadget_submit_buf()`.

--- a/include/gadget/buffer.h
+++ b/include/gadget/buffer.h
@@ -11,12 +11,19 @@
 #define GADGET_MAX_EVENT_SIZE 10240
 #endif
 
-#define GADGET_TRACER_MAP(name, size)               \
-	struct {                                    \
-		__uint(type, BPF_MAP_TYPE_RINGBUF); \
-		__uint(max_entries, size);          \
-	} name SEC(".maps");                        \
-	const void *gadget_map_tracer_##name __attribute__((unused));
+#define GADGET_TRACER_MAP(name, size)                                 \
+	struct {                                                      \
+		__uint(type, BPF_MAP_TYPE_RINGBUF);                   \
+		__uint(max_entries, size);                            \
+	} name SEC(".maps");                                          \
+	const void *gadget_map_tracer_##name __attribute__((unused)); \
+                                                                      \
+	struct {                                                      \
+		__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);              \
+		__uint(max_entries, 1);                               \
+		__uint(key_size, sizeof(__u32));                      \
+		__uint(value_size, sizeof(__u64));                    \
+	} name##_lost_samples SEC(".maps");
 
 #ifndef GADGET_NO_BUF_RESERVE
 struct {
@@ -26,13 +33,25 @@ struct {
 	__uint(value_size, GADGET_MAX_EVENT_SIZE);
 } gadget_heap SEC(".maps");
 
-static __always_inline void *gadget_reserve_buf(void *map, __u64 size)
+// _lost_samples has to be suffixed because user will give &map as argument.
+#define gadget_reserve_buf(map, size) \
+	__gadget_reserve_buf(map, map##_lost_samples, size)
+
+static __always_inline void *__gadget_reserve_buf(void *map, void *lost_samples,
+						  __u64 size)
 {
-	static const int zero = 0;
+	const int zero = 0;
 
 	if (bpf_core_enum_value_exists(enum bpf_func_id,
-				       BPF_FUNC_ringbuf_reserve))
-		return bpf_ringbuf_reserve(map, size, 0);
+				       BPF_FUNC_ringbuf_reserve)) {
+		void *mem = bpf_ringbuf_reserve(map, size, 0);
+		if (mem == NULL) {
+			__u64 *cnt = bpf_map_lookup_elem(lost_samples, &zero);
+			if (cnt)
+				*cnt += 1;
+		}
+		return mem;
+	}
 
 	return bpf_map_lookup_elem(&gadget_heap, &zero);
 }

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
@@ -28,6 +30,7 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 )
 
@@ -42,9 +45,11 @@ type Tracer struct {
 
 	mapType       ebpf.MapType
 	eventSize     uint32 // needed to trim trailing bytes when reading for perf event array
+	lostSampleMap *ebpf.Map
 	ringbufReader *ringbuf.Reader
 	perfReader    *perf.Reader
 	slowBuf       []byte
+	logger        logger.Logger
 }
 
 func validateTracerMap(traceMap *ebpf.MapSpec) error {
@@ -121,12 +126,58 @@ func (t *Tracer) receiveEvents(gadgetCtx operators.GadgetContext, wg *sync.WaitG
 
 	var readCb func() (data []byte, lost uint64, err error)
 
+	cpus, err := ebpf.PossibleCPU()
+	if err != nil {
+		return fmt.Errorf("getting eBPF possibles CPUs: %w", err)
+	}
+
 	switch t.mapType {
 	case ebpf.RingBuf:
 		var rec ringbuf.Record
+		lostSamples := uint64(0)
+
+		if t.lostSampleMap != nil {
+			readLostSamples := func() {
+				ticker := time.NewTicker(time.Second)
+				for range ticker.C {
+					// Ring buffer does not report the number of lost samples. For this,
+					// we have a specific map, for each ring buffer, which store the
+					// number of lost samples when gadget_reserve_buf() is used.
+					// We periodically read this map to know the number of lost samples
+					// for this period. The next time the ring buffer will be read, the
+					// number of lost samples will be reported and reset until next period.
+					readValues := make([]uint64, cpus)
+					zeroValues := make([]uint64, cpus)
+					zero := uint32(0)
+
+					err := t.lostSampleMap.Lookup(&zero, readValues)
+					if err != nil {
+						t.logger.Warnf("getting lost samples: %w", err)
+
+						continue
+					}
+
+					err = t.lostSampleMap.Update(&zero, zeroValues, ebpf.UpdateExist)
+					if err != nil {
+						t.logger.Warnf("resetting lost samples: %w", err)
+
+						continue
+					}
+
+					sum := uint64(0)
+					for i := range readValues {
+						sum += readValues[i]
+					}
+					atomic.StoreUint64(&lostSamples, sum)
+				}
+			}
+
+			go readLostSamples()
+		}
+
 		readCb = func() ([]byte, uint64, error) {
 			err := t.ringbufReader.ReadInto(&rec)
-			return rec.RawSample, 0, err
+			return rec.RawSample, atomic.SwapUint64(&lostSamples, 0), err
 		}
 	case ebpf.PerfEventArray:
 		var rec perf.Record
@@ -241,6 +292,14 @@ func (i *ebpfInstance) runTracer(gadgetCtx operators.GadgetContext, tracer *Trac
 	case ebpf.RingBuf:
 		i.logger.Debugf("creating ringbuf reader for map %q", tracer.mapName)
 		tracer.ringbufReader, err = ringbuf.NewReader(m)
+
+		lostSamplesMapName := tracer.mapName + "_lost_samples"
+		lostSamplesMap, ok := i.collection.Maps[lostSamplesMapName]
+		if !ok {
+			i.logger.Warnf("looking up lost sample map %q: not found; ring buffer lost samples will not be reported.", lostSamplesMapName)
+		}
+		tracer.lostSampleMap = lostSamplesMap
+		tracer.logger = i.logger
 	case ebpf.PerfEventArray:
 		i.logger.Debugf("creating perf reader for map %q", tracer.mapName)
 		tracer.perfReader, err = perf.NewReader(m, gadgets.PerfBufferPages*os.Getpagesize())


### PR DESCRIPTION
Contrary to perf buffer, ring buffer does not offer a mechanism to count lost samples.
So, when bpf_ringbuf_reserve() returns NULL, i.e. when the ring buffer is full, there is no way for user space to know about this.

This commit modifies the GADGET_TRACER_MAP macro in order to create a per cpu array corresponding to the ring buffer. This per cpu array would be used to count the number of lost samples when bpf_ringbuf_reserve() returns NULL. Accordingly, the gadget_reserve_buf() was converted to a macro to get the corresponding per cpu array from the ring buffer name. The value stored in the per cpu array is read and reset by user space to inform about lost samples. To avoid decreasing the performance, this occurs periodically in a go routine.

Fixes: GHSA-wv52-frfv-mfh4 ("Tracing Denial of Service via Event Flooding")
Reported-by: Pietro Tirenna <pietro.tirenna@shielder.it>
