### PR TITLE
[BACKPORT] security hardening fixes for USDT/uprobe ELF/ld.so.cache parsing

### DIFF
--- a/pkg/operators/ebpf/extrainfo.go
+++ b/pkg/operators/ebpf/extrainfo.go
@@ -16,7 +16,6 @@ package ebpfoperator
 
 import (
 	"bytes"
-	"debug/elf"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -27,6 +26,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	graphutils "github.com/inspektor-gadget/inspektor-gadget/pkg/utils/ebpf2graph"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeelf"
 )
 
 type extraInfoMap struct {
@@ -48,7 +48,7 @@ type extraInfoVariable struct {
 }
 
 func (i *ebpfInstance) addExtraInfo(gadgetCtx operators.GadgetContext) error {
-	ef, err := elf.NewFile(bytes.NewReader(i.program))
+	ef, err := safeelf.NewFile(bytes.NewReader(i.program))
 	if err != nil {
 		return fmt.Errorf("parsing elf file: %w", err)
 	}

--- a/pkg/symbolizer/table.go
+++ b/pkg/symbolizer/table.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"slices"
 	"time"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeelf"
 )
 
 const (
@@ -53,7 +55,7 @@ func (e *SymbolTable) LookupByAddr(address uint64) string {
 func NewSymbolTableFromFile(file *os.File) (*SymbolTable, error) {
 	var symbols []*Symbol
 
-	elfFile, err := elf.NewFile(file)
+	elfFile, err := safeelf.NewFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("parsing ELF file: %w", err)
 	}

--- a/pkg/symbolizer/table.go
+++ b/pkg/symbolizer/table.go
@@ -86,9 +86,9 @@ func NewSymbolTableFromFile(file *os.File) (*SymbolTable, error) {
 			Size:  sym.Size,
 		})
 		symbolCount++
-	}
-	if symbolCount > MaxSymbolCount {
-		return nil, fmt.Errorf("too many symbols: %d", symbolCount)
+		if symbolCount > MaxSymbolCount {
+			return nil, fmt.Errorf("too many symbols: %d (exceeds limit %d)", symbolCount, MaxSymbolCount)
+		}
 	}
 	slices.SortFunc(symbols, func(a, b *Symbol) int {
 		if a.Value < b.Value {

--- a/pkg/uprobetracer/bytes.go
+++ b/pkg/uprobetracer/bytes.go
@@ -16,30 +16,62 @@ package uprobetracer
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"unsafe"
 )
 
-func readFromBytes[T any](obj *T, rawData []byte) error {
+// plainDataStruct constrains types to fixed-size structs containing only
+// numeric fields (int32, uint32, uint64, fixed-size arrays of int8, etc.).
+// These types have no pointers, strings, slices, or interfaces, making them
+// safe to reinterpret directly from a byte buffer without serialization.
+// Adding a new type here requires verifying it meets these criteria.
+type plainDataStruct interface {
+	ldCache1 | ldCache1Entry | ldCache2 | ldCache2Entry
+}
+
+// reinterpretBytes interprets rawData as a value of type T using direct memory
+// reinterpretation (equivalent to a C memcpy/cast). This assumes:
+//   - T satisfies plainDataStruct (only fixed-size numeric fields)
+//   - rawData is in native byte order (matching the host architecture)
+//   - len(rawData) == unsafe.Sizeof(T)
+//
+// This is used instead of encoding/binary.Read for performance: binary.Read
+// uses reflection and allocates intermediate buffers, which is significantly
+// slower when called in tight loops (e.g., parsing ~700K ld.so.cache entries).
+func reinterpretBytes[T plainDataStruct](obj *T, rawData []byte) error {
 	if int(unsafe.Sizeof(*obj)) != len(rawData) {
 		return errors.New("reading from bytes: length mismatched")
 	}
-	buffer := bytes.NewBuffer(rawData)
-	err := binary.Read(buffer, binary.NativeEndian, obj)
-	if err != nil {
-		return err
-	}
+	*obj = *(*T)(unsafe.Pointer(&rawData[0]))
 	return nil
 }
 
+// readStringFromBytes reads a null-terminated string starting at startPos in
+// data. Returns "" if startPos is out of bounds or no null terminator is found.
+// Uses bytes.IndexByte for O(n) performance.
 func readStringFromBytes(data []byte, startPos uint32) string {
-	res := ""
-	for i := startPos; i < uint32(len(data)); i++ {
-		if data[i] == 0 {
-			return res
-		}
-		res += string(data[i])
+	if startPos >= uint32(len(data)) {
+		return ""
 	}
-	return ""
+	end := bytes.IndexByte(data[startPos:], 0)
+	if end == -1 {
+		return ""
+	}
+	return string(data[startPos : startPos+uint32(end)])
+}
+
+// matchStringInBytes checks whether the null-terminated string at startPos in
+// data begins with prefix. This avoids allocating a Go string for entries that
+// don't match, reducing GC pressure when scanning large caches.
+// Note: string([]byte) in a comparison is optimized by the Go compiler to
+// avoid allocation when the result is not stored.
+func matchStringInBytes(data []byte, startPos uint32, prefix string) bool {
+	if startPos >= uint32(len(data)) {
+		return false
+	}
+	remaining := data[startPos:]
+	if uint32(len(remaining)) < uint32(len(prefix)) {
+		return false
+	}
+	return string(remaining[:len(prefix)]) == prefix
 }

--- a/pkg/uprobetracer/ldcache_parser.go
+++ b/pkg/uprobetracer/ldcache_parser.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
 	"unsafe"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/secureopen"
@@ -63,48 +62,60 @@ const (
 	// ld.so.cache is typically less than 200 KiB.
 	// 16 MiB should be enough.
 	ldCacheMaxSize = int64(16 * 1024 * 1024)
+
+	// A real ld.so.cache has only a handful of entries per library name
+	// (typically 1–3 across architecture variants). Cap results to bound
+	// memory usage when parsing a crafted file.
+	ldCacheMaxResults = 64
 )
 
-type ldEntry struct {
-	Key   string
-	Value string
-}
+func readCacheFormat1(data []byte, libraryPrefix string) []string {
+	var results []string
 
-func readCacheFormat1(data []byte) []ldEntry {
-	var ldEntries []ldEntry
-
-	ldCache := ldCache1{}
 	if uint32(len(data)) <= ldCache1Size {
 		return nil
 	}
-	err := readFromBytes(&ldCache, data[:ldCache1Size])
+	ldCache := ldCache1{}
+	err := reinterpretBytes(&ldCache, data[:ldCache1Size])
 	if err != nil {
 		return nil
 	}
 	ldEntriesOffset := ldCache1Size
-	ldStringsOffset := ldCache1Size + ldCache1EntrySize*ldCache.EntryCount
+	// Cap entry count based on actual file size to prevent excessive iteration.
+	maxEntries := (uint32(len(data)) - ldEntriesOffset) / ldCache1EntrySize
+	if ldCache.EntryCount > maxEntries {
+		ldCache.EntryCount = maxEntries
+	}
+	ldStringsOffset := ldEntriesOffset + ldCache1EntrySize*ldCache.EntryCount
 	for i := uint32(0); i < ldCache.EntryCount; i++ {
 		entryOffset := ldEntriesOffset + i*ldCache1EntrySize
 		entry := ldCache1Entry{}
 		if uint32(len(data)) <= entryOffset+ldCache1EntrySize {
 			return nil
 		}
-		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache1EntrySize])
+		err := reinterpretBytes(&entry, data[entryOffset:entryOffset+ldCache1EntrySize])
 		if err != nil {
 			return nil
 		}
 		keyOffset := ldStringsOffset + entry.Key
-		valueOffset := ldStringsOffset + entry.Value
-		key := readStringFromBytes(data, keyOffset)
-		value := readStringFromBytes(data, valueOffset)
-		ldEntries = append(ldEntries, ldEntry{key, value})
+		if matchStringInBytes(data, keyOffset, libraryPrefix) {
+			valueOffset := ldStringsOffset + entry.Value
+			value := readStringFromBytes(data, valueOffset)
+			results = append(results, value)
+			if len(results) >= ldCacheMaxResults {
+				break
+			}
+		}
 	}
-	return ldEntries
+	return results
 }
 
-func readCacheFormat2(data []byte) []ldEntry {
-	var ldEntries []ldEntry
+func readCacheFormat2(data []byte, libraryPrefix string) []string {
+	var results []string
 
+	if len(data) < len(cache2Header) {
+		return nil
+	}
 	if !bytes.Equal([]byte(cache2Header), data[:len(cache2Header)]) {
 		return nil
 	}
@@ -112,28 +123,37 @@ func readCacheFormat2(data []byte) []ldEntry {
 	if uint32(len(data)) <= ldCache2Size {
 		return nil
 	}
-	err := readFromBytes(&ldCache, data[:ldCache2Size])
+	err := reinterpretBytes(&ldCache, data[:ldCache2Size])
 	if err != nil {
 		return nil
 	}
 	ldEntriesOffset := ldCache2Size
+	// Cap entry count based on actual file size to prevent excessive iteration.
+	maxEntries := (uint32(len(data)) - ldEntriesOffset) / ldCache2EntrySize
+	if ldCache.EntryCount > maxEntries {
+		ldCache.EntryCount = maxEntries
+	}
 	for i := uint32(0); i < ldCache.EntryCount; i++ {
 		entryOffset := ldEntriesOffset + i*ldCache2EntrySize
 		entry := ldCache2Entry{}
 		if uint32(len(data)) <= entryOffset+ldCache2EntrySize {
 			return nil
 		}
-		err := readFromBytes(&entry, data[entryOffset:entryOffset+ldCache2EntrySize])
+		err := reinterpretBytes(&entry, data[entryOffset:entryOffset+ldCache2EntrySize])
 		if err != nil {
 			return nil
 		}
 		keyOffset := entry.Key
-		valueOffset := entry.Value
-		key := readStringFromBytes(data, keyOffset)
-		value := readStringFromBytes(data, valueOffset)
-		ldEntries = append(ldEntries, ldEntry{key, value})
+		if matchStringInBytes(data, keyOffset, libraryPrefix) {
+			valueOffset := entry.Value
+			value := readStringFromBytes(data, valueOffset)
+			results = append(results, value)
+			if len(results) >= ldCacheMaxResults {
+				break
+			}
+		}
 	}
-	return ldEntries
+	return results
 }
 
 // simulate the loader's behaviour, find library path in containers' `/etc/ld.so.cache`.
@@ -146,38 +166,33 @@ func parseLdCache(containerPid uint32, ldCachePath string, libraryName string) (
 	}
 	ldCacheFileSize := uint32(len(ldCacheFile))
 
-	var ldEntries []ldEntry
 	var filteredLibraries []string
+	libraryPrefix := libraryName + ".so"
 
-	if bytes.Equal([]byte(cache1Header), ldCacheFile[:len(cache1Header)]) {
+	if len(ldCacheFile) >= len(cache1Header) && bytes.Equal([]byte(cache1Header), ldCacheFile[:len(cache1Header)]) {
 		cache1 := ldCache1{}
 		if uint32(len(ldCacheFile)) <= ldCache1Size {
 			return nil, errors.New("ldCache format error")
 		}
-		err := readFromBytes(&cache1, ldCacheFile[:ldCache1Size])
+		err := reinterpretBytes(&cache1, ldCacheFile[:ldCache1Size])
 		if err != nil {
 			return nil, errors.New("ldCache format error")
 		}
-		cache1Len := ldCache1Size + cache1.EntryCount*ldCache1EntrySize
+		// Use uint64 arithmetic to avoid overflow when computing the
+		// cache1 section length from the untrusted EntryCount field.
+		cache1Len := uint64(ldCache1Size) + uint64(cache1.EntryCount)*uint64(ldCache1EntrySize)
 		cache1Len = (cache1Len + 7) / 8 * 8
-		if ldCacheFileSize > (cache1Len + ldCache2Size) {
-			ldEntries = readCacheFormat2(ldCacheFile)
+		if uint64(ldCacheFileSize) > (cache1Len + uint64(ldCache2Size)) {
+			filteredLibraries = readCacheFormat2(ldCacheFile, libraryPrefix)
 		} else {
-			ldEntries = readCacheFormat1(ldCacheFile)
+			filteredLibraries = readCacheFormat1(ldCacheFile, libraryPrefix)
 		}
 	} else {
-		ldEntries = readCacheFormat2(ldCacheFile)
+		filteredLibraries = readCacheFormat2(ldCacheFile, libraryPrefix)
 	}
 
-	if ldEntries == nil {
+	if filteredLibraries == nil {
 		return nil, errors.New("ldCache format error")
-	}
-
-	// filter library entries with given library name
-	for _, entry := range ldEntries {
-		if strings.HasPrefix(entry.Key, libraryName+".so") {
-			filteredLibraries = append(filteredLibraries, entry.Value)
-		}
 	}
 
 	return filteredLibraries, nil

--- a/pkg/uprobetracer/usdt.go
+++ b/pkg/uprobetracer/usdt.go
@@ -31,6 +31,12 @@ import (
 const (
 	sdtNoteSectionName = ".note.stapsdt"
 	sdtBaseSectionName = ".stapsdt.base"
+
+	// maxNoteFieldSize limits the size of individual note name/desc fields to
+	// prevent excessive memory allocation from malformed ELF files. There is no
+	// standard upper bound for ELF note fields; 1 MiB is a generous arbitrary
+	// cap — legitimate USDT notes are typically under 1 KB.
+	maxNoteFieldSize = 1024 * 1024
 )
 
 type noteHeader struct {
@@ -107,6 +113,9 @@ func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) 
 		wordSize = 8
 	}
 
+	// Minimum desc size for a stapsdt note: 3 address fields.
+	minDescSize := 3 * wordSize
+
 	// walk through USDT notes, and match with providerName and probeName
 	// For details of the structure of ELF notes, please refer to
 	// https://man7.org/linux/man-pages/man5/elf.5.html, the `Notes (Nhdr)` section
@@ -120,13 +129,23 @@ func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) 
 			return nil, fmt.Errorf("reading USDT note header: %w", err)
 		}
 
-		name := make([]byte, alignUp(uint64(header.NameSize), 4))
+		alignedNameSize := alignUp(uint64(header.NameSize), 4)
+		alignedDescSize := alignUp(uint64(header.DescSize), 4)
+
+		if alignedNameSize > maxNoteFieldSize {
+			return nil, fmt.Errorf("USDT note name too large: %d bytes", alignedNameSize)
+		}
+		if alignedDescSize > maxNoteFieldSize {
+			return nil, fmt.Errorf("USDT note desc too large: %d bytes", alignedDescSize)
+		}
+
+		name := make([]byte, alignedNameSize)
 		err = binary.Read(notesReader, elfReader.ByteOrder, &name)
 		if err != nil {
 			return nil, fmt.Errorf("reading USDT note name: %w", err)
 		}
 
-		desc := make([]byte, alignUp(uint64(header.DescSize), 4))
+		desc := make([]byte, alignedDescSize)
 		err = binary.Read(notesReader, elfReader.ByteOrder, &desc)
 		if err != nil {
 			return nil, fmt.Errorf("reading USDT note desc: %w", err)
@@ -134,6 +153,10 @@ func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) 
 
 		if string(name) != "stapsdt\x00" || header.Type != 3 {
 			continue
+		}
+
+		if len(desc) < minDescSize {
+			return nil, fmt.Errorf("malformed stapsdt note: desc too short (%d bytes, need %d)", len(desc), minDescSize)
 		}
 
 		elfLocation := elfReader.ByteOrder.Uint64(desc[:wordSize])

--- a/pkg/uprobetracer/usdt.go
+++ b/pkg/uprobetracer/usdt.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeelf"
 )
 
 // For details regarding the data format of USDT notes, please refer to:
@@ -77,7 +79,7 @@ func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) 
 		return nil, fmt.Errorf("ELF file %q is not regular", filepath)
 	}
 
-	elfReader, err := elf.NewFile(file)
+	elfReader, err := safeelf.NewFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("reading elf file %q: %w", filepath, err)
 	}
@@ -139,13 +141,13 @@ func getUsdtInfo(filepath string, attachSymbol string) (*usdtAttachInfo, error) 
 		elfSemaphore := elfReader.ByteOrder.Uint64(desc[2*wordSize : 3*wordSize])
 
 		diff := baseSection.Addr - elfBase
-		location, err := vaddr2ElfOffset(elfReader, elfLocation+diff)
+		location, err := vaddr2ElfOffset(elfReader.File, elfLocation+diff)
 		if err != nil {
 			return nil, err
 		}
 
 		if elfSemaphore != 0 {
-			elfSemaphore, err = vaddr2ElfOffset(elfReader, elfSemaphore+diff)
+			elfSemaphore, err = vaddr2ElfOffset(elfReader.File, elfSemaphore+diff)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/utils/safeelf/safeelf.go
+++ b/pkg/utils/safeelf/safeelf.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safeelf provides panic-safe wrappers around debug/elf.
+//
+// Go's debug/elf is not hardened against adversarial inputs and may panic on
+// malformed data. Since Inspektor Gadget parses ELF files from untrusted
+// containers in a privileged process, we wrap all operations in recover() to
+// turn panics into errors.
+//
+// This approach is inspired by cilium/ebpf's internal SafeELFFile:
+// https://github.com/cilium/ebpf/blob/main/internal/elf.go
+package safeelf
+
+import (
+	"debug/elf"
+	"fmt"
+	"io"
+)
+
+// File wraps an *elf.File with panic recovery on operations that may crash
+// on malformed input.
+type File struct {
+	*elf.File
+}
+
+// NewFile reads an ELF file safely. Any panic during parsing is turned into
+// an error.
+func NewFile(r io.ReaderAt) (safe *File, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			safe = nil
+			err = fmt.Errorf("panic reading ELF file: %v", r)
+		}
+	}()
+
+	f, err := elf.NewFile(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{f}, nil
+}
+
+// Symbols is the safe version of elf.File.Symbols.
+func (f *File) Symbols() (syms []elf.Symbol, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			syms = nil
+			err = fmt.Errorf("panic reading ELF symbols: %v", r)
+		}
+	}()
+
+	return f.File.Symbols()
+}
+
+// DynamicSymbols is the safe version of elf.File.DynamicSymbols.
+func (f *File) DynamicSymbols() (syms []elf.Symbol, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			syms = nil
+			err = fmt.Errorf("panic reading ELF dynamic symbols: %v", r)
+		}
+	}()
+
+	return f.File.DynamicSymbols()
+}


### PR DESCRIPTION
Backport of 4 security patches from `main` to the `release-v0.53` branch. These fix denial-of-service and crash vulnerabilities when Inspektor Gadget (running as a privileged process) parses untrusted ELF files or ld.so.cache from containers.
