### PR TITLE
trace_exec: read args from the new process address space

### DIFF
--- a/gadgets/trace_exec/dev.md
+++ b/gadgets/trace_exec/dev.md
@@ -12,31 +12,41 @@ The following diagrams are generated using the `ig image inspect` command. Note 
 flowchart LR
 bufs[("bufs")]
 events[("events")]
+events_lost_samples[("events_lost_samples")]
+exec_argv[("exec_argv")]
 execs[("execs")]
 gadget_mntns_filter_map[("gadget_mntns_filter_map")]
 security_bprm_hit_map[("security_bprm_hit_map")]
 ig_execve_e -- "Lookup" --> gadget_mntns_filter_map
 ig_execve_e -- "Lookup+Update" --> execs
 ig_execve_e -- "Lookup" --> bufs
+ig_execve_e -- "Update" --> exec_argv
 ig_execve_e["ig_execve_e"]
 ig_execve_x -- "Lookup+Delete" --> execs
+ig_execve_x -- "Lookup+Delete" --> exec_argv
 ig_execve_x -- "Lookup" --> bufs
+ig_execve_x -- "Lookup" --> events_lost_samples
 ig_execve_x -- "EventOutput" --> events
 ig_execve_x -- "Delete" --> security_bprm_hit_map
 ig_execve_x["ig_execve_x"]
 ig_execveat_e -- "Lookup" --> gadget_mntns_filter_map
 ig_execveat_e -- "Lookup+Update" --> execs
 ig_execveat_e -- "Lookup" --> bufs
+ig_execveat_e -- "Update" --> exec_argv
 ig_execveat_e["ig_execveat_e"]
 ig_execveat_x -- "Lookup+Delete" --> execs
+ig_execveat_x -- "Lookup+Delete" --> exec_argv
 ig_execveat_x -- "Lookup" --> bufs
+ig_execveat_x -- "Lookup" --> events_lost_samples
 ig_execveat_x -- "EventOutput" --> events
 ig_execveat_x -- "Delete" --> security_bprm_hit_map
 ig_execveat_x["ig_execveat_x"]
 ig_sched_exec -- "Lookup+Delete" --> execs
 ig_sched_exec -- "Lookup" --> bufs
+ig_sched_exec -- "Lookup" --> events_lost_samples
 ig_sched_exec -- "EventOutput" --> events
 ig_sched_exec -- "Delete" --> security_bprm_hit_map
+ig_sched_exec -- "Delete" --> exec_argv
 ig_sched_exec["ig_sched_exec"]
 security_bprm_check -- "Lookup" --> execs
 security_bprm_check -- "Lookup+Update" --> security_bprm_hit_map
@@ -60,6 +70,8 @@ box eBPF Maps
 participant gadget_mntns_filter_map
 participant execs
 participant bufs
+participant exec_argv
+participant events_lost_samples
 participant events
 participant security_bprm_hit_map
 end
@@ -67,25 +79,35 @@ ig_execve_e->>gadget_mntns_filter_map: Lookup
 ig_execve_e->>execs: Update
 ig_execve_e->>execs: Lookup
 ig_execve_e->>bufs: Lookup
+ig_execve_e->>exec_argv: Update
 ig_execve_x->>execs: Lookup
+ig_execve_x->>exec_argv: Lookup
 ig_execve_x->>bufs: Lookup
+ig_execve_x->>events_lost_samples: Lookup
 ig_execve_x->>events: EventOutput
 ig_execve_x->>execs: Delete
 ig_execve_x->>security_bprm_hit_map: Delete
+ig_execve_x->>exec_argv: Delete
 ig_execveat_e->>gadget_mntns_filter_map: Lookup
 ig_execveat_e->>execs: Update
 ig_execveat_e->>execs: Lookup
 ig_execveat_e->>bufs: Lookup
+ig_execveat_e->>exec_argv: Update
 ig_execveat_x->>execs: Lookup
+ig_execveat_x->>exec_argv: Lookup
 ig_execveat_x->>bufs: Lookup
