### PR TITLE
go.mod: update opentelemetry-ebpf-profiler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,4 +230,4 @@ replace github.com/notaryproject/notation-go => github.com/inspektor-gadget/nota
 // - correlation ID for stack cache with LRU hash map
 // - u32 key type for generic_params map
 // - GetStackCacheMap() accessor for userspace cleanup
-replace go.opentelemetry.io/ebpf-profiler => github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260503100916-1bcbf380a5bd
+replace go.opentelemetry.io/ebpf-profiler => github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inspektor-gadget/notation-go v1.3.3 h1:yygDXeFVU3zvYzaNWwhRkTMiJNq4iWnn7Ssayek00RI=
 github.com/inspektor-gadget/notation-go v1.3.3/go.mod h1:/1kuq5WuLF6Gaer5re0Z6HlkQRlKYO4EbWWT/L7J1Uw=
-github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260503100916-1bcbf380a5bd h1:qC6O9unsow5q3wnTlARnfzdtGDZLE+FC8PaT7Kj512M=
-github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260503100916-1bcbf380a5bd/go.mod h1:YcOGWpHl5DRZQxxSLH9P2a4MI51eexSeSWODzPY5FTc=
+github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5 h1:dvYqqM1E3WUn4p/xZTJ4yIvHPtUpwIVJZ7tiS+SDf2Y=
+github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5/go.mod h1:YcOGWpHl5DRZQxxSLH9P2a4MI51eexSeSWODzPY5FTc=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=


### PR DESCRIPTION
Update to inspektor-gadget/opentelemetry-ebpf-profiler ig branch at commit [79c7c1509ef5](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/commits/79c7c1509ef5) which includes fixes from upstream.