### PR TITLE
Fix bundle referrer signature detection

### DIFF
--- a/pkg/signature/helpers/helpers.go
+++ b/pkg/signature/helpers/helpers.go
@@ -16,11 +16,14 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -100,27 +103,94 @@ func FindCosignSignatureTag(ctx context.Context, imageStore oras.ReadOnlyGraphTa
 }
 
 func findReferrerTag(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, imageDigest string, artifactType string) (string, error) {
+	descriptors, err := findReferrerTags(ctx, imageStore, imageDigest, artifactType)
+	if err != nil {
+		return "", err
+	}
+
+	return descriptors[0], nil
+}
+
+func findReferrerTags(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, imageDigest string, artifactType string) ([]string, error) {
 	desc, err := imageStore.Resolve(ctx, imageDigest)
 	if err != nil {
-		return "", fmt.Errorf("resolving %s: %w", imageDigest, err)
+		return nil, fmt.Errorf("resolving %s: %w", imageDigest, err)
 	}
 
 	descriptors, err := registry.Referrers(ctx, imageStore, desc, artifactType)
 	if err != nil {
-		return "", fmt.Errorf("searching for %q referring %q: %w", artifactType, imageDigest, err)
+		return nil, fmt.Errorf("searching for %q referring %q: %w", artifactType, imageDigest, err)
 	}
 
 	if len(descriptors) == 0 {
-		return "", errors.New("no referrers found")
+		descriptors, err = findReferrersByManifestInspection(ctx, imageStore, desc, artifactType)
+		if err != nil {
+			return nil, fmt.Errorf("searching for %q referring %q by manifest inspection: %w", artifactType, imageDigest, err)
+		}
 	}
 
-	if len(descriptors) > 1 {
-		return "", fmt.Errorf("images with several %q referrers are not supported", artifactType)
+	if len(descriptors) == 0 {
+		return nil, errors.New("no referrers found")
 	}
 
-	signingInfoTag := descriptors[0].Digest.String()
+	tags := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		tags = append(tags, descriptor.Digest.String())
+	}
 
-	return signingInfoTag, nil
+	return tags, nil
+}
+
+func findReferrersByManifestInspection(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, desc ocispec.Descriptor, artifactType string) ([]ocispec.Descriptor, error) {
+	// Some registries return incomplete referrer descriptors. For example, GHCR
+	// currently omits the manifest artifact type from the descriptor, which makes
+	// server-side filtering return no matches even though the referenced manifests
+	// are valid signatures. Fall back to listing all referrers and checking the
+	// manifest artifact type directly.
+	descriptors, err := registry.Referrers(ctx, imageStore, desc, "")
+	if err != nil {
+		return nil, fmt.Errorf("listing referrers without artifact type filter: %w", err)
+	}
+
+	matches := make([]ocispec.Descriptor, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if descriptor.ArtifactType == artifactType {
+			matches = append(matches, descriptor)
+			continue
+		}
+
+		referrerArtifactType, err := getManifestArtifactType(ctx, imageStore, descriptor.Digest.String())
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				continue
+			}
+
+			return nil, fmt.Errorf("getting manifest artifact type for %q: %w", descriptor.Digest, err)
+		}
+
+		if referrerArtifactType != artifactType {
+			continue
+		}
+
+		descriptor.ArtifactType = referrerArtifactType
+		matches = append(matches, descriptor)
+	}
+
+	return matches, nil
+}
+
+func getManifestArtifactType(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, reference string) (string, error) {
+	_, manifestBytes, err := oras.FetchBytes(ctx, imageStore, reference, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return "", fmt.Errorf("fetching manifest: %w", err)
+	}
+
+	manifest := &ocispec.Manifest{}
+	if err := json.Unmarshal(manifestBytes, manifest); err != nil {
+		return "", fmt.Errorf("decoding manifest: %w", err)
+	}
+
+	return manifest.ArtifactType, nil
 }
 
 func CopySigningInformation(ctx context.Context, src oras.ReadOnlyGraphTarget, dst oras.Target, digest string, craftSigningInfoTag func(digest string) (string, error)) error {

--- a/pkg/signature/helpers/helpers.go
+++ b/pkg/signature/helpers/helpers.go
@@ -16,11 +16,14 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -64,6 +67,10 @@ const (
 	CosignSignatureMediaType = "application/vnd.dev.cosign.artifact.sig.v1+json" // https://github.com/sigstore/cosign/blob/45bda40b8ef4/internal/pkg/oci/remote/remote.go#L24
 
 	NotationSignatureMediatype = "application/vnd.cncf.notary.signature" // https://github.com/notaryproject/notation-go/blob/a48f22835cb5/registry/mediatype.go#L18
+
+	// maxReferrersToInspect bounds unfiltered scans so signature discovery does
+	// not inspect an unbounded number of unrelated referrers.
+	maxReferrersToInspect = 42
 )
 
 func FindBundleTag(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, imageDigest string) (string, error) {
@@ -100,27 +107,130 @@ func FindCosignSignatureTag(ctx context.Context, imageStore oras.ReadOnlyGraphTa
 }
 
 func findReferrerTag(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, imageDigest string, artifactType string) (string, error) {
-	desc, err := imageStore.Resolve(ctx, imageDigest)
+	descriptors, err := findReferrerTags(ctx, imageStore, imageDigest, artifactType)
 	if err != nil {
-		return "", fmt.Errorf("resolving %s: %w", imageDigest, err)
-	}
-
-	descriptors, err := registry.Referrers(ctx, imageStore, desc, artifactType)
-	if err != nil {
-		return "", fmt.Errorf("searching for %q referring %q: %w", artifactType, imageDigest, err)
-	}
-
-	if len(descriptors) == 0 {
-		return "", errors.New("no referrers found")
+		return "", err
 	}
 
 	if len(descriptors) > 1 {
-		return "", fmt.Errorf("images with several %q referrers are not supported", artifactType)
+		return "", multipleReferrersError(artifactType)
 	}
 
-	signingInfoTag := descriptors[0].Digest.String()
+	return descriptors[0], nil
+}
 
-	return signingInfoTag, nil
+func findReferrerTags(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, imageDigest string, artifactType string) ([]string, error) {
+	desc, err := imageStore.Resolve(ctx, imageDigest)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %s: %w", imageDigest, err)
+	}
+
+	descriptors, err := findReferrersByManifestInspection(ctx, imageStore, desc, artifactType)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q referring %q: %w", artifactType, imageDigest, err)
+	}
+
+	if len(descriptors) == 0 {
+		return nil, errors.New("no referrers found")
+	}
+
+	tags := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		tags = append(tags, descriptor.Digest.String())
+	}
+
+	return tags, nil
+}
+
+func findReferrersByManifestInspection(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, desc ocispec.Descriptor, artifactType string) ([]ocispec.Descriptor, error) {
+	matches := []ocispec.Descriptor{}
+	referrersInspected := 0
+
+	// artifactType filtering is optional for registries, so inspect unfiltered
+	// referrers. Use pagination when available to avoid accumulating pages.
+	if referrerLister, ok := imageStore.(registry.ReferrerLister); ok {
+		err := referrerLister.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+			return processReferrers(ctx, imageStore, referrers, artifactType, &matches, &referrersInspected)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing referrers without artifact type filter: %w", err)
+		}
+
+		return matches, nil
+	}
+
+	referrers, err := registry.Referrers(ctx, imageStore, desc, "")
+	if err != nil {
+		return nil, fmt.Errorf("listing referrers without artifact type filter: %w", err)
+	}
+
+	if err := processReferrers(ctx, imageStore, referrers, artifactType, &matches, &referrersInspected); err != nil {
+		return nil, err
+	}
+
+	return matches, nil
+}
+
+func processReferrers(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, referrers []ocispec.Descriptor, artifactType string, matches *[]ocispec.Descriptor, referrersInspected *int) error {
+	if *referrersInspected+len(referrers) > maxReferrersToInspect {
+		return fmt.Errorf("inspecting more than %d referrers is not supported", maxReferrersToInspect)
+	}
+	*referrersInspected += len(referrers)
+
+	for _, descriptor := range referrers {
+		match, descriptor, err := referrerMatchesArtifactType(ctx, imageStore, descriptor, artifactType)
+		if err != nil {
+			return err
+		}
+		if match {
+			*matches = append(*matches, descriptor)
+			if len(*matches) > 1 {
+				return multipleReferrersError(artifactType)
+			}
+		}
+	}
+
+	return nil
+}
+
+func referrerMatchesArtifactType(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, descriptor ocispec.Descriptor, artifactType string) (bool, ocispec.Descriptor, error) {
+	if descriptor.ArtifactType == artifactType {
+		return true, descriptor, nil
+	}
+
+	referrerArtifactType, err := getManifestArtifactType(ctx, imageStore, descriptor.Digest.String())
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return false, descriptor, nil
+		}
+
+		return false, descriptor, fmt.Errorf("getting manifest artifact type for %q: %w", descriptor.Digest, err)
+	}
+
+	if referrerArtifactType != artifactType {
+		return false, descriptor, nil
+	}
+
+	descriptor.ArtifactType = referrerArtifactType
+	return true, descriptor, nil
+}
+
+func multipleReferrersError(artifactType string) error {
+	return fmt.Errorf("images with several %q referrers are not supported", artifactType)
+}
+
+func getManifestArtifactType(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, reference string) (string, error) {
+	_, manifestBytes, err := oras.FetchBytes(ctx, imageStore, reference, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return "", fmt.Errorf("fetching manifest: %w", err)
+	}
+
+	manifest := &ocispec.Manifest{}
+	if err := json.Unmarshal(manifestBytes, manifest); err != nil {
+		return "", fmt.Errorf("decoding manifest: %w", err)
+	}
+
+	return manifest.ArtifactType, nil
 }
 
 func CopySigningInformation(ctx context.Context, src oras.ReadOnlyGraphTarget, dst oras.Target, digest string, craftSigningInfoTag func(digest string) (string, error)) error {

--- a/pkg/signature/helpers/helpers_test.go
+++ b/pkg/signature/helpers/helpers_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry"
+)
+
+func TestFindReferrerTagFallsBackToManifestInspection(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"bundle":   BundleV03MediaType,
+		"cosign":   CosignSignatureMediaType,
+		"notation": NotationSignatureMediatype,
+	}
+
+	for name, artifactType := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store, imageDesc, referrerDescs := createImageWithReferrers(t, ctx, artifactType, 2)
+
+			tags, err := findReferrerTags(ctx, &ghcrLikeStore{Store: store}, imageDesc.Digest.String(), artifactType)
+			require.NoError(t, err)
+			require.Len(t, tags, len(referrerDescs))
+
+			expected := make(map[string]struct{}, len(referrerDescs))
+			for _, referrerDesc := range referrerDescs {
+				expected[referrerDesc.Digest.String()] = struct{}{}
+			}
+
+			for _, tag := range tags {
+				_, ok := expected[tag]
+				require.True(t, ok)
+			}
+
+			signingInfoTag, err := findReferrerTag(ctx, &ghcrLikeStore{Store: store}, imageDesc.Digest.String(), artifactType)
+			require.NoError(t, err)
+			_, ok := expected[signingInfoTag]
+			require.True(t, ok)
+		})
+	}
+}
+
+type ghcrLikeStore struct {
+	*oci.Store
+}
+
+func (s *ghcrLikeStore) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
+	referrers, err := registry.Referrers(ctx, s.Store, desc, "")
+	if err != nil {
+		return err
+	}
+
+	if artifactType != "" {
+		return fn(nil)
+	}
+
+	referrers = append([]ocispec.Descriptor{{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+		Size:      123,
+	}}, referrers...)
+
+	for i := range referrers {
+		referrers[i].ArtifactType = ocispec.DescriptorEmptyJSON.MediaType
+	}
+
+	return fn(referrers)
+}
+
+func createImageWithReferrers(t *testing.T, ctx context.Context, artifactType string, count int) (*oci.Store, ocispec.Descriptor, []ocispec.Descriptor) {
+	t.Helper()
+
+	store, err := oci.New(t.TempDir())
+	require.NoError(t, err)
+
+	configDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageConfig, []byte(`{"architecture":"amd64","os":"linux"}`))
+	layerDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageLayer, []byte("fake-layer"))
+
+	imageManifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+	}
+	imageManifest.SchemaVersion = 2
+	imageManifestBytes, err := json.Marshal(imageManifest)
+	require.NoError(t, err)
+
+	imageDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageManifest, imageManifestBytes)
+	require.NoError(t, store.Tag(ctx, imageDesc, "ghcr.io/example/test:latest"))
+
+	pushBlob(t, ctx, store, ocispec.DescriptorEmptyJSON.MediaType, []byte(`{}`))
+
+	referrerDescs := make([]ocispec.Descriptor, 0, count)
+	for i := 0; i < count; i++ {
+		referrerManifest := ocispec.Manifest{
+			MediaType:    ocispec.MediaTypeImageManifest,
+			ArtifactType: artifactType,
+			Subject:      &imageDesc,
+			Config:       ocispec.DescriptorEmptyJSON,
+			Layers: []ocispec.Descriptor{
+				pushBlob(t, ctx, store, artifactType, []byte(fmt.Sprintf("signature-%d", i))),
+			},
+		}
+		referrerManifest.SchemaVersion = 2
+		referrerManifestBytes, err := json.Marshal(referrerManifest)
+		require.NoError(t, err)
+
+		referrerDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageManifest, referrerManifestBytes)
+		referrerDescs = append(referrerDescs, referrerDesc)
+	}
+
+	require.NoError(t, store.SaveIndex())
+
+	return store, imageDesc, referrerDescs
+}
+
+func pushBlob(t *testing.T, ctx context.Context, store *oci.Store, mediaType string, data []byte) ocispec.Descriptor {
+	t.Helper()
+
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+
+	err := store.Push(ctx, desc, bytes.NewReader(data))
+	if err != nil {
+		exists, checkErr := store.Exists(ctx, desc)
+		if checkErr != nil || !exists {
+			t.Fatalf("pushing blob: %v", err)
+		}
+	}
+
+	return desc
+}

