### PR TITLE
ci: remove SBOMs from image index, sign them separately

### DIFF
--- a/.github/actions/sign-oci-artifact/action.yml
+++ b/.github/actions/sign-oci-artifact/action.yml
@@ -1,15 +1,15 @@
-name: "Sign the container image"
-description: "Sign the container image given as argument with cosign using the provided private key."
+name: "Sign the OCI artifact"
+description: "Sign the OCI artifact given as argument with cosign using the provided private key."
 
 inputs:
   password:
     description: "Private key password"
     required: true
   private_key:
-    description: "Private key to sign the image"
+    description: "Private key to sign the OCI artifact"
     required: true
-  image:
-    description: "The image to sign"
+  oci_artifact:
+    description: "The OCI artifact to sign"
     required: true
 
 runs:
@@ -17,13 +17,13 @@ runs:
   steps:
     - name: Install Cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-    - name: Sign the container image
+    - name: Sign the OCI artifact
       env:
         COSIGN_PASSWORD: '${{ inputs.password }}'
         COSIGN_PRIVATE_KEY: '${{ inputs.private_key }}'
-        IMAGE: '${{ inputs.image }}'
+        OCI_ARTIFACT: '${{ inputs.oci_artifact }}'
       shell: bash
       run: |
         # Force using legacy .sig format.
         # TODO Switch to bundle format.
-        cosign sign --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes --recursive "${IMAGE}"
+        cosign sign --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY --yes --recursive "${OCI_ARTIFACT}"

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -431,7 +431,9 @@ jobs:
   build-gadget-container-images:
     name: gadget img
     # level: 1
-    needs: btfgen
+    needs:
+      - btfgen
+      - check-secrets
     runs-on: ubuntu-latest
     permissions:
       # allow publishing container image
@@ -441,8 +443,6 @@ jobs:
     outputs:
       digest-amd64: ${{ steps.published-gadget-container-images.outputs.amd64 }}
       digest-arm64: ${{ steps.published-gadget-container-images.outputs.arm64 }}
-      sbom-digest-amd64: ${{ steps.gadget-container-images-attach-sbom.outputs.sbom-amd64 }}
-      sbom-digest-arm64: ${{ steps.gadget-container-images-attach-sbom.outputs.sbom-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -565,6 +565,13 @@ jobs:
         sbom_digest=$(oras attach "${CONTAINER_REPO}@${image_digest}" /tmp/gadget-container-image-${{ matrix.os }}-${{ matrix.platform }}/sbom_cyclonedx.json --disable-path-validation --artifact-type example/sbom | grep 'Digest:' | awk '{ print $2 }')
 
         echo "sbom-${{ matrix.platform }}=${sbom_digest}" >> $GITHUB_OUTPUT
+    - name: Sign the SBOM
+      if: github.event_name != 'pull_request' && needs.check-secrets.outputs.cosign == 'true'
+      uses: ./.github/actions/sign-oci-artifact
+      with:
+        password: '${{ secrets.COSIGN_PASSWORD }}'
+        private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
+        oci_artifact: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.gadget-container-images-attach-sbom.outputs[format('sbom-{0}', matrix.platform)] }}"
     - name: Save gadget ${{ matrix.os }} ${{ matrix.platform }} container image digest output
       id: published-gadget-container-images
       if: github.event_name != 'pull_request'
@@ -586,6 +593,7 @@ jobs:
     needs:
       - btfgen
       - build-helper-images
+      - check-secrets
     runs-on: ubuntu-latest
     permissions:
       # allow publishing container image
@@ -595,8 +603,6 @@ jobs:
     outputs:
       digest-amd64: ${{ steps.published-ig-container-images.outputs.amd64 }}
       digest-arm64: ${{ steps.published-ig-container-images.outputs.arm64 }}
-      sbom-digest-amd64: ${{ steps.ig-container-images-attach-sbom.outputs.sbom-amd64 }}
-      sbom-digest-arm64: ${{ steps.ig-container-images-attach-sbom.outputs.sbom-arm64 }}
     strategy:
       fail-fast: false
       matrix:
@@ -719,6 +725,13 @@ jobs:
         sbom_digest=$(oras attach "${CONTAINER_REPO}@${image_digest}" /tmp/ig-container-image-${{ matrix.os }}-${{ matrix.platform }}/sbom_cyclonedx.json --disable-path-validation --artifact-type example/sbom | grep 'Digest:' | awk '{ print $2 }')
 
         echo "sbom-${{ matrix.platform }}=${sbom_digest}" >> $GITHUB_OUTPUT
