### PR TITLE
fix(wasm-operator): handle index overflow

### DIFF
--- a/pkg/operators/wasm/testdata/Makefile
+++ b/pkg/operators/wasm/testdata/Makefile
@@ -15,6 +15,7 @@ TEST_ARTIFACTS = \
 	perf \
 	kallsyms \
 	filtering \
+	handleoverflow \
 	#
 
 all: $(TEST_ARTIFACTS)

--- a/pkg/operators/wasm/testdata/handleoverflow/build.yaml
+++ b/pkg/operators/wasm/testdata/handleoverflow/build.yaml
@@ -1,0 +1,1 @@
+wasm: program.go

--- a/pkg/operators/wasm/testdata/handleoverflow/go.mod
+++ b/pkg/operators/wasm/testdata/handleoverflow/go.mod
@@ -1,0 +1,8 @@
+module main
+
+go 1.25.7
+
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// use this to be able to compile it locally
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../../../

--- a/pkg/operators/wasm/testdata/handleoverflow/program.go
+++ b/pkg/operators/wasm/testdata/handleoverflow/program.go
@@ -1,0 +1,80 @@
+// Copyright 2024 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+//go:wasmexport gadgetInit
+func gadgetInit() int32 {
+	ds, err := api.GetDataSource("myds")
+	if err != nil {
+		return 1
+	}
+
+	inField, err := ds.GetField("in")
+	if err != nil {
+		return 1
+	}
+
+	outField, err := ds.GetField("out")
+	if err != nil {
+		return 1
+	}
+
+	// Create dummy packets, indirectly increasing the internal handler index sequence.
+	// This forces `lastHandleIndex` higher than maxHandleIndexValue.
+	for range 70000 {
+		packet, err := ds.NewPacketArray()
+		if err != nil {
+			return 1
+		}
+		if err := ds.Release(api.Packet(packet)); err != nil {
+			return 1
+		}
+	}
+
+	// Simple callback, should continue to work as expected after handle index surpasses maxHandleIndexValue.
+	if err := ds.SubscribeArray(func(source api.DataSource, dataArray api.DataArray) error {
+		var errs error
+		for i := range dataArray.Len() {
+			data := dataArray.Get(i)
+			val, err := inField.Uint32(data)
+			if err != nil {
+				errs = errors.Join(errs, err)
+				continue
+			}
+			if err := outField.SetUint32(data, val*2); err != nil {
+				errs = errors.Join(errs, err)
+				continue
+			}
+		}
+		if errs != nil {
+			api.Warnf("Errors processing data array: %v", errs.Error())
+			return errs
+		}
+		return nil
+	}, 0); err != nil {
+		api.Warnf("failed to subscribe: %v", err)
+		return 1
+	}
+
+	return 0
+}
+
+func main() {}

--- a/pkg/operators/wasm/wasm.go
+++ b/pkg/operators/wasm/wasm.go
@@ -53,6 +53,9 @@ const (
 	// Indicates the handle encodes a member of a data array as index << 16 | arrayHandle
 	dataArrayHandleFlag = uint32(1 << 31)
 
+	// Indicates the max value for a handle index, as the rest of the uint32 is used to store other data
+	maxHandleIndexValue = 0xFFFF // 16 bits
+
 	// cache path for the wasm compilation
 	cacheDir = "/var/run/ig/wasm-cache"
 )
