### PR TITLE
operators/generate_networkpolicy: add Cilium NetworkPolicy output format

### DIFF
--- a/pkg/operators/generate_networkpolicy/cilium_networkpolicy.go
+++ b/pkg/operators/generate_networkpolicy/cilium_networkpolicy.go
@@ -1,0 +1,323 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate_networkpolicy
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+// CiliumNetworkPolicy is a minimal representation of the CiliumNetworkPolicy CRD (cilium.io/v2).
+// Defined locally to avoid importing the full Cilium dependency tree.
+// See the upstream types at:
+// https://github.com/cilium/cilium/blob/main/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+type CiliumNetworkPolicy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              *CiliumNetworkPolicySpec `json:"spec,omitempty"`
+}
+
+type CiliumNetworkPolicySpec struct {
+	EndpointSelector metav1.LabelSelector `json:"endpointSelector"`
+	Ingress          []CiliumIngressRule  `json:"ingress,omitempty"`
+	Egress           []CiliumEgressRule   `json:"egress,omitempty"`
+}
+
+type CiliumIngressRule struct {
+	FromEndpoints []metav1.LabelSelector `json:"fromEndpoints,omitempty"`
+	FromCIDR      []string               `json:"fromCIDR,omitempty"`
+	ToPorts       []CiliumPortRule       `json:"toPorts,omitempty"`
+}
+
+type CiliumEgressRule struct {
+	ToEndpoints []metav1.LabelSelector `json:"toEndpoints,omitempty"`
+	ToCIDR      []string               `json:"toCIDR,omitempty"`
+	ToPorts     []CiliumPortRule       `json:"toPorts,omitempty"`
+}
+
+// CiliumPortRule groups ports for a single rule. Cilium uses string port values.
+type CiliumPortRule struct {
+	Ports []CiliumPortProtocol `json:"ports"`
+}
+
+type CiliumPortProtocol struct {
+	Port     string `json:"port"`
+	Protocol string `json:"protocol,omitempty"`
+}
+
+// ciliumPeerKey identifies a unique endpoint peer without the port, so that events
+// sharing the same peer but different ports can be grouped into a single Cilium rule.
+func ciliumPeerKey(e NetworkEvent) (string, error) {
+	switch e.endpoint.Kind {
+	case types.EndpointKindPod:
+		return string(e.endpoint.Kind) + ":" + e.endpoint.Namespace + ":" + labelKeyString(e.endpoint.PodLabels), nil
+	case types.EndpointKindService:
+		return string(e.endpoint.Kind) + ":" + e.endpoint.Namespace + ":" + labelKeyString(e.endpoint.PodSelector), nil
+	case types.EndpointKindRaw:
+		return string(e.endpoint.Kind) + ":" + e.endpoint.Addr, nil
+	default:
+		return "", fmt.Errorf("unknown endpoint kind: %s", e.endpoint.Kind)
+	}
+}
+
+// ciliumEndpointSelector builds the LabelSelector for a Cilium endpoint peer.
+// For cross-namespace peers, the target namespace is embedded via the standard
+// io.kubernetes.pod.namespace label that Cilium maps from Kubernetes identity labels.
+func ciliumEndpointSelector(e NetworkEvent, localNamespace string) (metav1.LabelSelector, error) {
+	var base map[string]string
+	switch e.endpoint.Kind {
+	case types.EndpointKindPod:
+		base = labelFilter(e.endpoint.PodLabels)
+	case types.EndpointKindService:
+		base = e.endpoint.PodSelector
+	default:
+		return metav1.LabelSelector{}, fmt.Errorf("endpointSelector called for non-pod kind: %s", e.endpoint.Kind)
+	}
+
+	sel := make(map[string]string, len(base)+1)
+	for k, v := range base {
+		sel[k] = v
+	}
+
+	// Cilium resolves namespace membership via the io.kubernetes.pod.namespace identity
+	// label; unlike K8s NetworkPolicy there is no separate namespaceSelector field.
+	if e.endpoint.Namespace != "" && e.endpoint.Namespace != localNamespace {
+		sel["io.kubernetes.pod.namespace"] = e.endpoint.Namespace
+	}
+
+	return metav1.LabelSelector{MatchLabels: sel}, nil
+}
+
+// peerGroup collects all NetworkEvents that share the same peer endpoint (same
+// labels/address, different ports). Ports are aggregated into a single Cilium rule.
+type peerGroup struct {
+	events []NetworkEvent
+}
+
+// handleCiliumEvents converts observed network events into CiliumNetworkPolicy objects.
+// Compared to the K8s NetworkPolicy output, this groups all ports for the same peer
+// into a single rule, which produces shorter and easier-to-read policies.
+func handleCiliumEvents(eventsBySource map[string][]NetworkEvent) ([]CiliumNetworkPolicy, error) {
+	policies := make([]CiliumNetworkPolicy, 0, len(eventsBySource))
+
+	for _, events := range eventsBySource {
+		if len(events) == 0 {
+			continue
+		}
+
+		egressByPeer := map[string]*peerGroup{}
+		ingressByPeer := map[string]*peerGroup{}
+
+		for _, e := range events {
+			key, err := ciliumPeerKey(e)
+			if err != nil {
+				return nil, fmt.Errorf("computing cilium peer key: %w", err)
+			}
+			if e.egress {
+				if _, ok := egressByPeer[key]; !ok {
+					egressByPeer[key] = &peerGroup{}
+				}
+				egressByPeer[key].events = append(egressByPeer[key].events, e)
+			} else {
+				if _, ok := ingressByPeer[key]; !ok {
+					ingressByPeer[key] = &peerGroup{}
+				}
+				ingressByPeer[key].events = append(ingressByPeer[key].events, e)
+			}
+		}
+
+		localNamespace := events[0].K8s.Namespace
+
+		ingressRules, err := buildCiliumIngressRules(ingressByPeer, localNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("building cilium ingress rules: %w", err)
+		}
+		egressRules, err := buildCiliumEgressRules(egressByPeer, localNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("building cilium egress rules: %w", err)
+		}
+
+		sortCiliumIngressRules(ingressRules)
+		sortCiliumEgressRules(egressRules)
+
+		name := events[0].K8s.PodName
+		if events[0].K8s.Owner.Name != "" {
+			name = events[0].K8s.Owner.Name
+		}
+		name += "-network"
+
+		policy := CiliumNetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "cilium.io/v2",
+				Kind:       "CiliumNetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: localNamespace,
+			},
+			Spec: &CiliumNetworkPolicySpec{
+				EndpointSelector: metav1.LabelSelector{
+					MatchLabels: labelFilter(events[0].K8s.PodLabels),
+				},
+				Ingress: ingressRules,
+				Egress:  egressRules,
+			},
+		}
+		policies = append(policies, policy)
+	}
+
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].Name < policies[j].Name
+	})
+
+	return policies, nil
+}
+
+func buildCiliumIngressRules(byPeer map[string]*peerGroup, localNamespace string) ([]CiliumIngressRule, error) {
+	rules := make([]CiliumIngressRule, 0, len(byPeer))
+	for _, pg := range byPeer {
+		e0 := pg.events[0]
+		ports := aggregateCiliumPorts(pg.events)
+
+		switch e0.endpoint.Kind {
+		case types.EndpointKindPod, types.EndpointKindService:
+			sel, err := ciliumEndpointSelector(e0, localNamespace)
+			if err != nil {
+				return nil, err
+			}
+			rules = append(rules, CiliumIngressRule{
+				FromEndpoints: []metav1.LabelSelector{sel},
+				ToPorts:       ports,
+			})
+		case types.EndpointKindRaw:
+			if e0.endpoint.Addr == "127.0.0.1" {
+				continue
+			}
+			rules = append(rules, CiliumIngressRule{
+				FromCIDR: []string{e0.endpoint.Addr + "/32"},
+				ToPorts:  ports,
+			})
+		default:
+			return nil, fmt.Errorf("unknown endpoint kind: %s", e0.endpoint.Kind)
+		}
+	}
+	return rules, nil
+}
+
+func buildCiliumEgressRules(byPeer map[string]*peerGroup, localNamespace string) ([]CiliumEgressRule, error) {
+	rules := make([]CiliumEgressRule, 0, len(byPeer))
+	for _, pg := range byPeer {
+		e0 := pg.events[0]
+		ports := aggregateCiliumPorts(pg.events)
+
+		switch e0.endpoint.Kind {
+		case types.EndpointKindPod, types.EndpointKindService:
+			sel, err := ciliumEndpointSelector(e0, localNamespace)
+			if err != nil {
+				return nil, err
+			}
+			rules = append(rules, CiliumEgressRule{
+				ToEndpoints: []metav1.LabelSelector{sel},
+				ToPorts:     ports,
+			})
+		case types.EndpointKindRaw:
+			if e0.endpoint.Addr == "127.0.0.1" {
+				continue
+			}
+			rules = append(rules, CiliumEgressRule{
+				ToCIDR:  []string{e0.endpoint.Addr + "/32"},
+				ToPorts: ports,
+			})
+		default:
+			return nil, fmt.Errorf("unknown endpoint kind: %s", e0.endpoint.Kind)
+		}
+	}
+	return rules, nil
+}
+
+// aggregateCiliumPorts deduplicates and sorts all port+protocol pairs from a peer group.
+func aggregateCiliumPorts(events []NetworkEvent) []CiliumPortRule {
+	seen := map[string]struct{}{}
+	ports := []CiliumPortProtocol{}
+
+	for _, e := range events {
+		key := strconv.Itoa(int(e.endpoint.Port)) + "/" + e.proto
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		ports = append(ports, CiliumPortProtocol{
+			Port:     strconv.Itoa(int(e.endpoint.Port)),
+			Protocol: e.proto,
+		})
+	}
+
+	if len(ports) == 0 {
+		return nil
+	}
+
+	sort.Slice(ports, func(i, j int) bool {
+		if ports[i].Protocol != ports[j].Protocol {
+			return ports[i].Protocol < ports[j].Protocol
+		}
+		pi, ei := strconv.Atoi(ports[i].Port)
+		pj, ej := strconv.Atoi(ports[j].Port)
+		if ei == nil && ej == nil {
+			return pi < pj
+		}
+		return ports[i].Port < ports[j].Port
+	})
+
+	return []CiliumPortRule{{Ports: ports}}
+}
+
+func sortCiliumIngressRules(rules []CiliumIngressRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		yi, _ := k8syaml.Marshal(rules[i])
+		yj, _ := k8syaml.Marshal(rules[j])
+		return string(yi) < string(yj)
+	})
+}
+
+func sortCiliumEgressRules(rules []CiliumEgressRule) {
+	sort.Slice(rules, func(i, j int) bool {
+		yi, _ := k8syaml.Marshal(rules[i])
+		yj, _ := k8syaml.Marshal(rules[j])
+		return string(yi) < string(yj)
+	})
+}
+
+// FormatCiliumPolicies serializes a list of CiliumNetworkPolicy objects to YAML,
+// separated by "---" document markers.
+func FormatCiliumPolicies(policies []CiliumNetworkPolicy) (out string) {
+	for i, p := range policies {
+		yamlOutput, err := k8syaml.Marshal(p)
+		if err != nil {
+			continue
+		}
+		sep := "---\n"
+		if i == len(policies)-1 {
+			sep = ""
+		}
+		out += fmt.Sprintf("%s%s", string(yamlOutput), sep)
+	}
+	return
+}