+ig_execveat_x->>events_lost_samples: Lookup
 ig_execveat_x->>events: EventOutput
 ig_execveat_x->>execs: Delete
 ig_execveat_x->>security_bprm_hit_map: Delete
+ig_execveat_x->>exec_argv: Delete
 ig_sched_exec->>execs: Lookup
 ig_sched_exec->>bufs: Lookup
+ig_sched_exec->>events_lost_samples: Lookup
 ig_sched_exec->>events: EventOutput
 ig_sched_exec->>execs: Delete
 ig_sched_exec->>security_bprm_hit_map: Delete
+ig_sched_exec->>exec_argv: Delete
 security_bprm_check->>execs: Lookup
 security_bprm_check->>security_bprm_hit_map: Lookup
 security_bprm_check->>security_bprm_hit_map: Update

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -244,6 +244,29 @@ static __always_inline bool has_upper_layer(struct inode *inode)
 	return upperdentry != NULL;
 }
 
+// read_committed_args re-reads the process arguments from the new process's
+// address space (mm->arg_start .. mm->arg_end)
+static __always_inline void read_committed_args(struct event *event,
+						struct task_struct *task)
+{
+	struct mm_struct *mm = BPF_CORE_READ(task, mm);
+	if (!mm)
+		return;
+
+	unsigned long arg_start = BPF_CORE_READ(mm, arg_start);
+	unsigned long arg_end = BPF_CORE_READ(mm, arg_end);
+	if (arg_end <= arg_start)
+		return;
+
+	u64 args_size = arg_end - arg_start;
+	if (args_size > sizeof(event->args))
+		args_size = sizeof(event->args);
+
+	if (bpf_probe_read_user(event->args, args_size,
+				(const void *)arg_start) == 0)
+		event->args_size = args_size;
+}
+
 // tracepoint/sched/sched_process_exec is called after a successful execve
 SEC("tracepoint/sched/sched_process_exec")
 int ig_sched_exec(struct trace_event_raw_sched_process_exec *ctx)
@@ -275,6 +298,9 @@ int ig_sched_exec(struct trace_event_raw_sched_process_exec *ctx)
 
 	gadget_process_populate(&event->proc);
 	event->error_raw = 0;
