### PR TITLE
pkg/oci: Use Lock in newLocalOciStore

### DIFF
--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -46,7 +46,8 @@ func newLocalOciStore() (*localOciStore, error) {
 	indexLock := flock.New(path.Join(defaultOciStore, "index.json.lock"))
 
 	// lock the file before reading the index below
-	indexLock.RLock()
+	// RLock can't be used since we might create and init an empty index file in oci.New()
+	indexLock.Lock()
 	defer indexLock.Unlock()
 
 	ociStore, err := oci.New(defaultOciStore)


### PR DESCRIPTION
From https://github.com/inspektor-gadget/inspektor-gadget/pull/5486#discussion_r3186947470
The problem is that oci.New(...) doesn't only read. It also modifies the filesystem when the oci store files are not even there. It will then create them.

And doing that concurrently is not safe + the .RLock() is also not correct

This PR supersedes https://github.com/inspektor-gadget/inspektor-gadget/pull/5486
cc @mqasimsarfraz 