### PR TITLE
inventorycache: reduce memory usage/GC pressure

### DIFF
--- a/pkg/operators/common/common_test.go
+++ b/pkg/operators/common/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Inspektor Gadget authors
+// Copyright 2025-2026 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
 package common
 
 import (
-	"bytes"
+	"context"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +27,8 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/cachedmap"
 )
+
+const eventuallyTimeout = 2 * time.Second
 
 func TestStartIncrementsUseCount(t *testing.T) {
 	fakeClientSet := fake.NewClientset()
@@ -52,289 +53,167 @@ func TestStartIncrementsUseCount(t *testing.T) {
 	// Verify resources are cleaned up after last Stop
 	assert.Nil(t, cache.factory)
 	assert.Nil(t, cache.pods)
+	assert.Nil(t, cache.svcs)
 }
 
-func TestInventoryCacheAdd(t *testing.T) {
-	type addTestCase struct {
-		testName      string
-		kind          string
-		initialObj    any
-		expectedName  string
-		expectedIP    string
-		ok            bool
-		expectedError string
+// TestInventoryCacheInformer drives a real shared informer (over a fake
+// clientset) end-to-end. It proves the informer accepts our custom transformed
+// type (*SlimPod/*SlimService) and that by-name and by-IP indexer lookups, plus
+// updates and deletions, behave as expected.
+func TestInventoryCacheInformer(t *testing.T) {
+	pod := constructPod("test-pod", "default", "1.2.3.4")
+	svc := constructService("test-svc", "default", "10.0.0.1")
+	cache := &inventoryCache{
+		clientset: fake.NewClientset(pod, svc),
+		graceTTL:  200 * time.Millisecond,
 	}
+	cache.Start()
+	defer cache.Stop()
 
-	testCases := []addTestCase{
-		{
-			testName:     "Add valid Pod with IP",
-			kind:         "pod",
-			initialObj:   constructPod("test-pod", "default", "1.2.3.4"),
-			expectedName: "test-pod",
-			expectedIP:   "1.2.3.4",
-			ok:           true,
-		},
-		{
-			testName:     "Add valid Service with ClusterIP",
-			kind:         "svc",
-			initialObj:   constructService("test-svc", "default", "10.0.0.1"),
-			expectedName: "test-svc",
-			expectedIP:   "10.0.0.1",
-			ok:           true,
-		},
-		{
-			testName:     "Add Pod with no IP",
-			kind:         "pod",
-			initialObj:   constructPod("no-ip-pod", "default", ""),
-			expectedName: "no-ip-pod",
-			expectedIP:   "",
-			ok:           true,
-		},
-		{
-			testName:     "Add Service with no ClusterIP",
-			kind:         "svc",
-			initialObj:   constructService("no-ip-svc", "default", ""),
-			expectedName: "no-ip-svc",
-			expectedIP:   "",
-			ok:           true,
-		},
-		{
-			testName: "Add Pod with invalid key",
-			kind:     "pod",
-			// Create a pod with no metadata to trigger a key error.
-			initialObj:    &v1.Pod{},
-			expectedError: "OnAdd: empty key for pod",
-			ok:            false,
-		},
-		{
-			testName:      "Add unknown object",
-			kind:          "unknown",
-			initialObj:    "not a valid object",
-			expectedError: "OnAdd: unknown object type:",
-			ok:            false,
-		},
-	}
+	// Initial objects are stored via the transform and reachable by name and IP.
+	require.Eventually(t, func() bool {
+		return cache.GetPodByName("default", "test-pod") != nil
+	}, eventuallyTimeout, 5*time.Millisecond)
 
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			// Prepare the cache with all maps.
-			cache := &inventoryCache{
-				pods:     cachedmap.NewCachedMap[string, *SlimPod](time.Second),
-				podsByIp: cachedmap.NewCachedMap[string, *SlimPod](time.Second),
-				svcs:     cachedmap.NewCachedMap[string, *SlimService](time.Second),
-				svcsByIp: cachedmap.NewCachedMap[string, *SlimService](time.Second),
-			}
+	gotPod := cache.GetPodByName("default", "test-pod")
+	require.NotNil(t, gotPod)
+	assert.Equal(t, "test-pod", gotPod.Name)
+	assert.Equal(t, "1.2.3.4", gotPod.Status.PodIP)
 
-			// If we expect an error, capture log output.
-			if !tc.ok {
-				var logBuffer bytes.Buffer
-				origOut := logrus.StandardLogger().Out
-				logrus.SetOutput(&logBuffer)
-				defer logrus.SetOutput(origOut)
+	require.NotNil(t, cache.GetPodByIp("1.2.3.4"))
+	require.NotNil(t, cache.GetSvcByName("default", "test-svc"))
+	require.NotNil(t, cache.GetSvcByIp("10.0.0.1"))
 
-				cache.OnAdd(tc.initialObj, false)
-				logContent := logBuffer.String()
-				assert.Contains(t, logContent, tc.expectedError)
-				return
-			}
+	// GetPods/GetSvcs return the live set.
+	assert.Len(t, cache.GetPods(), 1)
+	assert.Len(t, cache.GetSvcs(), 1)
 
-			// Otherwise, perform the addition.
-			cache.OnAdd(tc.initialObj, false)
+	// Update the pod IP; the new IP must resolve and the stale IP must be dropped.
+	updated := constructPod("test-pod", "default", "5.6.7.8")
+	_, err := cache.clientset.CoreV1().Pods("default").Update(context.TODO(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return cache.GetPodByIp("5.6.7.8") != nil && cache.GetPodByIp("1.2.3.4") == nil
+	}, eventuallyTimeout, 5*time.Millisecond)
 
-			// Verify results based on kind.
-			switch tc.kind {
-			case "pod":
-				retrieved := cache.GetPodByName("default", tc.expectedName)
-				require.NotNil(t, retrieved, "expected pod to be added")
-				assert.Equal(t, tc.expectedName, retrieved.Name)
-				if tc.expectedIP != "" {
-					retrievedByIP := cache.GetPodByIp(tc.expectedIP)
-					require.NotNil(t, retrievedByIP, "expected pod to be retrievable by IP")
-					assert.Equal(t, tc.expectedName, retrievedByIP.Name)
-				}
-			case "svc":
-				retrieved := cache.GetSvcByName("default", tc.expectedName)
-				require.NotNil(t, retrieved, "expected service to be added")
-				assert.Equal(t, tc.expectedName, retrieved.Name)
-				if tc.expectedIP != "" {
-					retrievedByIP := cache.GetSvcByIp(tc.expectedIP)
-					require.NotNil(t, retrievedByIP, "expected service to be retrievable by IP")
-					assert.Equal(t, tc.expectedName, retrievedByIP.Name)
-				}
-			}
-		})
-	}
+	// Delete the pod; after the grace TTL it must no longer resolve.
+	err = cache.clientset.CoreV1().Pods("default").Delete(context.TODO(), "test-pod", metav1.DeleteOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return cache.GetPodByName("default", "test-pod") == nil &&
+			cache.GetPodByIp("5.6.7.8") == nil
+	}, 3*time.Second, 5*time.Millisecond)
 }
 