+
+	// Re-read the arguments from the new process's memory
+	read_committed_args(event, task);
 
 	if (paths) {
 		char *exepath = get_path_str(&exe_file->f_path);

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -103,7 +103,7 @@ GADGET_TRACER_MAP(events, 1024 * 256);
 
 GADGET_TRACER(exec, events, event);
 
-static __always_inline int enter_execve(const char *pathname, const char **args)
+static __always_inline int enter_execve(const char **args)
 {
 	u64 id;
 	pid_t pid;
@@ -149,7 +149,10 @@ static __always_inline int enter_execve(const char *pathname, const char **args)
 		bpf_probe_read_kernel_str(event->cwd, sizeof(event->cwd), cwd);
 	}
 
-	ret = bpf_probe_read_user_str(event->args, ARGSIZE, pathname);
+	/* args[0] is argv[0] (the command name) */
+	argp = NULL;
+	bpf_probe_read_user(&argp, sizeof(argp), &args[0]);
+	ret = bpf_probe_read_user_str(event->args, ARGSIZE, argp);
 	if (ret <= ARGSIZE) {
 		event->args_size += ret;
 	} else {
@@ -189,17 +192,15 @@ static __always_inline int enter_execve(const char *pathname, const char **args)
 SEC("tracepoint/syscalls/sys_enter_execve")
 int ig_execve_e(struct syscall_trace_enter *ctx)
 {
-	const char *pathname = (const char *)ctx->args[0];
 	const char **args = (const char **)(ctx->args[1]);
-	return enter_execve(pathname, args);
+	return enter_execve(args);
 }
 
 SEC("tracepoint/syscalls/sys_enter_execveat")
 int ig_execveat_e(struct syscall_trace_enter *ctx)
 {
-	const char *pathname = (const char *)ctx->args[1];
 	const char **args = (const char **)(ctx->args[2]);
-	return enter_execve(pathname, args);
+	return enter_execve(args);
 }
 
 static __always_inline bool __is_from_rootfs(struct task_struct *task,

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -99,6 +99,18 @@ struct {
 	__type(value, __u8);
 } security_bprm_hit_map SEC(".maps");
 
+// exec_argv stores the userspace argv pointer captured at sys_enter_execve. The
+// arguments are parsed lazily: from the new process' memory in ig_sched_exec for
+// successful execs, or from the caller's still-mapped memory in exit_execve for
+// failed ones. This avoids parsing argv on the (common) successful path, where
+// the result would be overwritten by the memory read anyway.
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, pid_t);
+	__type(value, __u64);
+} exec_argv SEC(".maps");
+
 GADGET_TRACER_MAP(events, 1024 * 256);
 
 GADGET_TRACER(exec, events, event);
@@ -109,9 +121,7 @@ static __always_inline int enter_execve(const char **args)
 	pid_t pid;
 	struct event *event;
 	struct task_struct *task;
-	unsigned int ret;
-	const char *argp;
-	int i;
+	u64 argv = (u64)args;
 
 	if (gadget_should_discard_data_current())
 		return 0;
@@ -138,9 +148,6 @@ static __always_inline int enter_execve(const char **args)
 	if (bpf_core_field_exists(task->sessionid))
 		event->sessionid = BPF_CORE_READ(task, sessionid);
 
-	event->args_count = 0;
-	event->args_size = 0;
-
 	event->tty = BPF_CORE_READ(task, signal, tty, index);
 
 	if (paths) {
@@ -149,43 +156,11 @@ static __always_inline int enter_execve(const char **args)
 		bpf_probe_read_kernel_str(event->cwd, sizeof(event->cwd), cwd);
 	}
 
-	/* args[0] is argv[0] (the command name) */
-	argp = NULL;
-	bpf_probe_read_user(&argp, sizeof(argp), &args[0]);
-	ret = bpf_probe_read_user_str(event->args, ARGSIZE, argp);
-	if (ret <= ARGSIZE) {
-		event->args_size += ret;
-	} else {
-		/* write an empty string */
-		event->args[0] = '\0';
-		event->args_size++;
-	}
+	// Save the argv pointer; the arguments are parsed later (see
+	// read_committed_args for successful execs and read_args_from_user for
+	// failed ones).
+	bpf_map_update_elem(&exec_argv, &pid, &argv, BPF_ANY);
 
-	event->args_count++;
-#pragma unroll
-	for (i = 1; i < TOTAL_MAX_ARGS; i++) {
-		bpf_probe_read_user(&argp, sizeof(argp), &args[i]);
-		if (!argp)
-			return 0;
-
-		if (event->args_size > LAST_ARG)
-			return 0;
-
-		ret = bpf_probe_read_user_str(&event->args[event->args_size],
-					      ARGSIZE, argp);
-		if (ret > ARGSIZE)
-			return 0;
-
-		event->args_count++;
-		event->args_size += ret;
-	}
-	/* try to read one more argument to check if there is one */
-	bpf_probe_read_user(&argp, sizeof(argp), &args[TOTAL_MAX_ARGS]);
-	if (!argp)
-		return 0;
-
-	/* pointer to max_args+1 isn't null, assume we have more arguments */
-	event->args_count++;
 	return 0;
 }
 
@@ -264,8 +239,12 @@ static __always_inline void read_committed_args(struct event *event,
 		args_size = sizeof(event->args);
 
 	if (bpf_probe_read_user(event->args, args_size,
-				(const void *)arg_start) == 0)
+				(const void *)arg_start) == 0) {
 		event->args_size = args_size;
+		// args_count only needs to be at least the number of arguments; the
+		// byte count is a cheap, safe upper bound (each argument is >= 1 byte).
+		event->args_count = args_size;
+	}
 }
 
 // tracepoint/sched/sched_process_exec is called after a successful execve
@@ -322,14 +301,70 @@ int ig_sched_exec(struct trace_event_raw_sched_process_exec *ctx)
 
 	bpf_map_delete_elem(&execs, &pre_sched_pid);
 	bpf_map_delete_elem(&security_bprm_hit_map, &pre_sched_pid);
