### PR TITLE
gadgets/trace_capabilities: reduce current_syscall map size from 1M to 10K

### DIFF
--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -157,8 +157,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(key_size, sizeof(u32));
 	__uint(value_size, sizeof(struct syscall_context));
-	__uint(max_entries,
-	       1048576); // There can be many threads sleeping in some futex/poll syscalls
+	__uint(max_entries, 10240); // keyed by TID; capability checks are momentary
 } current_syscall SEC(".maps");
 
 GADGET_TRACER_MAP(events, 1024 * 256);


### PR DESCRIPTION
## Problem

`current_syscall` is a `BPF_MAP_TYPE_HASH` with `max_entries = 1048576`. This map type pre-allocates all entries at load time. With a u32 key and u64 value, each entry consumes roughly 36 bytes (key + value + htab node overhead), and the bucket array adds another ~8 MiB — totalling **~44 MiB of kernel memory per gadget instance**.

The comment was copied from `trace_exec` ("there can be many threads sleeping in some futex/poll syscalls") but does not apply here:

- `cap_capable` is a momentary kernel call, not a long-sleeping syscall.
- The execve context tracking (sys_enter/sys_exit_execve) in this gadget also cannot produce anywhere near 1M simultaneous entries; even the default Linux `pid_max` is only 32768.

## Fix

Reduce `max_entries` to `10240`, consistent with the two other maps in this file (`seen` and the events map). This is still generous for the actual workload.

## Memory savings

~43 MiB of kernel memory freed per gadget instance at load time.

In environments running many containers (each with its own gadget instance), the savings multiply accordingly.