### PR TITLE
fix(bpfstats): reset method to MethodNone after DisableBPFStats to av…

### DIFF
--- a/pkg/bpfstats/bpfstats.go
+++ b/pkg/bpfstats/bpfstats.go
@@ -116,6 +116,8 @@ func DisableBPFStats() error {
 		}
 	}
 
+	method = MethodNone
+
 	return nil
 }
 


### PR DESCRIPTION
# fix(bpfstats): reset method to MethodNone after `DisableBPFStats` to avoid stale state
After a full disable cycle, method was never reset and stayed at `MethodBPFFunc `or `MethodSysctl` even after `DisableBPFStats `completed successfully. This meant `GetMethod() `would return a stale, incorrect value to any caller checking whether stats collection was active.
The fix adds method -> MethodNone after the switch block in `DisableBPFStats`, immediately before the final return nil. This ensures the package-level state accurately reflects that stats collection is disabled, consistent with refCnt being back at zero.

## How to use
Review the single-line change in pkg/bpfstats/bpfstats.go inside DisableBPFStats. Call EnableBPFStats() once, then DisableBPFStats() once, and verify that GetMethod() returns MethodNone afterwards instead of the previously used method.

