### PR TITLE
kubemamanger: fix race for writes to attachedContainers

### DIFF
--- a/pkg/container-collection/pubsub.go
+++ b/pkg/container-collection/pubsub.go
@@ -21,6 +21,12 @@ import (
 
 type EventType int
 
+// FuncNotify is the callback invoked for each container event. Callbacks may be
+// invoked concurrently: Publish runs every subscriber in its own goroutine, and
+// overlapping Publish calls (e.g. from simultaneous container add/remove events)
+// can invoke the same callback from multiple goroutines at once. Implementations
+// must therefore be safe for concurrent use and protect any shared state with
+// their own synchronization.
 type FuncNotify func(event PubSubEvent)
 
 const (

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
@@ -224,6 +225,7 @@ type KubeManagerInstance struct {
 	mountnsmap   *ebpf.Map
 	subscribed   bool
 
+	containerMutex     sync.Mutex
 	attachedContainers map[string]*containercollection.Container
 	attacher           Attacher
 	params             *params.Params
@@ -291,7 +293,9 @@ func (m *KubeManagerInstance) handleGadgetInstance(log logger.Logger) error {
 				return
 			}
 
+			m.containerMutex.Lock()
 			m.attachedContainers[container.Runtime.ContainerID] = container
+			m.containerMutex.Unlock()
 
 			log.Debugf("tracer attached: container %q pid %d mntns %d netns %d",
 				container.K8s.ContainerName, container.ContainerPid(), container.Mntns, container.Netns)
@@ -299,7 +303,9 @@ func (m *KubeManagerInstance) handleGadgetInstance(log logger.Logger) error {
 
 		detachContainerFunc := func(container *containercollection.Container) {
 			log.Debugf("calling gadget.Detach()")
+			m.containerMutex.Lock()
 			delete(m.attachedContainers, container.Runtime.ContainerID)
+			m.containerMutex.Unlock()
 
 			err := attacher.DetachContainer(container)
 			if err != nil {
@@ -360,8 +366,17 @@ func (m *KubeManagerInstance) PostGadgetRun() error {
 		m.gadgetCtx.Logger().Debugf("calling Unsubscribe()")
 		m.manager.containerCollection.Unsubscribe(m.id)
 
-		// emit detach for all remaining containers
+		// emit detach for all remaining containers. Snapshot the map under
+		// the lock so we don't hold it while calling DetachContainer and so we
+		// don't race with callbacks that might still be running.
+		m.containerMutex.Lock()
+		remaining := make([]*containercollection.Container, 0, len(m.attachedContainers))
 		for _, container := range m.attachedContainers {
+			remaining = append(remaining, container)
+		}
+		m.containerMutex.Unlock()
+
+		for _, container := range remaining {
 			m.attacher.DetachContainer(container)
 		}
 	}


### PR DESCRIPTION
Fix panic for concurrent writes to `attachedContainers` when `Publish()` is called for multiple goroutines.

Fixes: #5507 

Note: `LocalManager` already handles is correctly, https://github.com/inspektor-gadget/inspektor-gadget/pull/5148

## Tesing Done

Used the steps here: https://gist.github.com/mqasimsarfraz/b883775b909899419810ceb4d525c09b
