### PR TITLE
Clarify applicability of built-in gadgets migration guide

### DIFF
--- a/docs/gadgets/switching_to_image_based_gadgets.mdx
+++ b/docs/gadgets/switching_to_image_based_gadgets.mdx
@@ -3,7 +3,7 @@ title: Switching to image-based Gadgets
 sidebar_position: 1
 ---
 
-This guide covers how to switch from built-in Gadgets to image-based Gadgets.
+Older versions of Inspektor Gadget included built-in Gadgets. This guide covers how to switch from built-in Gadgets to image-based Gadgets, for users of such older versions. It is not applicable to new users of the latest version, which only supports image-based Gadgets.
 
 ### CLI Users
 


### PR DESCRIPTION
Clarify that the guide is for users of older versions of Inspektor Gadget, as newer versions only support image-based Gadgets. Please validate this is correct, I think it is -- and will avoid any misunderstandings.

