### PR TITLE
secureopen: Add O_CLOEXEC flag to O_PATH openat2 call

### DIFF
--- a/pkg/kfilefields/tracer.go
+++ b/pkg/kfilefields/tracer.go
@@ -101,7 +101,7 @@ func (t *Tracer) close() {
 func (t *Tracer) install() error {
 	// Create a socket pair
 	var err error
-	t.sock, err = unix.Socketpair(unix.AF_UNIX, unix.SOCK_DGRAM, 0)
+	t.sock, err = unix.Socketpair(unix.AF_UNIX, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return fmt.Errorf("creating socket pair: %w", err)
 	}

--- a/pkg/utils/secureopen/secureopen.go
+++ b/pkg/utils/secureopen/secureopen.go
@@ -51,7 +51,7 @@ func OpenInContainer(containerPid uint32, unsafePath string) (*os.File, error) {
 	// Open with O_PATH first to avoid blocking on opening the file in case it
 	// is a pipe.
 	howOPath := unix.OpenHow{
-		Flags:   unix.O_PATH,
+		Flags:   unix.O_PATH | unix.O_CLOEXEC,
 		Mode:    0,
 		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
 	}


### PR DESCRIPTION
Add O_CLOEXEC to the initial O_PATH open in OpenInContainer to prevent file descriptor leaks to child processes spawned between open and close.

cc @florianl
