### PR TITLE
Rootless image commands

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -449,6 +449,20 @@ func ensureBuilderImage(ctx context.Context, cli *client.Client, builderImage st
 	return nil
 }
 
+func isRootlessEngine(ctx context.Context, cli *client.Client) (bool, error) {
+	info, err := cli.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return false, fmt.Errorf("getting engine info: %w", err)
+	}
+
+	for _, opt := range info.Info.SecurityOptions {
+		if strings.Contains(opt, "name=rootless") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -532,20 +546,30 @@ func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 		})
 	}
 
-	resp, err := cli.ContainerCreate(
-		ctx,
-		client.ContainerCreateOptions{
-			Config: &container.Config{
-				Image:      opts.builderImage,
-				Cmd:        []string{"sleep", "inf"},
-				WorkingDir: gadgetSourcePath,
-				User:       fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-			},
-			HostConfig: &container.HostConfig{
-				Mounts: mounts,
-			},
+	containerCreateOptions := client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image:      opts.builderImage,
+			Cmd:        []string{"sleep", "inf"},
+			WorkingDir: gadgetSourcePath,
 		},
-	)
+		HostConfig: &container.HostConfig{
+			Mounts: mounts,
+		},
+	}
+
+	isRootless, err := isRootlessEngine(ctx, cli)
+	if err != nil {
+		return fmt.Errorf("getting container engine information: %w", err)
+	}
+	if isRootless {
+		if os.Geteuid() == 0 {
+			return errors.New("running build as root user with rootless container engine is not possible, run build as your user")
+		}
+	} else {
+		containerCreateOptions.Config.User = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	}
+
+	resp, err := cli.ContainerCreate(ctx, containerCreateOptions)
 	if err != nil {
 		return fmt.Errorf("creating builder container: %w", err)
 	}

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -34,6 +34,7 @@ import (
 	gadgetmanifest "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-manifest"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
@@ -163,6 +164,9 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		if err := utils.ParseEarlyFlags(cmd, args); err != nil {
 			return err
 		}
+
+		ociStoreUser, _ := cmd.PersistentFlags().GetBool("oci-store-user")
+		oci.SetUseUserOciStore(ociStoreUser)
 
 		// Before running the gadget, we need to get the gadget info to be able to set
 		// things (like params) up correctly
@@ -431,6 +435,12 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		"t",
 		0,
 		"Number of seconds that the gadget will run for, 0 to run indefinitely",
+	)
+
+	cmd.PersistentFlags().Bool(
+		"oci-store-user",
+		false,
+		"Use user OCI store (~/.ig/oci-store) instead of system-wide store (/var/lib/ig/oci-store)",
 	)
 
 	if commandMode != CommandModeAttach {

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -34,6 +34,7 @@ import (
 	gadgetmanifest "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-manifest"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
@@ -162,6 +163,22 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		// Parse flags that are known at this time, like the ones we get from the gadget descriptor
 		if err := utils.ParseEarlyFlags(cmd, args); err != nil {
 			return err
+		}
+
+		if !runtime.IsClient() {
+			ociStoreUser, _ := cmd.PersistentFlags().GetBool("oci-store-user")
+			if ociStoreUser && os.Geteuid() == 0 {
+				if f := cmd.Flags().Lookup("pull"); f != nil {
+					if f.Changed && f.Value.String() != oci.PullImageNever {
+						return errors.New("--oci-store-user requires --pull=never: pulling as root would create root-owned files in the user's store")
+					}
+					if err := f.Value.Set(oci.PullImageNever); err != nil {
+						return err
+					}
+					log.Warnf("--oci-store-user is set: forcing --pull=%q", oci.PullImageNever)
+				}
+			}
+			oci.SetUseUserOciStore(ociStoreUser)
 		}
 
 		// Before running the gadget, we need to get the gadget info to be able to set
@@ -432,6 +449,14 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		0,
 		"Number of seconds that the gadget will run for, 0 to run indefinitely",
 	)
+
+	if !runtime.IsClient() {
+		cmd.PersistentFlags().Bool(
+			"oci-store-user",
+			false,
+			"Use user OCI store (~/.ig/oci-store) instead of system-wide store (/var/lib/ig/oci-store)",
+		)
+	}
 
 	if commandMode != CommandModeAttach {
 		AddOCIFlags(cmd, ociParams, skipParams, runtime)

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -491,3 +491,22 @@ $ sudo ig image verify ghcr.io/inspektor-gadget/gadget/trace_exec:v0.45.0
 Verifying image: trace_exec:v0.45.0
 Image verified successfully!
 ```
+
+#### Image store location
+
+Gadget images are stored in an OCI store whose location depends on the user:
+`/var/lib/ig/oci-store` for `root`, `~/.ig/oci-store` otherwise. A gadget built
+as your user is therefore not visible to `sudo ig image list`.
+
+All `ig image` subcommands can be run without `root`. Only `ig run` needs it, to
+load eBPF programs. Use `--oci-store-user` to run a gadget from your user store:
+
+```bash
+$ ig image build -t mygadget .
+$ sudo ig run --oci-store-user mygadget
+```
+
+This flag requires `sudo` (the store is located using `SUDO_USER`) and an
+existing user store. The store is opened read-only to avoid creating `root`
+owned files in your home directory: `--pull` is forced to `never` and signatures
+cannot be downloaded, so pull the gadget as your user first.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -19,6 +19,7 @@ CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
 DOCKER ?= docker
+SUDO ?= sudo -E
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -99,7 +100,7 @@ pull-builder-image:
 .PHONY: $(GADGETS)
 $(GADGETS): pull-builder-image
 	@echo "Building $@"
-	@sudo -E \
+	@$(SUDO) \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -143,34 +144,34 @@ $(GADGETS_README_DEV):
 
 %-push: %-build
 	@echo "Pushing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
 
 %-sign: %-push
 	@echo "Signing $*"
-	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+	digest=$$($(SUDO) $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
-	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 
 %-clean:
-	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 clean: $(addsuffix -clean,$(GADGETS))
@@ -180,14 +181,14 @@ pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
 	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
 	done
 
 .PHONY:
 %/pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 test-unit: build
@@ -199,9 +200,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./.../$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./.../$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./.../$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-unit: %
@@ -213,9 +214,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./$*/$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./$*/$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./$*/$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-integration: %
@@ -225,7 +226,7 @@ test-unit: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./$*/$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./$*/$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-integration: build
@@ -235,7 +236,7 @@ test-integration: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./.../$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./.../$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-local: IG_PATH=$(IG)

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -23,6 +23,7 @@ CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
 DOCKER ?= docker
+SUDO ?= sudo -E
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -107,7 +108,7 @@ pull-builder-image:
 .PHONY: $(GADGETS)
 $(GADGETS): pull-builder-image
 	@echo "Building $@"
-	@sudo -E \
+	@$(SUDO) \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -151,34 +152,34 @@ $(GADGETS_README_DEV):
 
 %-push: %-build
 	@echo "Pushing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
 
 %-sign: %-push
 	@echo "Signing $*"
-	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+	digest=$$($(SUDO) $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
-	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 
 %-clean:
-	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 clean: $(addsuffix -clean,$(GADGETS))
@@ -188,14 +189,14 @@ pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
 	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
 	done
 
 .PHONY:
 %/pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 test-unit: build
@@ -207,9 +208,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./.../$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./.../$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./.../$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-unit: %
@@ -221,9 +222,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./$*/$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./$*/$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./$*/$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-integration: %
@@ -234,7 +235,7 @@ test-unit: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./$*/$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./$*/$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-integration: build
@@ -245,7 +246,7 @@ test-integration: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./.../$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./.../$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-local: IG_PATH=$(IG)

--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -16,9 +16,12 @@ package oci
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path"
+	"path/filepath"
 	"reflect"
 
 	"github.com/gofrs/flock"
@@ -34,15 +37,62 @@ type localOciStore struct {
 	indexFlock *flock.Flock
 }
 
+const userOciStoreSubDir = ".ig/oci-store"
+
+var useUserOciStore bool
+
+func SetUseUserOciStore(v bool) {
+	useUserOciStore = v
+}
+
+func getOciStorePath() (string, error) {
+	username := ""
+	if os.Geteuid() == 0 {
+		if useUserOciStore {
+			// Running as root through sudo, with --oci-store-user.
+			username = os.Getenv("SUDO_USER")
+			if username == "" {
+				return "", errors.New("--oci-store-user requires being run with sudo, not as root directly")
+			}
+		} else {
+			// Running as root, without --oci-store-user
+			return rootOciStore, nil
+		}
+	} else {
+		// Running as normal user.
+		u, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("getting current user: %w", err)
+		}
+		username = u.Username
+	}
+
+	return getUserOciStorePath(username)
+}
+
+func getUserOciStorePath(username string) (string, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return "", fmt.Errorf("finding user %q: %w", username, err)
+	}
+
+	return filepath.Join(u.HomeDir, userOciStoreSubDir), nil
+}
+
 // newLocalOciStore returns a localOciStore that is safe when executed
 // concurrently, even from different processes.
 func newLocalOciStore() (*localOciStore, error) {
-	if err := os.MkdirAll(defaultOciStore, 0o700); err != nil {
-		return nil, fmt.Errorf("creating oci store directory %q: %w", defaultOciStore, err)
+	ociStorePath, err := getOciStorePath()
+	if err != nil {
+		return nil, fmt.Errorf("getting OCI store path: %w", err)
 	}
 
-	indexPath := path.Join(defaultOciStore, "index.json")
-	indexLock := flock.New(path.Join(defaultOciStore, "index.json.lock"))
+	if err := os.MkdirAll(ociStorePath, 0o700); err != nil {
+		return nil, fmt.Errorf("creating oci store directory %q: %w", ociStorePath, err)
+	}
+
+	indexPath := path.Join(ociStorePath, "index.json")
+	indexLock := flock.New(path.Join(ociStorePath, "index.json.lock"))
 
 	// lock the file before reading the index below
 	// RLock can't be used since we might create and init an empty index file in oci.New()
@@ -51,7 +101,7 @@ func newLocalOciStore() (*localOciStore, error) {
 	}
 	defer indexLock.Unlock()
 
-	ociStore, err := oci.New(defaultOciStore)
+	ociStore, err := oci.New(ociStorePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -16,9 +16,12 @@ package oci
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path"
+	"path/filepath"
 	"reflect"
 
 	"github.com/gofrs/flock"
@@ -32,17 +35,78 @@ type localOciStore struct {
 	indexPath  string
 	oldIndex   *ocispec.Index
 	indexFlock *flock.Flock
+	readOnly   bool
+}
+
+const userOciStoreSubDir = ".ig/oci-store"
+
+var useUserOciStore bool
+
+func SetUseUserOciStore(v bool) {
+	useUserOciStore = v
+}
+
+func getOciStorePath() (string, error) {
+	username := ""
+	if os.Geteuid() == 0 {
+		if useUserOciStore {
+			// Running as root through sudo, with --oci-store-user.
+			username = os.Getenv("SUDO_USER")
+			if username == "" {
+				return "", errors.New("--oci-store-user requires being run with sudo, not as root directly")
+			}
+		} else {
+			// Running as root, without --oci-store-user
+			return rootOciStore, nil
+		}
+	} else {
+		// Running as normal user.
+		u, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("getting current user: %w", err)
+		}
+		username = u.Username
+	}
+
+	return getUserOciStorePath(username)
+}
+
+func getUserOciStorePath(username string) (string, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return "", fmt.Errorf("finding user %q: %w", username, err)
+	}
+
+	return filepath.Join(u.HomeDir, userOciStoreSubDir), nil
 }
 
 // newLocalOciStore returns a localOciStore that is safe when executed
 // concurrently, even from different processes.
 func newLocalOciStore() (*localOciStore, error) {
-	if err := os.MkdirAll(defaultOciStore, 0o700); err != nil {
-		return nil, fmt.Errorf("creating oci store directory %q: %w", defaultOciStore, err)
+	ociStorePath, err := getOciStorePath()
+	if err != nil {
+		return nil, fmt.Errorf("getting OCI store path: %w", err)
 	}
 
-	indexPath := path.Join(defaultOciStore, "index.json")
-	indexLock := flock.New(path.Join(defaultOciStore, "index.json.lock"))
+	// When running as root with --oci-store-user, let's open everything as
+	// read only in order to avoid polluting user directories with root
+	// owned files.
+	readOnly := useUserOciStore && os.Geteuid() == 0
+
+	if readOnly {
+		for _, f := range []string{"index.json", "index.json.lock"} {
+			if _, err := os.Stat(path.Join(ociStorePath, f)); err != nil {
+				return nil, fmt.Errorf("--oci-store-user with root requires user's store (%q) to already exist: %w", ociStorePath, err)
+			}
+		}
+	} else {
+		if err := os.MkdirAll(ociStorePath, 0o700); err != nil {
+			return nil, fmt.Errorf("creating oci store directory %q: %w", ociStorePath, err)
+		}
+	}
+
+	indexPath := path.Join(ociStorePath, "index.json")
+	indexLock := flock.New(path.Join(ociStorePath, "index.json.lock"))
 
 	// lock the file before reading the index below
 	// RLock can't be used since we might create and init an empty index file in oci.New()
@@ -51,7 +115,7 @@ func newLocalOciStore() (*localOciStore, error) {
 	}
 	defer indexLock.Unlock()
 
-	ociStore, err := oci.New(defaultOciStore)
+	ociStore, err := oci.New(ociStorePath)
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +131,7 @@ func newLocalOciStore() (*localOciStore, error) {
 		indexPath:  indexPath,
 		oldIndex:   oldIndex,
 		indexFlock: indexLock,
+		readOnly:   readOnly,
 	}, nil
 }
 

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -76,7 +76,7 @@ type ImageOptions struct {
 }
 
 const (
-	defaultOciStore = "/var/lib/ig/oci-store"
+	rootOciStore    = "/var/lib/ig/oci-store"
 	DefaultAuthFile = "/var/lib/ig/config.json"
 
 	PullImageAlways  = "always"

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -76,7 +76,7 @@ type ImageOptions struct {
 }
 
 const (
-	defaultOciStore = "/var/lib/ig/oci-store"
+	rootOciStore    = "/var/lib/ig/oci-store"
 	DefaultAuthFile = "/var/lib/ig/config.json"
 
 	PullImageAlways  = "always"
@@ -155,6 +155,10 @@ func VerifyGadgetImage(ctx context.Context, image string, imgOpts *ImageOptions)
 			}
 
 			log.Warn("signature not found, will pull signing information and try verification again")
+
+			if imageStore.readOnly {
+				return fmt.Errorf("disabling signature pull for %q as --oci-store-user opens the user's store as read only", image)
+			}
 
 			repo, err := newRepository(imageRef, &imgOpts.AuthOptions)
 			if err != nil {


### PR DESCRIPTION
This PR enables running every ig image subcommands without being root.
There are mainly 3 cases:
1. Running any command, i.e. image and run, as root: The previous behavior of using /var/lig/ig/oci-store is kept.
2. Rootless ig image: The OCI store is located under ~/.ig/oci-store.
3. Running run as root with user OCI store: The --oci-store-user flag should be used to indicate to run to use ~/.ig/oci-store instead of /var/lib/ig/oci-store.

```bash
# Expose podman socket, not needed for docker:
$ systemctl --user start podman.socket
# Needed by golang docker API, not needed for docker:
$ export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
# Actual gadget build:
$ SUDO= IG=../ig make -C gadgets trace_exec -o pull-builder-image
Building trace_exec
Successfully built ghcr.io/inspektor-gadget/gadget/trace_exec:francis-rootless-ig-image@sha256:75724f64db9e4e48218aafb8b167974ad05d207511d79dca55bdac951a16e85e
$ ls ~/.ig/oci-store/blobs/sha256/ | head -5
000352f3fd9b1681ab06839f4afe85926931e3a40b308963ff5951a3a2069512
037a8143e8bdef8d71342b3764aa2c9cca6232d2ebac88f3a5d9d274a81f706d
0421c298d9166820e0c6f17679fbd61ed0c77842dbefb9ee67d377bfd17fadbc
06480b4005a0387584c4c63306dedcb635c20522cff9e4b995f2f9cc4892abaf
0e0f963223dc7019ac6f106cae5da27c3257b7db98875b4e6a91a342c82931dc
$ ./ig image list
REPOSITORY                                         TAG                                               DIGEST       CREATED                                          
trace_exec                                         francis-rootless-ig-image                         75724f64db9e about a minute ago
$ sudo ./ig run --verify-image=false --oci-store-user trace_exec:francis-rootless-ig-image
WARN[0000] gadget signature verification is disabled due to using corresponding option 
WARN[0000] gadget signature verification is disabled due to using corresponding option 
RUNTIME.CONTAINERNAME                                       COMM                    PID        TID TID        TTY        ARGS                                 ERROR
cool_khorana                                                bash                  70607      70607 70605      0          /bin/bash                                 
cool_khorana                                                grepconf.sh           70613      70613 70607      0          /usr/libexec/grepconf.sh\u00a0-c
...
```

TODO:
- [x]: Documentation once agreed on the UX.