### PR TITLE
otel-profiles: Add support for profile name

### DIFF
--- a/gadgets/profile_cpu/gadget.yaml
+++ b/gadgets/profile_cpu/gadget.yaml
@@ -21,6 +21,9 @@ datasources:
       # profiling exporter annotations
       profiles.stack-fields: kern_stack,user_stack_raw.symbols
       profiles.value-field: samples
+      profiles.name: process_cpu
+      profiles.type: samples
+      profiles.unit: count
     fields:
       runtime.containerName:
         annotations:

--- a/gadgets/profile_cuda/gadget.yaml
+++ b/gadgets/profile_cuda/gadget.yaml
@@ -10,6 +10,7 @@ datasources:
       cli.clear-screen-before: "true"
       profiles.stack-fields: ustack_raw.symbols
       profiles.value-field: count
+      profiles.name: process_cuda
       profiles.type: malloc
       profiles.unit: bytes
     fields:

--- a/pkg/operators/otel-profiles/otel-profiles.go
+++ b/pkg/operators/otel-profiles/otel-profiles.go
@@ -52,6 +52,7 @@ const (
 	stackFieldsAnnotation     = "profiles.stack-fields"
 	valueFieldAnnotation      = "profiles.value-field"
 	sampleAttributeAnnotation = "profiles.sample-attribute"
+	profilesNameAnnotation    = "profiles.name"
 	profilesTypeAnnotation    = "profiles.type"
 	profilesUnitAnnotation    = "profiles.unit"
 
@@ -289,6 +290,11 @@ func (o *otelProfilesOperatorInstance) PreStart(gadgetCtx operators.GadgetContex
 			profilesUnit = val
 		}
 
+		profilesName := ds.Name()
+		if val, ok := ds.Annotations()[profilesNameAnnotation]; ok && val != "" {
+			profilesName = val
+		}
+
 		client, ok := o.o.clients[exporterName]
 		if !ok {
 			return fmt.Errorf("client not found: %q", exporterName)
@@ -334,6 +340,14 @@ func (o *otelProfilesOperatorInstance) PreStart(gadgetCtx operators.GadgetContex
 			st := prof.SampleType()
 			st.SetTypeStrindex(stringSet.Add(profilesType))
 			st.SetUnitStrindex(stringSet.Add(profilesUnit))
+
+			// Pyroscope derives the profile name from PeriodType.Type
+			// (see grafana/pyroscope pkg/ingester/otlp/convert.go).
+			// Set PeriodType and Period so the profile is named correctly.
+			pt := prof.PeriodType()
+			pt.SetTypeStrindex(stringSet.Add(profilesName))
+			pt.SetUnitStrindex(stringSet.Add(profilesUnit))
+			prof.SetPeriod(1)
 
 			attributeKeys := make(map[string]int32)
 			for name := range attributesGetter {

--- a/pkg/operators/otel-profiles/otel-profiles_test.go
+++ b/pkg/operators/otel-profiles/otel-profiles_test.go
@@ -99,122 +99,158 @@ func TestOtelProfilesOperator(t *testing.T) {
 	const profilesType = "profiles_type"
 	const profilesUnit = "profiles_unit"
 
-	tt := initTest(t)
-
-	tt.ds.AddAnnotation(stackFieldsAnnotation, stackField1Name+","+stackField2Name)
-	tt.ds.AddAnnotation(valueFieldAnnotation, valueFieldName)
-	tt.ds.AddAnnotation(profilesTypeAnnotation, profilesType)
-	tt.ds.AddAnnotation(profilesUnitAnnotation, profilesUnit)
-
-	// Add required fields to the datasource
-	stackField1, err := tt.ds.AddField(stackField1Name, api.Kind_String)
-	require.NoError(t, err)
-
-	stackField2, err := tt.ds.AddField(stackField2Name, api.Kind_String)
-	require.NoError(t, err)
-
-	valueField, err := tt.ds.AddField(valueFieldName, api.Kind_Int64)
-	require.NoError(t, err)
-
-	// Call PreStart to set up subscriptions
-	err = tt.opInst.PreStart(tt.gadgetCtx)
-	require.NoError(t, err)
-
-	// Emit fake events using NewPacketArray
-	dataArray, err := tt.ds.NewPacketArray()
-	require.NoError(t, err)
-
-	for i := 0; i < 3; i++ {
-		data := dataArray.New()
-
-		functions1 := fmt.Sprintf("function%d; function%d; function%d", i*5, i*10, i*20)
-		err = stackField1.PutString(data, functions1)
-		require.NoError(t, err)
-
-		functions2 := fmt.Sprintf("function%d; function%d; function%d", i*6, i*12, i*24)
-		err = stackField2.PutString(data, functions2)
-		require.NoError(t, err)
-
-		err = valueField.PutInt64(data, 42)
-		require.NoError(t, err)
-
-		dataArray.Append(data)
+	tests := []struct {
+		name                string
+		profilesName        string
+		expectedProfileName string
+	}{
+		{
+			name:                "explicit profile name",
+			profilesName:        "my_profile",
+			expectedProfileName: "my_profile",
+		},
+		{
+			name:                "default to datasource name",
+			profilesName:        "",
+			expectedProfileName: "test-datasource",
+		},
 	}
 
-	// Emit the data array
-	err = tt.ds.EmitAndRelease(dataArray)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Check that Export was called
-	require.Equal(t, 1, len(tt.mockClient.exportReq), "Export was not called on the mock client")
+			tt := initTest(t)
 
-	exportReq := tt.mockClient.exportReq[0]
-	profiles := exportReq.Profiles()
-	require.Equal(t, 1, profiles.ResourceProfiles().Len(), "Expected one ResourceProfile")
+			tt.ds.AddAnnotation(stackFieldsAnnotation, stackField1Name+","+stackField2Name)
+			tt.ds.AddAnnotation(valueFieldAnnotation, valueFieldName)
+			if tc.profilesName != "" {
+				tt.ds.AddAnnotation(profilesNameAnnotation, tc.profilesName)
+			}
+			tt.ds.AddAnnotation(profilesTypeAnnotation, profilesType)
+			tt.ds.AddAnnotation(profilesUnitAnnotation, profilesUnit)
 
-	// Validate the profile structure
-	rp := profiles.ResourceProfiles().At(0)
+			// Add required fields to the datasource
+			stackField1, err := tt.ds.AddField(stackField1Name, api.Kind_String)
+			require.NoError(t, err)
 
-	// Validate resource attributes (service.name and service.version)
-	resAttrs := rp.Resource().Attributes()
-	serviceName, ok := resAttrs.Get("service.name")
-	require.True(t, ok, "Expected service.name resource attribute")
-	require.Equal(t, "inspektor-gadget", serviceName.Str(), "Expected service.name to be inspektor-gadget")
+			stackField2, err := tt.ds.AddField(stackField2Name, api.Kind_String)
+			require.NoError(t, err)
 
-	serviceVersion, ok := resAttrs.Get("service.version")
-	require.True(t, ok, "Expected service.version resource attribute")
-	require.NotEmpty(t, serviceVersion.Str(), "Expected service.version to be non-empty")
+			valueField, err := tt.ds.AddField(valueFieldName, api.Kind_Int64)
+			require.NoError(t, err)
 
-	require.Equal(t, 1, rp.ScopeProfiles().Len(), "Expected one ScopeProfile")
+			// Call PreStart to set up subscriptions
+			err = tt.opInst.PreStart(tt.gadgetCtx)
+			require.NoError(t, err)
 
-	sp := rp.ScopeProfiles().At(0)
-	require.Equal(t, "inspektor-gadget", sp.Scope().Name(), "Expected scope name to be inspektor-gadget")
-	require.Equal(t, 1, sp.Profiles().Len(), "Expected one Profile")
+			// Emit fake events using NewPacketArray
+			dataArray, err := tt.ds.NewPacketArray()
+			require.NoError(t, err)
 
-	prof := sp.Profiles().At(0)
-	require.Equal(t, 3, prof.Samples().Len(), "Expected three samples")
+			for i := 0; i < 3; i++ {
+				data := dataArray.New()
 
-	// Check the sample
-	sample := prof.Samples().At(0)
-	require.Equal(t, 1, sample.Values().Len(), "Expected one value in sample")
-	require.Equal(t, int64(42), sample.Values().At(0), "Bad sample value")
+				functions1 := fmt.Sprintf("function%d; function%d; function%d", i*5, i*10, i*20)
+				err = stackField1.PutString(data, functions1)
+				require.NoError(t, err)
 
-	// Check the stack
-	dic := profiles.Dictionary()
-	require.Equal(t, int32(1), sample.StackIndex(), "Expected stack index to be 1")
+				functions2 := fmt.Sprintf("function%d; function%d; function%d", i*6, i*12, i*24)
+				err = stackField2.PutString(data, functions2)
+				require.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
-		stack := dic.StackTable().At(i + 1)
-		require.Equal(t, 6, stack.LocationIndices().Len(), "Bad number of locations in stack")
+				err = valueField.PutInt64(data, 42)
+				require.NoError(t, err)
 
-		// Check the functions in the stack
-		expectedFunctions := []string{
-			fmt.Sprintf("function%d", i*5),
-			fmt.Sprintf("function%d", i*10),
-			fmt.Sprintf("function%d", i*20),
-			fmt.Sprintf("function%d", i*6),
-			fmt.Sprintf("function%d", i*12),
-			fmt.Sprintf("function%d", i*24),
-		}
-		for i, expectedFunc := range expectedFunctions {
-			locationIdx := stack.LocationIndices().At(i)
-			location := dic.LocationTable().At(int(locationIdx))
-			require.Equal(t, 1, location.Lines().Len(), "Expected one line per location")
+				dataArray.Append(data)
+			}
 
-			functionIdx := location.Lines().At(0).FunctionIndex()
-			function := dic.FunctionTable().At(int(functionIdx))
+			// Emit the data array
+			err = tt.ds.EmitAndRelease(dataArray)
+			require.NoError(t, err)
 
-			nameStrIndex := function.NameStrindex()
-			functionName := dic.StringTable().At(int(nameStrIndex))
-			require.Equal(t, expectedFunc, functionName, "Expected function name to match")
-		}
+			// Check that Export was called
+			require.Equal(t, 1, len(tt.mockClient.exportReq), "Export was not called on the mock client")
+
+			exportReq := tt.mockClient.exportReq[0]
+			profiles := exportReq.Profiles()
+			require.Equal(t, 1, profiles.ResourceProfiles().Len(), "Expected one ResourceProfile")
+
+			// Validate the profile structure
+			rp := profiles.ResourceProfiles().At(0)
+
+			// Validate resource attributes (service.name and service.version)
+			resAttrs := rp.Resource().Attributes()
+			serviceName, ok := resAttrs.Get("service.name")
+			require.True(t, ok, "Expected service.name resource attribute")
+			require.Equal(t, "inspektor-gadget", serviceName.Str(), "Expected service.name to be inspektor-gadget")
+
+			serviceVersion, ok := resAttrs.Get("service.version")
+			require.True(t, ok, "Expected service.version resource attribute")
+			require.NotEmpty(t, serviceVersion.Str(), "Expected service.version to be non-empty")
+
+			require.Equal(t, 1, rp.ScopeProfiles().Len(), "Expected one ScopeProfile")
+
+			sp := rp.ScopeProfiles().At(0)
+			require.Equal(t, "inspektor-gadget", sp.Scope().Name(), "Expected scope name to be inspektor-gadget")
+			require.Equal(t, 1, sp.Profiles().Len(), "Expected one Profile")
+
+			prof := sp.Profiles().At(0)
+			require.Equal(t, 3, prof.Samples().Len(), "Expected three samples")
+
+			// Check the sample
+			sample := prof.Samples().At(0)
+			require.Equal(t, 1, sample.Values().Len(), "Expected one value in sample")
+			require.Equal(t, int64(42), sample.Values().At(0), "Bad sample value")
+
+			// Check the stack
+			dic := profiles.Dictionary()
+			require.Equal(t, int32(1), sample.StackIndex(), "Expected stack index to be 1")
+
+			for i := 0; i < 3; i++ {
+				stack := dic.StackTable().At(i + 1)
+				require.Equal(t, 6, stack.LocationIndices().Len(), "Bad number of locations in stack")
+
+				// Check the functions in the stack
+				expectedFunctions := []string{
+					fmt.Sprintf("function%d", i*5),
+					fmt.Sprintf("function%d", i*10),
+					fmt.Sprintf("function%d", i*20),
+					fmt.Sprintf("function%d", i*6),
+					fmt.Sprintf("function%d", i*12),
+					fmt.Sprintf("function%d", i*24),
+				}
+				for i, expectedFunc := range expectedFunctions {
+					locationIdx := stack.LocationIndices().At(i)
+					location := dic.LocationTable().At(int(locationIdx))
+					require.Equal(t, 1, location.Lines().Len(), "Expected one line per location")
+
+					functionIdx := location.Lines().At(0).FunctionIndex()
+					function := dic.FunctionTable().At(int(functionIdx))
+
+					nameStrIndex := function.NameStrindex()
+					functionName := dic.StringTable().At(int(nameStrIndex))
+					require.Equal(t, expectedFunc, functionName, "Expected function name to match")
+				}
+			}
+
+			// Check sample type
+			st := prof.SampleType()
+			sampleTypeStr := dic.StringTable().At(int(st.TypeStrindex()))
+			require.Equal(t, profilesType, sampleTypeStr, "Bad sample type")
+
+			sampleUnitStr := dic.StringTable().At(int(st.UnitStrindex()))
+			require.Equal(t, profilesUnit, sampleUnitStr, "Bad sample unit")
+
+			// Check period type (used by Pyroscope to derive profile name)
+			pt := prof.PeriodType()
+			periodTypeStr := dic.StringTable().At(int(pt.TypeStrindex()))
+			require.Equal(t, tc.expectedProfileName, periodTypeStr, "Bad period type")
+
+			periodUnitStr := dic.StringTable().At(int(pt.UnitStrindex()))
+			require.Equal(t, profilesUnit, periodUnitStr, "Bad period unit")
+
+			require.Equal(t, int64(1), prof.Period(), "Bad period value")
+		})
 	}
-
-	// Check sample type
-	st := prof.SampleType()
-	sampleTypeStr := dic.StringTable().At(int(st.TypeStrindex()))
-	require.Equal(t, profilesType, sampleTypeStr, "Bad sample type")
-
-	sampleUnitStr := dic.StringTable().At(int(st.UnitStrindex()))
-	require.Equal(t, profilesUnit, sampleUnitStr, "Bad sample unit")
 }


### PR DESCRIPTION
Currently if we don't set the profile name, it fallback to `process_cpu` resulting in final name of `process_cpu:malloc` which might the confusing for users (and LLMs), see: https://github.com/grafana/pyroscope/blob/v1.16.0/pkg/ingester/otlp/convert.go#L144
 
This change allows setting custom profile name e.g we are setting profile name to be `process_cuda` for `profile_cuda` gadget. 

## before

<img width="1529" height="502" alt="Screenshot from 2026-04-20 09-44-31" src="https://github.com/user-attachments/assets/88bd9031-106a-49ce-acee-9c715cfd9a33" />


## after

<img width="1168" height="408" alt="Screenshot from 2026-04-17 19-53-09" src="https://github.com/user-attachments/assets/432ebc5e-8329-4ca6-9379-f1c545c10fd6" />

Edit: I renamed the profile name from `profile_cuda` to `process_cuda` to allign with pyroscope conventions but haven't updated the screenshot. 

Also, this pyroscope version >= 1.16.0