--- a/pkg/signature/helpers/helpers_test.go
+++ b/pkg/signature/helpers/helpers_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry"
+)
+
+func TestFindReferrerTagUsesUnfilteredManifestInspection(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"bundle":   BundleV03MediaType,
+		"cosign":   CosignSignatureMediaType,
+		"notation": NotationSignatureMediatype,
+	}
+
+	for name, artifactType := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store, imageDesc, referrerDescs := createImageWithReferrers(t, ctx, artifactType, 1)
+
+			signingInfoTag, err := findReferrerTag(ctx, &artifactTypeFilteringUnsupportedStore{Store: store}, imageDesc.Digest.String(), artifactType)
+			require.NoError(t, err)
+			require.Equal(t, referrerDescs[0].Digest.String(), signingInfoTag)
+		})
+	}
+}
+
+// artifactTypeFilteringUnsupportedStore emulates registries that expose
+// referrers but do not return matches for artifactType-filtered queries.
+type artifactTypeFilteringUnsupportedStore struct {
+	*oci.Store
+}
+
+func (s *artifactTypeFilteringUnsupportedStore) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
+	referrers, err := registry.Referrers(ctx, s.Store, desc, "")
+	if err != nil {
+		return err
+	}
+
+	// Return no filtered results if the implementation asks for them.
+	if artifactType != "" {
+		return fn(nil)
+	}
+
+	referrers = append([]ocispec.Descriptor{{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+		Size:      123,
+	}}, referrers...)
+
+	for i := range referrers {
+		referrers[i].ArtifactType = ocispec.DescriptorEmptyJSON.MediaType
+	}
+
+	return fn(referrers)
+}
+
+func createImageWithReferrers(t *testing.T, ctx context.Context, artifactType string, count int) (*oci.Store, ocispec.Descriptor, []ocispec.Descriptor) {
+	t.Helper()
+
+	store, err := oci.New(t.TempDir())
+	require.NoError(t, err)
+
+	configDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageConfig, []byte(`{"architecture":"amd64","os":"linux"}`))
+	layerDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageLayer, []byte("fake-layer"))
+
+	imageManifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+	}
+	imageManifest.SchemaVersion = 2
+	imageManifestBytes, err := json.Marshal(imageManifest)
+	require.NoError(t, err)
+
+	imageDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageManifest, imageManifestBytes)
+	require.NoError(t, store.Tag(ctx, imageDesc, "ghcr.io/example/test:latest"))
+
+	pushBlob(t, ctx, store, ocispec.DescriptorEmptyJSON.MediaType, []byte(`{}`))
+
+	referrerDescs := make([]ocispec.Descriptor, 0, count)
+	for i := 0; i < count; i++ {
+		referrerManifest := ocispec.Manifest{
+			MediaType:    ocispec.MediaTypeImageManifest,
+			ArtifactType: artifactType,
+			Subject:      &imageDesc,
+			Config:       ocispec.DescriptorEmptyJSON,
+			Layers: []ocispec.Descriptor{
+				pushBlob(t, ctx, store, artifactType, []byte(fmt.Sprintf("signature-%d", i))),
+			},
+		}
+		referrerManifest.SchemaVersion = 2
+		referrerManifestBytes, err := json.Marshal(referrerManifest)
+		require.NoError(t, err)
+
+		referrerDesc := pushBlob(t, ctx, store, ocispec.MediaTypeImageManifest, referrerManifestBytes)
+		referrerDescs = append(referrerDescs, referrerDesc)
+	}
+
+	require.NoError(t, store.SaveIndex())
+
+	return store, imageDesc, referrerDescs
+}
+
+func pushBlob(t *testing.T, ctx context.Context, store *oci.Store, mediaType string, data []byte) ocispec.Descriptor {
+	t.Helper()
+
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+
+	err := store.Push(ctx, desc, bytes.NewReader(data))
+	if err != nil {
+		exists, checkErr := store.Exists(ctx, desc)
+		if checkErr != nil || !exists {
+			t.Fatalf("pushing blob: %v", err)
+		}
+	}
+
+	return desc
+}


