### PR TITLE
gadget: Add trace_nvidia_errors

### DIFF
--- a/docs/gadgets/trace_nvidia_errors.mdx
+++ b/docs/gadgets/trace_nvidia_errors.mdx
@@ -1,0 +1,1 @@
+../../gadgets/trace_nvidia_errors/README.mdx

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -57,6 +57,7 @@ GADGETS ?= \
 	trace_tcp \
 	trace_tcpdrop \
 	trace_tcpretrans \
+	trace_nvidia_errors \
 	top_blockio \
 	top_cpu_throttle \
 	top_file \

--- a/gadgets/trace_nvidia_errors/README.md
+++ b/gadgets/trace_nvidia_errors/README.md
@@ -1,0 +1,5 @@
+# trace_nvidia_errors
+
+The `trace_nvidia_errors` gadget traces NVIDIA GPU errors — both CUDA Driver API failures and in-kernel XID events — with enriched severity, category, and actionable suggestions.
+
+Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/trace_nvidia_errors

--- a/gadgets/trace_nvidia_errors/README.mdx
+++ b/gadgets/trace_nvidia_errors/README.mdx
@@ -1,0 +1,133 @@
+---
+title: trace_nvidia_errors
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# trace_nvidia_errors
+
+The `trace_nvidia_errors` gadget traces NVIDIA GPU errors — both CUDA Driver API failures (from
+user-space `libcuda.so` via uprobes) and in-kernel XID events (from the NVIDIA kernel module via
+a kprobe on `nv_report_error`). Every event is enriched with a human-readable name, a one-line
+explanation, an actionable suggestion, and a severity/category label.
+
+## Requirements
+
+- CUDA workload using `libcuda.so` (Driver API)
+- For XID events: open-source NVIDIA kernel module exporting `nv_report_error`
+
+## Getting started
+
+Running the gadget:
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+kubectl gadget run trace_nvidia_errors:%IG_TAG%
+```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+```bash
+sudo ig run trace_nvidia_errors:%IG_TAG%
+```
+    </TabItem>
+</Tabs>
+
+## When to use it
+
+| Symptom | This gadget reports |
+|---|---|
+| `RuntimeError: CUDA error: ...` in Python / C++ | The exact `CUresult` + the API it came from + the args |
+| `dmesg` line `NVRM: Xid (PCI:...): 13, ...` | Same information, structured, with PCI address |
+| `compute-sanitizer memcheck` too slow for prod | Realtime, eBPF-only, near-zero overhead |
+
+## Events
+
+All events share the common IG fields (`timestamp`, `proc.{pid,comm,tid}`, container metadata)
+plus:
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | enum | `SOURCE_CUDA_API` or `SOURCE_XID` |
+| `error_code` | enum | CUDA `CUresult` name (e.g. `CUDA_ERROR_OUT_OF_MEMORY`). Populated for CUDA API events only. |
+| `api_id` | enum | CUDA Driver API name (e.g. `cuMemAlloc_v2`). Populated for CUDA API events only. |
+| `xid_code` | uint32 | NVIDIA XID number. Populated for XID events only. |
+| `gpu_pci_addr` | string | PCI address `DDDD:BB:SS.F` of the GPU that reported the XID. |
+| `severity` | string | `LOW` / `MEDIUM` / `HIGH` / `CRITICAL`. |
+| `category` | string | `memory`, `launch`, `context`, `device`, `hardware_ecc`, `firmware`, … |
+| `description` | string | One-line plain-English explanation. |
+| `why` | string | Why this happened in this context, derived from API args. |
+| `suggestion` | string | Recommended remediation step. |
+| `context_info` | string | Argument/context details (e.g. `requested_bytes=274877906944 (256.0 GiB)`). |
+| `active_cuda_call` | string | Active CUDA call correlated with an XID event. |
+| `xid_attribution` | string | How the XID was attributed to the workload. |
+| `ustack` | stack | User-space call stack for CUDA API events (requires `--collect-ustack`). |
+
+## Example
+
+<Tabs groupId="env">
+    <TabItem value="kubectl-gadget" label="kubectl gadget">
+```bash
+kubectl gadget run trace_nvidia_errors:%IG_TAG%
+```
+    </TabItem>
+
+    <TabItem value="ig" label="ig">
+```bash
+sudo ig run trace_nvidia_errors:%IG_TAG%
+```
+    </TabItem>
+</Tabs>
+
+```
+RUNTIME.CONTAINERNAME  COMM     PID    XID_CODE  ERROR_CODE                  API_ID          SOURCE           SEVERITY  CATEGORY  WHY                                              CONTEXT_INFO
+oom-repro              t        84229  0         CUDA_ERROR_OUT_OF_MEMORY    cuMemAlloc_v2   SOURCE_CUDA_API  HIGH      memory    GPU memory allocation request exceeded free dev…  requested_bytes=274877906944 (256.0 GiB)
+invdev-repro           t        91532  0         CUDA_ERROR_INVALID_DEVICE   cuCtxCreate_v2  SOURCE_CUDA_API  MEDIUM    device    Device ordinal out of range [0, N-1]. ordinal=9…  flags=0x0 device_ordinal=9999
+```
+
+## Severity legend
+
+| Severity | Meaning |
+|---|---|
+| LOW | Informational / recoverable / API misuse with no side effects |
+| MEDIUM | App error requiring a code change |
+| HIGH | Context-destroying error; process usually must restart |
+| CRITICAL | Hardware/firmware fault; operator intervention required |
+
+## Architecture
+
+```
+┌──────────────────┐  uprobe/uretprobe      ┌──────────────┐
+│  libcuda.so      │─────────────────────▶  │ program.bpf.c│──▶ events ringbuf
+│ cuMemAlloc_v2 …  │                        │  save_entry/  │            │
+└──────────────────┘                        │  handle_return│            ▼
+                                            └──────────────┘     WASM enricher
+┌──────────────────┐  kprobe                        ▲            (program.go)
+│  nvidia.ko       │─────────────────────────────────┘                │
+│  nv_report_error │  (1 in-kernel function)                          ▼
+└──────────────────┘                                         ig columns / json
+```
+
+The BPF program only emits events when `ret != CUDA_SUCCESS`; successful calls cost one hash-map
+insert + one hash-map delete on the uretprobe.
+
+## Limitations
+
+* Only the **CUDA Driver API** is hooked directly. Errors returned by the higher-level Runtime API
+  (`cudaMalloc`, `cudaLaunchKernel`) surface through their Driver-API callees, so they are still
+  observed — but with the Driver API name, not the Runtime name.
+* XID capture relies on the symbol `nv_report_error` exported by the open-source NVIDIA kernel
+  module. Older proprietary-only driver builds may not export this symbol; the gadget still loads
+  but no XID events will be emitted.
+* The WASM enricher catalog is embedded at build time; new XID numbers or CUDA error codes
+  introduced by a future driver release will be rendered as `XID_<n>` / `CUDA_ERROR_<n>` with an
+  "Unknown" suggestion until the catalog is updated.
+
+## See also
+
+* [NVIDIA XID documentation](https://docs.nvidia.com/deploy/xid-errors/)
+* [CUDA Driver API error codes](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html)
+* `profile_cuda` gadget — for per-kernel timing, not errors.

--- a/gadgets/trace_nvidia_errors/artifacthub-pkg.yml
+++ b/gadgets/trace_nvidia_errors/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+# Artifact Hub package metadata file
+version: 0.53.0
+name: "trace nvidia errors"
+category: monitoring-logging
+displayName: "trace nvidia errors"
+createdAt: "2026-05-26T00:00:00Z"
+digest: "2026-05-26T00:00:00Z"
+description: "Trace NVIDIA CUDA Driver API errors and in-kernel XID events with enrichment"
+logoURL: "https://inspektor-gadget.io/media/brand-icon.svg"
+license: "Apache-2.0"
+homeURL: "https://inspektor-gadget.io/docs/latest/gadgets/trace_nvidia_errors"
+containersImages:
+    - name: gadget
+      image: "ghcr.io/inspektor-gadget/gadget/trace_nvidia_errors:latest"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+keywords:
+    - gadget
+    - nvidia
+    - cuda
+    - gpu
+    - xid
+links:
+    - name: source
+      url: "https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_nvidia_errors"
+install: |
+    # Run
+    ```bash
+    sudo ig run ghcr.io/inspektor-gadget/gadget/trace_nvidia_errors:latest
+    ```
+provider:
+    name: Inspektor Gadget

--- a/gadgets/trace_nvidia_errors/build.yaml
+++ b/gadgets/trace_nvidia_errors/build.yaml
@@ -1,0 +1,1 @@
+wasm: go/program.go

--- a/gadgets/trace_nvidia_errors/gadget.yaml
+++ b/gadgets/trace_nvidia_errors/gadget.yaml
@@ -1,0 +1,186 @@
+name: trace nvidia errors
+description: Trace NVIDIA CUDA Driver API errors and in-kernel XID events with enrichment
+homepageURL: https://github.com/inspektor-gadget/inspektor-gadget
+documentationURL: https://github.com/inspektor-gadget/inspektor-gadget/blob/main/gadgets/trace_nvidia_errors/README.md
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget
+datasources:
+  nvidia_errors:
+    fields:
+      timestamp_raw:
+        annotations:
+          description: Event timestamp (boot nanoseconds)
+          columns.hidden: "true"
+      proc.pid:
+        annotations:
+          description: Process ID
+          columns.width: "7"
+      proc.tid:
+        annotations:
+          description: Thread ID
+          columns.hidden: "true"
+      proc.comm:
+        annotations:
+          description: Process name
+          columns.width: "16"
+      source_raw:
+        annotations:
+          description: "Raw source discriminator (1=CUDA API, 2=XID)"
+          columns.hidden: "true"
+          value.one-of: |
+            1: SOURCE_CUDA_API
+            2: SOURCE_XID
+      error_code_raw:
+        annotations:
+          description: "Raw CUDA error code (CUresult). Only meaningful for CUDA API events."
+          columns.hidden: "true"
+          value.one-of: |
+            0: CUDA_SUCCESS
+            1: CUDA_ERROR_INVALID_VALUE
+            2: CUDA_ERROR_OUT_OF_MEMORY
+            3: CUDA_ERROR_NOT_INITIALIZED
+            4: CUDA_ERROR_DEINITIALIZED
+            34: CUDA_ERROR_STUB_LIBRARY
+            100: CUDA_ERROR_NO_DEVICE
+            101: CUDA_ERROR_INVALID_DEVICE
+            200: CUDA_ERROR_INVALID_IMAGE
+            201: CUDA_ERROR_INVALID_CONTEXT
+            209: CUDA_ERROR_NO_BINARY_FOR_GPU
+            214: CUDA_ERROR_ECC_UNCORRECTABLE
+            218: CUDA_ERROR_INVALID_PTX
+            220: CUDA_ERROR_NVLINK_UNCORRECTABLE
+            700: CUDA_ERROR_ILLEGAL_ADDRESS
+            701: CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES
+            719: CUDA_ERROR_LAUNCH_FAILED
+            999: CUDA_ERROR_UNKNOWN
+      api_id_raw:
+        annotations:
+          description: "Raw CUDA API identifier (see api_name for string)"
+          columns.hidden: "true"
+          value.one-of: |
+            1: cuMemAlloc_v2
+            2: cuMemAllocPitch_v2
+            3: cuMemAllocManaged
+            4: cuLaunchKernel
+            5: cuCtxCreate_v2
+            6: cuDeviceGet
+            7: cuDeviceGetCount
+            8: cuModuleLoad
+            9: cuModuleLoadData
+            10: cuModuleGetFunction
+            11: cuMemcpyHtoD_v2
+            12: cuMemcpyDtoH_v2
+            13: cuStreamCreate
+            14: cuStreamQuery
+            15: cuStreamSynchronize
+            16: cuEventCreate
+            17: cuEventRecord
+            18: cuEventQuery
+            19: cuEventSynchronize
+            20: cuMemFree_v2
+            21: cuCtxSynchronize
+            22: cuInit
+      xid_code:
+        annotations:
+          description: "NVIDIA XID number (only for SOURCE_XID events)"
+          columns.width: "8"
+          columns.alignment: right
+      source:
+        annotations:
+          description: "Event source: SOURCE_CUDA_API or SOURCE_XID"
+          columns.width: "16"
+      error_code:
+        annotations:
+          description: "CUDA error name"
+          columns.width: "36"
+      api_id:
+        annotations:
+          description: "CUDA API name"
+          columns.width: "22"
+      severity:
+        annotations:
+          description: "Severity: LOW | MEDIUM | HIGH | CRITICAL"
+          columns.width: "10"
+      category:
+        annotations:
+          description: "Error category"
+          columns.width: "14"
+      description:
+        annotations:
+          description: "Plain-English error description"
+          columns.hidden: "true"
+      why:
+        annotations:
+          description: "Why this error happened in this context"
+          columns.width: "48"
+      suggestion:
+        annotations:
+          description: "Actionable remediation suggestion"
+          columns.hidden: "true"
+      context_info:
+        annotations:
+          description: "Argument and context details"
+          columns.width: "40"
+      gpu_pci_addr:
+        annotations:
+          description: "GPU PCI address (DDDD:BB:SS.F) for XID events"
+          columns.width: "14"
+      pci_domain:
+        annotations:
+          description: "PCI domain (raw)"
+          columns.hidden: "true"
+      pci_bus:
+        annotations:
+          description: "PCI bus (raw)"
+          columns.hidden: "true"
+      pci_slot:
+        annotations:
+          description: "PCI slot (raw)"
+          columns.hidden: "true"
+      pci_func:
+        annotations:
+          description: "PCI function (raw)"
+          columns.hidden: "true"
+      arg1:
+        annotations: { description: "Raw argument 1", columns.hidden: "true" }
+      arg2:
+        annotations: { description: "Raw argument 2", columns.hidden: "true" }
+      arg3:
+        annotations: { description: "Raw argument 3", columns.hidden: "true" }
+      arg4:
+        annotations: { description: "Raw argument 4", columns.hidden: "true" }
+      arg5:
+        annotations: { description: "Raw argument 5", columns.hidden: "true" }
+      arg6:
+        annotations: { description: "Raw argument 6", columns.hidden: "true" }
+      active_cuda_api:
+        annotations:
+          description: "API_* id of the most recent CUDA call by the offending PID within 100 ms of the XID (raw)"
+          columns.hidden: "true"
+      xid_attrib_flags:
+        annotations:
+          description: "XID→workload attribution bitmask (raw)"
+          columns.hidden: "true"
+      active_cuda_delta_ns:
+        annotations:
+          description: "Time between the active CUDA call and the XID event (ns)"
+          columns.hidden: "true"
+      active_cuda_args:
+        annotations:
+          description: "Arguments of the active CUDA call (raw)"
+          columns.hidden: "true"
+      _pad:
+        annotations:
+          description: "padding"
+          columns.hidden: "true"
+      active_cuda_call:
+        annotations:
+          description: "Active CUDA call correlated with an XID"
+          columns.width: "28"
+      xid_attribution:
+        annotations:
+          description: "How the XID was attributed to the workload"
+          columns.width: "24"
+      ustack_raw:
+        annotations:
+          description: "User-space call stack (CUDA and XID events)"
+          columns.hidden: "true"

--- a/gadgets/trace_nvidia_errors/go/go.mod
+++ b/gadgets/trace_nvidia_errors/go/go.mod
@@ -1,0 +1,9 @@
+module trace_nvidia_errors
+
+go 1.25.7
+
+// Version doesn't matter because of the replace directive below.
+require github.com/inspektor-gadget/inspektor-gadget v0.0.0
+
+// Only needed by in-tree gadgets
+replace github.com/inspektor-gadget/inspektor-gadget => ../../../

--- a/gadgets/trace_nvidia_errors/go/program.go
+++ b/gadgets/trace_nvidia_errors/go/program.go
@@ -1,0 +1,552 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is the WASM enricher for the trace_nvidia_errors gadget.
+//
+// It subscribes to the single "nvidia_errors" datasource emitted by the BPF
+// program and fans out on `source_raw`:
+//
+//	SOURCE_CUDA_API → look up CUDA CUresult + API name, run arg heuristics
+//	SOURCE_XID      → look up XID, format PCI address
+//
+// The catalog is embedded at compile time (WASM has no filesystem access).
+package main
+
+import (
+	"fmt"
+
+	api "github.com/inspektor-gadget/inspektor-gadget/wasmapi/go"
+)
+
+const (
+	sourceCUDAAPI = 1
+	sourceXID     = 2
+)
+
+// CUDA error codes (CUresult enum from cuda.h, stable across CUDA versions)
+// Reference: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html (enum CUresult)
+const (
+	cudaErrInvalidValue   int32 = 1
+	cudaErrOutOfMemory    int32 = 2
+	cudaErrNoDevice       int32 = 100
+	cudaErrInvalidDevice  int32 = 101
+	cudaErrIllegalAddress int32 = 700
+	cudaErrLaunchOutOfRes int32 = 701
+	cudaErrLaunchFailed   int32 = 719
+)
+
+// API IDs (mirrors program.bpf.c API_* defines)
+const (
+	apiCuMemAlloc_v2      uint32 = 1
+	apiCuMemAllocPitch_v2 uint32 = 2
+	apiCuMemAllocManaged  uint32 = 3
+	apiCuLaunchKernel     uint32 = 4
+	apiCuCtxCreate_v2     uint32 = 5
+	apiCuDeviceGet        uint32 = 6
+	apiCuModuleLoad       uint32 = 8
+	apiCuModuleLoadData   uint32 = 9
+	apiCuInit             uint32 = 22
+)
+
+// ─── CUDA error catalog ────────────────────────────────────────────────────
+//
+// Data sourced from NVIDIA Driver API documentation
+// (https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html)
+// and cross-referenced against driver 550+ headers. Only codes with a clear,
+// actionable description are included; unrecognised codes are rendered as
+// CUDA_ERROR_<n> with a generic suggestion.
+
+type cudaEntry struct {
+	name        string
+	category    string
+	severity    string // LOW | MEDIUM | HIGH | CRITICAL
+	description string
+	suggestion  string
+}
+
+var cudaCatalog = map[int32]cudaEntry{
+	1:   {"CUDA_ERROR_INVALID_VALUE", "parameter", "MEDIUM", "Invalid parameter passed to a CUDA Driver API call (NULL pointer, out-of-range, invalid handle).", "Log call arguments; validate sizes/pointers; check alignment requirements for device pointers."},
+	2:   {"CUDA_ERROR_OUT_OF_MEMORY", "memory", "HIGH", "GPU memory allocation request exceeded free device memory.", "Reduce batch size; enable gradient checkpointing; torch.cuda.empty_cache(); check for leaks with memory_summary()."},
+	3:   {"CUDA_ERROR_NOT_INITIALIZED", "lifecycle", "MEDIUM", "CUDA driver not initialized — cuInit() was not called or failed.", "Call cuInit(0) before any API; verify nvidia-smi works; check LD_LIBRARY_PATH."},
+	4:   {"CUDA_ERROR_DEINITIALIZED", "lifecycle", "MEDIUM", "CUDA driver is shutting down; subsequent calls are invalid.", "Ensure CUDA operations complete before atexit; join all CUDA threads first."},
+	5:   {"CUDA_ERROR_PROFILER_DISABLED", "profiler", "LOW", "Profiler API disabled in this build.", "Use nsys/ncu instead; remove deprecated cuProfiler* calls."},
+	34:  {"CUDA_ERROR_STUB_LIBRARY", "driver", "HIGH", "Application linked/loaded the stub libcuda.so shipped with the toolkit rather than the real driver.", "Ensure libcuda.so from NVIDIA driver precedes toolkit stub in LD_LIBRARY_PATH."},
+	100: {"CUDA_ERROR_NO_DEVICE", "device", "HIGH", "No CUDA-capable GPU detected.", "Check nvidia-smi; verify NVIDIA_VISIBLE_DEVICES; verify container runtime nvidia hook."},
+	101: {"CUDA_ERROR_INVALID_DEVICE", "device", "MEDIUM", "Device ordinal out of range [0, N-1].", "Query cuDeviceGetCount first; clamp ordinal."},
+	102: {"CUDA_ERROR_DEVICE_NOT_LICENSED", "device", "HIGH", "vGPU requires a license that is not checked-out.", "Verify license server reachability; nvidia-smi -q -d LICENSE."},
+	200: {"CUDA_ERROR_INVALID_IMAGE", "compilation", "MEDIUM", "Device kernel image (PTX/cubin) malformed or incompatible.", "Rebuild with matching -arch=sm_XX; verify CUDA toolkit version."},
+	201: {"CUDA_ERROR_INVALID_CONTEXT", "context", "MEDIUM", "No current context on the calling thread or context has been destroyed.", "cuCtxPushCurrent; avoid sharing handles across threads without synchronization."},
+	202: {"CUDA_ERROR_CONTEXT_ALREADY_CURRENT", "context", "LOW", "Redundant cuCtxSetCurrent — context already active.", "Remove the redundant push; likely a library double-init."},
+	205: {"CUDA_ERROR_MAP_FAILED", "interop", "MEDIUM", "Graphics resource map to CUDA failed.", "Re-register resource; verify driver versions match for OpenGL/CUDA."},
+	206: {"CUDA_ERROR_UNMAP_FAILED", "interop", "MEDIUM", "Unmap call without matching map.", "Audit map/unmap pairing."},
+	207: {"CUDA_ERROR_ARRAY_IS_MAPPED", "interop", "LOW", "Array cannot be modified while mapped.", "Unmap before modifying."},
+	208: {"CUDA_ERROR_ALREADY_MAPPED", "interop", "LOW", "cuGraphicsMapResources called twice.", "Remove duplicate map call."},
+	209: {"CUDA_ERROR_NO_BINARY_FOR_GPU", "compilation", "HIGH", "No kernel binary found for this GPU compute capability.", "Add PTX in fatbin (-arch=compute_80 -code=sm_80,compute_80) for forward compatibility."},
+	210: {"CUDA_ERROR_ALREADY_ACQUIRED", "interop", "LOW", "Resource acquired twice.", "Remove duplicate acquisition."},
+	211: {"CUDA_ERROR_NOT_MAPPED", "interop", "MEDIUM", "Access on unmapped resource.", "Call cuGraphicsMapResources first."},
+	214: {"CUDA_ERROR_ECC_UNCORRECTABLE", "hardware", "CRITICAL", "Uncorrectable ECC memory error on GPU DRAM.", "Stop workload; nvidia-smi -q -d ECC; consider RMA if recurring."},
+	215: {"CUDA_ERROR_UNSUPPORTED_LIMIT", "device", "LOW", "Limit type not supported on this GPU.", "Check compute capability matrix."},
+	216: {"CUDA_ERROR_CONTEXT_ALREADY_IN_USE", "context", "MEDIUM", "Context bound to another thread.", "Use cuCtxPopCurrent/PushCurrent pattern."},
+	217: {"CUDA_ERROR_PEER_ACCESS_UNSUPPORTED", "p2p", "MEDIUM", "Peer access not supported between these GPUs.", "nvidia-smi topo -m; use NVLink-connected GPUs."},
+	218: {"CUDA_ERROR_INVALID_PTX", "compilation", "MEDIUM", "PTX JIT compilation failed; malformed or incompatible PTX.", "Regenerate PTX with matching toolkit; update driver."},
+	219: {"CUDA_ERROR_INVALID_GRAPHICS_CONTEXT", "interop", "MEDIUM", "Graphics context invalid for CUDA interop.", "Verify GL/Vulkan context before interop init."},
+	220: {"CUDA_ERROR_NVLINK_UNCORRECTABLE", "hardware", "CRITICAL", "Uncorrectable NVLink fabric error.", "nvidia-smi nvlink -e; check NVSwitch logs; likely RMA."},
+	700: {"CUDA_ERROR_ILLEGAL_ADDRESS", "memory", "CRITICAL", "GPU kernel dereferenced an illegal device address (OOB, use-after-free, stale pointer).", "Run with CUDA_LAUNCH_BLOCKING=1 and compute-sanitizer --tool memcheck."},
+	701: {"CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES", "launch", "HIGH", "Launch needs more threads/registers/shared-mem than GPU offers.", "Lower block dim; --maxrregcount; reduce shared-mem usage."},
+	702: {"CUDA_ERROR_LAUNCH_TIMEOUT", "launch", "HIGH", "Kernel exceeded display driver watchdog.", "Split into smaller kernels; disable watchdog on headless GPUs."},
+	703: {"CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING", "launch", "MEDIUM", "Kernel uses incompatible texturing mode.", "Audit texture bindings; unbind between kernels."},
+	719: {"CUDA_ERROR_LAUNCH_FAILED", "launch", "HIGH", "Unspecified kernel failure — usually masks an illegal memory access.", "CUDA_LAUNCH_BLOCKING=1 + compute-sanitizer memcheck; inspect prior 700."},
+	720: {"CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE", "launch", "MEDIUM", "Cooperative launch grid exceeds device max resident blocks.", "Query cudaOccupancyMaxActiveBlocksPerMultiprocessor; clamp grid."},
+	800: {"CUDA_ERROR_NOT_PERMITTED", "permission", "MEDIUM", "Operation not permitted in current context (MIG, compute mode, peer access).", "Check nvidia-smi -q -d COMPUTE; enable peer access; review MIG config."},
+	911: {"CUDA_ERROR_EXTERNAL_DEVICE", "interop", "MEDIUM", "Operation on invalid external-memory handle (Vulkan/D3D import).", "Re-import the external resource; verify fd lifetime."},
+	999: {"CUDA_ERROR_UNKNOWN", "unknown", "HIGH", "Driver returned unspecified failure; usually precedes XID cascade.", "dmesg | grep NVRM; restart workload; update driver."},
+}
+
+// ─── CUDA API name catalog ────────────────────────────────────────────────
+
+var apiNames = map[uint32]string{
+	1:  "cuMemAlloc_v2",
+	2:  "cuMemAllocPitch_v2",
+	3:  "cuMemAllocManaged",
+	4:  "cuLaunchKernel",
+	5:  "cuCtxCreate_v2",
+	6:  "cuDeviceGet",
+	7:  "cuDeviceGetCount",
+	8:  "cuModuleLoad",
+	9:  "cuModuleLoadData",
+	10: "cuModuleGetFunction",
+	11: "cuMemcpyHtoD_v2",
+	12: "cuMemcpyDtoH_v2",
+	13: "cuStreamCreate",
+	14: "cuStreamQuery",
+	15: "cuStreamSynchronize",
+	16: "cuEventCreate",
+	17: "cuEventRecord",
+	18: "cuEventQuery",
+	19: "cuEventSynchronize",
+	20: "cuMemFree_v2",
+	21: "cuCtxSynchronize",
+	22: "cuInit",
+}
+
+// ─── XID catalog ──────────────────────────────────────────────────────────
+//
+// Sourced from https://docs.nvidia.com/deploy/xid-errors/ . Covers the codes
+// most frequently seen in production CUDA workloads; uncatalogued codes are
+// rendered as XID_<n>.
+
+type xidEntry struct {
+	name        string
+	category    string
+	severity    string
+	description string
+	suggestion  string
+}
+
+var xidCatalog = map[uint32]xidEntry{
+	13:  {"Graphics Engine Exception", "app_error", "HIGH", "Illegal instruction / OOB operation executed by a GPU shader.", "compute-sanitizer memcheck + CUDA_LAUNCH_BLOCKING=1; recompile for correct arch."},
+	31:  {"GPU memory page fault", "app_error", "CRITICAL", "GPU MMU fault on invalid virtual address.", "compute-sanitizer memcheck; check UVM eviction; audit cuMemcpy arguments."},
+	32:  {"Invalid/corrupted push buffer", "driver_bug", "CRITICAL", "Command buffer submitted to GPU is malformed.", "Driver bug most of the time — update driver; check PCIe errors."},
+	38:  {"Driver firmware error", "firmware", "CRITICAL", "Firmware/driver communication failure.", "Update firmware; check thermals; collect nvidia-bug-report."},
+	43:  {"GPU watchdog timeout", "app_error", "HIGH", "Kernel exceeded watchdog timer.", "Split long kernels; add early-exit checks; raise TDR if applicable."},
+	44:  {"Graphics context error", "app_error", "HIGH", "Error in graphics (not compute) context.", "Separate compute/display GPUs."},
+	45:  {"Preemptive cleanup", "cleanup", "MEDIUM", "Driver is cleaning up after a preceding fatal error.", "Find and fix the root-cause XID that occurred just before XID 45."},
+	48:  {"Double Bit ECC", "hardware_ecc", "CRITICAL", "Uncorrectable ECC DRAM failure.", "Stop workload; nvidia-smi -q -d ECC; RMA GPU."},
+	56:  {"Display engine error", "display", "MEDIUM", "Display pipeline error.", "Check cables/monitor."},
+	57:  {"Display engine channel error", "display", "MEDIUM", "Display channel error.", "Update display driver."},
+	61:  {"PMU_HALT_INTERNAL", "firmware", "CRITICAL", "GPU firmware hit internal error; micro-controller breakpoint.", "Reset GPU; collect nvidia-bug-report."},
+	62:  {"PMU_HALT", "firmware", "CRITICAL", "GPU firmware halted unrecoverably.", "System reboot; possible RMA."},
+	63:  {"ECC page retirement event", "hardware_ecc", "MEDIUM", "GPU retiring a DRAM page.", "Monitor retired-pages count; trend indicates failing DRAM."},
+	64:  {"ECC page retirement failure", "hardware_ecc", "HIGH", "Retirement table full or write failed.", "GPU DRAM degrading; plan RMA."},
+	68:  {"NVDEC0 Exception", "engine", "MEDIUM", "Video decoder engine error.", "Update driver; reduce decode rate."},
+	69:  {"Graphics engine class error", "engine", "HIGH", "Engine class-level error.", "Check thermals; update driver."},
+	74:  {"NVLink error", "fabric", "HIGH", "NVLink semaphore timeout / access violation.", "nvidia-smi nvlink -e; check NVSwitch."},
+	79:  {"GPU has fallen off the bus", "hardware_bus", "CRITICAL", "PCIe link to GPU lost.", "Check power/cables; reboot; if persistent RMA."},
+	92:  {"High single-bit ECC rate", "hardware_ecc", "HIGH", "Elevated correctable ECC rate.", "nvidia-smi -q -d ECC; plan replacement."},
+	94:  {"Contained ECC error", "hardware_ecc", "MEDIUM", "Contained ECC error — data corrected.", "Monitor frequency."},
+	95:  {"Uncontained ECC error", "hardware_ecc", "CRITICAL", "ECC error could not be contained.", "Reset GPU; rerun workload."},
+	109: {"Context switch failure", "engine", "CRITICAL", "Engine context switch failed.", "Driver bug report; firmware update."},
+	119: {"GSP RPC timeout", "firmware", "CRITICAL", "GPU System Processor RPC timed out.", "Disable GSP (options nvidia NVreg_EnableGpuFirmware=0) or update driver."},
+}
+
+// ─── Field handles (populated in gadgetInit) ──────────────────────────────
+
+var (
+	dsErrors api.DataSource
+
+	fSourceRaw                               api.Field
+	fErrorCodeRaw                            api.Field
+	fAPIIDRaw                                api.Field
+	fXidCode                                 api.Field
+	fPCIDomain                               api.Field
+	fPCIBus                                  api.Field
+	fPCISlot                                 api.Field
+	fPCIFunc                                 api.Field
+	fArg1, fArg2, fArg3, fArg4, fArg5, fArg6 api.Field
+
+	fErrorName  api.Field
+	fAPIName    api.Field
+	fSourceName api.Field
+	fSeverity   api.Field
+	fCategory   api.Field
+	fDesc       api.Field
+	fWhy        api.Field
+	fSuggestion api.Field
+	fContext    api.Field
+	fGPUAddr    api.Field
+
+	// XID→workload correlation (patch 0002)
+	fActiveCUDAAPIRaw  api.Field
+	fXIDAttribFlags    api.Field
+	fActiveCUDADeltaNS api.Field
+	fActiveCUDACall    api.Field
+	fXIDAttribution    api.Field
+)
+
+//go:wasmexport gadgetInit
+func gadgetInit() int32 {
+	var err error
+	dsErrors, err = api.GetDataSource("nvidia_errors")
+	if err != nil {
+		api.Warnf("trace_nvidia_errors: datasource: %v", err)
+		return 1
+	}
+	if err = bindRawFields(); err != nil {
+		api.Warnf("trace_nvidia_errors: bind raw: %v", err)
+		return 1
+	}
+	if err = addDerivedFields(); err != nil {
+		api.Warnf("trace_nvidia_errors: add derived: %v", err)
+		return 1
+	}
+	dsErrors.Subscribe(enrich, 0)
+	return 0
+}
+
+func bindRawFields() error {
+	var err error
+	for _, b := range []struct {
+		f    *api.Field
+		name string
+	}{
+		{&fSourceRaw, "source_raw"},
+		{&fErrorCodeRaw, "error_code_raw"},
+		{&fAPIIDRaw, "api_id_raw"},
+		{&fXidCode, "xid_code"},
+		{&fPCIDomain, "pci_domain"},
+		{&fPCIBus, "pci_bus"},
+		{&fPCISlot, "pci_slot"},
+		{&fPCIFunc, "pci_func"},
+		{&fArg1, "arg1"}, {&fArg2, "arg2"}, {&fArg3, "arg3"},
+		{&fArg4, "arg4"}, {&fArg5, "arg5"}, {&fArg6, "arg6"},
+		{&fActiveCUDAAPIRaw, "active_cuda_api"},
+		{&fXIDAttribFlags, "xid_attrib_flags"},
+		{&fActiveCUDADeltaNS, "active_cuda_delta_ns"},
+	} {
+		*b.f, err = dsErrors.GetField(b.name)
+		if err != nil {
+			return fmt.Errorf("get field %s: %w", b.name, err)
+		}
+	}
+	return nil
+}
+
+func addDerivedFields() error {
+	var err error
+	for _, b := range []struct {
+		f    *api.Field
+		name string
+	}{
+		{&fErrorName, "error_code"},
+		{&fAPIName, "api_id"},
+		{&fSourceName, "source"},
+		{&fSeverity, "severity"},
+		{&fCategory, "category"},
+		{&fDesc, "description"},
+		{&fWhy, "why"},
+		{&fSuggestion, "suggestion"},
+		{&fContext, "context_info"},
+		{&fGPUAddr, "gpu_pci_addr"},
+		{&fActiveCUDACall, "active_cuda_call"},
+		{&fXIDAttribution, "xid_attribution"},
+	} {
+		*b.f, err = dsErrors.AddField(b.name, api.Kind_String)
+		if err != nil {
+			return fmt.Errorf("add field %s: %w", b.name, err)
+		}
+	}
+	return nil
+}
+
+// enrich is the per-event subscription callback.
+func enrich(source api.DataSource, data api.Data) {
+	src, _ := fSourceRaw.Uint32(data)
+	switch src {
+	case sourceCUDAAPI:
+		enrichCUDA(data)
+	case sourceXID:
+		enrichXID(data)
+	default:
+		fSourceName.SetString(data, "SOURCE_UNKNOWN")
+	}
+}
+
+func enrichCUDA(data api.Data) {
+	fSourceName.SetString(data, "SOURCE_CUDA_API")
+
+	errCode, _ := fErrorCodeRaw.Int32(data)
+	apiID, _ := fAPIIDRaw.Uint32(data)
+
+	// error_name
+	entry, known := cudaCatalog[errCode]
+	if known {
+		fErrorName.SetString(data, entry.name)
+		fDesc.SetString(data, entry.description)
+		fSuggestion.SetString(data, entry.suggestion)
+		fCategory.SetString(data, entry.category)
+		fSeverity.SetString(data, entry.severity)
+	} else {
+		fErrorName.SetString(data, fmt.Sprintf("CUDA_ERROR_%d", errCode))
+		fDesc.SetString(data, "Uncatalogued CUDA error")
+		fSuggestion.SetString(data, "Consult the CUDA Driver API documentation for this return code.")
+		fCategory.SetString(data, "unknown")
+		fSeverity.SetString(data, "MEDIUM")
+	}
+
+	// api_name
+	if name, ok := apiNames[apiID]; ok {
+		fAPIName.SetString(data, name)
+	} else {
+		fAPIName.SetString(data, fmt.Sprintf("cuda_api_%d", apiID))
+	}
+
+	// argument heuristics (context_info + why)
+	a1, _ := fArg1.Uint64(data)
+	a2, _ := fArg2.Uint64(data)
+	a3, _ := fArg3.Uint64(data)
+	a4, _ := fArg4.Uint64(data)
+	a5, _ := fArg5.Uint64(data)
+	a6, _ := fArg6.Uint64(data)
+	ctx, why := heuristics(errCode, apiID, [6]uint64{a1, a2, a3, a4, a5, a6}, entry.description)
+	fContext.SetString(data, ctx)
+	fWhy.SetString(data, why)
+}
+
+func enrichXID(data api.Data) {
+	fSourceName.SetString(data, "SOURCE_XID")
+
+	xid, _ := fXidCode.Uint32(data)
+	entry, known := xidCatalog[xid]
+	if !known {
+		entry = xidEntry{
+			name:        fmt.Sprintf("XID_%d", xid),
+			category:    "unknown",
+			severity:    "MEDIUM",
+			description: "Unrecognised XID; consult NVIDIA XID documentation.",
+			suggestion:  "Update driver / check dmesg for matching NVRM line.",
+		}
+	}
+
+	dom, _ := fPCIDomain.Uint32(data)
+	bus, _ := fPCIBus.Uint32(data)
+	slot, _ := fPCISlot.Uint32(data)
+	fn, _ := fPCIFunc.Uint32(data)
+	addr := fmt.Sprintf("%04x:%02x:%02x.%x", dom, bus, slot, fn)
+
+	fErrorName.SetString(data, fmt.Sprintf("XID_%d", xid))
+	fAPIName.SetString(data, "")
+	fDesc.SetString(data, fmt.Sprintf("%s: %s", entry.name, entry.description))
+	fSuggestion.SetString(data, entry.suggestion)
+	fCategory.SetString(data, entry.category)
+	fSeverity.SetString(data, entry.severity)
+	fGPUAddr.SetString(data, addr)
+	// XID→workload correlation (patch 0002): render the active CUDA API
+	// call, attribution strategy, and augment why/context_info.
+	attribFlags, _ := fXIDAttribFlags.Uint32(data)
+	activeAPI, _ := fActiveCUDAAPIRaw.Uint32(data)
+	activeDelta, _ := fActiveCUDADeltaNS.Int64(data)
+
+	attribParts := []string{}
+	if attribFlags&xidAttribPIDFromContext != 0 {
+		attribParts = append(attribParts, "process_context")
+	}
+	if attribFlags&xidAttribCUDARingMatch != 0 {
+		attribParts = append(attribParts, "cuda_ring_match")
+	}
+	if attribFlags&xidAttribUserStack != 0 {
+		attribParts = append(attribParts, "user_stack")
+	}
+	if attribFlags&xidAttribGlobalRing != 0 {
+		attribParts = append(attribParts, "global_ring")
+	}
+	if attribFlags&xidAttribInterruptCtx != 0 {
+		attribParts = append(attribParts, "interrupt_ctx")
+	}
+	attribStr := "none"
+	if len(attribParts) > 0 {
+		attribStr = joinParts(attribParts, ",")
+	}
+	fXIDAttribution.SetString(data, attribStr)
+
+	activeCall := ""
+	if attribFlags&(xidAttribCUDARingMatch|xidAttribGlobalRing) != 0 {
+		name, ok := apiNames[activeAPI]
+		if !ok {
+			name = fmt.Sprintf("cuda_api_%d", activeAPI)
+		}
+		activeCall = fmt.Sprintf("%s (Δ-%s ago)", name, fmtDuration(activeDelta))
+	}
+	fActiveCUDACall.SetString(data, activeCall)
+
+	pidContext := "(no process context)"
+	if attribFlags&xidAttribPIDFromContext != 0 {
+		pidContext = "in process context"
+	}
+	fContext.SetString(data, fmt.Sprintf("xid=%d pci=%s active_cuda=%s attribution=%s",
+		xid, addr, firstNonEmpty(activeCall, "-"), attribStr))
+	whyBase := fmt.Sprintf("NVIDIA driver reported XID %d (%s) from kernel context on GPU %s %s.",
+		xid, entry.name, addr, pidContext)
+	if activeCall != "" {
+		whyBase += fmt.Sprintf(" Offending workload last invoked %s.", activeCall)
+	}
+	fWhy.SetString(data, whyBase)
+}
+
+// XID→workload correlation bit-flags — mirrors program.bpf.c.
+const (
+	xidAttribPIDFromContext uint32 = 1 << 0
+	xidAttribCUDARingMatch  uint32 = 1 << 1
+	xidAttribUserStack      uint32 = 1 << 2
+	xidAttribGlobalRing     uint32 = 1 << 3
+	xidAttribInterruptCtx   uint32 = 1 << 4
+)
+
+// fmtDuration formats a ns delta as a short human-friendly string.
+func fmtDuration(ns int64) string {
+	if ns < 1000 {
+		return fmt.Sprintf("%dns", ns)
+	}
+	if ns < 1000*1000 {
+		return fmt.Sprintf("%.1fµs", float64(ns)/1000.0)
+	}
+	if ns < 1000*1000*1000 {
+		return fmt.Sprintf("%.1fms", float64(ns)/1000000.0)
+	}
+	return fmt.Sprintf("%.2fs", float64(ns)/1e9)
+}
+
+func joinParts(parts []string, sep string) string {
+	out := ""
+	for i, s := range parts {
+		if i > 0 {
+			out += sep
+		}
+		out += s
+	}
+	return out
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// ─── heuristics ───────────────────────────────────────────────────────────
+//
+// heuristics returns (context_info, why) for a CUDA error+api pair, using the
+// six captured arguments. When no API-specific logic applies, context_info
+// falls back to a hex dump of arg1/arg2 and why falls back to the catalog
+// description.
+func heuristics(errCode int32, apiID uint32, a [6]uint64, desc string) (string, string) {
+	// OOM on any allocator API → size in human units
+	if errCode == cudaErrOutOfMemory {
+		switch apiID {
+		case apiCuMemAlloc_v2, apiCuMemAllocManaged:
+			return fmtBytesField("requested_bytes", a[1]),
+				fmt.Sprintf("%s Allocation request %s failed.", desc, fmtBytes(a[1]))
+		case apiCuMemAllocPitch_v2:
+			total := a[2] * a[3]
+			return fmt.Sprintf("width=%d height=%d element_size=%d (~%s)",
+					a[2], a[3], a[4], fmtBytes(total)),
+				fmt.Sprintf("%s Pitch allocation of ~%s failed.", desc, fmtBytes(total))
+		}
+	}
+
+	// INVALID_DEVICE on cuCtxCreate or cuDeviceGet → bad ordinal
+	if errCode == cudaErrInvalidDevice {
+		switch apiID {
+		case apiCuCtxCreate_v2:
+			return fmt.Sprintf("flags=0x%x device_ordinal=%d", a[1], a[2]),
+				fmt.Sprintf("%s ordinal=%d is not in [0, cuDeviceGetCount()).",
+					desc, a[2])
+		case apiCuDeviceGet:
+			return fmt.Sprintf("ordinal=%d", a[1]),
+				fmt.Sprintf("%s ordinal=%d is not in [0, cuDeviceGetCount()).",
+					desc, a[1])
+		}
+	}
+
+	// Launch failures → print the launch grid/block
+	if (errCode == cudaErrLaunchOutOfRes || errCode == cudaErrLaunchFailed || errCode == cudaErrIllegalAddress) && apiID == apiCuLaunchKernel {
+		return fmt.Sprintf("grid=(%d,%d,%d) block=(%d,%d,...)",
+				a[1], a[2], a[3], a[4], a[5]),
+			fmt.Sprintf("%s Launch grid=(%d,%d,%d) block=(%d,%d,...).",
+				desc, a[1], a[2], a[3], a[4], a[5])
+	}
+
+	// NO_DEVICE on cuInit → context is the flags arg
+	if errCode == cudaErrNoDevice && apiID == apiCuInit {
+		return fmt.Sprintf("cuInit flags=0x%x", a[0]),
+			fmt.Sprintf("%s No GPU visible to this process (check CUDA_VISIBLE_DEVICES).",
+				desc)
+	}
+
+	// Module load failures → print pointers
+	if apiID == apiCuModuleLoad || apiID == apiCuModuleLoadData {
+		return fmt.Sprintf("module=0x%x data_or_path=0x%x", a[0], a[1]), desc
+	}
+
+	// Fallback
+	if a[1] != 0 {
+		return fmt.Sprintf("arg1=0x%x arg2=0x%x", a[0], a[1]), desc
+	}
+	return fmt.Sprintf("arg1=0x%x", a[0]), desc
+}
+
+// fmtBytes prints a byte count with the most-readable unit.
+func fmtBytes(v uint64) string {
+	const (
+		gib = 1 << 30
+		mib = 1 << 20
+		kib = 1 << 10
+	)
+	switch {
+	case v >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(v)/float64(gib))
+	case v >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(v)/float64(mib))
+	case v >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(v)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", v)
+	}
+}
+
+func fmtBytesField(name string, v uint64) string {
+	return fmt.Sprintf("%s=%d (%s)", name, v, fmtBytes(v))
+}
+
+func main() {}

--- a/gadgets/trace_nvidia_errors/program.bpf.c
+++ b/gadgets/trace_nvidia_errors/program.bpf.c
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2026 The Inspektor Gadget authors
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/types.h>
+#include <gadget/macros.h>
+#include <gadget/user_stack_map.h>
+
+#define MAX_ENTRIES 16384
+
+/* Event source discriminator */
+enum error_source {
+	SOURCE_CUDA_API = 1,
+	SOURCE_XID = 2,
+};
+
+/* CUDA_SUCCESS — the only return we do NOT record */
+#define CUDA_SUCCESS 0
+
+/*
+ * API IDs — stable identifiers for each hooked libcuda function.
+ * Kept as #define (not enum) so they match the WASM catalog's uint32 keys
+ * directly without sign-extension ambiguity.
+ */
+#define API_cuMemAlloc_v2 1
+#define API_cuMemAllocPitch_v2 2
+#define API_cuMemAllocManaged 3
+#define API_cuLaunchKernel 4
+#define API_cuCtxCreate_v2 5
+#define API_cuDeviceGet 6
+#define API_cuDeviceGetCount 7
+#define API_cuModuleLoad 8
+#define API_cuModuleLoadData 9
+#define API_cuModuleGetFunction 10
+#define API_cuMemcpyHtoD_v2 11
+#define API_cuMemcpyDtoH_v2 12
+#define API_cuStreamCreate 13
+#define API_cuStreamQuery 14
+#define API_cuStreamSynchronize 15
+#define API_cuEventCreate 16
+#define API_cuEventRecord 17
+#define API_cuEventQuery 18
+#define API_cuEventSynchronize 19
+#define API_cuMemFree_v2 20
+#define API_cuCtxSynchronize 21
+#define API_cuInit 22
+
+/* XID→workload attribution flags (bitmask) */
+#define XID_ATTRIB_PID_FROM_CONTEXT 0x1
+#define XID_ATTRIB_CUDA_RING_MATCH 0x2
+#define XID_ATTRIB_USER_STACK 0x4
+#define XID_ATTRIB_GLOBAL_RING 0x8 /* fell back to cross-PID ring */
+#define XID_ATTRIB_INTERRUPT_CTX 0x10 /* PID captured is a kernel IRQ thread */
+
+/* Ring-match window for XID ↔ recent CUDA call correlation. */
+#define CUDA_RING_MATCH_WINDOW_NS (100ULL * 1000ULL * 1000ULL)
+
+struct event {
+	gadget_timestamp timestamp_raw;
+	struct gadget_process proc;
+
+	__u32 source_raw; /* enum error_source */
+
+	__s32 error_code_raw; /* CUresult; 0 for XID */
+	__u32 api_id_raw; /* API_*; 0 for XID */
+
+	__u32 xid_code;
+	__u32 pci_domain;
+	__u8 pci_bus;
+	__u8 pci_slot;
+	__u8 pci_func;
+	__u8 _pad;
+
+	__u64 arg1;
+	__u64 arg2;
+	__u64 arg3;
+	__u64 arg4;
+	__u64 arg5;
+	__u64 arg6;
+
+	/* XID→workload correlation (zero on CUDA-API events) */
+	__u32 active_cuda_api; /* API_* id of matched recent call, 0 if none */
+	__u32 xid_attrib_flags; /* XID_ATTRIB_* bitmask */
+	__s64 active_cuda_delta_ns; /* xid_ts - last_cuda_ts (ns); 0 if no match */
+
+	struct gadget_user_stack ustack_raw;
+};
+
+/* Per-TID stash so uretprobe can emit the args captured at entry. */
+struct entry_args {
+	__u32 api_id;
+	__u32 _pad;
+	__u64 arg1;
+	__u64 arg2;
+	__u64 arg3;
+	__u64 arg4;
+	__u64 arg5;
+	__u64 arg6;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u64); /* bpf_get_current_pid_tgid() */
+	__type(value, struct entry_args);
+} entries SEC(".maps");
+
+/*
+ * Per-TID "last CUDA call" record, stamped unconditionally on every
+ * uretprobe. Used to attribute XID events to the most recent CUDA activity
+ * from the same thread when the XID fires in process context.
+ *
+ * LRU_HASH so the map auto-evicts entries from exited threads.
+ */
+struct cuda_last_call {
+	__u32 api_id;
+	__u32 _pad;
+	__u64 ts_ns;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u32); /* tgid */
+	__type(value, struct cuda_last_call);
+} cuda_last SEC(".maps");
+
+/*
+ * Single "most recent CUDA call across any PID" slot.  Used as the
+ * strategy-C fallback when an XID fires in IRQ/DPC context — it attributes
+ * to the PID that most recently touched the GPU, which is a reasonable
+ * heuristic on single-GPU / single-tenant nodes and is marked with the
+ * XID_ATTRIB_GLOBAL_RING flag so user-space can surface lower confidence.
+ */
+struct cuda_last_any {
+	struct cuda_last_call call;
+	struct gadget_process proc;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct cuda_last_any);
+} cuda_last_any SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 512);
+GADGET_TRACER(nvidia_errors, events, event);
+
+static __always_inline int save_entry(__u32 api_id, __u64 a1, __u64 a2,
+				      __u64 a3, __u64 a4, __u64 a5, __u64 a6)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct entry_args args = {
+		.api_id = api_id,
+		._pad = 0,
+		.arg1 = a1,
+		.arg2 = a2,
+		.arg3 = a3,
+		.arg4 = a4,
+		.arg5 = a5,
+		.arg6 = a6,
+	};
+	bpf_map_update_elem(&entries, &pid_tgid, &args, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int handle_return(struct pt_regs *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct entry_args *args = bpf_map_lookup_elem(&entries, &pid_tgid);
+	if (!args)
+		return 0;
+
+	__s32 ret = (__s32)PT_REGS_RC(ctx);
+
+	/* Always stamp the per-TGID "last CUDA call" record — success or
+	 * failure — so an XID arriving within 100 ms can attribute to the
+	 * right workload even when the CUDA call itself succeeded, and even
+	 * when the XID is reported from the CUDA driver's internal event
+	 * handler thread rather than the one that submitted the API call.
+	 */
+	__u32 tgid_key = (__u32)(pid_tgid >> 32);
+	struct cuda_last_call rec = {
+		.api_id = args->api_id,
+		.ts_ns = bpf_ktime_get_boot_ns(),
+	};
+	bpf_map_update_elem(&cuda_last, &tgid_key, &rec, BPF_ANY);
+
+	/*
+	 * Only update the global-ring slot for APIs that can plausibly submit
+	 * GPU work or release resources (and thus trigger an XID).  Hot
+	 * polling APIs (cuStreamQuery, cuEventQuery, cuEventRecord) are not
+	 * instrumented at all to avoid overhead in ML inference workloads.
+	 */
+	switch (args->api_id) {
+	case API_cuLaunchKernel:
+	case API_cuMemcpyHtoD_v2:
+	case API_cuMemcpyDtoH_v2:
+	case API_cuCtxSynchronize:
+	case API_cuStreamSynchronize:
+	case API_cuMemFree_v2:
+	case API_cuMemAlloc_v2:
+	case API_cuMemAllocManaged:
+	case API_cuMemAllocPitch_v2:
+	case API_cuCtxCreate_v2:
+	case API_cuModuleLoad:
+	case API_cuModuleLoadData:
+	case API_cuModuleGetFunction:
+	case API_cuEventSynchronize: {
+		__u32 zero = 0;
+		struct cuda_last_any g = { .call = rec };
+		gadget_process_populate(&g.proc);
+		bpf_map_update_elem(&cuda_last_any, &zero, &g, BPF_ANY);
+		break;
+	}
+	default:
+		break;
+	}
+
+	if (ret == CUDA_SUCCESS) {
+		bpf_map_delete_elem(&entries, &pid_tgid);
+		return 0;
+	}
+
+	struct event *e = gadget_reserve_buf(&events, sizeof(*e));
+	if (!e) {
+		bpf_map_delete_elem(&entries, &pid_tgid);
+		return 0;
+	}
+
+	e->timestamp_raw = bpf_ktime_get_boot_ns();
+	gadget_process_populate(&e->proc);
+
+	e->source_raw = SOURCE_CUDA_API;
+	e->error_code_raw = ret;
+	e->api_id_raw = args->api_id;
+	e->arg1 = args->arg1;
+	e->arg2 = args->arg2;
+	e->arg3 = args->arg3;
+	e->arg4 = args->arg4;
+	e->arg5 = args->arg5;
+	e->arg6 = args->arg6;
+
+	gadget_get_user_stack(ctx, &e->ustack_raw);
+	gadget_submit_buf(ctx, &events, e, sizeof(*e));
+	bpf_map_delete_elem(&entries, &pid_tgid);
+	return 0;
+}
+
+/* ─── Process exit cleanup ────────────────────────────────────────────────
+ * If a thread is killed (e.g. SIGKILL) between a uprobe entry and the
+ * corresponding uretprobe, the entries map entry leaks. This tracepoint
+ * fires for every exiting thread and removes any stale entry.
+ */
+SEC("tracepoint/sched/sched_process_exit")
+int trace_sched_process_exit(void *ctx)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	bpf_map_delete_elem(&entries, &pid_tgid);
+	return 0;
+}
+
+/* ─── XID kprobe ──────────────────────────────────────────────────────────
+ * nv_report_error is exported by the NVIDIA kernel module (open-source build).
+ * Signature: void nv_report_error(struct pci_dev *dev, NvU32 error_number,
+ *                                 const char *format, va_list ap);
+ *
+ * Correlation with the offending workload:
+ *   1. Process context: bpf_get_current_pid_tgid() — reliable when
+ *      nv_report_error is invoked from a user ioctl (XID 13/31/43/45).
+ *      For XIDs raised from IRQ/DPC (48/61/62/63/64/79) it is noise;
+ *      the XID_ATTRIB_PID_FROM_CONTEXT flag lets user-space filter.
+ *   2. Recent CUDA call: if the same TID ran a libcuda API within
+ *      CUDA_RING_MATCH_WINDOW_NS, surface it on the XID event.
+ *   3. User stack: gadget_get_user_stack() is a no-op when current is
+ *      not a user thread, so unconditionally calling it is safe.
+ */
+SEC("kprobe/nv_report_error")
+int BPF_KPROBE(trace_nv_report_error, struct pci_dev *dev, __u32 error_number)
+{
+	struct event *e = gadget_reserve_buf(&events, sizeof(*e));
+	if (!e)
+		return 0;
+
+	e->timestamp_raw = bpf_ktime_get_boot_ns();
+	gadget_process_populate(&e->proc);
+
+	e->source_raw = SOURCE_XID;
+	e->xid_code = error_number;
+
+	if (dev) {
+		e->pci_bus = BPF_CORE_READ(dev, bus, number);
+		__u32 devfn = BPF_CORE_READ(dev, devfn);
+		e->pci_slot = devfn >> 3;
+		e->pci_func = devfn & 0x7;
+		e->pci_domain = 0;
+	}
+
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 pid = (__u32)(pid_tgid >> 32);
+	__u32 flags = 0;
+
+	if (pid != 0)
+		flags |= XID_ATTRIB_PID_FROM_CONTEXT;
+
+	struct cuda_last_call *last = bpf_map_lookup_elem(&cuda_last, &pid);
+	if (last) {
+		__s64 delta = (__s64)(e->timestamp_raw - last->ts_ns);
+		if (delta >= 0 && delta <= (__s64)CUDA_RING_MATCH_WINDOW_NS) {
+			e->active_cuda_api = last->api_id;
+			e->active_cuda_delta_ns = delta;
+			flags |= XID_ATTRIB_CUDA_RING_MATCH;
+		}
+	}
+	/*
+	 * Strategy-C fallback: if no per-PID hit (common for XID 31/48/79
+	 * which are raised from IRQ/DPC context), use the global "most
+	 * recent CUDA call across any PID" slot.  Widen the window to 2s.
+	 */
+	if (!(flags & XID_ATTRIB_CUDA_RING_MATCH)) {
+		__u32 zero = 0;
+		struct cuda_last_any *g =
+			bpf_map_lookup_elem(&cuda_last_any, &zero);
+		if (g && g->call.ts_ns) {
+			__s64 delta = (__s64)(e->timestamp_raw - g->call.ts_ns);
+			if (delta >= 0 &&
+			    delta <= (__s64)(CUDA_RING_MATCH_WINDOW_NS * 20)) {
+				e->active_cuda_api = g->call.api_id;
+				e->active_cuda_delta_ns = delta;
+				/* Replace interrupt-ctx proc snapshot with the
+				 * offending workload's captured proc so the
+				 * downstream container enricher can resolve it
+				 * to the right K8s pod. */
+				flags |= XID_ATTRIB_GLOBAL_RING;
+				flags |= XID_ATTRIB_INTERRUPT_CTX;
+				flags &= ~XID_ATTRIB_PID_FROM_CONTEXT;
+				__builtin_memcpy(&e->proc, &g->proc,
+						 sizeof(e->proc));
+			}
+		}
+	}
+
+	gadget_get_user_stack(ctx, &e->ustack_raw);
+	flags |= XID_ATTRIB_USER_STACK;
+	e->xid_attrib_flags = flags;
+
+	gadget_submit_buf(ctx, &events, e, sizeof(*e));
+	return 0;
+}
+
+/* ─── libcuda uprobes (22 entry/return pairs) ───────────────────────────── */
+
+SEC("uprobe/libcuda:cuInit")
+int BPF_UPROBE(probe_cuInit_entry, unsigned int flags)
+{
+	return save_entry(API_cuInit, flags, 0, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuInit")
+int BPF_URETPROBE(probe_cuInit_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuDeviceGet")
+int BPF_UPROBE(probe_cuDeviceGet_entry, void *device, int ordinal)
+{
+	return save_entry(API_cuDeviceGet, (__u64)(unsigned long)device,
+			  ordinal, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuDeviceGet")
+int BPF_URETPROBE(probe_cuDeviceGet_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuDeviceGetCount")
+int BPF_UPROBE(probe_cuDeviceGetCount_entry, void *count)
+{
+	return save_entry(API_cuDeviceGetCount, (__u64)(unsigned long)count, 0,
+			  0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuDeviceGetCount")
+int BPF_URETPROBE(probe_cuDeviceGetCount_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuCtxCreate_v2")
+int BPF_UPROBE(probe_cuCtxCreate_entry, void *pctx, unsigned int flags, int dev)
+{
+	return save_entry(API_cuCtxCreate_v2, (__u64)(unsigned long)pctx, flags,
+			  dev, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuCtxCreate_v2")
+int BPF_URETPROBE(probe_cuCtxCreate_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuCtxSynchronize")
+int BPF_UPROBE(probe_cuCtxSynchronize_entry)
+{
+	return save_entry(API_cuCtxSynchronize, 0, 0, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuCtxSynchronize")
+int BPF_URETPROBE(probe_cuCtxSynchronize_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemAlloc_v2")
+int BPF_UPROBE(probe_cuMemAlloc_entry, void *dptr, __u64 bytesize)
+{
+	return save_entry(API_cuMemAlloc_v2, (__u64)(unsigned long)dptr,
+			  bytesize, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuMemAlloc_v2")
+int BPF_URETPROBE(probe_cuMemAlloc_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemAllocPitch_v2")
+int BPF_UPROBE(probe_cuMemAllocPitch_entry, void *dptr, void *pitch,
+	       __u64 width, __u64 height, unsigned int element_size)
+{
+	return save_entry(API_cuMemAllocPitch_v2, (__u64)(unsigned long)dptr,
+			  (__u64)(unsigned long)pitch, width, height,
+			  element_size, 0);
+}
+SEC("uretprobe/libcuda:cuMemAllocPitch_v2")
+int BPF_URETPROBE(probe_cuMemAllocPitch_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemAllocManaged")
+int BPF_UPROBE(probe_cuMemAllocManaged_entry, void *dptr, __u64 bytesize,
+	       unsigned int flags)
+{
+	return save_entry(API_cuMemAllocManaged, (__u64)(unsigned long)dptr,
+			  bytesize, flags, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuMemAllocManaged")
+int BPF_URETPROBE(probe_cuMemAllocManaged_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemFree_v2")
+int BPF_UPROBE(probe_cuMemFree_entry, __u64 dptr)
+{
+	return save_entry(API_cuMemFree_v2, dptr, 0, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuMemFree_v2")
+int BPF_URETPROBE(probe_cuMemFree_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_UPROBE(probe_cuMemcpyHtoD_entry, __u64 dst, const void *src,
+	       __u64 bytes)
+{
+	return save_entry(API_cuMemcpyHtoD_v2, dst, (__u64)(unsigned long)src,
+			  bytes, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuMemcpyHtoD_v2")
+int BPF_URETPROBE(probe_cuMemcpyHtoD_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_UPROBE(probe_cuMemcpyDtoH_entry, void *dst, __u64 src, __u64 bytes)
+{
+	return save_entry(API_cuMemcpyDtoH_v2, (__u64)(unsigned long)dst, src,
+			  bytes, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuMemcpyDtoH_v2")
+int BPF_URETPROBE(probe_cuMemcpyDtoH_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuModuleLoad")
+int BPF_UPROBE(probe_cuModuleLoad_entry, void *module, const char *fname)
+{
+	return save_entry(API_cuModuleLoad, (__u64)(unsigned long)module,
+			  (__u64)(unsigned long)fname, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuModuleLoad")
+int BPF_URETPROBE(probe_cuModuleLoad_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuModuleLoadData")
+int BPF_UPROBE(probe_cuModuleLoadData_entry, void *module, const void *image)
+{
+	return save_entry(API_cuModuleLoadData, (__u64)(unsigned long)module,
+			  (__u64)(unsigned long)image, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuModuleLoadData")
+int BPF_URETPROBE(probe_cuModuleLoadData_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuModuleGetFunction")
+int BPF_UPROBE(probe_cuModuleGetFunction_entry, void *hfunc, void *hmod,
+	       const char *name)
+{
+	return save_entry(API_cuModuleGetFunction, (__u64)(unsigned long)hfunc,
+			  (__u64)(unsigned long)hmod,
+			  (__u64)(unsigned long)name, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuModuleGetFunction")
+int BPF_URETPROBE(probe_cuModuleGetFunction_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuLaunchKernel")
+int BPF_UPROBE(probe_cuLaunchKernel_entry, void *f, unsigned int gridX,
+	       unsigned int gridY, unsigned int gridZ, unsigned int blockX,
+	       unsigned int blockY)
+{
+	return save_entry(API_cuLaunchKernel, (__u64)(unsigned long)f, gridX,
+			  gridY, gridZ, blockX, blockY);
+}
+SEC("uretprobe/libcuda:cuLaunchKernel")
+int BPF_URETPROBE(probe_cuLaunchKernel_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuStreamCreate")
+int BPF_UPROBE(probe_cuStreamCreate_entry, void *phstream, unsigned int flags)
+{
+	return save_entry(API_cuStreamCreate, (__u64)(unsigned long)phstream,
+			  flags, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuStreamCreate")
+int BPF_URETPROBE(probe_cuStreamCreate_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuStreamSynchronize")
+int BPF_UPROBE(probe_cuStreamSynchronize_entry, void *hstream)
+{
+	return save_entry(API_cuStreamSynchronize,
+			  (__u64)(unsigned long)hstream, 0, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuStreamSynchronize")
+int BPF_URETPROBE(probe_cuStreamSynchronize_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuEventCreate")
+int BPF_UPROBE(probe_cuEventCreate_entry, void *phevent, unsigned int flags)
+{
+	return save_entry(API_cuEventCreate, (__u64)(unsigned long)phevent,
+			  flags, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuEventCreate")
+int BPF_URETPROBE(probe_cuEventCreate_return)
+{
+	return handle_return(ctx);
+}
+
+SEC("uprobe/libcuda:cuEventSynchronize")
+int BPF_UPROBE(probe_cuEventSynchronize_entry, void *hevent)
+{
+	return save_entry(API_cuEventSynchronize, (__u64)(unsigned long)hevent,
+			  0, 0, 0, 0, 0);
+}
+SEC("uretprobe/libcuda:cuEventSynchronize")
+int BPF_URETPROBE(probe_cuEventSynchronize_return)
+{
+	return handle_return(ctx);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/gadgets/trace_nvidia_errors/test/integration/trace_nvidia_errors_test.go
+++ b/gadgets/trace_nvidia_errors/test/integration/trace_nvidia_errors_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tests is the integration-test suite for the trace_nvidia_errors
+// gadget. It follows the Inspektor Gadget convention of a single *_test.go
+// file in test/integration/, driven via `make trace_nvidia_errors/test-integration`.
+package tests
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+// cudaImage has gcc + the libcuda headers/stub; the NVIDIA container runtime
+// replaces the stub libcuda.so.1 with the real driver library at run time.
+const cudaImage = "nvidia/cuda:12.3.2-devel-ubuntu22.04"
+
+// traceNvidiaErrorEvent is the JSON shape emitted by the gadget after WASM
+// enrichment.
+type traceNvidiaErrorEvent struct {
+	utils.CommonData
+
+	Timestamp string        `json:"timestamp"`
+	Proc      utils.Process `json:"proc"`
+
+	Source      string `json:"source"`
+	ErrorCode   string `json:"error_code"`
+	APIID       string `json:"api_id"`
+	XIDCode     uint32 `json:"xid_code"`
+	Severity    string `json:"severity"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Why         string `json:"why"`
+	Suggestion  string `json:"suggestion"`
+	ContextInfo string `json:"context_info"`
+}
+
+// skipIfNoGPU skips the test when IG_NVIDIA_GPU_TESTS is not set. This
+// protects CI runners without GPUs from attempting to run these tests.
+func skipIfNoGPU(t *testing.T) {
+	if os.Getenv("IG_NVIDIA_GPU_TESTS") != "1" {
+		t.Skip("skipping: IG_NVIDIA_GPU_TESTS!=1")
+	}
+}
+
+// buildWorkloadCmd returns a shell command that compiles and loops a CUDA C
+// source snippet inside the container.
+func buildWorkloadCmd(cSource string) string {
+	enc := base64.StdEncoding.EncodeToString([]byte(cSource))
+	return fmt.Sprintf(
+		`echo %s | base64 -d > /tmp/t.c && `+
+			`gcc -I/usr/local/cuda/include -o /tmp/t /tmp/t.c -lcuda && `+
+			`while true; do /tmp/t >/dev/null 2>&1; sleep 1; done`,
+		enc,
+	)
+}
+
+// runCase starts the workload via the container framework, runs the gadget
+// with --timeout=15 against that container, and asserts at least one event
+// matches expect.
+func runCase(t *testing.T, containerName, cSource string,
+	expect *traceNvidiaErrorEvent,
+) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+	skipIfNoGPU(t)
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(cudaImage),
+		containers.WithGPUs(),
+	}
+
+	var ns string
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		ns = utils.GenerateTestNamespaceName(t, containerName)
+		containerOpts = append(containerOpts, containers.WithContainerNamespace(ns))
+	}
+
+	testContainer := containerFactory.NewContainer(
+		containerName,
+		buildWorkloadCmd(cSource),
+		containerOpts...,
+	)
+
+	testContainer.Start(t)
+	t.Cleanup(func() {
+		testContainer.Stop(t)
+	})
+
+	commonDataOpts := []utils.CommonDataOption{
+		utils.WithContainerImageName(utils.NormalizedStr),
+		utils.WithContainerID(utils.NormalizedStr),
+	}
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-r=%s", utils.Runtime),
+				fmt.Sprintf("--containername=%s", containerName),
+				"--timeout=15",
+			),
+		)
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-n=%s", ns),
+				"--timeout=15",
+			),
+		)
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
+		commonDataOpts = append(commonDataOpts, utils.WithK8sNamespace(ns))
+	}
+
+	expect.CommonData = utils.BuildCommonData(containerName, commonDataOpts...)
+
+	runnerOpts = append(runnerOpts,
+		igrunner.WithValidateOutput(
+			func(t *testing.T, output string) {
+				normalize := func(e *traceNvidiaErrorEvent) {
+					utils.NormalizeCommonData(&e.CommonData)
+					utils.NormalizeString(&e.Runtime.ContainerID)
+					utils.NormalizeString(&e.Runtime.ContainerImageName)
+					utils.NormalizeString(&e.Timestamp)
+					utils.NormalizeProc(&e.Proc)
+					utils.NormalizeString(&e.Description)
+					utils.NormalizeString(&e.Why)
+					utils.NormalizeString(&e.Suggestion)
+					utils.NormalizeString(&e.ContextInfo)
+					utils.NormalizeString(&e.APIID)
+					e.XIDCode = 0
+				}
+				match.MatchEntries(t, match.JSONMultiObjectMode, output,
+					normalize, expect)
+			},
+		),
+	)
+
+	cmd := igrunner.New("trace_nvidia_errors", runnerOpts...)
+	igtesting.RunTestSteps([]igtesting.TestStep{cmd}, t, testingOpts...)
+}
+
+// TestTraceNvidiaErrors_InvalidDevice triggers CUDA_ERROR_INVALID_DEVICE via
+// cuCtxCreate_v2 with an ordinal far outside [0, N).
+func TestTraceNvidiaErrors_InvalidDevice(t *testing.T) {
+	const src = `
+#include <cuda.h>
+int main(void) {
+    cuInit(0);
+    CUcontext ctx;
+    cuCtxCreate_v2(&ctx, 0, 9999);
+    return 0;
+}
+`
+	runCase(t, "nvte-invdev", src,
+		&traceNvidiaErrorEvent{
+			Source:      "SOURCE_CUDA_API",
+			ErrorCode:   "CUDA_ERROR_INVALID_DEVICE",
+			Severity:    "MEDIUM",
+			Category:    "device",
+			APIID:       utils.NormalizedStr,
+			Description: utils.NormalizedStr,
+			Why:         utils.NormalizedStr,
+			Suggestion:  utils.NormalizedStr,
+			ContextInfo: utils.NormalizedStr,
+			Proc:        utils.BuildProc("t", 0, 0),
+			Timestamp:   utils.NormalizedStr,
+		})
+}
+
+// TestTraceNvidiaErrors_OOM triggers CUDA_ERROR_OUT_OF_MEMORY via a 256 GiB
+// cuMemAlloc_v2 request.
+func TestTraceNvidiaErrors_OOM(t *testing.T) {
+	const src = `
+#include <cuda.h>
+int main(void) {
+    cuInit(0);
+    CUdevice dev;
+    cuDeviceGet(&dev, 0);
+    CUcontext ctx;
+    cuCtxCreate_v2(&ctx, 0, dev);
+    CUdeviceptr p;
+    cuMemAlloc_v2(&p, 256ULL * 1024 * 1024 * 1024);
+    return 0;
+}
+`
+	runCase(t, "nvte-oom", src,
+		&traceNvidiaErrorEvent{
+			Source:      "SOURCE_CUDA_API",
+			ErrorCode:   "CUDA_ERROR_OUT_OF_MEMORY",
+			Severity:    "HIGH",
+			Category:    "memory",
+			APIID:       utils.NormalizedStr,
+			Description: utils.NormalizedStr,
+			Why:         utils.NormalizedStr,
+			Suggestion:  utils.NormalizedStr,
+			ContextInfo: utils.NormalizedStr,
+			Proc:        utils.BuildProc("t", 0, 0),
+			Timestamp:   utils.NormalizedStr,
+		})
+}
+
+// TestTraceNvidiaErrors_InvalidImage triggers CUDA_ERROR_INVALID_IMAGE by passing
+// a non-PTX blob to cuModuleLoadData (driver reports INVALID_IMAGE before
+// reaching the PTX JIT path when the blob is plainly malformed).
+func TestTraceNvidiaErrors_InvalidImage(t *testing.T) {
+	const src = `
+#include <cuda.h>
+int main(void) {
+    cuInit(0);
+    CUdevice dev;
+    cuDeviceGet(&dev, 0);
+    CUcontext ctx;
+    cuCtxCreate_v2(&ctx, 0, dev);
+    CUmodule m;
+    const char *bad = "THIS IS NOT PTX";
+    cuModuleLoadData(&m, bad);
+    return 0;
+}
+`
+	runCase(t, "nvte-badptx", src,
+		&traceNvidiaErrorEvent{
+			Source:      "SOURCE_CUDA_API",
+			ErrorCode:   "CUDA_ERROR_INVALID_IMAGE",
+			Severity:    "MEDIUM",
+			Category:    "compilation",
+			APIID:       utils.NormalizedStr,
+			Description: utils.NormalizedStr,
+			Why:         utils.NormalizedStr,
+			Suggestion:  utils.NormalizedStr,
+			ContextInfo: utils.NormalizedStr,
+			Proc:        utils.BuildProc("t", 0, 0),
+			Timestamp:   utils.NormalizedStr,
+		})
+}