+	bpf_map_delete_elem(&exec_argv, &pre_sched_pid);
 
 	return 0;
+}
+
+// read_args_from_user parses the argument vector at argv (a userspace pointer
+// captured at sys_enter_execve) into event->args. It is used for failed execs,
+// whose arguments never made it into a new process' memory. The caller's address
+// space is still intact at sys_exit_execve (a failing execve returns before the
+// point of no return), so the userspace argv is readable there.
+static __always_inline void read_args_from_user(struct event *event, u64 argv)
+{
+	const char **args = (const char **)argv;
+	const char *argp;
+	unsigned int ret;
+	int i;
+
+	event->args_count = 0;
+	event->args_size = 0;
+
+	/* args[0] is argv[0] (the command name) */
+	argp = NULL;
+	bpf_probe_read_user(&argp, sizeof(argp), &args[0]);
+	ret = bpf_probe_read_user_str(event->args, ARGSIZE, argp);
+	if (ret <= ARGSIZE) {
+		event->args_size += ret;
+	} else {
+		/* write an empty string */
+		event->args[0] = '\0';
+		event->args_size++;
+	}
+
+	event->args_count++;
+#pragma unroll
+	for (i = 1; i < TOTAL_MAX_ARGS; i++) {
+		bpf_probe_read_user(&argp, sizeof(argp), &args[i]);
+		if (!argp)
+			return;
+
+		if (event->args_size > LAST_ARG)
+			return;
+
+		ret = bpf_probe_read_user_str(&event->args[event->args_size],
+					      ARGSIZE, argp);
+		if (ret > ARGSIZE)
+			return;
+
+		event->args_count++;
+		event->args_size += ret;
+	}
+	/* try to read one more argument to check if there is one */
+	bpf_probe_read_user(&argp, sizeof(argp), &args[TOTAL_MAX_ARGS]);
+	if (!argp)
+		return;
+
+	/* pointer to max_args+1 isn't null, assume we have more arguments */
+	event->args_count++;
 }
 
 static __always_inline int exit_execve(void *ctx, int retval)
 {
 	u32 pid = (u32)bpf_get_current_pid_tgid();
 	struct event *event;
+	u64 *argv;
 
 	// If the execve was successful, sched/sched_process_exec handled the event
 	// already and deleted the entry. So if we find the entry, it means the
@@ -340,6 +375,13 @@ static __always_inline int exit_execve(void *ctx, int retval)
 
 	if (ignore_failed)
 		goto cleanup;
+
+	// The execve failed, so its arguments never made it into a new process'
+	// memory. Read them from the caller's still-mapped memory using the argv
+	// pointer captured at sys_enter_execve.
+	argv = bpf_map_lookup_elem(&exec_argv, &pid);
+	if (argv)
+		read_args_from_user(event, *argv);
 
 	gadget_process_populate(&event->proc);
 	event->error_raw = -retval;
@@ -359,6 +401,7 @@ static __always_inline int exit_execve(void *ctx, int retval)
 cleanup:
 	bpf_map_delete_elem(&execs, &pid);
 	bpf_map_delete_elem(&security_bprm_hit_map, &pid);
+	bpf_map_delete_elem(&exec_argv, &pid);
 	return 0;
 }
 

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -134,6 +134,10 @@ int main(int argc, char *argv[], char **envp) {
 	// copies /usr/bin/sh to /usr/bin/sh2 to check that the upper_layer is true when executing /usr/bin/sh2
 	cmd := fmt.Sprintf("%s %s && cp /usr/bin/sh /usr/bin/sh2 && setpriv --reuid 1000 --regid 1111 --clear-groups /usr/bin/sh2 -c '%s'", prepareScriptsCmd, buildCmd, innerCmd)
 	innerShArgs := []string{"/usr/bin/sh2", "-c", innerCmd}
+	// with_shebeng.sh has a "#!/bin/sh" shebang, so the kernel executes it as
+	// "/bin/sh /bin/with_shebeng.sh". As the arguments are read from the new
+	// process' memory (/proc/<pid>/cmdline), they reflect the interpreter's argv.
+	shebangArgs := []string{"/bin/sh", "/bin/with_shebeng.sh"}
 
 	testContainer := containerFactory.NewContainer(containerName, cmd, containerOpts...)
 
@@ -207,7 +211,7 @@ int main(int argc, char *argv[], char **envp) {
 						CommonData:    utils.BuildCommonData(containerName, commonDataOpts...),
 						Proc:          utils.BuildProc("with_shebeng.sh", 1000, 1111),
 						Cwd:           "/tmp",
-						Args:          "/bin/with_shebeng.sh",
+						Args:          strings.Join(shebangArgs, consts.ArgsSeparator),
 						PupperLayer:   true,
 						UpperLayer:    false,
 						FupperLayer:   true,

--- a/gadgets/trace_exec/test/unit/trace_exec_test.go
+++ b/gadgets/trace_exec/test/unit/trace_exec_test.go
@@ -66,11 +66,14 @@ func TestTraceExecGadget(t *testing.T) {
 		},
 		"large_argument_list": {
 			runnerConfig: &utils.RunnerConfig{},
-			// should only capture TOTAL_ARGS_SIZE ~ 20 arguments
+			// The arguments are read from the new process' memory
+			// (mm->arg_start .. mm->arg_end), so the whole argument list is
+			// captured as long as it fits in the args buffer (bounded by bytes,
+			// FULL_MAX_ARGS_ARR, rather than by a fixed number of arguments).
 			argv: []string{"/bin/echo", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10", "arg11", "arg12", "arg13", "arg14", "arg15", "arg16", "arg17", "arg18", "arg19", "arg20", "arg21"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
-				expectedArgs := strings.Join(inputArgs[:20], traceexec.ArgsSeparator)
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[0].Args)
 			},
 		},
@@ -133,8 +136,9 @@ func TestTraceExecGadget(t *testing.T) {
 			runFromThread: true,
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 2, "Expected 2 events but got %d", len(events))
-				// We do not check the full path of the executable/symlink here, as it may vary depending on the environment.
-				require.Contains(t, events[0].Args, "/bin/python3"+traceexec.ArgsSeparator+"-c")
+				// args are read from the new process' memory, so argv[0] is the
+				// value passed to execve ("python3") and not the resolved path.
+				require.Contains(t, events[0].Args, "python3"+traceexec.ArgsSeparator+"-c")
 				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[1].Args)
 			},
