### PR TITLE
include: mask I_CTIME_QUERIED flag when reading inode ctime

### DIFF
--- a/include/gadget/core_fixes.bpf.h
+++ b/include/gadget/core_fixes.bpf.h
@@ -278,6 +278,12 @@ struct inode___older_v611 {
 	struct timespec64 __i_ctime;
 };
 
+// On kernels with multigrain timestamps (>= v6.13), the top bit of i_ctime_nsec
+// holds the I_CTIME_QUERIED flag, which the kernel masks out in
+// inode_get_ctime_nsec().
+// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4e40eff0b5737c0de39e1ae5812509efbc0b986e
+#define I_CTIME_QUERIED (1U << 31)
+
 // Based on get_ctime_nanosec_timespec from:
 // https://github.com/aquasecurity/tracee/blob/main/pkg/ebpf/c/common/filesystem.h#L61
 static __always_inline u64
@@ -309,7 +315,9 @@ gadget_get_ctime_nanosec_from_inode(struct inode *inode)
 	if (sec < 0)
 		return 0;
 
-	return (u64)sec * 1000000000ULL + (u32)nsec;
+	// Mask I_CTIME_QUERIED so the value matches stat(); harmless on older
+	// kernels where nsec < 1e9 keeps the bit clear.
+	return (u64)sec * 1000000000ULL + ((u32)nsec & ~I_CTIME_QUERIED);
 }
 
 /**


### PR DESCRIPTION
# include: mask I_CTIME_QUERIED flag when reading inode ctime

Fixes: 86ea94b7d2db ("include: add CO-RE helpers for inode ctime and syscall access")

`gadget_get_ctime_nanosec_from_inode()` in `include/gadget/core_fixes.bpf.h` returns `sec * 1e9 + nsec` using the raw `i_ctime_nsec` field. On kernels with multigrain timestamps (>= v6.13), the top bit of `i_ctime_nsec` is not part of the nanoseconds — it carries the `I_CTIME_QUERIED` flag (`BIT(31)`), which the kernel sets when a coarse-grained ctime is observed (e.g. via `stat()`) and masks out in `inode_get_ctime_nsec()` before exposing it to userspace. This helper never masks it, so when the flag is set the reported change time is exactly `2^31` ns (~2.147 s) too high.

This is a low-severity, conditional correctness bug: it only affects the `ctime`/`fctime`/`pctime` fields of `trace_exec` (the sole user of the helper upstream), only on a >= v6.13 kernel backed by a multigrain filesystem (ext4, XFS, btrfs, tmpfs), and only while the inode's ctime has been queried since its last change. The skew is bounded and deterministic (`+2^31` ns, always), toggles on/off as the flag is set and cleared, and those fields are hidden by default but it silently breaks any exact comparison of the reported change time against `stat()`/the filesystem (e.g. baseline or drift detection based on ctime).

The fix masks `BIT(31)`, mirroring the kernel's own `inode_get_ctime_nsec()`. It is provably safe on every kernel and filesystem: a valid nanosecond value is always `< 10^9 < 2^30`, so bit 31 is never part of real time data. On kernels without multigrain, and on filesystems that did not opt in, the flag is never set and the mask is a pure no-op.

## How to use

Reproducing requires a >= v6.13 kernel and a multigrain filesystem, so the executed binary's inode can carry the flag (ext4/XFS/btrfs/tmpfs). Note the kernel-matrix CI job runs the gadget tests under vimto, where files are served over virtiofs which is a non-multigrain filesystem, so the flag is never set there and the bug does not reproduce in that job.

Run the `trace_exec` unit tests directly on such a host (they compare the gadget's `ctime`/`fctime` against `stat()` of `/bin/echo`):

```bash
cd gadgets && GADGET_REPOSITORY=ghcr.io/inspektor-gadget/gadget GADGET_TAG=latest \
  go test -v -exec 'sudo -E' -run 'TestTraceExecGadget/ctime' ./trace_exec/test/unit/...
```

## Testing done

On a v6.17 host (`6.17.0-1008-azure`) with `/bin/echo` on ext4.

**Before**: the gadget's ctime was exactly `2^31` ns above `stat()`:

```
--- FAIL: TestTraceExecGadget/ctime
    trace_exec_test.go:123:
        Error:      Not equal:
                    expected: 0x189dedd1b448b34d   (stat of /bin/echo)
                    actual  : 0x189dedd23448b34d   (gadget ctime)
        Messages:   ctime should match stat ctime of /bin/echo
```

(`actual - expected == 0x80000000 == 2^31`; the seconds are identical — the
whole delta is the flag bit in `i_ctime_nsec`.)

**After**: the test passes:

```
$ cd gadgets && GADGET_REPOSITORY=ghcr.io/inspektor-gadget/gadget GADGET_TAG=ctimefix \
    go test -v -exec 'sudo -E' -run 'TestTraceExecGadget/ctime' ./trace_exec/test/unit/...
--- PASS: TestTraceExecGadget (0.00s)
    --- PASS: TestTraceExecGadget/ctime (9.94s)
ok      github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/test/unit       10.023s
```

Reference: kernel commit [`4e40eff0b573`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4e40eff0b5737c0de39e1ae5812509efbc0b986e)