### PR TITLE
fix: trimmed gadget to the right

### DIFF
--- a/cmd/common/instances.go
+++ b/cmd/common/instances.go
@@ -102,7 +102,7 @@ func AddInstanceCommands(
 			cols.MustAddColumn(columns.Attributes{
 				Name:         "Gadget",
 				Visible:      true,
-				EllipsisType: ellipsis.End,
+				EllipsisType: ellipsis.Start,
 				Order:        40,
 			}, func(g *GadgetInfo) any {
 				if g.pg == nil {


### PR DESCRIPTION
# Makes the Gadget aligned to right

tested via ./kubectl-gadget list
have attached the image below.

## Testing done

<img width="1099" height="102" alt="image" src="https://github.com/user-attachments/assets/5574817d-c49c-48bc-8a14-1f8e67703a3b" />

Fixes #5524 