--- a/pkg/operators/generate_networkpolicy/cilium_networkpolicy_test.go
+++ b/pkg/operators/generate_networkpolicy/cilium_networkpolicy_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate_networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func makeEvent(egress bool, localNs string, localLabels map[string]string, kind types.EndpointKind, peerNs string, peerLabels map[string]string, addr string, port uint16, proto string) NetworkEvent {
+	e := NetworkEvent{
+		egress: egress,
+		K8s: types.K8sMetadata{
+			BasicK8sMetadata: types.BasicK8sMetadata{
+				Namespace: localNs,
+				PodLabels: localLabels,
+			},
+		},
+		endpoint: types.L4Endpoint{
+			L3Endpoint: types.L3Endpoint{
+				Kind:      kind,
+				Namespace: peerNs,
+				Addr:      addr,
+			},
+			Port: port,
+		},
+		proto: proto,
+	}
+	switch kind {
+	case types.EndpointKindPod:
+		e.endpoint.PodLabels = peerLabels
+	case types.EndpointKindService:
+		e.endpoint.PodSelector = peerLabels
+	}
+	return e
+}
+
+func TestHandleCiliumEvents_SameNamespacePod(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(false, "prod", map[string]string{"app": "backend"},
+			types.EndpointKindPod, "prod", map[string]string{"app": "frontend"},
+			"", 8080, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	p := policies[0]
+	assert.Equal(t, "cilium.io/v2", p.APIVersion)
+	assert.Equal(t, "CiliumNetworkPolicy", p.Kind)
+	assert.Equal(t, "prod", p.Namespace)
+	assert.Equal(t, map[string]string{"app": "backend"}, p.Spec.EndpointSelector.MatchLabels)
+
+	require.Len(t, p.Spec.Ingress, 1)
+	ingress := p.Spec.Ingress[0]
+	require.Len(t, ingress.FromEndpoints, 1)
+	// Same namespace: no io.kubernetes.pod.namespace label
+	assert.Equal(t, map[string]string{"app": "frontend"}, ingress.FromEndpoints[0].MatchLabels)
+	require.Len(t, ingress.ToPorts, 1)
+	assert.Equal(t, "8080", ingress.ToPorts[0].Ports[0].Port)
+	assert.Equal(t, "TCP", ingress.ToPorts[0].Ports[0].Protocol)
+
+	assert.Empty(t, p.Spec.Egress)
+}
+
+func TestHandleCiliumEvents_CrossNamespacePod(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(true, "prod", map[string]string{"app": "backend"},
+			types.EndpointKindPod, "monitoring", map[string]string{"app": "prometheus"},
+			"", 9090, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	egress := policies[0].Spec.Egress
+	require.Len(t, egress, 1)
+	require.Len(t, egress[0].ToEndpoints, 1)
+	// Cross-namespace: io.kubernetes.pod.namespace must be present
+	labels := egress[0].ToEndpoints[0].MatchLabels
+	assert.Equal(t, "monitoring", labels["io.kubernetes.pod.namespace"])
+	assert.Equal(t, "prometheus", labels["app"])
+}
+
+func TestHandleCiliumEvents_RawIP_Egress(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(true, "prod", map[string]string{"app": "backend"},
+			types.EndpointKindRaw, "", nil,
+			"93.184.216.34", 443, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	egress := policies[0].Spec.Egress
+	require.Len(t, egress, 1)
+	assert.Equal(t, []string{"93.184.216.34/32"}, egress[0].ToCIDR)
+	assert.Empty(t, egress[0].ToEndpoints)
+}
+
+func TestHandleCiliumEvents_Localhost_Skipped(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(true, "prod", map[string]string{"app": "backend"},
+			types.EndpointKindRaw, "", nil,
+			"127.0.0.1", 8080, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	// Localhost traffic must not produce any egress rule
+	assert.Empty(t, policies[0].Spec.Egress)
+}
+
+func TestHandleCiliumEvents_PortAggregation(t *testing.T) {
+	// Two events to the same peer, different ports — must produce ONE rule with both ports.
+	base := makeEvent(true, "prod", map[string]string{"app": "backend"},
+		types.EndpointKindPod, "prod", map[string]string{"app": "db"},
+		"", 5432, "TCP")
+	extra := base
+	extra.endpoint.Port = 5433
+
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(base): {base, extra},
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	egress := policies[0].Spec.Egress
+	require.Len(t, egress, 1, "same peer → single egress rule")
+	require.Len(t, egress[0].ToPorts, 1)
+	assert.Len(t, egress[0].ToPorts[0].Ports, 2, "both ports must be listed in the same rule")
+}
+
+func TestHandleCiliumEvents_PortDeduplication(t *testing.T) {
+	// Same port observed twice (e.g. two separate connections) — must appear only once.
+	base := makeEvent(true, "prod", map[string]string{"app": "backend"},
+		types.EndpointKindPod, "prod", map[string]string{"app": "db"},
+		"", 5432, "TCP")
+
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(base): {base, base},
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Len(t, policies[0].Spec.Egress[0].ToPorts[0].Ports, 1)
+}
+
+func TestHandleCiliumEvents_Service(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(false, "prod", map[string]string{"app": "frontend"},
+			types.EndpointKindService, "prod", map[string]string{"app": "backend"},
+			"", 80, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	ingress := policies[0].Spec.Ingress
+	require.Len(t, ingress, 1)
+	require.Len(t, ingress[0].FromEndpoints, 1)
+	assert.Equal(t, map[string]string{"app": "backend"}, ingress[0].FromEndpoints[0].MatchLabels)
+}
+
+func TestFormatCiliumPolicies_YAMLOutput(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(true, "prod", map[string]string{"app": "backend"},
+			types.EndpointKindRaw, "", nil,
+			"1.2.3.4", 443, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+
+	out := FormatCiliumPolicies(policies)
+	assert.Contains(t, out, "cilium.io/v2")
+	assert.Contains(t, out, "CiliumNetworkPolicy")
+	assert.Contains(t, out, "toCIDR")
+	assert.Contains(t, out, "1.2.3.4/32")
+	assert.Contains(t, out, `port: "443"`)
+}
+
+func TestFormatCiliumPolicies_MultipleDocumentSeparator(t *testing.T) {
+	events1 := makeEvent(true, "prod", map[string]string{"app": "a"},
+		types.EndpointKindRaw, "", nil, "1.1.1.1", 80, "TCP")
+	events2 := makeEvent(true, "prod", map[string]string{"app": "b"},
+		types.EndpointKindRaw, "", nil, "2.2.2.2", 80, "TCP")
+
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events1): {events1},
+		localPodKey(events2): {events2},
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 2)
+
+	out := FormatCiliumPolicies(policies)
+	assert.Contains(t, out, "---\n", "multiple policies must be separated by ---")
+}

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy_op.go
@@ -31,6 +31,11 @@ import (
 const (
 	name     = "GenerateNetworkPolicy"
 	Priority = 9200
+
+	ParamPolicyFormat   = "policy-format"
+	PolicyFormatK8s     = "k8s"
+	PolicyFormatCilium  = "cilium"
+	defaultPolicyFormat = PolicyFormatK8s
 )
 
 type gnpOperator struct{}
@@ -48,7 +53,16 @@ func (s *gnpOperator) GlobalParams() api.Params {
 }
 
 func (s *gnpOperator) InstanceParams() api.Params {
-	return nil
+	return api.Params{
+		{
+			Key:            ParamPolicyFormat,
+			Title:          "Policy format",
+			Description:    "Output format for the generated network policies. Possible values: \"k8s\" (networking.k8s.io/v1 NetworkPolicy) or \"cilium\" (cilium.io/v2 CiliumNetworkPolicy).",
+			DefaultValue:   defaultPolicyFormat,
+			TypeHint:       api.TypeString,
+			PossibleValues: []string{PolicyFormatK8s, PolicyFormatCilium},
+		},
+	}
 }
 
 type k8sAccesors struct {
@@ -179,8 +193,18 @@ func (s *gnpOperator) InstantiateDataOperator(gadgetCtx operators.GadgetContext,
 		gadgetCtx.Logger().Debug("GenerateNetworkPolicy: no datasources requiring the operator found")
 		return nil, nil
 	}
+
+	policyFormat := instanceParamValues[ParamPolicyFormat]
+	if policyFormat == "" {
+		policyFormat = defaultPolicyFormat
+	}
+	if policyFormat != PolicyFormatK8s && policyFormat != PolicyFormatCilium {
+		return nil, fmt.Errorf("invalid policy format %q: must be %q or %q", policyFormat, PolicyFormatK8s, PolicyFormatCilium)
+	}
+
 	return &gnpOperatorInstance{
-		accessors: accessors,
+		accessors:    accessors,
+		policyFormat: policyFormat,
 	}, nil
 }
 
@@ -189,7 +213,8 @@ func (s *gnpOperator) Priority() int {
 }
 
 type gnpOperatorInstance struct {
-	accessors map[datasource.DataSource]k8sAccesors
+	accessors    map[datasource.DataSource]k8sAccesors
+	policyFormat string
 }
 
 func (s *gnpOperatorInstance) Name() string {
@@ -284,14 +309,21 @@ func (s *gnpOperatorInstance) PreStart(gadgetCtx operators.GadgetContext) error 
 			}
 
 			if len(eventsBySource) != 0 {
-				// api.Warnf("Got %d events by source", len(eventsBySource))
-				policies, err := handleEvents(eventsBySource)
-				if err != nil {
-					return fmt.Errorf("handling events: %w", err)
+				var policiesStr string
+				switch s.policyFormat {
+				case PolicyFormatCilium:
+					ciliumPolicies, err := handleCiliumEvents(eventsBySource)
+					if err != nil {
+						return fmt.Errorf("handling cilium events: %w", err)
+					}
+					policiesStr = FormatCiliumPolicies(ciliumPolicies)
+				default:
+					k8sPolicies, err := handleEvents(eventsBySource)
+					if err != nil {
+						return fmt.Errorf("handling events: %w", err)
+					}
+					policiesStr = FormatPolicies(k8sPolicies)
 				}
-				// api.Warnf("> Created %d policies", len(policies))
-				policiesStr := FormatPolicies(policies)
-				//// api.Warnf("> Policies:\n%s", policiesStr[:100])
 
 				yamlPack, err := acc.adviseDS.NewPacketSingle()
 				if err != nil {


### PR DESCRIPTION
## Motivation

`advise_networkpolicy` currently only emits `networking.k8s.io/v1`
`NetworkPolicy` objects. On clusters that use Cilium as the CNI, users
often prefer the richer `cilium.io/v2` `CiliumNetworkPolicy` CRD
either to take advantage of Cilium-specific features later, or simply
because their existing tooling/GitOps pipelines already deal with
`CiliumNetworkPolicy` objects.

Today there is no way to get that output from Inspektor Gadget: users
have to translate the generated `NetworkPolicy` by hand, which is
error-prone (cross-namespace selectors, port grouping, …).

This PR adds a new `--policy-format` flag to `advise_networkpolicy`
with two values:

- `k8s` (default, unchanged): existing `networking.k8s.io/v1`
  `NetworkPolicy` output.
- `cilium`: new `cilium.io/v2` `CiliumNetworkPolicy` output.

The default is `k8s`, so existing behaviour is fully preserved.

## Example

Pod `client` in namespace `poc-inspektor-gadget` connecting to:
`nginx` (same ns), `kube-dns` in `kube-system`, and `1.1.1.1:80` /
`1.1.1.1:443`.

`kubectl gadget run advise_networkpolicy:latest -n poc-inspektor-gadget --policy-format cilium`:

```yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: client-network
  namespace: poc-inspektor-gadget
spec:
  endpointSelector:
    matchLabels:
      run: client
  egress:
  - toCIDR:
    - 1.1.1.1/32
    toPorts:
    - ports:
      - port: "443"
        protocol: TCP
      - port: "80"
        protocol: TCP
  - toEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: kube-system
        k8s-app: kube-dns
    toPorts:
    - ports:
      - port: "53"
        protocol: UDP
  - toEndpoints:
    - matchLabels:
        run: nginx
    toPorts:
    - ports:
      - port: "80"
        protocol: TCP
---
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: nginx-network
  namespace: poc-inspektor-gadget
spec:
  endpointSelector:
    matchLabels:
      run: nginx
  ingress:
  - fromEndpoints:
    - matchLabels:
        run: client
    toPorts:
    - ports:
      - port: "80"
        protocol: TCP
```

Same trace with the default `--policy-format k8s` produces the
existing `networking.k8s.io/v1` output (unchanged).

## Notes for reviewers

- I deliberately avoided importing `github.com/cilium/cilium` to keep
  the dependency surface small. The local `CiliumNetworkPolicy` struct
  covers only the fields actually produced by
  `advise_networkpolicy` — happy to switch to the official type if you
  prefer.
- No change to the K8s code path: the dispatch happens in `PreStart`
  via a `switch` on the new parameter; the default keeps invoking
  `handleEvents` / `FormatPolicies` exactly as before.
- Default value is `"k8s"`, so existing users see no behaviour change.