### PR TITLE
charts: Allow setting resources

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -50,6 +50,10 @@ spec:
           image: {{ .Values.image.repository }}:{{ include "gadget.image.tag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "/bin/gadgettracermanager", "-serve" ]
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -149,6 +149,24 @@
           }
         }
       }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource requests and limits for the gadget container.",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "integer"]
+          }
+        },
+        "requests": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "integer"]
+          }
+        }
+      }
     }
   }
 }

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -86,6 +86,16 @@ capabilities: {}
 # -- Tolerations used by `gadget` container
 tolerations: {}
 
+# -- Resource requests and limits for the `gadget` container.
+# See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources: {}
+  # limits:
+  #   cpu: 1000m
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 # -- Skip Helm labels
 skipLabels: false
 


### PR DESCRIPTION
Allow setting resources when installing via helm charts! 


## Testing Done

```
$ HELM_PARAMS="--set resources.requests.cpu=100m --set resources.requests.memory=128Mi --set resources.limits.cpu=1000m --set resources.limits.memory=1G" make -C charts template
...
          resources:
            limits:
              cpu: 1000m
              memory: 1G
            requests:
              cpu: 100m
              memory: 128Mi
...
```

Verified resources are added to `spec.template.spec.containers[0].resources`.
