### PR TITLE
gadgets: extend `trace_init_module` with finit_module syscall support

### DIFF
--- a/gadgets/trace_init_module/README.md
+++ b/gadgets/trace_init_module/README.md
@@ -1,13 +1,27 @@
 # trace_init_module
 
-The trace_init_module gadget emits events when processes invoke the `init_module(module_image, len, param_values)` syscall to load kernel modules.
+The trace_init_module gadget emits events when processes invoke the `init_module()` or `finit_module()` syscalls to load kernel modules.
+
+**Syscalls traced:**
+- `init_module(module_image, len, param_values)` - loads a module from a memory buffer
+- `finit_module(fd, param_values, flags)` - loads a module from a file descriptor
 
 It captures:
 
+For `init_module`:
 - `len` (module image length in bytes)
-- `param_values` (module parameters as a userspace string, truncated to 256 bytes for safety)
-- common process context fields (comm/pid/tid, uid/gid, etc.)
+- `param_values` (module parameters)
 
-**Note:** The `module_image` pointer is not captured (it points to a potentially large binary blob).
+For `finit_module`:
+- `fd` (file descriptor)
+- `filepath` (resolved from fd when possible. Empty when fd pointing to memory.)
+- `flags` (finit_module flags)
+- `param_values` (module parameters)
+
+**Common fields:**
+- Process context (comm/pid/tid, uid/gid, etc.)
+- `syscall` field to distinguish between init_module and finit_module
+
+**Note:** The `module_image` buffer from `init_module` is not captured. Parameter strings are truncated to 256 bytes.
 
 Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/trace_init_module

--- a/gadgets/trace_init_module/README.mdx
+++ b/gadgets/trace_init_module/README.mdx
@@ -8,9 +8,17 @@ import TabItem from '@theme/TabItem';
 
 # trace_init_module
 
-The trace_init_module gadget emits events when processes invoke the `init_module(module_image, len, param_values)` syscall to load kernel modules.
+The trace_init_module gadget emits events when processes invoke the `init_module()` or `finit_module()` syscalls to load kernel modules.
 
-This gadget captures the module size (`len`) and parameters (`param_values`) passed during module initialization.
+**Syscalls traced:**
+- `init_module(module_image, len, param_values)` - loads a module from a memory buffer
+- `finit_module(fd, param_values, flags)` - loads a module from a file descriptor
+
+This gadget captures:
+- For `init_module`: module size (`len`) and parameters (`param_values`)
+- For `finit_module`: file descriptor (`fd`), resolved filepath, flags, and parameters (`param_values`)
+
+**Note:** The `module_image` parameter from `init_module` is intentionally not captured.
 
 ## Requirements
 

--- a/gadgets/trace_init_module/dev.md
+++ b/gadgets/trace_init_module/dev.md
@@ -10,11 +10,20 @@ The following diagrams are generated using the `ig image inspect` command. Note 
 
 ```mermaid
 flowchart LR
+bufs[("bufs")]
 events[("events")]
+events_lost_samples[("events_lost_samples")]
 gadget_heap[("gadget_heap")]
 gadget_mntns_filter_map[("gadget_mntns_filter_map")]
+ig_finit_module_e -- "Lookup" --> gadget_mntns_filter_map
+ig_finit_module_e -- "Lookup" --> gadget_heap
+ig_finit_module_e -- "Lookup" --> bufs
+ig_finit_module_e -- "Lookup" --> events_lost_samples
+ig_finit_module_e -- "EventOutput" --> events
+ig_finit_module_e["ig_finit_module_e"]
 ig_init_module_e -- "Lookup" --> gadget_mntns_filter_map
 ig_init_module_e -- "Lookup" --> gadget_heap
+ig_init_module_e -- "Lookup" --> events_lost_samples
 ig_init_module_e -- "EventOutput" --> events
 ig_init_module_e["ig_init_module_e"]
 ```
@@ -24,14 +33,23 @@ ig_init_module_e["ig_init_module_e"]
 ```mermaid
 sequenceDiagram
 box eBPF Programs
+participant ig_finit_module_e
 participant ig_init_module_e
 end
 box eBPF Maps
 participant gadget_mntns_filter_map
 participant gadget_heap
+participant bufs
+participant events_lost_samples
 participant events
 end
+ig_finit_module_e->>gadget_mntns_filter_map: Lookup
+ig_finit_module_e->>gadget_heap: Lookup
+ig_finit_module_e->>bufs: Lookup
+ig_finit_module_e->>events_lost_samples: Lookup
+ig_finit_module_e->>events: EventOutput
 ig_init_module_e->>gadget_mntns_filter_map: Lookup
 ig_init_module_e->>gadget_heap: Lookup
+ig_init_module_e->>events_lost_samples: Lookup
 ig_init_module_e->>events: EventOutput
 ```

