### PR TITLE
gadgets/trace_capabilities: reduce current_syscall map size from 1M to 10K

### DIFF
--- a/gadgets/trace_capabilities/program.bpf.c
+++ b/gadgets/trace_capabilities/program.bpf.c
@@ -158,7 +158,7 @@ struct {
 	__uint(key_size, sizeof(u32));
 	__uint(value_size, sizeof(struct syscall_context));
 	__uint(max_entries,
-	       1048576); // There can be many threads sleeping in some futex/poll syscalls
+	       10240); // keyed by TID; capability checks are momentary
 } current_syscall SEC(".maps");
 
 GADGET_TRACER_MAP(events, 1024 * 256);


### PR DESCRIPTION
## Problem

`current_syscall` is a `BPF_MAP_TYPE_HASH` with `max_entries = 1048576`. This map type pre-allocates all entries at load time. With a u32 key and u64 value, each entry consumes roughly 36 bytes (key + value + htab node overhead), and the bucket array adds another ~8 MiB — totalling **~44 MiB of kernel memory per gadget instance**.

The comment was copied from `trace_exec` ("there can be many threads sleeping in some futex/poll syscalls") but does not apply here:

- `cap_capable` is a momentary kernel call, not a long-sleeping syscall.
- The execve context tracking (sys_enter/sys_exit_execve) in this gadget also cannot produce anywhere near 1M simultaneous entries; even the default Linux `pid_max` is only 32768.

## Fix

Reduce `max_entries` to `10240`, consistent with the two other maps in this file (`seen` and the events map). This is still generous for the actual workload.

## Memory impact of reducing `current_syscall` map size
 
 The `current_syscall` BPF hash map was defined with `max_entries = 1,048,576` (1 M entries).
 It is keyed by TID and holds at most one entry per concurrently-running thread, so 10,240 entries is sufficient for even highly-threaded workloads.
 
 `BPF_MAP_TYPE_HASH` pre-allocates its bucket array and element pool at load time.
 For this map (`key = u32`, `value = u64`):
 
 | | Before (1 M entries) | After (10 K entries) |
 |---|---|---|
 | Bucket array | ~8 MB | ~128 KB |
 | Pre-allocated elements | ~56 MB | ~560 KB |
 | **Total map** | **~64 MB** | **~688 KB** |
 | **Saving** | | **~63 MB** |
 
 #### Measured (3 runs each)
 
 Total system memory increase on gadget start (`vmstat` used-memory delta):
 
 | Run | Before | After |
 |---|---|---|
 | 1 | 265 MB | 211 MB |
 | 2 | 298 MB | 283 MB |
 | 3 | 244 MB | 218 MB |
 | **Average** | **~269 MB** | **~238 MB** |
 | **Reduction** | | **~31 MB** |
