### PR TITLE
container-utils/docker: populate image digest in GetContainer

### DIFF
--- a/pkg/container-utils/docker/docker.go
+++ b/pkg/container-utils/docker/docker.go
@@ -128,7 +128,7 @@ func (c *DockerClient) GetContainers() ([]*runtimeclient.ContainerData, error) {
 	ret := make([]*runtimeclient.ContainerData, len(containers))
 
 	for i, container := range containers {
-		ret[i] = DockerContainerToContainerData(&container)
+		ret[i] = c.dockerContainerToContainerData(&container)
 	}
 
 	return ret, nil
@@ -150,7 +150,7 @@ func (c *DockerClient) GetContainer(containerID string) (*runtimeclient.Containe
 			len(containers), containerID, containers)
 	}
 
-	return DockerContainerToContainerData(&containers[0]), nil
+	return c.dockerContainerToContainerData(&containers[0]), nil
 }
 
 func (c *DockerClient) GetContainerDetails(containerID string) (*runtimeclient.ContainerDetailsData, error) {
@@ -237,7 +237,6 @@ func (c *DockerClient) Close() error {
 
 // Gets the image digest for the given image ID, if the digest exists.
 // The digest is usually only available if the image was either pulled from a registry, or if the image was pushed to a registry, which is when the manifest is generated and its digest calculated.
-// Note: This function only works for already running containers and not for containers that are being created.
 func (c *DockerClient) getContainerImageDigest(imageId string) string {
 	result, err := c.client.ImageInspect(context.Background(), imageId)
 	if err != nil {
@@ -276,8 +275,7 @@ func containerStatusStateToRuntimeClientState(containerState string) (runtimeCli
 	return
 }
 
-func DockerContainerToContainerData(container *container.Summary) *runtimeclient.ContainerData {
-	imageDigest := ""
+func (c *DockerClient) dockerContainerToContainerData(container *container.Summary) *runtimeclient.ContainerData {
 	containerName := ""
 	if len(container.Names) > 0 {
 		containerName = container.Names[0]
@@ -287,7 +285,7 @@ func DockerContainerToContainerData(container *container.Summary) *runtimeclient
 		containerName,
 		container.Image,
 		container.ImageID,
-		imageDigest,
+		c.getContainerImageDigest(container.ImageID),
 		string(container.State),
 		container.Labels)
 }

--- a/pkg/container-utils/runtime-client/runtimeclient_test.go
+++ b/pkg/container-utils/runtime-client/runtimeclient_test.go
@@ -108,7 +108,11 @@ func TestRuntimeClientInterface(t *testing.T) {
 				for _, eData := range expectedData {
 					found := false
 					for _, cData := range containers {
-						// ContainerImageDigest may vary among versions, so we do not check it for now
+						if cData.Runtime.ContainerID != eData.Runtime.ContainerID {
+							continue
+						}
+						require.NotEmpty(t, cData.Runtime.ContainerImageDigest, "ContainerImageDigest should be populated")
+						// ContainerImageDigest may vary among versions, so we do not check its value
 						cData.Runtime.ContainerImageDigest = ""
 						cData.Runtime.ContainerImageID = ""
 						if cmp.Equal(*cData, eData.ContainerData) {
@@ -126,11 +130,12 @@ func TestRuntimeClientInterface(t *testing.T) {
 
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainer(eData.Runtime.ContainerID)
-					// ContainerImageDigest may vary among versions, so we do not check it for now
-					cData.Runtime.ContainerImageDigest = ""
-					cData.Runtime.ContainerImageID = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
+					require.NotEmpty(t, cData.Runtime.ContainerImageDigest, "ContainerImageDigest should be populated")
+					// ContainerImageDigest may vary among versions, so we do not check its value
+					cData.Runtime.ContainerImageDigest = ""
+					cData.Runtime.ContainerImageID = ""
 					require.True(t, cmp.Equal(*cData, eData.ContainerData),
 						"unexpected container data:\n%s", cmp.Diff(*cData, eData.ContainerData))
 				}
@@ -141,11 +146,12 @@ func TestRuntimeClientInterface(t *testing.T) {
 
 				for _, eData := range expectedData {
 					cData, err := rc.GetContainerDetails(eData.Runtime.ContainerID)
-					// ContainerImageDigest may vary among versions, so we do not check it for now
-					cData.Runtime.ContainerImageDigest = ""
-					cData.Runtime.ContainerImageID = ""
 					require.Nil(t, err)
 					require.NotNil(t, cData)
+					require.NotEmpty(t, cData.Runtime.ContainerImageDigest, "ContainerImageDigest should be populated")
+					// ContainerImageDigest may vary among versions, so we do not check its value
+					cData.Runtime.ContainerImageDigest = ""
+					cData.Runtime.ContainerImageID = ""
 
 					// TODO: Is it worth to compare the cgroups path and mounts?
 					require.NotEmpty(t, cData.CgroupsPath)


### PR DESCRIPTION
# container-utils/docker: populate image digest in GetContainer
For newly created Docker containers, the runtime enrichment pipeline never populated `Runtime.ContainerImageDigest.containerRuntimeEnricher` enriches new containers via `DockerClient.GetContainer()`, which used `DockerContainerToContainerData` that hardcoded the digest to "". Only `GetContainerDetails()` (used for already-running containers discovered at startup) actually called `getContainerImageDigest()`. As a result, Docker containers created after ig started up came through with an empty digest, and BasicRuntimeMetadata.IsEnriched() (which requires a non-empty digest) would keep treating them as not fully enriched.

This change adds a new client-aware helper `(*DockerClient).dockerContainerToContainerData` that calls the
existing `getContainerImageDigest(container.ImageID)` helper which is the same approach already used by
`GetContainerDetails`. `GetContainer` now uses it, so newly created Docker containers are enriched with the repo digest just like already-running ones. `GetContainers()` is intentionally left unchanged: the startup path already enriches via GetContainerDetails, and adding an ImageInspect call per container in GetContainers is not necessary.

Also strengthens `TestRuntimeClientInterface` to assert that `ContainerImageDigest` is non-empty in the `GetContainer` and `GetContainerDetails` subtests (the exact digest value is still not compared, to stay version-agnostic). Without this assertion, the bug was invisible to the existing test because it was zeroing the field out
before comparison.

Fixes #5463

## How to use

 1. Check out this branch and build ig.
 2. Start ig against the Docker runtime with an event-producing gadget (e.g. trace_exec) on a host where the
image has been pulled from a registry.
 3. Start a new container: docker run --rm --name demo busybox sh -c 'echo hi'
 4. Verify that events for the new container have runtime.containerImageDigest populated with a sha256:... value
 (previously empty).
 5. Also verify already-running containers (created before ig started) still show the digest. behavior there is
 unchanged.

## Testing done

Manual validation with `ig list-containers` and an trace_exec gadget against Docker, confirming `containerImageDigest` is populated for both containers created before and after ig starts.