### PR TITLE
ebpf: release CollectionSpec after programs are attached

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -951,6 +951,11 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 		return fmt.Errorf("running map iterators: %w", err)
 	}
 
+	// Release the CollectionSpec after all programs are attached and iterators
+	// are running; it is not referenced at runtime and holds BTF
+	// type/line info that the GC cannot otherwise reclaim.
+	i.collectionSpec = nil
+
 	return nil
 }
 


### PR DESCRIPTION
# release CollectionSpec after programs are attached

The CollectionSpec holds ~30 MiB of BTF type/line info and BPF program bytecode that is needed only during loading and CO-RE relocation. After all programs are attached and iterators are running the spec is no longer referenced at runtime, so setting it to nil allows the GC to reclaim that memory.

## Memory Profile

### What's freed

`ebpfInstance.collectionSpec` holds the parsed ELF content for every BPF program in the gadget:

- `ProgramSpec.Instructions` — the BPF bytecode for each program
- BTF line info and relocation info tables (`btf.newLineInfo`, `btf.newRelocationInfo`)
- Extended info from the ELF (`btf.loadExtInfosFromELF`) used for CO-RE relocation

All of this is consumed by `ebpf.NewCollectionWithOptions` when the kernel loads the programs. After that call returns, the spec is never read again at runtime. This PR sets `i.collectionSpec = nil` at the end of `Start()`, allowing the GC to reclaim the memory.

### Measurement

Heap profiles captured with `--pprof-addr=localhost:6060` + `?gc=1` (forced GC before snapshot), averaged over 3 runs.

#### `trace_exec` gadget (1.6 MiB ELF)

| Binary | Heap inuse (avg of 3 runs) |
|--------|---------------------------|
| Before (`collectionSpec` retained) | 60.5 MiB |
| After (`collectionSpec = nil` post-attach) | 57.1 MiB |
| **Savings** | **~3.4 MiB** |

#### Scaling to the kubescape/node-agent workload

The savings scale roughly linearly with the total ELF size loaded. With a **19 MiB `tracers.tar`**:

| ELF size | Measured savings | Ratio |
|----------|-----------------|-------|
| 1.6 MiB (`trace_exec`) | ~3.4 MiB | ~2.1× |
| **19 MiB (`tracers.tar`)** | **~40 MiB** | ~2.1× |

This is consistent with the PR's ~30 MiB claim.

#### What disappears from the heap (pprof inuse_space, `trace_exec`)

These entries appear **before** but are **gone after** the fix:

```
# BEFORE — entries freed by this PR
    1.00MB  btf.newLineInfo        (line tables for BPF programs)
    1.00MB  btf.newRelocationInfo  (CO-RE relocation tables)
    2.00MB  btf.loadExtInfosFromELF (extended infos from ELF)
    # + partial savings in btf.newDecoder / LoadCollectionSpecFromReader
```

```
# AFTER — none of the above entries present in inuse_space
Showing nodes accounting for 57.1MB, 100% of 57.1MB total
      flat  flat%
    3.64MB  6.27%  github.com/cilium/ebpf/btf.newDecoder
    1.91MB  3.29%  github.com/cilium/ebpf/btf.newFuzzyStringIndex
    ...
    (no newLineInfo, no newRelocationInfo, no loadExtInfosFromELF)
```

