### PR TITLE
ustack,ebpf,symbolizer: remove [N] prefix from stack symbols and show binary+offset

### DIFF
--- a/pkg/operators/ebpf/formatters.go
+++ b/pkg/operators/ebpf/formatters.go
@@ -222,11 +222,11 @@ func fetchAndFormatStackTrace(stackId uint32, stackLookup func(interface{}, inte
 		return "", err
 	}
 	outString := ""
-	for depth, addr := range stack {
+	for _, addr := range stack {
 		if addr == 0 {
 			break
 		}
-		outString += fmt.Sprintf("[%d]%s; ", depth, lookupByInstructionPointer(addr))
+		outString += fmt.Sprintf("%s; ", lookupByInstructionPointer(addr))
 	}
 	return outString, nil
 }

--- a/pkg/operators/ebpf/formatters_test.go
+++ b/pkg/operators/ebpf/formatters_test.go
@@ -306,7 +306,7 @@ func TestFetchAndFormatStackTrace(t *testing.T) {
 			stackEntries: [ebpftypes.KernelPerfMaxStackDepth]uint64{
 				0xabcdef, 0x123456, 0x312414, 0,
 			},
-			expectedTrace: "[0]funcA; [1]funcB; [2]unknown; ",
+			expectedTrace: "funcA; funcB; unknown; ",
 		},
 		{
 			name: "Empty stack trace",
@@ -320,7 +320,7 @@ func TestFetchAndFormatStackTrace(t *testing.T) {
 			stackEntries: [ebpftypes.KernelPerfMaxStackDepth]uint64{
 				0xabcdef, 0, 0, 0,
 			},
-			expectedTrace: "[0]funcA; ",
+			expectedTrace: "funcA; ",
 		},
 	}
 

--- a/pkg/operators/ustack/ustack.go
+++ b/pkg/operators/ustack/ustack.go
@@ -366,12 +366,6 @@ func (o *OperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 					buildidList := strings.Split(buildIDStr, "; ")
 					alreadyKnownSymbolsStr, _ := symbolsField.String(data)
 					alreadyKnownSymbols = strings.Split(alreadyKnownSymbolsStr, "; ")
-					for i := range alreadyKnownSymbols {
-						index := strings.IndexByte(alreadyKnownSymbols[i], ']')
-						if index >= 0 {
-							alreadyKnownSymbols[i] = alreadyKnownSymbols[i][index+1:]
-						}
-					}
 
 					for i := range addressesList {
 						if addressesList[i] == "" {
@@ -384,20 +378,19 @@ func (o *OperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 							alreadyKnownSymbols = append(alreadyKnownSymbols, "")
 						}
 
-						var idx int
 						var addr uint64
 						var buildidStr string
 						var buildid [20]byte
 						var validBuildID bool
 						var offset uint64
 						var ip uint64
-						_, err := fmt.Sscanf(addressesList[i], "[%d]0x%x", &idx, &addr)
+						_, err := fmt.Sscanf(addressesList[i], "0x%x", &addr)
 						if err != nil {
 							break
 						}
-						_, err = fmt.Sscanf(buildidList[i], "[%d]%s +%x", &idx, &buildidStr, &offset)
+						_, err = fmt.Sscanf(buildidList[i], "%s +%x", &buildidStr, &offset)
 						if err != nil {
-							_, _ = fmt.Sscanf(buildidList[i], "[%d]%x", &idx, &ip)
+							_, _ = fmt.Sscanf(buildidList[i], "%x", &ip)
 							// It's ok if we don't have a build ID.
 						} else {
 							validBuildID = true
@@ -456,7 +449,10 @@ func (o *OperatorInstance) init(gadgetCtx operators.GadgetContext) error {
 						if !res.Found && i < len(alreadyKnownSymbols) {
 							s = alreadyKnownSymbols[i]
 						}
-						fmt.Fprintf(&symbolsBuilder, "[%d]%s; ", i, s)
+						if s == "" && i < len(stackQueries) {
+							s = fmt.Sprintf("0x%x", stackQueries[i].Addr)
+						}
+						fmt.Fprintf(&symbolsBuilder, "%s; ", s)
 					}
 					symbolsField.PutString(data, symbolsBuilder.String())
 				}

--- a/pkg/operators/ustack/ustack_linux.go
+++ b/pkg/operators/ustack/ustack_linux.go
@@ -60,12 +60,12 @@ func readUserStackMap(gadgetCtx operators.GadgetContext, userStackMap, buildIDMa
 
 	var addressesBuilder strings.Builder
 	stackQueries := make([]symbolizer.StackItemQuery, 0, ebpftypes.UserPerfMaxStackDepth)
-	for i, addr := range stack {
+	for _, addr := range stack {
 		if addr == 0 {
 			break
 		}
 		stackQueries = append(stackQueries, symbolizer.StackItemQuery{Addr: addr})
-		fmt.Fprintf(&addressesBuilder, "[%d]0x%016x; ", i, addr)
+		fmt.Fprintf(&addressesBuilder, "0x%016x; ", addr)
 	}
 	addressesStr := addressesBuilder.String()
 	buildIDStr := ""
@@ -92,7 +92,6 @@ func readUserStackMap(gadgetCtx operators.GadgetContext, userStackMap, buildIDMa
 			case unix.BPF_STACK_BUILD_ID_EMPTY:
 				break buildid_iter
 			case unix.BPF_STACK_BUILD_ID_VALID:
-				fmt.Fprintf(&buildIDsBuilder, "[%d]", i)
 				for _, byte := range b.BuildID {
 					fmt.Fprintf(&buildIDsBuilder, "%02x", byte)
 				}
@@ -101,7 +100,7 @@ func readUserStackMap(gadgetCtx operators.GadgetContext, userStackMap, buildIDMa
 				stackQueries[i].BuildID = b.BuildID
 				stackQueries[i].Offset = b.OffsetOrIP
 			case unix.BPF_STACK_BUILD_ID_IP:
-				fmt.Fprintf(&buildIDsBuilder, "[%d]%x; ", i, b.OffsetOrIP)
+				fmt.Fprintf(&buildIDsBuilder, "%x; ", b.OffsetOrIP)
 				stackQueries[i].IP = b.OffsetOrIP
 			}
 

--- a/pkg/symbolizer/otel/otel.go
+++ b/pkg/symbolizer/otel/otel.go
@@ -219,8 +219,15 @@ func (o *otelResolverInstance) Resolve(task symbolizer.Task, stackQueries []symb
 		if v.Type == libpf.KernelFrame {
 			continue
 		}
+		name := v.FunctionName.String()
+		if name == "" && v.Mapping.Valid() {
+			fileName := v.Mapping.Value().File.Value().FileName.String()
+			if fileName != "" {
+				name = fmt.Sprintf("%s+0x%x", fileName, uint64(v.AddressOrLineno))
+			}
+		}
 		userFrames = append(userFrames, userFrame{
-			functionName: v.FunctionName.String(),
+			functionName: name,
 		})
 	}
 


### PR DESCRIPTION
Remove the [N] index prefix from stack trace symbols to improve flamegraph rendering. Previously, each symbol was prefixed with its position (e.g., [0]funcA; [1]funcB;) which prevented flamegraph tools from collapsing identical function names across different stack traces.

For unresolved symbols in the otel-ebpf-profiler path, show the mapping file name and address offset (e.g., libcudart.so.12+0x1234) instead of leaving the entry empty.

For unresolved symbols without otel, fall back to showing the raw address (0x...) to ensure no empty entries appear in the output.

Fixes: https://github.com/inspektor-gadget/inspektor-gadget/issues/5505

