### PR TITLE
ci: remove SBOM digests from image index manifests

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -440,8 +440,6 @@ jobs:
     outputs:
       digest-amd64: ${{ steps.published-gadget-container-images.outputs.amd64 }}
       digest-arm64: ${{ steps.published-gadget-container-images.outputs.arm64 }}
-      sbom-digest-amd64: ${{ steps.gadget-container-images-attach-sbom.outputs.sbom-amd64 }}
-      sbom-digest-arm64: ${{ steps.gadget-container-images-attach-sbom.outputs.sbom-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -594,8 +592,6 @@ jobs:
     outputs:
       digest-amd64: ${{ steps.published-ig-container-images.outputs.amd64 }}
       digest-arm64: ${{ steps.published-ig-container-images.outputs.arm64 }}
-      sbom-digest-amd64: ${{ steps.ig-container-images-attach-sbom.outputs.sbom-amd64 }}
-      sbom-digest-arm64: ${{ steps.ig-container-images-attach-sbom.outputs.sbom-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -891,8 +887,6 @@ jobs:
           IMAGE_TAG: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
           DIGEST_AMD64: ${{ needs.build-gadget-container-images.outputs.digest-amd64 }}
           DIGEST_ARM64: ${{ needs.build-gadget-container-images.outputs.digest-arm64 }}
-          SBOM_DIGEST_AMD64: ${{ needs.build-gadget-container-images.outputs.sbom-digest-amd64 }}
-          SBOM_DIGEST_ARM64: ${{ needs.build-gadget-container-images.outputs.sbom-digest-arm64 }}
         run: |
           IMAGE_REF="${CONTAINER_REPO}:${IMAGE_TAG}"
           IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
@@ -909,9 +903,7 @@ jobs:
               --annotation index:org.opencontainers.image.source="$IMAGE_SOURCE" \
               --annotation index:org.opencontainers.image.title="$IMAGE_TITLE" \
               "${CONTAINER_REPO}@${DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${DIGEST_ARM64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_ARM64}"
+              "${CONTAINER_REPO}@${DIGEST_ARM64}"
 
           image_digest=$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' $IMAGE_REF | jq -r)
           echo "image-digest=${image_digest}" >> $GITHUB_OUTPUT
@@ -961,8 +953,6 @@ jobs:
           IMAGE_TAG: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
           DIGEST_AMD64: ${{ needs.build-ig-container-images.outputs.digest-amd64 }}
           DIGEST_ARM64: ${{ needs.build-ig-container-images.outputs.digest-arm64 }}
-          SBOM_DIGEST_AMD64: ${{ needs.build-ig-container-images.outputs.sbom-digest-amd64 }}
-          SBOM_DIGEST_ARM64: ${{ needs.build-ig-container-images.outputs.sbom-digest-arm64 }}
         run: |
           IMAGE_REF="${CONTAINER_REPO}:${IMAGE_TAG}"
           IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
@@ -974,9 +964,7 @@ jobs:
           docker buildx imagetools create \
             -t "$IMAGE_REF" \
               "${CONTAINER_REPO}@${DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_AMD64}" \
               "${CONTAINER_REPO}@${DIGEST_ARM64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_ARM64}" \
             --annotation index:org.opencontainers.image.documentation="$IMAGE_DOCUMENTATION" \
             --annotation index:org.opencontainers.image.description="$IMAGE_DESCRIPTION" \
             --annotation index:org.opencontainers.image.licenses="$IMAGE_LICENSES" \


### PR DESCRIPTION
## Summary

Remove SBOM digests from the `docker buildx imagetools create` calls in `publish-gadget-images-manifest` and `publish-ig-images-manifest`. The image index now contains only platform images and their attestation manifests.

## Problem

The `oras attach` step creates SBOM artifacts with platform `linux` and an **empty architecture string**. When these digests are passed to `imagetools create`, the resulting OCI image index contains entries like:

```json
{
  "platform": { "architecture": "", "os": "linux" },
  "config": { "mediaType": "application/vnd.oci.empty.v1+json" }
}
```

Some container registries -- notably AWS ECR pull-through cache -- fail to resolve architecture-specific images when these malformed `linux/""` platform entries are present, breaking image pulls on arm64 nodes.

For comparison, the `unknown/unknown` attestation manifests (created by buildx, with `vnd.docker.reference.type: attestation-manifest` annotations) are handled correctly by ECR and containerd. The `linux/""` SBOM entries are the problem.

### Current v0.51.0 index (6 entries)

| platform | type |
|----------|------|
| linux/amd64 | platform image |
| linux/arm64 | platform image |
| unknown/unknown | attestation (amd64) -- harmless |
| unknown/unknown | attestation (arm64) -- harmless |
| linux/"" | SBOM (amd64) -- **breaks ECR** |
| linux/"" | SBOM (arm64) -- **breaks ECR** |

### After this change (4 entries)

| platform | type |
|----------|------|
| linux/amd64 | platform image |
| linux/arm64 | platform image |
| unknown/unknown | attestation (amd64) |
| unknown/unknown | attestation (arm64) |

This matches the index shape of other multi-arch images (e.g. `vectordotdev/vector`) that work correctly through ECR pull-through cache.

## Why this is safe

SBOMs are already attached to each per-platform image via `oras attach` (steps `gadget-container-images-attach-sbom` and `ig-container-images-attach-sbom`). They remain discoverable through the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) and tools like `oras discover`. Including them in the image index was redundant.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge: verify `docker buildx imagetools inspect ghcr.io/inspektor-gadget/inspektor-gadget:<next-tag>` shows only linux/amd64, linux/arm64, and unknown/unknown attestation entries (no linux/"" entries)
- [ ] After merge: verify `oras discover ghcr.io/inspektor-gadget/inspektor-gadget:<next-tag>` still shows SBOM artifacts attached to per-platform images