--- a/gadgets/trace_nvidia_errors/test/integration/xid_workload_test.go
+++ b/gadgets/trace_nvidia_errors/test/integration/xid_workload_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Gated by IG_NVIDIA_GPU_TESTS=1, matching the pattern established by the
+// baseline tests — CI runners without a GPU stay green.
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+// xidCorrelationEvent is a trimmed event shape focused on the
+// correlation-specific fields introduced by the XID→workload patch series.
+type xidCorrelationEvent struct {
+	Source         string `json:"source"`
+	ErrorCode      string `json:"error_code"`
+	XIDCode        uint32 `json:"xid_code"`
+	ActiveCUDAAPI  uint32 `json:"active_cuda_api"`
+	ActiveCUDACall string `json:"active_cuda_call"`
+	XIDAttribFlags uint32 `json:"xid_attrib_flags"`
+	XIDAttribution string `json:"xid_attribution"`
+
+	K8s struct {
+		Namespace     string `json:"namespace"`
+		PodName       string `json:"podName"`
+		ContainerName string `json:"containerName"`
+	} `json:"k8s"`
+	Runtime struct {
+		ContainerName string `json:"containerName"`
+	} `json:"runtime"`
+}
+
+func skipIfNoXIDCorrelation(t *testing.T) {
+	if os.Getenv("IG_NVIDIA_GPU_TESTS") != "1" {
+		t.Skip("skipping XID correlation test: IG_NVIDIA_GPU_TESTS!=1")
+	}
+	skipIfNoGPU(t)
+}
+
+// runXIDCorrelationCase compiles and runs a CUDA source that provokes an
+// XID, then asserts at least one XID event carries a populated attribution.
+func runXIDCorrelationCase(t *testing.T, containerName, cSource string,
+	wantXID uint32,
+) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+	skipIfNoXIDCorrelation(t)
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(cudaImage),
+		containers.WithGPUs(),
+	}
+
+	var ns string
+	if utils.CurrentTestComponent == utils.KubectlGadgetTestComponent {
+		ns = utils.GenerateTestNamespaceName(t, containerName)
+		containerOpts = append(containerOpts, containers.WithContainerNamespace(ns))
+	}
+
+	testContainer := containerFactory.NewContainer(
+		containerName,
+		buildWorkloadCmd(cSource),
+		containerOpts...,
+	)
+
+	testContainer.Start(t)
+	t.Cleanup(func() {
+		testContainer.Stop(t)
+	})
+
+	var runnerOpts []igrunner.Option
+	var testingOpts []igtesting.Option
+
+	switch utils.CurrentTestComponent {
+	case utils.IgLocalTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-r=%s", utils.Runtime),
+				fmt.Sprintf("--containername=%s", containerName),
+				"--timeout=30",
+			),
+		)
+	case utils.KubectlGadgetTestComponent:
+		runnerOpts = append(runnerOpts,
+			igrunner.WithFlags(
+				fmt.Sprintf("-n=%s", ns),
+				"--timeout=30",
+			),
+		)
+		testingOpts = append(testingOpts, igtesting.WithCbBeforeCleanup(utils.PrintLogsFn(ns)))
+	}
+
+	var captured []xidCorrelationEvent
+	runnerOpts = append(runnerOpts,
+		igrunner.WithValidateOutput(func(t *testing.T, out string) {
+			for _, line := range strings.Split(out, "\n") {
+				line = strings.TrimSpace(line)
+				if !strings.HasPrefix(line, "{") {
+					continue
+				}
+				var e xidCorrelationEvent
+				if err := json.Unmarshal([]byte(line), &e); err != nil {
+					continue
+				}
+				if e.Source == "SOURCE_XID" {
+					captured = append(captured, e)
+				}
+			}
+
+			// The XID must fire at least once during the 30 s window.
+			require.NotEmpty(t, captured,
+				"no XID events captured — reproducer did not trigger XID %d",
+				wantXID)
+
+			// The driver on this host may classify some XIDs differently
+			// (e.g. XID 13 may be reported as XID 43 on 595.x GSP-RM); the
+			// correlation machinery is the same for both, so accept either
+			// as long as it is a known-safe code.
+			acceptableCodes := map[uint32]bool{13: true, 31: true, 43: true}
+
+			var sawValid bool
+			for _, e := range captured {
+				if !acceptableCodes[e.XIDCode] {
+					continue
+				}
+				// The headline assertions added by this patch series:
+				require.NotZero(t, e.XIDAttribFlags,
+					"xid_attrib_flags must be non-zero on correlated XID events")
+				require.NotZero(t, e.ActiveCUDAAPI,
+					"active_cuda_api must be populated on correlated XID events")
+				require.NotEmpty(t, e.ActiveCUDACall,
+					"active_cuda_call rendering must be non-empty")
+				require.NotEmpty(t, e.XIDAttribution,
+					"xid_attribution rendering must be non-empty")
+
+				// Attribution must identify the workload — either via ig's
+				// K8s CRI enricher (k8s.podName) or, when running without
+				// kubelet, via ig's containerd/docker enricher
+				// (runtime.containerName).
+				attributed := e.K8s.PodName != "" || e.Runtime.ContainerName != ""
+				require.True(t, attributed,
+					"XID event carries no container/pod attribution")
+
+				sawValid = true
+				break
+			}
+			require.True(t, sawValid,
+				"captured %d XID events but none matched acceptable codes %v",
+				len(captured), acceptableCodes)
+		}),
+	)
+
+	cmd := igrunner.New("trace_nvidia_errors", runnerOpts...)
+	igtesting.RunTestSteps([]igtesting.TestStep{cmd}, t, testingOpts...)
+}
+
+// TestTraceNvidiaErrors_XIDWorkloadXID13 triggers XID 13 (graphics engine
+// exception / out-of-range address) via a shared-memory OOB store. On
+// driver 595.x the same fault may be classified as XID 43 by GSP-RM; the
+// test accepts either outcome because the correlation machinery — and the
+// asserted fields — are identical for both codes.
+func TestTraceNvidiaErrors_XIDWorkloadXID13(t *testing.T) {
+	// Use nvcc directly via the cuda devel image (startWorkload uses gcc
+	// for plain libcuda C programs — __global__ kernels need nvcc). We
+	// embed nvcc compilation in the workload source by writing a small
+	// main that cuModuleLoadData()s precompiled PTX.
+	const src = `
+#include <cuda.h>
+#include <stdio.h>
+// Precompiled PTX for a kernel that writes out-of-range past a 256-byte
+// shared-memory allocation. Generated with:
+//   nvcc -arch=sm_80 -ptx -o oob.ptx xid13_shmem_oob.cu
+// and base64-embedded verbatim. The XID correlator only cares that *some*
+// kernel launch preceded the XID, so even a driver that emits XID 43
+// instead of XID 13 satisfies the test's semantic requirements.
+static const char kPTX[] =
+"//\n"
+".version 7.5\n"
+".target sm_80\n"
+".address_size 64\n"
+".visible .entry oob(){\n"
+"  .shared .align 4 .b32 smem[1];\n"
+"  .reg .b64 %r<2>;\n"
+"  mov.u64 %r0, smem;\n"
+"  add.u64 %r1, %r0, 262144;\n"
+"  st.volatile.shared.u32 [%r1], 42;\n"
+"  ret;\n"
+"}\n";
+
+int main(void) {
+    cuInit(0);
+    CUdevice dev; cuDeviceGet(&dev, 0);
+    CUcontext ctx; cuCtxCreate_v2(&ctx, 0, dev);
+    CUmodule mod; cuModuleLoadData(&mod, kPTX);
+    CUfunction fn;
+    cuModuleGetFunction(&fn, mod, "oob");
+    cuLaunchKernel(fn, 1,1,1, 32,1,1, 256, 0, NULL, NULL);
+    cuCtxSynchronize();
+    return 0;
+}
+`
+	runXIDCorrelationCase(t, "nvte-xid13", src, 13)
+}

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -80,6 +80,14 @@ func (d *DockerContainer) Run(t *testing.T) {
 	if d.options.sysctls != nil {
 		hostConfig.Sysctls = d.options.sysctls
 	}
+	if d.options.gpus {
+		hostConfig.DeviceRequests = []container.DeviceRequest{
+			{
+				Count:        -1,
+				Capabilities: [][]string{{"gpu"}},
+			},
+		}
+	}
 
 	if d.options.portBindings != nil {
 		hostConfig.PortBindings = d.options.portBindings

--- a/pkg/container-utils/testutils/k8s.go
+++ b/pkg/container-utils/testutils/k8s.go
@@ -62,13 +62,21 @@ func (c *K8sContainer) Start(t *testing.T) {
 	require.False(t, c.options.privileged, "testutils/kubernetes: privileged containers are not supported yet")
 	require.Nil(t, c.options.portBindings, "testutils/kubernetes: port bindings are not supported yet")
 
+	limits := c.options.limits
+	if c.options.gpus {
+		if limits == nil {
+			limits = make(map[string]string)
+		}
+		limits["nvidia.com/gpu"] = "1"
+	}
+
 	waitCommand := waitUntilPodReadyCommand(t, c.options.namespace, c.name)
 	if c.options.waitOrOomKilled {
 		waitCommand = waitUntilPodReadyOrOOMKilledCommand(t, c.options.namespace, c.name)
 	}
 
 	testSteps := []igtesting.TestStep{
-		podCommand(t, c.name, c.options.image, c.options.namespace, `["/bin/sh", "-c"]`, c.cmd, c.options.limits),
+		podCommand(t, c.name, c.options.image, c.options.namespace, `["/bin/sh", "-c"]`, c.cmd, limits),
 		waitCommand,
 	}
 	if !c.options.useExistingNamespace {

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -45,6 +45,7 @@ type containerOptions struct {
 	limits               map[string]string
 	expectedExitCode     *int
 	sysctls              map[string]string
+	gpus                 bool
 
 	// forceDelete is mostly used for debugging purposes, when a container
 	// fails to be deleted and we want to force it.
@@ -177,5 +178,14 @@ func WithLimits(limits map[string]string) Option {
 func WithSysctls(sysctls map[string]string) Option {
 	return func(opts *containerOptions) {
 		opts.sysctls = sysctls
+	}
+}
+
+// WithGPUs requests all GPUs for the container. On Docker this sets
+// --gpus=all (DeviceRequests); on Kubernetes it adds nvidia.com/gpu to
+// resource limits.
+func WithGPUs() Option {
+	return func(opts *containerOptions) {
+		opts.gpus = true
 	}
 }

--- a/pkg/testing/containers/options.go
+++ b/pkg/testing/containers/options.go
@@ -101,3 +101,11 @@ func WithExpectedExitCode(code int) ContainerOption {
 		opts.options = append(opts.options, testutils.WithExpectedExitCode(code))
 	}
 }
+
+// WithGPUs requests all GPUs for the container (--gpus=all on Docker,
+// nvidia.com/gpu resource limit on Kubernetes).
+func WithGPUs() ContainerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithGPUs())
+	}
+}


### PR DESCRIPTION
This pull request adds a new gadget, `trace_nvidia_errors`, to Inspektor Gadget. This gadget provides unified tracing and enrichment of NVIDIA GPU errors, including both CUDA Driver API failures and in-kernel XID events, with detailed, actionable context for each error.

## Testing Done (on AKS node)

```
root@aks-nodepool1-39790247-vmss000005:/# ig run --verify-image=false ghcr.io/mqasimsarfraz/gadget/trace_nvidia_errors:main --pull always
WARN[0002] error pulling signature: pulling signing information with cosign: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/trace_nvidia_errors:sha256-88d26e5439ca9947e2eab1001b97854e6aa456b7038fbf8d53b46928ce22b8d1.sig: not found
pulling signing information with oci 1.1: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/trace_nvidia_errors:sha256-88d26e5439ca9947e2eab1001b97854e6aa456b7038fbf8d53b46928ce22b8d1: not found
pulling signing information with bundle: crafting signing information tag: no bundle found 
WARN[0002] gadget signature verification is disabled due to using corresponding option 
WARN[0002] This gadget was built with ig v0.51.1 and it's being run with v0.49.1. Gadget could be incompatible 
WARN[0003] error pulling signature: pulling signing information with cosign: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/trace_nvidia_errors:sha256-88d26e5439ca9947e2eab1001b97854e6aa456b7038fbf8d53b46928ce22b8d1.sig: not found
pulling signing information with oci 1.1: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/trace_nvidia_errors:sha256-88d26e5439ca9947e2eab1001b97854e6aa456b7038fbf8d53b46928ce22b8d1: not found
pulling signing information with bundle: crafting signing information tag: no bundle found 
WARN[0003] gadget signature verification is disabled due to using corresponding option 
WARN[0003] This gadget was built with ig v0.51.1 and it's being run with v0.49.1. Gadget could be incompatible 
RUNTIME.CONTAINERNAME           COMM                  PID TID         XID_CODE ERROR_CODE                            API_ID                  SOURCE           SEVERITY   CATEGORY       WHY                                              CONTEXT_INFO                             GPU_PCI_ADDR   ACTIVE_CUDA_CALL             XID_ATTRIBUTION         

oom-repro                       t                   84229 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84248 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84274 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84312 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84348 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84376 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84423 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84587 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84735 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB)                                                                     
oom-repro                       t                   84773 83785              0 CUDA_ERROR_OUT_OF_MEMORY              cuMemAlloc_v2           SOURCE_CUDA_API  HIGH       memory         GPU memory allocation request exceeded free dev… requested_bytes=274877906944 (256.0 GiB) 
invdev-repro                    t                   91532 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91560 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91595 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91613 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91648 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91660 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91704 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91871 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91895 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91931 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   91964 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999                                                                                
invdev-repro                    t                   92007 90967              0 CUDA_ERROR_INVALID_DEVICE             cuCtxCreate_v2          SOURCE_CUDA_API  MEDIUM     device         Device ordinal out of range [0, N-1]. ordinal=9… flags=0x0 device_ordinal=9999  
```