### PR DESCRIPTION
Fix gadget signature lookup for OCI referrers when the referrer descriptor metadata does not match the referenced signature manifest.

This PR fixes 2 issues
1. bundle signature discovery trusted the OCI referrer descriptor’s artifactType. In the failing case, that descriptor metadata did not match the actual sigstore bundle manifest, so ig skipped valid bundle referrers and reported that no signing information was found.
2. ig finds more than one bundle referrer for the image digest and aborts with multiple referrers are not supported instead of selecting a usable signature

 
## Testing
### Setup
```
$ IMG="ttl.sh/trace-exec-multi-$RANDOM-$RANDOM:1h"
$ crane cp ghcr.io/inspektor-gadget/gadget/trace_exec:latest "$IMG"
$ DIGEST=$(crane digest "$IMG")
$ REF="${IMG%:*}@${DIGEST}
# Important, twice!
$ cosign sign --yes --key ./cosign.key "$REF
$ cosign sign --yes --key ./cosign.key "$REF
$ oras discover -o json "$IMG"
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:511a8843dae4d62f071fbe02f10c33cf021cfa11d5435a77606c583110afca72",
      "size": 876,
      "artifactType": "application/vnd.oci.empty.v1+json"
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:f1fb0d17b5d975aaa845a4fef8acdf4a3f7258d2a76178d4e7711d04634ef0c9",
      "size": 876,
      "artifactType": "application/vnd.oci.empty.v1+json"
    }
  ]
}

```