--- a/gadgets/trace_init_module/gadget.yaml
+++ b/gadgets/trace_init_module/gadget.yaml
@@ -1,19 +1,44 @@
 name: trace init_module
-description: trace init_module syscalls
+description: trace init_module and finit_module syscalls
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_init_module
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_init_module
 datasources:
   init:
     fields:
+      syscall_raw:
+        annotations:
+          columns.hidden: true
+      syscall:
+        annotations:
+          description: System call name (init_module or finit_module)
+          columns.width: 14
+          columns.minwidth: 12
       len:
         annotations:
-          description: Module image length (bytes)
+          description: Module image length in bytes (init_module only)
           columns.alignment: right
           columns.minwidth: 3
           columns.maxwidth: 12
+      fd:
+        annotations:
+          description: File descriptor (finit_module only)
+          columns.alignment: right
+          columns.width: 6
+          columns.minwidth: 2
+      filepath:
+        annotations:
+          description: Path resolved from fd (finit_module only)
+          columns.width: 32
+          columns.minwidth: 16
+      flags:
+        annotations:
+          description: Flags passed to finit_module
+          columns.alignment: right
+          columns.width: 8
+          columns.minwidth: 5
       param_values:
         annotations:
-          description: Parameter string passed to init_module (truncated)
+          description: Parameter string passed to syscall (truncated)
           columns.width: 32
           columns.minwidth: 16

--- a/gadgets/trace_init_module/program.bpf.c
+++ b/gadgets/trace_init_module/program.bpf.c
@@ -7,16 +7,32 @@
 #include <gadget/buffer.h>
 #include <gadget/common.h>
 #include <gadget/filter.h>
+#include <gadget/filesystem.h>
 #include <gadget/macros.h>
 #include <gadget/types.h>
 
 #define PARAM_VALUES_MAX 256
 
+enum syscall_type {
+	init_module,
+	finit_module,
+};
+
 struct event {
 	gadget_timestamp timestamp_raw;
 	struct gadget_process proc;
-	__u64 len;
+
+	// Common fields
+	enum syscall_type syscall_raw;
 	char param_values[PARAM_VALUES_MAX];
+
+	// init_module specific
+	__u64 len;
+
+	// finit_module specific
+	__s32 fd;
+	__u32 flags;
+	char filepath[GADGET_PATH_MAX];
 };
 
 GADGET_TRACER_MAP(events, 1024 * 256);
@@ -39,7 +55,62 @@ int ig_init_module_e(struct syscall_trace_enter *ctx)
 
 	gadget_process_populate(&event->proc);
 	event->timestamp_raw = bpf_ktime_get_boot_ns();
+
+	event->syscall_raw = init_module;
+
 	event->len = len;
