### PR TITLE
include: Format buffer.h correctly.

### DIFF
--- a/include/gadget/buffer.h
+++ b/include/gadget/buffer.h
@@ -37,8 +37,8 @@ struct {
 #define gadget_reserve_buf(map, size) \
 	__gadget_reserve_buf(map, map##_lost_samples, size)
 
-static __always_inline void *
-__gadget_reserve_buf(void *map, void *lost_samples, __u64 size)
+static __always_inline void *__gadget_reserve_buf(void *map, void *lost_samples,
+						  __u64 size)
 {
 	const int zero = 0;
 


### PR DESCRIPTION
Fixes: a59d93b15e94 ("include: Add maps dedicated to count ring buffer lost samples.")