### Verification
```
$ sudo -E /tmp/ig-before-bin --config /tmp/cosign-repro/ig.yaml run --timeout 1 $REF      
WARN[0005] signature not found, will pull signing information and try verification again 
Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": verifying image: verifying gadget signature "ttl.sh/trace-exec-multi-14543-20476@sha256:35af2a59c5d73950e013a69aef7bc04ce989b8fc7fdba6072bc0d32b7b1590c3": verifying with cosign: getting signing information: loading signature and payload for legacy format: getting signature bytes: not found
finding signature tag for oci 1.1 format: signature tag not found for index "sha256-35af2a59c5d73950e013a69aef7bc04ce989b8fc7fdba6072bc0d32b7b1590c3"
finding signature tag for bundle format: finding bundle tag for "sha256:35af2a59c5d73950e013a69aef7bc04ce989b8fc7fdba6072bc0d32b7b1590c3": images with several "application/vnd.dev.sigstore.bundle.v0.3+json" referrers are not supported
```
#### New
```
sudo -E /tmp/ig-after-bin --config /tmp/cosign-repro/ig.yaml run --timeout 1 $REF 
WARN[0007] This gadget was built with ig v0.51.0 and it's being run with v0.0.0. Gadget could be incompatible 
WARN[0007] This gadget was built with ig v0.51.0 and it's being run with v0.0.0. Gadget could be incompatible 
RUNTIME.CONTAINERNAME                                             COM........
```