### PR TITLE
fix(socketenricher): guard nil enricher on PostGadgetRun teardown

### DIFF
--- a/pkg/operators/socketenricher/socketenricher.go
+++ b/pkg/operators/socketenricher/socketenricher.go
@@ -161,7 +161,11 @@ func (i *SocketEnricherInstance) PostGadgetRun() error {
 	defer i.manager.mu.Unlock()
 
 	i.manager.refCount--
-	if i.manager.refCount == 0 {
+	// Guard against a nil enricher: the manager-level Close() (see above) may
+	// have already torn it down independently of refCount (e.g. on agent
+	// shutdown/restart), so calling Close() here unconditionally would
+	// dereference a nil *tracer.SocketEnricher and panic.
+	if i.manager.refCount == 0 && i.manager.socketEnricher != nil {
 		i.manager.socketEnricher.Close()
 		i.manager.socketEnricher = nil
 	}


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

`SocketEnricherInstance.PostGadgetRun()` calls `socketEnricher.Close()` when `refCount` hits zero, but the manager-level `Close()` nils the enricher independently of `refCount` — so on agent shutdown/restart a later `PostGadgetRun()` dereferences a nil `*tracer.SocketEnricher` and panics. This guards the call with a `!= nil` check, mirroring the existing guard in the manager-level `Close()`.

## Description

`SocketEnricherInstance.PostGadgetRun()` decrements the shared `refCount` and, when it reaches zero, calls `socketEnricher.Close()` unconditionally:

```go
i.manager.refCount--
if i.manager.refCount == 0 {
    i.manager.socketEnricher.Close()   // panics if socketEnricher is already nil
    i.manager.socketEnricher = nil
}
```

The manager-level `SocketEnricher.Close()` nils the enricher **independently of `refCount`** (and already guards with `if s.socketEnricher != nil`). So if that teardown path runs first — e.g. during agent shutdown/restart — a subsequent `PostGadgetRun()` reaching `refCount == 0` dereferences a nil `*tracer.SocketEnricher` and panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
  socketenricher.(*SocketEnricher).Close(0x0)               pkg/socketenricher/tracer.go:395
  socketenricher.(*SocketEnricherInstance).PostGadgetRun    pkg/operators/socketenricher/socketenricher.go:165
  gadget-context.(*GadgetContext).stopOperators            pkg/gadget-context/run.go:174
```

## How to test it

Build/vet pass. The crash reproduces by stopping a socket-enricher-using gadget after its manager-level `Close()` has already run; with this guard the teardown is a no-op instead of a SIGSEGV.
