### PR TITLE
otel-profiles: Add service name

### DIFF
--- a/pkg/operators/otel-profiles/otel-profiles.go
+++ b/pkg/operators/otel-profiles/otel-profiles.go
@@ -320,6 +320,8 @@ func (o *otelProfilesOperatorInstance) PreStart(gadgetCtx operators.GadgetContex
 			// resource profile
 			rp := profiles.ResourceProfiles().AppendEmpty()
 			rp.SetSchemaUrl(semconv.SchemaURL)
+			rp.Resource().Attributes().PutStr(string(semconv.ServiceNameKey), "inspektor-gadget")
+			rp.Resource().Attributes().PutStr(string(semconv.ServiceVersionKey), version.Version().String())
 
 			// scope profile
 			sp := rp.ScopeProfiles().AppendEmpty()

--- a/pkg/operators/otel-profiles/otel-profiles_test.go
+++ b/pkg/operators/otel-profiles/otel-profiles_test.go
@@ -154,6 +154,17 @@ func TestOtelProfilesOperator(t *testing.T) {
 
 	// Validate the profile structure
 	rp := profiles.ResourceProfiles().At(0)
+
+	// Validate resource attributes (service.name and service.version)
+	resAttrs := rp.Resource().Attributes()
+	serviceName, ok := resAttrs.Get("service.name")
+	require.True(t, ok, "Expected service.name resource attribute")
+	require.Equal(t, "inspektor-gadget", serviceName.Str(), "Expected service.name to be inspektor-gadget")
+
+	serviceVersion, ok := resAttrs.Get("service.version")
+	require.True(t, ok, "Expected service.version resource attribute")
+	require.NotEmpty(t, serviceVersion.Str(), "Expected service.version to be non-empty")
+
 	require.Equal(t, 1, rp.ScopeProfiles().Len(), "Expected one ScopeProfile")
 
 	sp := rp.ScopeProfiles().At(0)


### PR DESCRIPTION
This pull request updates the OpenTelemetry profiles operator to include additional resource attributes for service identification and adds corresponding test coverage to ensure these attributes are set correctly. Currently fetching profiles gives something like:

```
● Here's what Pyroscope captured around 16:01 (local time):

  Profile: process_cpu:malloc — Service: unknown_service

   - Total memory allocated: 2 MB (2,097,152 bytes) over a 600s window
   - Single data point at ~16:01 showing 2 MB allocation

  Hot path (call graph):
```

The service name is useful when creating links in dashboards! 