-func TestInventoryCacheUpdate(t *testing.T) {
-	type updateTestCase struct {
-		testName      string
-		kind          string
-		initialObj    any
-		updatedObj    any
-		expectedIP    string
-		ok            bool
-		expectedError string
+// TestOnDeleteAtomicGrace verifies the gap-closure guarantee: deleting an object
+// moves it from the live map to the grace window atomically, so a lookup
+// immediately after OnDelete still resolves it (never a gap where it is absent),
+// and it disappears only after the grace TTL.
+func TestOnDeleteAtomicGrace(t *testing.T) {
+	ttl := 100 * time.Millisecond
+	cache := &inventoryCache{
+		pods:     cachedmap.NewCachedMap[string, *SlimPod](ttl),
+		podsByIp: cachedmap.NewCachedMap[string, *SlimPod](ttl),
+		svcs:     cachedmap.NewCachedMap[string, *SlimService](ttl),
+		svcsByIp: cachedmap.NewCachedMap[string, *SlimService](ttl),
 	}
+	defer func() {
+		cache.pods.Close()
+		cache.podsByIp.Close()
+		cache.svcs.Close()
+		cache.svcsByIp.Close()
+	}()
 
-	testCases := []updateTestCase{
-		{
-			testName:   "Update Pod IP",
-			kind:       "pod",
-			initialObj: constructPod("test-pod", "default", "1.2.3.4"),
-			updatedObj: constructPod("test-pod", "default", "5.6.7.8"),
-			expectedIP: "5.6.7.8",
-			ok:         true,
-		},
-		{
-			testName:   "Update Service ClusterIP",
-			kind:       "svc",
-			initialObj: constructService("test-svc", "default", "10.0.0.1"),
-			updatedObj: constructService("test-svc", "default", "10.0.0.2"),
-			expectedIP: "10.0.0.2",
-			ok:         true,
-		},
-		{
-			testName:   "Update Pod with invalid key",
-			kind:       "pod",
-			initialObj: constructPod("invalid-pod", "default", "1.2.3.4"),
-			// Updated object is missing metadata to force key error.
-			updatedObj:    &v1.Pod{},
-			expectedError: "OnUpdate: empty key for pod",
-			ok:            false,
-		},
-		{
-			testName:      "Update unknown object",
-			kind:          "unknown",
-			initialObj:    constructPod("some-pod", "default", "1.2.3.4"),
-			updatedObj:    "not a valid object",
-			expectedError: "OnUpdate: unknown object type:",
-			ok:            false,
-		},
-	}
+	pod := NewSlimPod(constructPod("test-pod", "default", "1.2.3.4"))
+	svc := NewSlimService(constructService("test-svc", "default", "10.0.0.1"))
 
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			cache := &inventoryCache{
-				pods:     cachedmap.NewCachedMap[string, *SlimPod](time.Nanosecond),
-				podsByIp: cachedmap.NewCachedMap[string, *SlimPod](time.Nanosecond),
-				svcs:     cachedmap.NewCachedMap[string, *SlimService](time.Nanosecond),
-				svcsByIp: cachedmap.NewCachedMap[string, *SlimService](time.Nanosecond),
-			}
+	cache.OnAdd(pod, false)
+	cache.OnAdd(svc, false)
+	require.NotNil(t, cache.GetPodByName("default", "test-pod"))
+	require.NotNil(t, cache.GetPodByIp("1.2.3.4"))
+	require.NotNil(t, cache.GetSvcByName("default", "test-svc"))
+	require.NotNil(t, cache.GetSvcByIp("10.0.0.1"))
 
-			cache.OnAdd(tc.initialObj, false)
+	cache.OnDelete(pod)
+	cache.OnDelete(svc)
 
-			if !tc.ok {
-				var logBuffer bytes.Buffer
-				origOut := logrus.StandardLogger().Out
-				logrus.SetOutput(&logBuffer)
-				defer logrus.SetOutput(origOut)
+	// Atomic handoff: immediately resolvable after delete (no gap).
+	require.NotNil(t, cache.GetPodByName("default", "test-pod"), "must stay resolvable in grace right after delete")
+	require.NotNil(t, cache.GetPodByIp("1.2.3.4"))
+	require.NotNil(t, cache.GetSvcByName("default", "test-svc"))
+	require.NotNil(t, cache.GetSvcByIp("10.0.0.1"))
 
-				cache.OnUpdate(tc.initialObj, tc.updatedObj)
-				logContent := logBuffer.String()
-				assert.Contains(t, logContent, tc.expectedError)
-				return
-			}
-
-			cache.OnUpdate(tc.initialObj, tc.updatedObj)
-
-			switch tc.kind {
-			case "pod":
-				retrieved := cache.GetPodByName("default", "test-pod")
-				require.NotNil(t, retrieved, "expected pod to exist after update")
-				assert.Equal(t, tc.expectedIP, retrieved.Status.PodIP)
-				retrievedByIP := cache.GetPodByIp(tc.expectedIP)
-				require.NotNil(t, retrievedByIP, "expected pod to be retrievable by new IP")
-			case "svc":
-				retrieved := cache.GetSvcByName("default", "test-svc")
-				require.NotNil(t, retrieved, "expected service to exist after update")
-				assert.Equal(t, tc.expectedIP, retrieved.Spec.ClusterIP)
-				retrievedByIP := cache.GetSvcByIp(tc.expectedIP)
-				require.NotNil(t, retrievedByIP, "expected service to be retrievable by new IP")
-			}
-		})
-	}
+	// Gone after the grace TTL expires.
+	require.Eventually(t, func() bool {
+		return cache.GetPodByName("default", "test-pod") == nil &&
+			cache.GetPodByIp("1.2.3.4") == nil &&
+			cache.GetSvcByName("default", "test-svc") == nil &&
+			cache.GetSvcByIp("10.0.0.1") == nil
+	}, eventuallyTimeout, 5*time.Millisecond)
 }
 