@@ -180,9 +183,10 @@ func (i *wasmOperatorInstance) addHandle(obj any) uint32 {
 
 	// look for a free index in the map
 	for {
-		// zero is reserved, handle overflow
-		if handleIndex == 0 {
-			handleIndex++
+		// zero is reserved. 0xFFFF (65535) is the maximum value that fits in 16 bits.
+		// If we exceed 16 bits, wrap around to 1.
+		if handleIndex == 0 || handleIndex > maxHandleIndexValue {
+			handleIndex = 1
 		}
 
 		if _, ok := i.handleMap[handleIndex]; !ok {

--- a/pkg/operators/wasm/wasm_test.go
+++ b/pkg/operators/wasm/wasm_test.go
@@ -524,3 +524,81 @@ func testFiltering(t *testing.T, path string) {
 	err := runGadget(t, gadgetCtx, nil)
 	require.NoError(t, err, "running gadget")
 }
+
+func TestWasmHandleOverflow(t *testing.T) {
+	testWasmHandleOverflow(t, "testdata")
+}
+
+func testWasmHandleOverflow(t *testing.T, path string) {
+	utils.RequireRoot(t)
+
+	t.Parallel()
+
+	const (
+		inValue        = uint32(42)
+		expectedOutput = 2 * inValue
+	)
+	counter := 0
+
+	// WASM callback runs first (priority 0), Go callback verifies after (priority 2)
+	const goPriority = 2
+
+	myOperator := simple.New("myHandler",
+		simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+			datasources := gadgetCtx.GetDataSources()
+			myds, ok := datasources["myds"]
+			require.True(t, ok, "datasource not found")
+
+			outField := myds.GetField("out")
+
+			myds.SubscribeArray(func(source datasource.DataSource, dataArray datasource.DataArray) error {
+				counter++
+				require.Equal(t, 1, dataArray.Len())
+
+				data := dataArray.Get(0)
+				val, err := outField.Uint32(data)
+				require.NoError(t, err)
+				require.Equal(t, expectedOutput, val, "WASM module failed to process data array due to 16-bit handle truncation")
+
+				return nil
+			}, goPriority)
+			return nil
+		}),
+		simple.OnStart(func(gadgetCtx operators.GadgetContext) error {
+			datasources := gadgetCtx.GetDataSources()
+			myds, ok := datasources["myds"]
+			require.True(t, ok, "datasource not found")
+
+			packet, err := myds.NewPacketArray()
+			require.NoError(t, err, "creating packet")
+
+			inField := myds.GetField("in")
+
+			data := packet.New()
+			err = inField.PutUint32(data, inValue)
+			require.NoError(t, err, "putting data")
+
+			packet.Append(data)
+
+			err = myds.EmitAndRelease(packet)
+			require.NoError(t, err, "emitting data")
+
+			return nil
+		}),
+	)
+
+	gadgetCtx := createGadgetCtx(t, path, "handleoverflow", myOperator)
+
+	ds, err := gadgetCtx.RegisterDataSource(datasource.TypeArray, "myds")
+	require.NoError(t, err, "registering datasource")
+
+	_, err = ds.AddField("in", api.Kind_Uint32)
+	require.NoError(t, err)
+	_, err = ds.AddField("out", api.Kind_Uint32)
+	require.NoError(t, err)
+
+	err = runGadget(t, gadgetCtx, nil)
+	require.NoError(t, err, "running gadget")
+
+	require.Equal(t, counter, 1)
+}


### PR DESCRIPTION
After a sufficient number of refresh cycles (depending mainly on the interval, but it's also faster if WASM-based gadget uses `dataArray.New()` or any other mechanism that requires calling `addHandler`), the handler index sequence will overflow the 16bit space (out of the `uint32` size) reserved for the handler ID, as the rest is used for storing the type and other information.
This causes long-running gadgets to start failing with the following error, trying to `Get(i)` from a `DataArray` inside a `SubscribeArray` callback func:
```
WARN[2804] bad handle type for 8
WARN[2804] 1 reading "_ts" field: error getting field
WARN[2804] bad handle type for 8
WARN[2804] 1 reading "_ts" field: error getting field
...
```
While following cycles would then become:
```
WARN[2805] handle 46 not found
WARN[2805] 1 reading "_ts" field: error getting field
WARN[2805] handle 46 not found
WARN[2805] 1 reading "_ts" field: error getting field
...
```

## How to use

The fix adds an additional validation to `addHandler`, resetting the index sequence to 1 once the maximum value permitted is reached.
Related but not relevant, there is also this constant:
```
	// Maximum number of handles a gadget can have opened at the same time
	maxHandles = 4 * 1024
```
Given this is much smaller than the max value for 16bit, the `addHandler` logic should quickly find the next available/free handle ID after the max value is reached.

## Testing done

I've tested the fix by building a local `ig` binary using the `Makefile`.
Nonetheless, I've also added a minimal reproducer tests (see first commit in this PR), which artificially increases the handler index counter, by generating (and immediately releasing) single packets, finally verifying the test gadget continues to work as expected.
- Before fix:
```
=== RUN   TestWasmHandleOverflow
=== PAUSE TestWasmHandleOverflow
=== CONT  TestWasmHandleOverflow
WARN[0000] Builder version not found in the gadget image. Gadget could be incompatible
WARN[0000] handle 4468 not found
WARN[0000] Errors processing data array: error getting field
    wasm_test.go:561:
        	Error Trace:	/ws/inspektor-gadget/pkg/operators/wasm/wasm_test.go:561
        	            				/ws/inspektor-gadget/pkg/datasource/data.go:639
        	            				/ws/inspektor-gadget/pkg/datasource/data.go:670
        	            				/ws/inspektor-gadget/pkg/operators/wasm/wasm_test.go:583
        	            				/ws/inspektor-gadget/pkg/operators/simple/simple.go:75
        	            				/ws/inspektor-gadget/pkg/gadget-context/run.go:142
        	            				/ws/inspektor-gadget/pkg/gadget-context/run.go:255
        	            				/ws/inspektor-gadget/pkg/runtime/local/oci.go:34
        	            				/ws/inspektor-gadget/pkg/operators/wasm/wasm_test.go:54
        	            				/ws/inspektor-gadget/pkg/operators/wasm/wasm_test.go:600
        	            				/ws/inspektor-gadget/pkg/operators/wasm/wasm_test.go:529
        	Error:      	Not equal:
        	            	expected: 0x54
        	            	actual  : 0x0
        	Test:       	TestWasmHandleOverflow
        	Messages:   	WASM module failed to process data array due to 16-bit handle truncation
--- FAIL: TestWasmHandleOverflow (0.10s)
FAIL
exit status 1
FAIL	github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm	0.148s
```
- After the fix:
```
=== RUN   TestWasmHandleOverflow
=== PAUSE TestWasmHandleOverflow
=== CONT  TestWasmHandleOverflow
WARN[0000] Builder version not found in the gadget image. Gadget could be incompatible
--- PASS: TestWasmHandleOverflow (10.01s)
PASS
ok  	github.com/inspektor-gadget/inspektor-gadget/pkg/operators/wasm	10.066s
```