+    - name: Sign the SBOM
+      if: github.event_name != 'pull_request' && needs.check-secrets.outputs.cosign == 'true'
+      uses: ./.github/actions/sign-oci-artifact
+      with:
+        password: '${{ secrets.COSIGN_PASSWORD }}'
+        private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
+        oci_artifact: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.ig-container-images-attach-sbom.outputs[format('sbom-{0}', matrix.platform)] }}"
     - name: Save ig ${{ matrix.os }} ${{ matrix.platform }} container image digest output
       id: published-ig-container-images
       if: github.event_name != 'pull_request'
@@ -892,8 +905,6 @@ jobs:
           IMAGE_TAG: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
           DIGEST_AMD64: ${{ needs.build-gadget-container-images.outputs.digest-amd64 }}
           DIGEST_ARM64: ${{ needs.build-gadget-container-images.outputs.digest-arm64 }}
-          SBOM_DIGEST_AMD64: ${{ needs.build-gadget-container-images.outputs.sbom-digest-amd64 }}
-          SBOM_DIGEST_ARM64: ${{ needs.build-gadget-container-images.outputs.sbom-digest-arm64 }}
         run: |
           IMAGE_REF="${CONTAINER_REPO}:${IMAGE_TAG}"
           IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
@@ -910,9 +921,7 @@ jobs:
               --annotation index:org.opencontainers.image.source="$IMAGE_SOURCE" \
               --annotation index:org.opencontainers.image.title="$IMAGE_TITLE" \
               "${CONTAINER_REPO}@${DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${DIGEST_ARM64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_ARM64}"
+              "${CONTAINER_REPO}@${DIGEST_ARM64}"
 
           image_digest=$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' $IMAGE_REF | jq -r)
           echo "image-digest=${image_digest}" >> $GITHUB_OUTPUT
@@ -962,8 +971,6 @@ jobs:
           IMAGE_TAG: ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
           DIGEST_AMD64: ${{ needs.build-ig-container-images.outputs.digest-amd64 }}
           DIGEST_ARM64: ${{ needs.build-ig-container-images.outputs.digest-arm64 }}
-          SBOM_DIGEST_AMD64: ${{ needs.build-ig-container-images.outputs.sbom-digest-amd64 }}
-          SBOM_DIGEST_ARM64: ${{ needs.build-ig-container-images.outputs.sbom-digest-arm64 }}
         run: |
           IMAGE_REF="${CONTAINER_REPO}:${IMAGE_TAG}"
           IMAGE_SOURCE="https://github.com/inspektor-gadget/inspektor-gadget"
@@ -975,9 +982,7 @@ jobs:
           docker buildx imagetools create \
             -t "$IMAGE_REF" \
               "${CONTAINER_REPO}@${DIGEST_AMD64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_AMD64}" \
               "${CONTAINER_REPO}@${DIGEST_ARM64}" \
-              "${CONTAINER_REPO}@${SBOM_DIGEST_ARM64}" \
             --annotation index:org.opencontainers.image.documentation="$IMAGE_DOCUMENTATION" \
             --annotation index:org.opencontainers.image.description="$IMAGE_DESCRIPTION" \
             --annotation index:org.opencontainers.image.licenses="$IMAGE_LICENSES" \

--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -918,11 +918,11 @@ jobs:
           echo "image-digest=${image_digest}" >> $GITHUB_OUTPUT
       - name: Sign the manifest list
         if: needs.check-secrets.outputs.cosign == 'true'
-        uses: ./.github/actions/sign-container-image
+        uses: ./.github/actions/sign-oci-artifact
         with:
           password: '${{ secrets.COSIGN_PASSWORD }}'
           private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-          image: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.publish-manifest-list.outputs.image-digest }}"
+          oci_artifact: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.publish-manifest-list.outputs.image-digest }}"
 
   publish-ig-images-manifest:
     name: Publish ig img manifest
@@ -988,11 +988,11 @@ jobs:
           echo "image-digest=${image_digest}" >> $GITHUB_OUTPUT
       - name: Sign the manifest list
         if: needs.check-secrets.outputs.cosign == 'true'
-        uses: ./.github/actions/sign-container-image
+        uses: ./.github/actions/sign-oci-artifact
         with:
           password: '${{ secrets.COSIGN_PASSWORD }}'
           private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-          image: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.publish-manifest-list.outputs.image-digest }}"
+          oci_artifact: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.publish-manifest-list.outputs.image-digest }}"
 
   build-helper-images:
     # level: 2