@@ -145,8 +149,9 @@ func TestTraceExecGadget(t *testing.T) {
 			runFromThread: true,
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 2, "Expected 2 events but got %d", len(events))
-				// We do not check the full path of the executable/symlink here, as it may vary depending on the environment.
-				require.Contains(t, events[0].Args, "/bin/python3"+traceexec.ArgsSeparator+"-c")
+				// args are read from the new process' memory, so argv[0] is the
+				// value passed to execve ("python3") and not the resolved path.
+				require.Contains(t, events[0].Args, "python3"+traceexec.ArgsSeparator+"-c")
 				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
 				require.Equal(t, expectedArgs, events[1].Args)
 				require.Equal(t, "ENOENT", events[1].Error)

--- a/gadgets/trace_exec/test/unit/trace_exec_test.go
+++ b/gadgets/trace_exec/test/unit/trace_exec_test.go
@@ -48,8 +48,12 @@ type testDef struct {
 	runnerConfig   *utils.RunnerConfig
 	mntnsFilterMap func(info *utils.RunnerInfo) *ebpf.Map
 	argv           []string
-	runFromThread  bool
-	validate       func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string)
+	// execPath, when set, is the path passed to execve while argv is used as
+	// the argument vector. It allows testing an argv[0] that differs from the
+	// executed path.
+	execPath      string
+	runFromThread bool
+	validate      func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string)
 }
 
 func TestTraceExecGadget(t *testing.T) {
@@ -105,6 +109,19 @@ func TestTraceExecGadget(t *testing.T) {
 		"error": {
 			runnerConfig: &utils.RunnerConfig{},
 			argv:         []string{"/bin/foobar", "hello"},
+			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
+				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
+				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
+				require.Equal(t, expectedArgs, events[0].Args)
+				require.Equal(t, "ENOENT", events[0].Error)
+			},
+		},
+		"failed_exec_argv0_differs_from_path": {
+			runnerConfig: &utils.RunnerConfig{},
+			// execve() a non-existent path with an argv[0] that differs from it.
+			// The reported args must reflect the real argv[0], not the path.
+			execPath: "/bin/nonexistent-trace-exec-xyz",
+			argv:     []string{"masked-name", "arg1"},
 			validate: func(t *testing.T, info *utils.RunnerInfo, events []ExpectedTraceExecEvent, inputArgs []string) {
 				require.Len(t, events, 1, "Expected 1 event but got %d", len(events))
 				expectedArgs := strings.Join(inputArgs, traceexec.ArgsSeparator)
@@ -175,7 +192,11 @@ func TestTraceExecGadget(t *testing.T) {
 					if testCase.runFromThread {
 						generateEventFromThread(t, testCase.argv)
 					} else {
-						p, err := os.StartProcess(testCase.argv[0], testCase.argv, &os.ProcAttr{})
+						path := testCase.argv[0]
+						if testCase.execPath != "" {
+							path = testCase.execPath
+						}
+						p, err := os.StartProcess(path, testCase.argv, &os.ProcAttr{})
 						if err == nil {
 							defer p.Wait()
 						}


### PR DESCRIPTION
# trace_exec: read args from the new process address space

The `trace_exec` gadget used to collect a process's arguments at `sys_enter_execve`/`sys_enter_execveat` by following the caller's userspace `argv` pointers. This PR introduces a second argument collection at `tracepoint/sched/sched_process_exec` and reads them straight from the new process's memory (`mm->arg_start .. mm->arg_end`) which is the exact region exposed by `/proc/<pid>/cmdline`. As a result, the reported `args` always match the command line the process actually runs with.

This makes `args` consistent with `/proc/<pid>/cmdline` and `ps`, with a few visible effects reviewers should be aware of:
- The first element is the real `argv[0]` the process was invoked with (e.g. `iptables`, `python3`) instead of the resolved executable path. The resolved path is still reported separately in `exepath`/`file` (with `--paths`).
- For scripts, `args` includes the interpreter that actually runs, e.g. `/bin/sh /path/script.sh`. This is a change from current behavior.
- The whole argument vector is captured up to the args buffer size (`FULL_MAX_ARGS_ARR`, 5120 bytes) instead of being limited to a fixed number of arguments.

The second args collection works only for successful executions. Failed `execve` never reaches `tracepoint/sched/sched_process_exec`, so failed executions keep reporting the attempted arguments captured at syscall entry, exactly as before. The change reuses the existing `args` buffer, so it does not add any per-event memory. The affected unit/integration tests are updated accordingly.


## How to use
Build the gadget and run it while executing a few processes, then confirm the reported `args` match `/proc/<pid>/cmdline`:

```bash
# Build the gadget
$ cd gadgets && make trace_exec

# Trace executions on the host
$ ig run ghcr.io/inspektor-gadget/gadget/trace_exec:dorser-exec-args --verify-image=false -o json --host
```

## Testing done

- Built the gadget
- Ran the unit tests that exercise the argument-collection paths:
```
'TestTraceExecGadget/(simple_executable|large_argument_list|successful_exec_from_thread|failed_exec_from_thread|error|uid_gid)' \
    ./trace_exec/test/unit/...
--- PASS: TestTraceExecGadget (0.00s)
    --- PASS: TestTraceExecGadget/error (21.65s)
    --- PASS: TestTraceExecGadget/simple_executable (27.35s)
    --- PASS: TestTraceExecGadget/uid_gid (32.22s)
    --- PASS: TestTraceExecGadget/failed_exec_from_thread (36.13s)
    --- PASS: TestTraceExecGadget/successful_exec_from_thread (39.32s)
    --- PASS: TestTraceExecGadget/large_argument_list (41.61s)
ok      github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/test/unit       41.714s
```
- Manually confirmed the output matches `/proc/<pid>/cmdline` for both binaries and scripts
