### PR TITLE
ebpf: release ELF/BPF object bytes after spec is loaded

### DIFF
--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -343,6 +343,10 @@ func (i *ebpfInstance) init(gadgetCtx operators.GadgetContext) error {
 		}
 	}
 
+	// Release the raw ELF/BPF object bytes; loadSpec() and addExtraInfo() are
+	// the only callers and both have completed.
+	i.program = nil
+
 	err = i.analyze(gadgetCtx, i.paramValues)
 	if err != nil {
 		return fmt.Errorf("analyzing: %w", err)


### PR DESCRIPTION
# release ELF/BPF object bytes after spec is loaded

The raw ELF/BPF object bytes read by InstantiateImageOperator are stored in ebpfInstance.program and used only by loadSpec() and addExtraInfo(). Once both have completed the bytes are never accessed again, yet they are retained for the lifetime of the gadget (~28 MiB per gadget process).

Set i.program = nil immediately after the addExtraInfo block so the GC can reclaim that memory before the gadget enters its run loop.

 ## Memory impact of releasing `i.program` after load
 
 `i.program` holds the raw ELF/BPF object bytes read at gadget startup.
 After `loadSpec()` and `addExtraInfo()` complete, `collectionSpec` owns all
 parsed data and the original byte slice is no longer needed — but it was
 kept alive for the gadget's entire lifetime.
 
 ### How much memory is freed
 
 The saving is exactly the size of the ELF binary in the gadget OCI image.
 Measured from the published images:
 
 | Gadget | ELF size (`i.program`) |
 |---|---|
 | `trace_dns` | 46 KB |
 | `trace_capabilities` | 104 KB |
 | `trace_open` | 106 KB |
 | `trace_tcp` | 165 KB |
 | `traceloop` | 66 KB |
 | `trace_exec` | **1.6 MB** |
 
 ### Go heap profile (trace_capabilities, `?gc=1`)
 
 `go tool pprof -alloc_space` confirms the ebpf operator's `io.ReadAll`
 allocation is reclaimed after the fix:
 

BEFORE ebpf operator io.ReadAll (inuse after GC): 548 KB AFTER ebpf operator io.ReadAll (inuse after GC): 0 B ✓

 
 Captured with:

sudo ig run trace_capabilities:v0.48.1 --pprof-addr=localhost:6060 ... curl "http://localhost:6060/debug/pprof/heap?gc=1" go tool pprof -alloc_space -traces heap.pb.gz

 
 The saving per gadget is modest for small gadgets but meaningful for
 `trace_exec` (~1.6 MB) and grows linearly when multiple gadget instances
 run concurrently.