@@ -1133,11 +1133,11 @@ jobs:
         echo "${{ matrix.image.name }}=${image}" >> $GITHUB_OUTPUT
     - name: Sign ${{ matrix.image.name }} image
       if:  needs.check-secrets.outputs.cosign == 'true' && vars.PUSH_HELPERS == 'ENABLE_PUSH_HELPERS'
-      uses: ./.github/actions/sign-container-image
+      uses: ./.github/actions/sign-oci-artifact
       with:
         password: '${{ secrets.COSIGN_PASSWORD }}'
         private_key: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-        image: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.push-image.outputs.digest }}"
+        oci_artifact: "${{ steps.set-repo-determine-image-tag.outputs.container-repo }}@${{ steps.push-image.outputs.digest }}"
     # old cache entries aren’t deleted, so the cache size keeps growing
     # remove old cache and move new cache to cache path to workaround the issue
     # https://github.com/docker/build-push-action/issues/252

--- a/docs/reference/verify-assets.mdx
+++ b/docs/reference/verify-assets.mdx
@@ -51,9 +51,8 @@ Digest: sha256:...
 
 Artifact Type   Digest
 example/sbom    sha256:hash_of_sbom_manifest
-# As we include SBOMs in our multi architecture container image, they are also
-# signed.
-# So, let's check the SBOM is signed with our private key:
+# SBOMs are signed individually per platform.
+# Let's check the SBOM is signed with our private key:
 $ cosign verify --key inspektor-gadget.pub ghcr.io/inspektor-gadget/inspektor-gadget@sha256:hash_of_sbom_manifest
 
 Verification for ghcr.io/inspektor-gadget/inspektor-gadget@sha256:hash_of_sbom_manifest


### PR DESCRIPTION
## Summary

Remove SBOM digests from `docker buildx imagetools create` in both publish manifest jobs. Add separate cosign signing steps for each per-platform SBOM. The image index now contains only platform images, and SBOMs are still signed.

## Problem

`oras attach` creates SBOM artifacts with platform `linux` and an **empty architecture string**. Including these digests in `imagetools create` produces index entries like:

```json
{
  "platform": { "architecture": "", "os": "linux" },
  "config": { "mediaType": "application/vnd.oci.empty.v1+json" }
}
```

These `linux/""` entries break registries that mirror the index as-is. I hit this with AWS ECR pull-through cache: it can't resolve arch-specific images when these are present, breaking pulls on arm64 nodes.

The `unknown/unknown` attestation manifests (buildx, `vnd.docker.reference.type: attestation-manifest`) are fine. ECR and containerd handle those. It's the `linux/""` SBOM entries that cause trouble.

### Current v0.51.0 index (6 entries)

| platform | type |
|----------|------|
| linux/amd64 | platform image |
| linux/arm64 | platform image |
| unknown/unknown | attestation (amd64), harmless |
| unknown/unknown | attestation (arm64), harmless |
| linux/"" | SBOM (amd64), **breaks ECR** |
| linux/"" | SBOM (arm64), **breaks ECR** |

### After this change (2 entries)

| platform | type |
|----------|------|
| linux/amd64 | platform image |
| linux/arm64 | platform image |

### Local verification (dry-run)

Verified with `imagetools create --dry-run` using the real v0.51.0 per-platform digests, without SBOM digests:

```json
{
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "digest": "sha256:59c6f31f699b...",
      "platform": { "architecture": "amd64", "os": "linux" }
    },
    {
      "digest": "sha256:c6104a2217df...",
      "platform": { "architecture": "arm64", "os": "linux" }
    }
  ],
  "annotations": {
    "org.opencontainers.image.source": "https://github.com/inspektor-gadget/inspektor-gadget"
  }
}
```

## What changed

1. **Removed** SBOM digests from `imagetools create` in both `publish-gadget-images-manifest` and `publish-ig-images-manifest`
2. **Added** cosign signing steps for each per-platform SBOM (amd64, arm64) in both publish jobs, after the manifest list signing
3. **Kept** SBOM digest outputs from build jobs (needed for the new signing steps)

SBOMs are still attached to per-platform images via `oras attach` and remain discoverable through the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) and `oras discover`. They're now signed individually rather than transitively through the index.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge: `docker buildx imagetools inspect ghcr.io/inspektor-gadget/inspektor-gadget:<next-tag>` shows only linux/amd64 and linux/arm64
- [ ] After merge: `oras discover ghcr.io/inspektor-gadget/inspektor-gadget:<next-tag>` still shows SBOM artifacts on per-platform images
- [ ] After merge: `cosign verify` on SBOM digests succeeds