-func TestInventoryCacheDelete(t *testing.T) {
-	type deleteTestCase struct {
-		testName      string
-		kind          string
-		initialObj    any
-		ok            bool
-		expectedError string
+func TestSlimDeepCopyObject(t *testing.T) {
+	pod := NewSlimPod(constructPod("p", "default", "1.2.3.4"))
+	pod.Labels = map[string]string{"a": "b"}
+	cp := pod.DeepCopyObject().(*SlimPod)
+	require.NotSame(t, pod, cp)
+	cp.Labels["a"] = "c"
+	assert.Equal(t, "b", pod.Labels["a"], "deep copy must not share the labels map")
+
+	svc := NewSlimService(constructService("s", "default", "10.0.0.1"))
+	svc.Spec.Selector = map[string]string{"app": "x"}
+	scp := svc.DeepCopyObject().(*SlimService)
+	require.NotSame(t, svc, scp)
+	assert.Equal(t, "10.0.0.1", scp.Spec.ClusterIP)
+	scp.Spec.Selector["app"] = "y"
+	assert.Equal(t, "x", svc.Spec.Selector["app"], "deep copy must not share the selector map")
+}
+
+func TestHostNetworkPodNotIndexedByIP(t *testing.T) {
+	ttl := time.Second
+	cache := &inventoryCache{
+		pods:     cachedmap.NewCachedMap[string, *SlimPod](ttl),
+		podsByIp: cachedmap.NewCachedMap[string, *SlimPod](ttl),
+		svcs:     cachedmap.NewCachedMap[string, *SlimService](ttl),
+		svcsByIp: cachedmap.NewCachedMap[string, *SlimService](ttl),
 	}
+	defer func() {
+		cache.pods.Close()
+		cache.podsByIp.Close()
+		cache.svcs.Close()
+		cache.svcsByIp.Close()
+	}()
 
-	testCases := []deleteTestCase{
-		{
-			testName:   "Delete Pod",
-			kind:       "pod",
-			initialObj: constructPod("test-pod", "default", "1.2.3.4"),
-			ok:         true,
-		},
-		{
-			testName:   "Delete Service",
-			kind:       "svc",
-			initialObj: constructService("test-svc", "default", "10.0.0.1"),
-			ok:         true,
-		},
-		{
-			testName:      "Delete unknown object",
-			kind:          "unknown",
-			initialObj:    "not a valid object",
-			expectedError: "OnDelete: unknown object type:",
-			ok:            false,
-		},
+	hostNetPod := NewSlimPod(constructPod("host-pod", "default", "10.0.0.5"))
+	hostNetPod.Spec.HostNetwork = true
+	cache.OnAdd(hostNetPod, false)
+
+	// Resolvable by name, but NOT by its (node-shared) IP.
+	require.NotNil(t, cache.GetPodByName("default", "host-pod"))
+	assert.Nil(t, cache.GetPodByIp("10.0.0.5"), "hostNetwork pod must not be indexed by IP")
+}
+
+// TestConcurrentGetAndStop exercises the RWMutex: concurrent Get* calls while
+// Stop() tears the cache down must not panic or data-race (run with -race).
+func TestConcurrentGetAndStop(t *testing.T) {
+	cache := &inventoryCache{
+		clientset: fake.NewClientset(constructPod("p", "default", "1.2.3.4")),
+		graceTTL:  200 * time.Millisecond,
 	}
+	cache.Start()
 
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			// Use a very short duration so that cache entries can expire.
-			cache := &inventoryCache{
-				pods:     cachedmap.NewCachedMap[string, *SlimPod](time.Nanosecond),
-				podsByIp: cachedmap.NewCachedMap[string, *SlimPod](time.Nanosecond),
-				svcs:     cachedmap.NewCachedMap[string, *SlimService](time.Nanosecond),
-				svcsByIp: cachedmap.NewCachedMap[string, *SlimService](time.Nanosecond),
-			}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10000; i++ {
+			cache.GetPodByName("default", "p")
+			cache.GetPodByIp("1.2.3.4")
+			cache.GetPods()
+		}
+	}()
 
-			if tc.ok {
-				cache.OnAdd(tc.initialObj, false)
-			}
-
-			if !tc.ok {
-				var logBuffer bytes.Buffer
-				origOut := logrus.StandardLogger().Out
-				logrus.SetOutput(&logBuffer)
-				defer logrus.SetOutput(origOut)
-
-				cache.OnDelete(tc.initialObj)
-				logContent := logBuffer.String()
-				assert.Contains(t, logContent, tc.expectedError)
-				return
-			}
-			cache.OnDelete(tc.initialObj)
-
-			start := time.Now()
-			for {
-				if tc.kind == "pod" {
-					rtvdName := cache.GetPodByName(tc.initialObj.(*v1.Pod).Namespace, tc.initialObj.(*v1.Pod).Name)
-					rtvdIp := cache.GetPodByIp(tc.initialObj.(*v1.Pod).Status.PodIP)
-					if rtvdName == nil && rtvdIp == nil {
-						break
-					}
-				} else if tc.kind == "svc" {
-					rtvdName := cache.GetSvcByName(tc.initialObj.(*v1.Service).Namespace, tc.initialObj.(*v1.Service).Name)
-					rtvdIp := cache.GetSvcByIp(tc.initialObj.(*v1.Service).Spec.ClusterIP)
-					if rtvdName == nil && rtvdIp == nil {
-						break
-					}
-				}
-				time.Sleep(time.Nanosecond)
-
-				require.False(t, time.Since(start) > 1*time.Second, "Timed out waiting for object to be deleted")
-			}
-		})
-	}
+	cache.Stop() // last user -> Close() nils the maps while Get* may be running
+	<-done
 }
 
 func constructPod(name, namespace, ip string) *v1.Pod {

--- a/pkg/operators/common/kubeinventorycache.go
+++ b/pkg/operators/common/kubeinventorycache.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Inspektor Gadget authors
+// Copyright 2023-2026 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@ package common
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	k8sCache "k8s.io/client-go/tools/cache"
@@ -30,21 +32,23 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/k8sutil"
 )
 
