### PR TITLE
pkg/oci: Add process-level mutex to protect local OCI store

### DIFF
--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -21,11 +21,16 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"sync"
 
 	"github.com/gofrs/flock"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content/oci"
 )
+
+// storeMu protects newLocalOciStore from concurrent goroutine access within
+// the same process. The file-based flock only provides inter-process locking.
+var storeMu sync.Mutex
 
 type localOciStore struct {
 	*oci.Store
@@ -38,6 +43,11 @@ type localOciStore struct {
 // newLocalOciStore returns a localOciStore that is safe when executed
 // concurrently, even from different processes.
 func newLocalOciStore() (*localOciStore, error) {
+	// Protect against concurrent goroutines, e.g. multiple headless
+	// gadget instances starting simultaneously.
+	storeMu.Lock()
+	defer storeMu.Unlock()
+
 	if err := os.MkdirAll(filepath.Dir(defaultOciStore), 0o700); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The file-based flock in newLocalOciStore only provides inter-process locking. Add a process-level sync.Mutex to also protect against concurrent goroutines within the same process, e.g. multiple headless [gadget instances starting simultaneously](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/pkg/gadget-service/instance-manager/manager.go#L120) at startup.

Found while testing #5485 on AKS but doesn't have to do anything with it. Users could create gadget instance configmaps and at first startup they might end up with the issue because multiple gadget run witll start to setup OCI store layout.

ref: https://github.com/oras-project/oras-go/blob/763cf5e4c812d6eb295ba9008d1d5ae377711b98/content/oci/oci.go#L113C27-L113C51

## Testing Done

### steps to reproduce

```
# start multiple gadgets w/o fix
helm install gadget --namespace=gadget --create-namespace oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget --version=1.0.0-dev -f https://gist.githubusercontent.com/mqasimsarfraz/ba17c549499deef5f70b833e5ab4e1e1/raw/410eda513ab424f791f9b836fb9a22147655a1e1/gadget-configmaps-values.yaml
# check the status of gadgets
kubectl gadget list
# uninstall current installation
helm uninstall -n gadget gadget
# start multiple gadgets with fix
helm install gadget --namespace=gadget --set image.repository=ghcr.io/mqasimsarfraz/inspektor-gadget --set image.tag=bugfix-lock-ocistore  --create-namespace oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget --version=1.0.0-dev -f https://gist.githubusercontent.com/mqasimsarfraz/ba17c549499deef5f70b833e5ab4e1e1/raw/410eda513ab424f791f9b836fb9a22147655a1e1/gadget-configmaps-values.yaml

# check status again
kubectl gadget list
```

### w/o this change

```
→ kubectl gadget list
WARN[0000] version skew detected: client (v0.51.1) vs server (v0.51.0) 
ID           NAME                                                                               TAGS                                                                               GADGET                                                                            STATUS                                                                           
1f945ccf5ff0 my-snapshot-process                                                                debug                                                                              ghcr.io/inspektor-gadget/gadget/snapshot_process:latest                           Error                                                                            
59561f4a918d my-trace-exec                                                                      security,audit                                                                     ghcr.io/inspektor-gadget/gadget/trace_exec:latest                                 Running                                                                          
95381cb91286 my-trace-tcp-gadget                                                                                                                                                   ghcr.io/inspektor-gadget/gadget/trace_tcp:latest                                  Running                                                                          
a59a0c9892ea my-trace-open                                                                                                                                                         ghcr.io/inspektor-gadget/gadget/trace_open:latest                                 Running                                                                          
c2a65bc902ae my-top-file-gadget                                                                                                                                                    ghcr.io/inspektor-gadget/gadget/top_file:latest                                   Error                                                                            
→ kubectl gadget show 1f
WARN[0000] version skew detected: client (v0.51.1) vs server (v0.51.0) 
ID: 1f945ccf5ff09a8bf86c82588f9e6b52
Name: my-snapshot-process
Image: ghcr.io/inspektor-gadget/gadget/snapshot_process:latest
TimeCreated: "2026-04-30T11:37:17+02:00"
Params: {}
NodeInstances:
    - Node: aks-nodepool1-58771399-vmss000002
      Status: Error
      Message: 'initializing and preparing operators: instantiating operator "oci": ensuring image: getting local oci store: invalid OCI Image Layout: failed to decode OCI layout file: EOF'
    - Node: aks-nodepool1-58771399-vmss000003
      Status: Running
      Message: ""
    - Node: aks-nodepool1-58771399-vmss000004
      Status: Running
      Message: ""

```

### with this change

```
→ kubectl gadget list
WARN[0000] version skew detected: client (v0.51.1) vs server (v0.51.0-91-gde8f68cd7) 
ID           NAME                                                                               TAGS                                                                               GADGET                                                                            STATUS                                                                           
1f945ccf5ff0 my-snapshot-process                                                                debug                                                                              ghcr.io/inspektor-gadget/gadget/snapshot_process:latest                           Running                                                                          
59561f4a918d my-trace-exec                                                                      security,audit                                                                     ghcr.io/inspektor-gadget/gadget/trace_exec:latest                                 Running                                                                          
95381cb91286 my-trace-tcp-gadget                                                                                                                                                   ghcr.io/inspektor-gadget/gadget/trace_tcp:latest                                  Running                                                                          
a59a0c9892ea my-trace-open                                                                                                                                                         ghcr.io/inspektor-gadget/gadget/trace_open:latest                                 Running                                                                          
c2a65bc902ae my-top-file-gadget                                                                                                                                                    ghcr.io/inspektor-gadget/gadget/top_file:latest                                   Running                                                                          
→ kubectl gadget show 1f
WARN[0000] version skew detected: client (v0.51.1) vs server (v0.51.0-91-gde8f68cd7) 
ID: 1f945ccf5ff09a8bf86c82588f9e6b52
Name: my-snapshot-process
Image: ghcr.io/inspektor-gadget/gadget/snapshot_process:latest
TimeCreated: "2026-04-30T11:40:58+02:00"
Params: {}
NodeInstances:
    - Node: aks-nodepool1-58771399-vmss000002
      Status: Running
      Message: ""
    - Node: aks-nodepool1-58771399-vmss000003
      Status: Running
      Message: ""
    - Node: aks-nodepool1-58771399-vmss000004
      Status: Running
      Message: ""

```

Note: Keeping it draft since I need to test few things! 