### PR TITLE
gadgets: reduce BPF stack frame size for older kernels

### DIFF
--- a/gadgets/profile_cpu/program.bpf.c
+++ b/gadgets/profile_cpu/program.bpf.c
@@ -22,6 +22,21 @@ struct key_t {
 	struct gadget_process proc;
 };
 
+/* Per-CPU temporary storage for struct key_t. Using a per-CPU array
+ * instead of a stack-local variable reduces the BPF stack frame size
+ * by sizeof(struct key_t) (~148 bytes). See the comment in
+ * profile_cuda/program.bpf.c for details on the 256-byte verifier
+ * limit with tail calls.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct key_t);
+} tmp_key SEC(".maps");
+
+static const struct key_t empty_key;
+
 const volatile bool kernel_stacks_only = false;
 GADGET_PARAM(kernel_stacks_only);
 
@@ -76,30 +91,35 @@ int ig_prof_cpu(struct bpf_perf_event_data *ctx)
 	static const struct values zero = {
 		0,
 	};
-	struct key_t key = {};
+	u32 map_key = 0;
+	bpf_map_update_elem(&tmp_key, &map_key, &empty_key, BPF_ANY);
+	struct key_t *key = bpf_map_lookup_elem(&tmp_key, &map_key);
+	if (!key)
+		return 0;
 
 	if (!include_idle && tid == 0)
 		return 0;
 
-	gadget_process_populate(&key.proc);
+	gadget_process_populate(&key->proc);
 
 	if (user_stacks_only)
-		key.kern_stack_raw = -1;
+		key->kern_stack_raw = -1;
 	else
-		key.kern_stack_raw = bpf_get_stackid(&ctx->regs, &ig_kstack, 0);
+		key->kern_stack_raw =
+			bpf_get_stackid(&ctx->regs, &ig_kstack, 0);
 
 	if (!kernel_stacks_only)
-		gadget_get_user_stack(ctx, &key.user_stack_raw);
+		gadget_get_user_stack(ctx, &key->user_stack_raw);
 
-	if (key.kern_stack_raw >= 0) {
+	if (key->kern_stack_raw >= 0) {
 		// populate extras to fix the kernel stack
 		u64 ip = PT_REGS_IP(&ctx->regs);
 
 		if (is_kernel_addr(ip))
-			key.kernel_ip = ip;
+			key->kernel_ip = ip;
 	}
 
-	valp = bpf_map_lookup_or_try_init(&counts, &key, &zero);
+	valp = bpf_map_lookup_or_try_init(&counts, key, &zero);
 	if (valp)
 		__sync_fetch_and_add(&valp->samples, 1);
 

--- a/gadgets/profile_cuda/program.bpf.c
+++ b/gadgets/profile_cuda/program.bpf.c
@@ -31,6 +31,28 @@ struct {
 	__type(value, u64);
 } sizes SEC(".maps");
 
+/* Per-CPU temporary storage for gadget_user_stack. Using a per-CPU array
+ * instead of a stack-local variable reduces the BPF stack frame size of
+ * gen_alloc_exit() by sizeof(struct gadget_user_stack) (~72 bytes). This
+ * is needed because gadget_get_user_stack() calls a noinline function
+ * containing bpf_tail_call(), which triggers the BPF verifier's 256-byte
+ * stack frame limit for callers with BPF-to-BPF subprogram calls on
+ * kernels < 6.13 (which lack private stack support).
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct gadget_user_stack);
+} tmp_gadget_user_stack SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct alloc_val);
+} tmp_alloc_val SEC(".maps");
+
 struct alloc_key {
 	__u32 stack_id_key;
 };
@@ -100,23 +122,29 @@ static __always_inline int gen_alloc_exit(struct pt_regs *ctx,
 	size = *size_ptr;
 	bpf_map_delete_elem(&sizes, &tid);
 
-	struct gadget_user_stack ustack_raw;
-	gadget_get_user_stack(ctx, &ustack_raw);
+	u32 zero = 0;
+	struct gadget_user_stack *ustack_raw =
+		bpf_map_lookup_elem(&tmp_gadget_user_stack, &zero);
+	if (ustack_raw == NULL)
+		return 0;
+	gadget_get_user_stack(ctx, ustack_raw);
 
 	struct alloc_key key = {
-		.stack_id_key = ustack_raw.stack_id,
+		.stack_id_key = ustack_raw->stack_id,
 	};
 
 	struct alloc_val *val = bpf_map_lookup_elem(&allocs, &key);
 	if (!val) {
-		struct alloc_val new_val = {
-			.count = size,
-			.ustack_raw = ustack_raw,
-		};
+		struct alloc_val *new_val =
+			bpf_map_lookup_elem(&tmp_alloc_val, &zero);
+		if (new_val == NULL)
+			return 0;
 
-		gadget_process_populate(&new_val.proc);
+		new_val->count = size;
+		new_val->ustack_raw = *ustack_raw;
+		gadget_process_populate(&new_val->proc);
 
-		bpf_map_update_elem(&allocs, &key, &new_val, BPF_NOEXIST);
+		bpf_map_update_elem(&allocs, &key, new_val, BPF_NOEXIST);
 	} else {
 		__sync_fetch_and_add(&val->count, size);
 	}


### PR DESCRIPTION
# gadgets: reduce BPF stack frame size for older kernels

## Problem

When combined with upcoming OTel eBPF Profiler symbolization work (PR #4925),
`TestProfileCuda` and `TestProfileCpu` fail on kernels 5.4 through 6.6 with
the BPF verifier error:

```
tail_calls are not allowed when call stack of previous frames is 256 bytes. Too large
```

PR #4925 adds a `noinline` function with `bpf_tail_call()` inside
`gadget_get_user_stack()`, creating a BPF-to-BPF subprogram call. The BPF
verifier enforces a 256-byte stack frame limit for callers in this case.

Both `profile_cuda` and `profile_cpu` have stack frames close to or exceeding
this limit due to large struct locals:

- **profile_cuda** `gen_alloc_exit()`: `struct gadget_user_stack` (72B) +
  `struct alloc_val` (144B) + locals (~32B) = ~248 bytes
- **profile_cpu** `ig_prof_cpu()`: `struct key_t` (148B) + locals = ~180 bytes

Other gadgets using `gadget_get_user_stack()` (audit_seccomp,
trace_capabilities, trace_malloc, trace_open) are unaffected because they
allocate event structs via `gadget_reserve_buf()` (ring buffer), keeping only
a pointer on the stack.

This issue is not reproducible on `main` today — it only manifests when
PR #4925 is merged. This PR preemptively fixes it so that these gadgets
work on older kernels with the OTel integration.

## Fix

Move large struct locals from the stack to per-CPU array maps:

- **profile_cuda**: `struct gadget_user_stack` and `struct alloc_val` moved
  to `tmp_gadget_user_stack` and `tmp_alloc_val` per-CPU arrays (-216 bytes).

- **profile_cpu**: `struct key_t` moved to `tmp_key` per-CPU array (-148
  bytes). The element is zeroed before use via `bpf_map_update_elem` with a
  `static const` zero-initialized value, since `key_t` is used as a hash map
  key and must not contain stale data.

## Why newer kernels don't have this problem

Linux 6.13 introduces **private stack support** (`PRIV_STACK_ADAPTIVE`) for
kprobe/tracepoint/perf_event programs (see
[torvalds/linux@a76ab57](https://github.com/torvalds/linux/commit/a76ab5731e32)
and
[torvalds/linux@e00931c](https://github.com/torvalds/linux/commit/e00931c02568)).
With private stacks, each subprogram's stack is allocated independently
rather than cumulatively, so the 256-byte depth check is bypassed.

## Testing

Verified with `vimto` on kernels 5.10 and 6.6:

```bash
make -C gadgets/ profile_cuda/test-unit KERNEL_VERSION=5.10 VIMTO=/path/to/vimto IG_VERIFY_IMAGE=false
make -C gadgets/ profile_cpu/test-unit KERNEL_VERSION=5.10 VIMTO=/path/to/vimto IG_VERIFY_IMAGE=false
```

Both pass.
