### PR TITLE
Account for lost samples in gadget_output_buf()

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -533,7 +533,7 @@ Then, you can interact with the buffer using these functions:
 1. `void *gadget_reserve_buf(void *map, __u64 size)`: Reserves memory in the corresponding buffer. This is actually a macro and you must call it by taking the address of the map, like `gadget_reserve_buf(&events, 256)`.
 1. `long gadget_submit_buf(void *ctx, void *map, void *buf, __u64 size)`: Writes the previously reserved memory in the corresponding buffer.
 1. `void gadget_discard_buf(void *buf)`: Discards the previously reserved buffer. This is needed to avoid wasting memory.
-1. `long gadget_output_buf(void *ctx, void *map, void *buf, __u64 size)`: Reserves and writes the buffer in the corresponding map. This is equivalent to calling `gadget_reserve_buf()` and `gadget_submit_buf()`.
+1. `long gadget_output_buf(void *ctx, void *map, void *buf, __u64 size)`: Reserves and writes the buffer in the corresponding map. This is equivalent to calling `gadget_reserve_buf()` and `gadget_submit_buf()`. Like `gadget_reserve_buf()`, if the ring buffer is full it increments the per-CPU `<map>_lost_samples` counter declared by `GADGET_TRACER_MAP()`, which is reported to userspace by the eBPF operator.
 
 The following snippet demonstrates how to use the code available in `<gadget/buffer.h>`, it is taken from `trace_open`:
 

--- a/include/gadget/buffer.h
+++ b/include/gadget/buffer.h
@@ -76,12 +76,23 @@ static __always_inline long gadget_submit_buf(void *ctx, void *map, void *buf,
 }
 #endif /* GADGET_NO_BUF_RESERVE */
 
-static __always_inline long gadget_output_buf(void *ctx, void *map, void *buf,
-					      __u64 size)
+// _lost_samples has to be suffixed because user will give &map as argument.
+#define gadget_output_buf(ctx, map, buf, size) \
+	__gadget_output_buf(ctx, map, map##_lost_samples, buf, size)
+
+static __always_inline long __gadget_output_buf(void *ctx, void *map,
+						void *lost_samples, void *buf,
+						__u64 size)
 {
 	if (bpf_core_enum_value_exists(enum bpf_func_id,
 				       BPF_FUNC_ringbuf_output)) {
-		bpf_ringbuf_output(map, buf, size, 0);
+		long ret = bpf_ringbuf_output(map, buf, size, 0);
+		if (ret) {
+			const int zero = 0;
+			__u64 *cnt = bpf_map_lookup_elem(lost_samples, &zero);
+			if (cnt)
+				*cnt += 1;
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
# Account for lost samples in gadget_output_buf()

`gadget_output_buf()` calls `bpf_ringbuf_output()` but discards its return value. When the ring buffer is full, `bpf_ringbuf_output()` returns `-E2BIG`/`-ENOSPC` and the event is dropped silently: the per-CPU `<map>_lost_samples` counter declared by GADGET_TRACER_MAP()` - polled once per second by the eBPF operator and surfaced via `DataSource.ReportLostData()` plus a "reading event: lost N samples" log - is never incremented on this path.
 
 This is the same bookkeeping `gadget_reserve_buf()` already does via its `__gadget_reserve_buf(map, map##_lost_samples, …)` indirection.
 
 `gadget_output_buf()` becomes a function-like macro that token-pastes the `_lost_samples` map name and delegates to a new `__gadget_output_buf()` helper. The helper: 
   * On the ring buffer path (`BPF_FUNC_ringbuf_output` available), calls `bpf_ringbuf_output()`, and on failure looks up the
     `_lost_samples` per-CPU counter and increments it (non-atomic `*cnt += 1`, matching the existing `__gadget_reserve_buf` style).
   * On the perf-event-array fallback, behaves exactly as before; the kernel already accounts for drops there via `rec.LostSamples`.
  The public call signature is preserved, so callers do not change. Both in-tree users (`gadgets/trace_exec`, `gadgets/trace_sni`) already declare their map with `GADGET_TRACER_MAP()`, and that macro sits outside the `GADGET_NO_BUF_RESERVE` guard, so `<map>_lost_samples` is always available for the token paste.
