### PR TITLE
Reuse local builder image by default

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -100,7 +100,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputDir, "output", "o", "", "Path to a folder to store generated files while building")
 	cmd.Flags().StringVarP(&opts.image, "tag", "t", "", "Name for the built image (format name:tag)")
 	cmd.Flags().StringVar(&opts.builderImage, "builder-image", builderImage, "Builder image to use")
-	cmd.Flags().StringVar(&opts.builderImagePull, "builder-image-pull", "always", "Specify when the builder image should be pulled [always, missing, never]")
+	cmd.Flags().StringVar(&opts.builderImagePull, "builder-image-pull", "missing", "Specify when the builder image should be pulled [always, missing, never]")
 	cmd.Flags().BoolVar(&opts.updateMetadata, "update-metadata", false, "Update the metadata according to the eBPF code")
 	cmd.Flags().BoolVar(&opts.validateMetadata, "validate-metadata", true, "Validate the metadata file before building the gadget image")
 


### PR DESCRIPTION
Fixes #4537 

cmd: reuse local builder image by default

Change the default value of --builder-image-pull from always to missing.

This avoids pulling the builder image on every ig image build invocation when the image is already available locally, while still pulling it when missing.
## How to use

Run:

ig image build .

Verify that the builder image is only pulled when it is not already present locally.
## Testing done

Removed the local builder image and verified ig image build . pulled it.
Ran ig image build . again and verified no builder image pull occurred when the image was already present locally.