+	event->fd = 0;
+	event->flags = 0;
+	event->filepath[0] = '\0';
+
+	if (param_values)
+		bpf_probe_read_user_str(event->param_values,
+					sizeof(event->param_values),
+					param_values);
+	else
+		event->param_values[0] = '\0';
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_finit_module")
+int ig_finit_module_e(struct syscall_trace_enter *ctx)
+{
+	struct event *event;
+	__s32 fd = (__s32)ctx->args[0];
+	const char *param_values = (const char *)ctx->args[1];
+	__u32 flags = (__u32)ctx->args[2];
+
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	gadget_process_populate(&event->proc);
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
+
+	event->syscall_raw = finit_module;
+
+	event->fd = fd;
+	event->flags = flags;
+	event->len = 0;
+
+	// Try to resolve fd to filepath
+	// Only returns a path when fd points to a file in the kernel filesystem.
+	// When fd points to memory (e.g., memfd), this is not yet handled and
+	// filepath will be set to empty string.
+	if (fd >= 0) {
+		long r = read_full_path_of_open_file_fd(
+			fd, event->filepath, sizeof(event->filepath));
+		if (r <= 0)
+			event->filepath[0] = '\0';
+	} else {
+		event->filepath[0] = '\0';
+	}
+
 	if (param_values)
 		bpf_probe_read_user_str(event->param_values,
 					sizeof(event->param_values),

--- a/gadgets/trace_init_module/test/unit/trace_init_test.go
+++ b/gadgets/trace_init_module/test/unit/trace_init_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
@@ -32,7 +34,11 @@ import (
 type ExpectedTraceInitModuleEvent struct {
 	Proc utils.Process `json:"proc"`
 
+	Syscall     string `json:"syscall"`
 	Len         uint64 `json:"len"`
+	Fd          int32  `json:"fd"`
+	Filepath    string `json:"filepath"`
+	Flags       uint32 `json:"flags"`
 	ParamValues string `json:"param_values"`
 }
 
@@ -47,7 +53,7 @@ func TestTraceInitModuleGadget(t *testing.T) {
 	gadgettesting.InitUnitTest(t)
 
 	cases := map[string]testDef{
-		"captures_all_events_with_no_filters_configured": {
+		"init_module_captures_all_events": {
 			runnerConfig:  &utils.RunnerConfig{},
 			generateEvent: generateInitModuleEvent,
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, expectedLen uint64, expectedParams string, events []ExpectedTraceInitModuleEvent) {
@@ -56,13 +62,14 @@ func TestTraceInitModuleGadget(t *testing.T) {
 					utils.NormalizeParentTid(&proc)
 					return &ExpectedTraceInitModuleEvent{
 						Proc:        proc,
+						Syscall:     "init_module",
 						Len:         expectedLen,
 						ParamValues: expectedParams,
 					}
 				})(t, info, expectedLen, events)
 			},
 		},
-		"captures_no_events_with_no_matching_filter": {
+		"init_module_no_matching_filter": {
 			runnerConfig: &utils.RunnerConfig{},
 			mntnsFilterMap: func(info *utils.RunnerInfo) *ebpf.Map {
 				return utils.CreateMntNsFilterMap(t, 0)
@@ -72,7 +79,7 @@ func TestTraceInitModuleGadget(t *testing.T) {
 				utils.ExpectNoEvent(t, info, uint64(0), events)
 			},
 		},
-		"captures_events_with_matching_filter": {
+		"init_module_matching_filter": {
 			runnerConfig: &utils.RunnerConfig{},
 			mntnsFilterMap: func(info *utils.RunnerInfo) *ebpf.Map {
 				return utils.CreateMntNsFilterMap(t, info.MountNsID)
@@ -80,8 +87,39 @@ func TestTraceInitModuleGadget(t *testing.T) {
 			generateEvent: generateInitModuleEvent,
 			validateEvent: func(t *testing.T, info *utils.RunnerInfo, expectedLen uint64, expectedParams string, events []ExpectedTraceInitModuleEvent) {
 				require.NotEmpty(t, events)
+				require.Equal(t, "init_module", events[0].Syscall)
 				require.Equal(t, expectedLen, events[0].Len)
 				require.Equal(t, expectedParams, events[0].ParamValues)
+			},
+		},
+		"finit_module_captures_all_events": {
+			runnerConfig:  &utils.RunnerConfig{},
+			generateEvent: generateFinitModuleEvent,
+			validateEvent: func(t *testing.T, info *utils.RunnerInfo, _ uint64, expectedParams string, events []ExpectedTraceInitModuleEvent) {
+				// Just check if we got any finit_module events
+				found := false
+				for _, event := range events {
+					if event.Syscall == "finit_module" {
+						found = true
+						t.Logf("Found finit_module event: fd=%d, filepath=%s, params=%s",
+							event.Fd, event.Filepath, event.ParamValues)
+						break
+					}
+				}
+				require.True(t, found, "Expected at least one finit_module event")
+			},
+		},
+		"finit_module_matching_filter": {
+			runnerConfig: &utils.RunnerConfig{},
+			mntnsFilterMap: func(info *utils.RunnerInfo) *ebpf.Map {
+				return utils.CreateMntNsFilterMap(t, info.MountNsID)
+			},
+			generateEvent: generateFinitModuleEvent,
+			validateEvent: func(t *testing.T, info *utils.RunnerInfo, _ uint64, expectedParams string, events []ExpectedTraceInitModuleEvent) {
+				require.NotEmpty(t, events)
+				require.Equal(t, "finit_module", events[0].Syscall)
+				require.Equal(t, expectedParams, events[0].ParamValues)
+				require.GreaterOrEqual(t, events[0].Fd, int32(0))
 			},
 		},
 	}
@@ -140,6 +178,36 @@ func generateInitModuleEvent(lenBytes uint64, params string) error {
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(len(buf)),
 		uintptr(unsafe.Pointer(paramPtr)),
+	)
+	_ = errno
+	return nil
+}
+
+func generateFinitModuleEvent(_ uint64, params string) error {
+	// Create a temporary file with dummy module content
+	tmpFile, err := os.CreateTemp("", "dummy-module-*.ko")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	// Write some dummy data
+	_, err = tmpFile.Write([]byte{0x7f, 0x45, 0x4c, 0x46}) // ELF magic
+	if err != nil {
+		return err
+	}
+
+	paramPtr, err := syscall.BytePtrFromString(params)
+	if err != nil {
+		return err
+	}
+
+	// Call finit_module syscall
+	_, _, errno := syscall.Syscall(unix.SYS_FINIT_MODULE,
+		tmpFile.Fd(),
+		uintptr(unsafe.Pointer(paramPtr)),
+		0, // flags
 	)
 	_ = errno
 	return nil


### PR DESCRIPTION
The gadget now captures:
- init_module: module_image length and parameters
- finit_module: file descriptor, resolved filepath (when possible), flags, and parameters