-type SlimObjectMeta struct {
-	Name            string                  `json:"name"`
-	Namespace       string                  `json:"namespace"`
-	ResourceVersion string                  `json:"resourceVersion"`
-	Labels          map[string]string       `json:"labels"`
-	OwnerReferences []metav1.OwnerReference `json:"ownerReferences"`
-}
+var (
+	_ metav1.Object  = (*SlimPod)(nil)
+	_ runtime.Object = (*SlimPod)(nil)
+	_ metav1.Object  = (*SlimService)(nil)
+	_ runtime.Object = (*SlimService)(nil)
+)
 
 // SlimPod is a reduced version of v1.Pod, it only contains the fields that are
-// needed to enrich events.
+// needed to enrich events. It embeds metav1.TypeMeta and metav1.ObjectMeta so
+// it satisfies metav1.Object and runtime.Object, which lets the shared informer
+// store it directly via WithTransform (the informer recomputes its store key
+// with MetaNamespaceKeyFunc on the transformed object).
 type SlimPod struct {
-	metav1.TypeMeta `json:",inline"`
-	SlimObjectMeta  `json:",inline"`
-	Spec            SlimPodSpec   `json:"spec"`
-	Status          SlimPodStatus `json:"status"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              SlimPodSpec   `json:"spec"`
+	Status            SlimPodStatus `json:"status"`
 }
 
 type SlimPodSpec struct {
@@ -60,7 +64,7 @@ type SlimPodStatus struct {
 func NewSlimPod(p *v1.Pod) *SlimPod {
 	return &SlimPod{
 		TypeMeta: p.TypeMeta,
-		SlimObjectMeta: SlimObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:            p.Name,
 			Namespace:       p.Namespace,
 			ResourceVersion: p.ResourceVersion,
@@ -78,12 +82,24 @@ func NewSlimPod(p *v1.Pod) *SlimPod {
 	}
 }
 
+func (in *SlimPod) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(SlimPod)
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Spec = in.Spec
+	out.Status = in.Status
+	return out
+}
+
 // SlimService is a reduced version of v1.Service, it only contains the fields
 // that are needed to enrich events.
 type SlimService struct {
-	metav1.TypeMeta `json:",inline"`
-	SlimObjectMeta  `json:",inline"`
-	Spec            SlimServiceSpec `json:"spec"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              SlimServiceSpec `json:"spec"`
 }
 
 type SlimServiceSpec struct {
@@ -94,7 +110,7 @@ type SlimServiceSpec struct {
 func NewSlimService(s *v1.Service) *SlimService {
 	return &SlimService{
 		TypeMeta: s.TypeMeta,
-		SlimObjectMeta: SlimObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:            s.Name,
 			Namespace:       s.Namespace,
 			ResourceVersion: s.ResourceVersion,
@@ -108,8 +124,27 @@ func NewSlimService(s *v1.Service) *SlimService {
 	}
 }
 
+func (in *SlimService) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(SlimService)
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Spec = in.Spec
+	out.Spec.Selector = maps.Clone(in.Spec.Selector)
+	return out
+}
+
 // K8sInventoryCache is a cache of Kubernetes resources such as pods and services
 // that can be used by operators to enrich events.
+//
+// Objects returned by the Get* methods are the same *SlimPod/*SlimService
+// pointers the shared informer produced and are shared across all callers (and
+// the informer's own store). They MUST be treated as read-only: mutating a
+// returned object (or its Labels/OwnerReferences/Selector maps) corrupts the
+// informer cache and races other consumers. Deep-copy first if you need to
+// modify or retain a stable view.
 type K8sInventoryCache interface {
 	Start()
 	Stop()
@@ -130,19 +165,37 @@ type inventoryCache struct {
 	podsHandler k8sCache.ResourceEventHandlerRegistration
 	svcsHandler k8sCache.ResourceEventHandlerRegistration
 
+	// Live store. These hold the SAME *SlimPod/*SlimService pointers the
+	// informer's transform produced (no extra copy of the data). We own these
+	// maps so that, on delete, the live->grace transition is atomic
+	// (cachedmap.Remove moves the entry from "current" to the TTL-pruned "old"
+	// set under one lock). That closes the lookup gap a delete would otherwise
+	// open: client-go drops the object from its own indexer synchronously but
+	// dispatches OnDelete to us asynchronously, so reading the informer's indexer
+	// directly would briefly miss a just-deleted object before we could re-add
+	// it. Here Get always sees it in current or old, never absent.
 	pods     cachedmap.CachedMap[string, *SlimPod]
 	podsByIp cachedmap.CachedMap[string, *SlimPod]
 	svcs     cachedmap.CachedMap[string, *SlimService]
 	svcsByIp cachedmap.CachedMap[string, *SlimService]
+	// mapsMu guards the map fields above (the pointers, not their contents -
+	// cachedmap is internally synchronized). Get* and the event handlers take
+	// RLock; Start (assigning the maps) and Close (nil-ing them) take Lock, so a
+	// concurrent Stop can never race a lookup into a nil-map panic.
+	mapsMu sync.RWMutex
 
 	exit chan struct{}
+
+	// graceTTL is how long deleted entries remain resolvable after deletion.
+	// Zero means the default of 2s; settable in tests.
+	graceTTL time.Duration
 
 	useCount      int
 	useCountMutex sync.Mutex
 }
 
 const (
-	informerResync = 10 * time.Minute
+	informerResync = 0 // no resync
 )
 
 var (
@@ -161,41 +214,9 @@ func GetK8sInventoryCache() (K8sInventoryCache, error) {
 func transformObject(obj any) (any, error) {
 	switch t := obj.(type) {
 	case *v1.Pod:
-		p := &v1.Pod{
-			TypeMeta: t.TypeMeta,
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            t.Name,
-				Namespace:       t.Namespace,
-				ResourceVersion: t.ResourceVersion,
-				Labels:          t.Labels,
-				OwnerReferences: t.OwnerReferences,
-			},
-			Status: v1.PodStatus{
-				HostIP: t.Status.HostIP,
-				PodIP:  t.Status.PodIP,
-			},
-			Spec: v1.PodSpec{
-				HostNetwork: t.Spec.HostNetwork,
-				NodeName:    t.Spec.NodeName,
-			},
-		}
-		return p, nil
+		return NewSlimPod(t), nil
 	case *v1.Service:
-		s := &v1.Service{
-			TypeMeta: t.TypeMeta,
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            t.Name,
-				Namespace:       t.Namespace,
-				ResourceVersion: t.ResourceVersion,
-				Labels:          t.Labels,
-				OwnerReferences: t.OwnerReferences,
-			},
-			Spec: v1.ServiceSpec{
-				ClusterIP: t.Spec.ClusterIP,
-				Selector:  t.Spec.Selector,
-			},
-		}
-		return s, nil
+		return NewSlimService(t), nil
 	default:
 		return obj, nil
 	}
@@ -221,6 +242,8 @@ func (cache *inventoryCache) Close() {
 		cache.factory.Shutdown()
 		cache.factory = nil
 	}
+	cache.mapsMu.Lock()
+	defer cache.mapsMu.Unlock()
 	if cache.pods != nil {
 		cache.pods.Close()
 		cache.pods = nil
@@ -248,13 +271,31 @@ func (cache *inventoryCache) Start() {
 		cache.factory = informers.NewSharedInformerFactoryWithOptions(
 			cache.clientset, informerResync, informers.WithTransform(transformObject),
 		)
-		cache.pods = cachedmap.NewCachedMap[string, *SlimPod](2 * time.Second)
-		cache.podsByIp = cachedmap.NewCachedMap[string, *SlimPod](2 * time.Second)
-		cache.svcs = cachedmap.NewCachedMap[string, *SlimService](2 * time.Second)
-		cache.svcsByIp = cachedmap.NewCachedMap[string, *SlimService](2 * time.Second)
+		// cachedmap keeps deleted entries resolvable for graceTTL (its "old" set).
+		graceTTL := cache.graceTTL
+		if graceTTL <= 0 {
+			graceTTL = 2 * time.Second
+		}
+		cache.mapsMu.Lock()
+		cache.pods = cachedmap.NewCachedMap[string, *SlimPod](graceTTL)
+		cache.podsByIp = cachedmap.NewCachedMap[string, *SlimPod](graceTTL)
+		cache.svcs = cachedmap.NewCachedMap[string, *SlimService](graceTTL)
+		cache.svcsByIp = cachedmap.NewCachedMap[string, *SlimService](graceTTL)
+		cache.mapsMu.Unlock()
 
-		cache.factory.Core().V1().Pods().Informer().AddEventHandler(cache)
-		cache.factory.Core().V1().Services().Informer().AddEventHandler(cache)
+		podsInformer := cache.factory.Core().V1().Pods().Informer()
+		svcsInformer := cache.factory.Core().V1().Services().Informer()
+
+		// Our handlers maintain the live maps from the transformed *SlimPod/
+		// *SlimService objects the informer delivers.
+		var err error
+		if cache.podsHandler, err = podsInformer.AddEventHandler(cache); err != nil {
+			log.Warnf("adding pod event handler: %v", err)
+		}
+		if cache.svcsHandler, err = svcsInformer.AddEventHandler(cache); err != nil {
+			log.Warnf("adding service event handler: %v", err)
+		}
+
 		cache.exit = make(chan struct{})
 		cache.factory.Start(cache.exit)
 		cache.factory.WaitForCacheSync(cache.exit)
@@ -274,10 +315,20 @@ func (cache *inventoryCache) Stop() {
 }
 
 func (cache *inventoryCache) GetPods() []*SlimPod {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.pods == nil {
+		return nil
+	}
 	return cache.pods.Values()
 }
 
 func (cache *inventoryCache) GetPodByName(namespace string, name string) *SlimPod {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.pods == nil {
+		return nil
+	}
 	pod, found := cache.pods.Get(namespace + "/" + name)
 	if !found {
 		return nil
@@ -286,6 +337,11 @@ func (cache *inventoryCache) GetPodByName(namespace string, name string) *SlimPo
 }
 
 func (cache *inventoryCache) GetPodByIp(ip string) *SlimPod {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.podsByIp == nil {
+		return nil
+	}
 	pod, found := cache.podsByIp.Get(ip)
 	if !found {
 		return nil
@@ -294,10 +350,20 @@ func (cache *inventoryCache) GetPodByIp(ip string) *SlimPod {
 }
 
 func (cache *inventoryCache) GetSvcs() []*SlimService {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.svcs == nil {
+		return nil
+	}
 	return cache.svcs.Values()
 }
 
 func (cache *inventoryCache) GetSvcByName(namespace string, name string) *SlimService {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.svcs == nil {
+		return nil
+	}
 	svc, found := cache.svcs.Get(namespace + "/" + name)
 	if !found {
 		return nil
@@ -306,6 +372,11 @@ func (cache *inventoryCache) GetSvcByName(namespace string, name string) *SlimSe
 }
 
 func (cache *inventoryCache) GetSvcByIp(ip string) *SlimService {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	if cache.svcsByIp == nil {
+		return nil
+	}
 	svc, found := cache.svcsByIp.Get(ip)
 	if !found {
 		return nil
@@ -314,103 +385,102 @@ func (cache *inventoryCache) GetSvcByIp(ip string) *SlimService {
 }
 
 func (cache *inventoryCache) OnAdd(obj any, _ bool) {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
 	switch o := obj.(type) {
-	case *v1.Pod:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnAdd: error getting key for pod: %v", err)
+	case *SlimPod:
+		if cache.pods == nil {
 			return
 		}
-		if key == "" {
-			log.Warnf("OnAdd: empty key for pod")
+		cache.pods.Add(o.Namespace+"/"+o.Name, o)
+		// hostNetwork pods share the node IP, so indexing them by IP would make
+		// the IP ambiguous - skip it.
+		if ip := o.Status.PodIP; ip != "" && !o.Spec.HostNetwork {
+			cache.podsByIp.Add(ip, o)
+		}
+	case *SlimService:
+		if cache.svcs == nil {
 			return
 		}
-		slimPod := NewSlimPod(o)
-		cache.pods.Add(key, slimPod)
-		if ip := slimPod.Status.PodIP; ip != "" {
-			cache.podsByIp.Add(ip, slimPod)
-		}
-	case *v1.Service:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnAdd: error getting key for service: %v", err)
-			return
-		}
-		if key == "" {
-			log.Warnf("OnAdd: empty key for svc")
-			return
-		}
-		slimService := NewSlimService(o)
-		cache.svcs.Add(key, slimService)
-		if ip := slimService.Spec.ClusterIP; ip != "" {
-			cache.svcsByIp.Add(ip, slimService)
+		cache.svcs.Add(o.Namespace+"/"+o.Name, o)
+		if ip := o.Spec.ClusterIP; ip != "" {
+			cache.svcsByIp.Add(ip, o)
 		}
 	default:
 		log.Warnf("OnAdd: unknown object type: %T", o)
 	}
 }
 
-func (cache *inventoryCache) OnUpdate(_, newObj any) {
-	switch o := newObj.(type) {
-	case *v1.Pod:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnUpdate: error getting key for pod: %v", err)
+func (cache *inventoryCache) OnUpdate(oldObj, newObj any) {
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
+	switch n := newObj.(type) {
+	case *SlimPod:
+		if cache.pods == nil {
 			return
 		}
-		if key == "" {
-			log.Warnf("OnUpdate: empty key for pod")
+		cache.pods.Add(n.Namespace+"/"+n.Name, n)
+		newIP := ""
+		if !n.Spec.HostNetwork {
+			newIP = n.Status.PodIP
+		}
+		// Drop the stale IP mapping when a pod's IP changes, otherwise the old
+		// IP would keep resolving to this pod.
+		if o, ok := oldObj.(*SlimPod); ok && !o.Spec.HostNetwork {
+			if oldIP := o.Status.PodIP; oldIP != "" && oldIP != newIP {
+				cache.podsByIp.Remove(oldIP)
+			}
+		}
+		if newIP != "" {
+			cache.podsByIp.Add(newIP, n)
+		}
+	case *SlimService:
+		if cache.svcs == nil {
 			return
 		}
-		slimPod := NewSlimPod(o)
-		cache.pods.Add(key, slimPod)
-		if ip := slimPod.Status.PodIP; ip != "" {
-			cache.podsByIp.Add(ip, slimPod)
+		cache.svcs.Add(n.Namespace+"/"+n.Name, n)
+		newIP := n.Spec.ClusterIP
+		if o, ok := oldObj.(*SlimService); ok {
+			if oldIP := o.Spec.ClusterIP; oldIP != "" && oldIP != newIP {
+				cache.svcsByIp.Remove(oldIP)
+			}
 		}
-	case *v1.Service:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnUpdate: error getting key for service: %v", err)
-			return
-		}
-		if key == "" {
-			log.Warnf("OnUpdate: empty key for svc")
-			return
-		}
-		slimService := NewSlimService(o)
-		cache.svcs.Add(key, slimService)
-		if ip := slimService.Spec.ClusterIP; ip != "" {
-			cache.svcsByIp.Add(ip, slimService)
+		if newIP != "" {
+			cache.svcsByIp.Add(newIP, n)
 		}
 	default:
-		log.Warnf("OnUpdate: unknown object type: %T", o)
+		log.Warnf("OnUpdate: unknown object type: %T", n)
 	}
 }
 
 func (cache *inventoryCache) OnDelete(obj any) {
+	// Unwrap the tombstone before locking so we never take RLock recursively
+	// (Go's RWMutex RLock is not safely reentrant when a writer is queued).
+	if tombstone, ok := obj.(k8sCache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	cache.mapsMu.RLock()
+	defer cache.mapsMu.RUnlock()
 	switch o := obj.(type) {
-	case *v1.Pod:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnDelete: error getting key for pod: %v", err)
+	case *SlimPod:
+		if cache.pods == nil {
 			return
 		}
-		cache.pods.Remove(key)
-		if ip := o.Status.PodIP; ip != "" {
+		// cachedmap.Remove atomically moves the entry from "current" to the
+		// TTL-pruned "old" set, so a concurrent Get still resolves it during the
+		// grace window - there is no gap where it is absent.
+		cache.pods.Remove(o.Namespace + "/" + o.Name)
+		if ip := o.Status.PodIP; ip != "" && !o.Spec.HostNetwork {
 			cache.podsByIp.Remove(ip)
 		}
-	case *v1.Service:
-		key, err := k8sCache.MetaNamespaceKeyFunc(o)
-		if err != nil {
-			log.Warnf("OnDelete: error getting key for service: %v", err)
+	case *SlimService:
+		if cache.svcs == nil {
 			return
 		}
-		cache.svcs.Remove(key)
+		cache.svcs.Remove(o.Namespace + "/" + o.Name)
 		if ip := o.Spec.ClusterIP; ip != "" {
 			cache.svcsByIp.Remove(ip)
 		}
-	case k8sCache.DeletedFinalStateUnknown:
-		cache.OnDelete(o.Obj)
 	default:
 		log.Warnf("OnDelete: unknown object type: %T", o)
 	}

--- a/pkg/operators/kubeipresolver/kubeipresolver.go
+++ b/pkg/operators/kubeipresolver/kubeipresolver.go
@@ -127,6 +127,8 @@ func (k *KubeIPResolver) InstanceParams() api.Params {
 
 type endpointAccessors struct {
 	root              datasource.FieldAccessor
+	ip                datasource.FieldAccessor
+	version           datasource.FieldAccessor
 	subK8sKind        datasource.FieldAccessor
 	subK8sName        datasource.FieldAccessor
 	subK8sNamespace   datasource.FieldAccessor
@@ -221,6 +223,8 @@ func (k *KubeIPResolver) InstantiateDataOperator(gadgetCtx operators.GadgetConte
 
 			ea := endpointAccessors{
 				root:              ep,
+				ip:                ips[0],
+				version:           version[0],
 				subK8sKind:        k8sKindAcc,
 				subK8sName:        k8sNameAcc,
 				subK8sNamespace:   k8sNamespaceAcc,
@@ -268,9 +272,7 @@ func (m *KubeIPResolverInstance) PreStart(gadgetCtx operators.GadgetContext) err
 		ds.Subscribe(func(source datasource.DataSource, data datasource.Data) error {
 			var errs error
 			for _, a := range acc {
-				ip := a.root.GetSubFieldsWithTag("type:" + ipAddrType)[0]
-				version := a.root.GetSubFieldsWithTag("name:version")[0]
-				addrStr, err := common.GetIPForVersion(data, version, ip)
+				addrStr, err := common.GetIPForVersion(data, a.version, a.ip)
 				if err != nil {
 					errors.Join(errs, fmt.Errorf("%s: getting IP: %w", a.root.Name(), err))
 					continue


### PR DESCRIPTION
## What

The K8s inventory cache kept the same pod/service data in RAM twice: the shared
informer stored a reduced `*v1.Pod`/`*v1.Service` in its own indexer (via
`WithTransform`), and the cache *also* built separate `*SlimPod`/`*SlimService`
objects in its `cachedmap`s. This makes the informer transform emit the slim
type directly, so there is now a single object per resource.

## How

- `transformObject` returns `*SlimPod`/`*SlimService` instead of a trimmed
  `*v1.Pod`/`*v1.Service`.
- `SlimPod`/`SlimService` embed `metav1.TypeMeta` + `metav1.ObjectMeta` and
  implement `DeepCopyObject()`, so they satisfy `metav1.Object` + `runtime.Object`
  (required for the informer to key and store them).
- The cache's `cachedmap`s now hold the *same* slim pointers the informer
  delivered — no second copy of the data, just pointer references.

The live→grace transition on delete stays atomic (`cachedmap.Remove` moves the
entry to its TTL-pruned set under one lock), so a lookup concurrent with a
deletion never sees a gap where the object is absent.

## Behavior changes / fixes

- **Fix stale by-IP entry on IP change:** `OnUpdate` now drops the old IP mapping
  when a pod/service IP changes (previously the old IP kept resolving).
- **Skip by-IP indexing for hostNetwork pods:** they share the node IP, so
  indexing them by IP is ambiguous; they remain resolvable by name.
- **Guard map access with an RWMutex:** `Get*`/handlers take `RLock`,
  `Start`/`Close` take `Lock`, removing a latent data race / nil-map panic when a
  concurrent `Stop()` tears the cache down.