### PR TITLE
cmd: Add --tls-insecure to ig daemon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ It's possible to control an `ig` running in Linux from different operating syste
 Run the following on a Linux machine to make `ig` available to clients.
 
 ```bash
-sudo ig daemon --host=tcp://0.0.0.0:1234
+sudo ig daemon --tls-insecure --host=tcp://0.0.0.0:1234
 ```
 
 Download the `gadgetctl` tools for MacOS

--- a/cmd/ig/daemon.go
+++ b/cmd/ig/daemon.go
@@ -52,6 +52,7 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 	var serverKey string
 	var serverCert string
 	var clientCA string
+	var useInsecureTLS bool
 
 	daemonCmd.PersistentFlags().StringVarP(
 		&group,
@@ -92,6 +93,12 @@ func newDaemonCommand(runtime runtime.Runtime) *cobra.Command {
 		"tls-client-ca-file",
 		"",
 		"Path to CA certificate for client validation")
+
+	daemonCmd.PersistentFlags().BoolVar(
+		&useInsecureTLS,
+		"tls-insecure",
+		false,
+		"Allow insecure connections from clients (no certificate validation)")
 
 	service := gadgetservice.NewService(log.StandardLogger())
 
@@ -168,7 +175,11 @@ All these options should be set at the same time to enable TLS connection`,
 
 			log.Debugf("TLS is enabled using %v, %v and %v", serverKey, serverCert, clientCA)
 		} else if !strings.HasPrefix(socketPath, "unix") {
-			log.Warnf("no TLS configuration provided, communication between daemon and CLI will not be encrypted")
+			if useInsecureTLS {
+				log.Warnf("no TLS configuration provided, communication between daemon and CLI will not be encrypted")
+			} else {
+				return fmt.Errorf("no TLS configuration provided, will not proceed until running with --tls-insecure")
+			}
 		}
 
 		mgr, err := instancemanager.New(runtime)

--- a/docs/api/golang.mdx
+++ b/docs/api/golang.mdx
@@ -289,7 +289,7 @@ import GRPC from '!!raw-loader!./_golang/grpc/main.go';
 In this case we need to run `ig` in daemon mode:
 
 ```bash
-$ sudo ig daemon --host tcp://127.0.0.1:8888
+$ sudo ig daemon --tls-insecure --host tcp://127.0.0.1:8888
 INFO[0000] starting Inspektor Gadget daemon at "tcp://127.0.0.1:8888"
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,7 +82,7 @@ It's possible to control an `ig` running in Linux from different operating syste
 Run the following on a Linux machine to make `ig` available to clients.
 
 ```bash
-sudo ig daemon --host=tcp://0.0.0.0:1234
+sudo ig daemon --tls-insecure --host=tcp://0.0.0.0:1234
 ```
 
 Download the `gadgetctl` tools for MacOS

--- a/docs/reference/disallow-pulling.mdx
+++ b/docs/reference/disallow-pulling.mdx
@@ -54,7 +54,7 @@ You can specify these options only at start time:
 $ sudo ig image list
 REPOSITORY                                TAG                                       DIGEST       CREATED
 trace_exec                                latest                                    24c0da566661 15 hours ago
-$ sudo ig daemon --disallow-pulling
+$ sudo ig daemon --tls-insecure --disallow-pulling
 ...
 # Switch to another terminal
 $ gadgetctl run trace_exec

--- a/docs/reference/export-metrics.mdx
+++ b/docs/reference/export-metrics.mdx
@@ -27,7 +27,7 @@ In order to enable the metrics listener, you need to set the
 
     <TabItem value="ig" label="ig">
         ```bash
-        sudo ig daemon --otel-metrics-listen=true
+        sudo ig daemon --tls-insecure --otel-metrics-listen=true
         ```
     </TabItem>
 </Tabs>

--- a/docs/reference/ig.md
+++ b/docs/reference/ig.md
@@ -231,7 +231,7 @@ User=root
 Restart=on-failure
 RestartSec=30
 WorkingDirectory=/usr/local/bin
-ExecStart=/usr/local/bin/ig daemon --group ig
+ExecStart=/usr/local/bin/ig daemon --tls-insecure --group ig
 
 [Install]
 WantedBy=multi-user.target
@@ -268,7 +268,7 @@ Modify the `ig.service` file to something like this:
 
 ```
 ...
-ExecStart=/usr/local/bin/ig daemon -H tcp://127.0.0.1:9999
+ExecStart=/usr/local/bin/ig daemon --tls-insecure -H tcp://127.0.0.1:9999
 ...
 ```
 
@@ -297,7 +297,7 @@ the verbose flag (-v) like so:
 
 ```ini
 ...
-ExecStart=/usr/local/bin/ig daemon -v --group ig
+ExecStart=/usr/local/bin/ig daemon --tls-insecure -v --group ig
 ...
 ```
 

--- a/docs/reference/restricting-gadgets.mdx
+++ b/docs/reference/restricting-gadgets.mdx
@@ -72,7 +72,7 @@ Error: fetching gadget information: initializing and preparing operators: instan
 You can specify these options only at start time:
 
 ```bash
-$ sudo ig daemon --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/your-repo/gadget/your_gadget@sha256:digest_of_your_gadget'
+$ sudo ig daemon --tls-insecure --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec@sha256:e13e3859be5ed8cef676a720274480d2748f66fd98cf8d963af6c4c05121526f,ghcr.io/your-repo/gadget/your_gadget@sha256:digest_of_your_gadget'
 ...
 # Switch to another terminal
 $ gadgetctl run trace_exec
@@ -149,7 +149,7 @@ Error: fetching gadget information: initializing and preparing operators: instan
 You can specify these options only at start time:
 
 ```bash
-$ sudo ig daemon --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec:latest,ghcr.io/your-repo/gadget/your_gadget:latest'
+$ sudo ig daemon --tls-insecure --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_exec:latest,ghcr.io/your-repo/gadget/your_gadget:latest'
 ...
 # Switch to another terminal
 $ gadgetctl run trace_exec:latest
@@ -223,7 +223,7 @@ You can specify these options only at start time:
 
 ```bash
 # Let's allow all the tracers from Inspektor Gadget repository and all the gadgets from your repository.
-$ sudo ig daemon --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_*,ghcr.io/your-repo/gadget/*'
+$ sudo ig daemon --tls-insecure --allowed-gadgets='ghcr.io/inspektor-gadget/gadget/trace_*,ghcr.io/your-repo/gadget/*'
 ...
 # Switch to another terminal
 $ gadgetctl run trace_exec

--- a/docs/reference/verify-gadgets.mdx
+++ b/docs/reference/verify-gadgets.mdx
@@ -122,7 +122,7 @@ This avoids them being tampered by any users.
 By default all image-based gadgets are verified using Inspektor Gadget public key:
 
 ```bash
-$ sudo ig daemon --public-keys="$(cat your-key.pub)"
+$ sudo ig daemon --tls-insecure --public-keys="$(cat your-key.pub)"
 ...
 # Switch to another terminal
 $ gadgetctl run ghcr.io/your_repo/trace_exec
@@ -137,7 +137,7 @@ You can specify several public keys, by using a comma to separate them:
 $ IP='your_ip'
 $ PORT='your_port'
 $ ADDR=tcp://$IP:$PORT
-$ sudo ig daemon --public-keys="$(cat your-key.pub),$(cat inspektor-gadget.pub)" --host=$ADDR
+$ sudo ig daemon --tls-insecure --public-keys="$(cat your-key.pub),$(cat inspektor-gadget.pub)" --host=$ADDR
 ...
 # Switch to another terminal
 $ gadgetctl run trace_open:latest
@@ -249,7 +249,7 @@ The signing information are set once when starting `ig` as a daemon.
 This avoids them being tampered by any users.
 
 ```bash
-$ sudo ig daemon --notation-certificates="$(cat your-certificate.crt)" --notation-policy-document="$(cat your-policy-document.json)"
+$ sudo ig daemon --tls-insecure --notation-certificates="$(cat your-certificate.crt)" --notation-policy-document="$(cat your-policy-document.json)"
 ...
 # Switch to another terminal
 $ gadgetctl run ghcr.io/your_repo/trace_exec
@@ -262,7 +262,7 @@ You can specify several certificates, by using a comma to separate them:
 $ IP='your_ip'
 $ PORT='your_port'
 $ ADDR=tcp://$IP:$PORT
-$ sudo ig daemon --notation-certificates="$(cat your-1st-certificate.crt),$(cat your-2nd-certificate.crt)" --notation-policy-document=$(cat your-policy-document.json) --host=$ADDR
+$ sudo ig daemon --tls-insecure --notation-certificates="$(cat your-1st-certificate.crt),$(cat your-2nd-certificate.crt)" --notation-policy-document=$(cat your-policy-document.json) --host=$ADDR
 ...
 # Switch to another terminal
 $ gadgetctl run ghcr.io/your-repo/gadget/trace_open:your_1st_tag
@@ -319,7 +319,7 @@ RUNTIME.CONTAINERNAME  PID          UID          GID          MNTNS_ID RET FL…
 
 <TabItem value="ig-daemon" label="ig daemon">
 ```bash
-$ sudo ig daemon --verify-image=false
+$ sudo ig daemon --tls-insecure --verify-image=false
 ...
 # Switch to another terminal
 $ gadgetctl run ghcr.io/your-repo/gadget/trace_open:latest

--- a/gadgets/bpfstats/README.mdx
+++ b/gadgets/bpfstats/README.mdx
@@ -49,7 +49,7 @@ $ kubectl gadget deploy
 
   <TabItem value="ig-daemon" label="ig-daemon">
 ```bash
-$ sudo ig daemon
+$ sudo ig daemon --tls-insecure
 ```
   </TabItem>
 </Tabs>

--- a/tools/monitoring/README.md
+++ b/tools/monitoring/README.md
@@ -4,7 +4,7 @@ This directory contains docker compose files for spinning up grafana and prometh
 Prometheus is configured to scrape metrics from the `ig` daemon running on the host machine as:
 
 ```bash
-go run -exec sudo ../../cmd/ig daemon --otel-metrics-listen=true
+go run -exec sudo ../../cmd/ig daemon --tls-insecure --otel-metrics-listen=true
 ```
 
 then start the gadget with


### PR DESCRIPTION
This flag is mandatory to run ig daemon without TLS.