### PR TITLE
ebpf: support map pinning and non-destructive map iteration

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -702,6 +702,38 @@ GADGET_PARAM(collect_ustack);
 	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
 ```
 
+## Map pinning
+
+Gadget maps can be pinned to bpffs by adding the `pinning` field to the map
+declaration:
+
+```c
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct mykey);
+	__type(value, struct myval);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} my_map SEC(".maps");
+```
+
+This pins the map at `/sys/fs/bpf/<map_name>`. Behaviour:
+
+- If no map exists at the pin path, libbpf creates the map and pins it.
+- If a compatible map already exists (matching type, key/value sizes,
+  max_entries, flags), libbpf reuses it instead of creating a new one. This
+  is what enables consumer gadgets to read maps written by an external
+  producer process (e.g. a userspace daemon polling hardware metrics and
+  publishing them through bpffs-pinned maps).
+- If an incompatible map exists at the pin path, gadget load fails with a
+  clear error.
+
+Pinned maps persist in bpffs across `ig run` invocations. To iterate the
+contents of such a map non-destructively, see
+[`iter/bpf_map_elem`](program-types.md#iterators) and the
+`GADGET_ITER_TARGET_MAP` macro. Inspektor Gadget won't perform any cleanup on
+pinned maps when the gadget stops.
+
 ## Metrics
 
 Check [metrics](metrics.md#using-well-known-types-in-the-ebpf-code).

--- a/docs/gadget-devel/program-types.md
+++ b/docs/gadget-devel/program-types.md
@@ -37,9 +37,49 @@ The section name must use `iter/<iter_type>`. ig supports the following `<iter_t
 - `task_file`
 - `tcp`
 - `udp`
+- `bpf_map_elem`
 
 `tcp` and `udp` iterators are invoked in different network namespaces matching
 the filter configuration when running the gadget.
+
+`bpf_map_elem` iterators run over the entries of a BPF map (any map type) and
+are non-destructive — entries remain in the map after iteration. Because the
+kernel requires the target map's file descriptor at attach time, the iter
+program must be associated with its map via the `GADGET_ITER_TARGET_MAP`
+macro. This is particularly useful when consuming maps pinned by an external
+producer (e.g. a userspace daemon writing to a `LIBBPF_PIN_BY_NAME` map):
+
+```c
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct mykey);
+	__type(value, struct myval);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} my_map SEC(".maps");
+
+struct my_event { /* ... */ };
+
+GADGET_ITER(my_iter, my_event, dump_my_map);
+GADGET_ITER_TARGET_MAP(dump_my_map, my_map);
+
+SEC("iter/bpf_map_elem")
+int dump_my_map(struct bpf_iter__bpf_map_elem *ctx)
+{
+	struct mykey *key = ctx->key;
+	struct myval *val = ctx->value;
+	if (!key || !val)
+		return 0;
+	/* ... build event ... */
+	bpf_seq_write(ctx->meta->seq, &ev, sizeof(ev));
+	return 0;
+}
+```
+
+This is the right primitive for any iter-style topper or snapshot gadget that
+needs to read map contents without modifying them. For periodic
+*destructive* draining of a `BPF_MAP_TYPE_HASH` (e.g. counters that should
+be reset on every fetch), use `GADGET_MAPITER` instead.
 
 You can find the list of iterator types supported by Linux with:
 - `git grep -w ^DEFINE_BPF_ITER_FUNC` in the Linux sources (16 types as of Linux 6.9)

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -72,6 +72,7 @@ GADGETS ?= \
 	ci/image_inspect \
 	ci/container_filtering \
 	ci/stacks \
+	ci/test_iter_map_elem \
 	snapshot_file \
 	top_cuda_memory \
 	#

--- a/gadgets/ci/test_iter_map_elem/program.bpf.c
+++ b/gadgets/ci/test_iter_map_elem/program.bpf.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2026 The Inspektor Gadget authors */
+
+/*
+ * Minimal CI gadget exercising SEC("iter/bpf_map_elem") together with
+ * GADGET_ITER_TARGET_MAP. The gadget declares one map with
+ * LIBBPF_PIN_BY_NAME, attaches an iter program to it, and emits one event
+ * per (key, value) pair via seq_file. Iteration is non-destructive: entries
+ * remain in the map after each ig run.
+ *
+ * The map is intentionally pinned by name and uses LRU_HASH (rejected by
+ * GADGET_MAPITER) so this also covers the case where another process pins
+ * the map externally and the gadget reuses it through bpffs.
+ */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+#include <gadget/macros.h>
+#include <gadget/types.h>
+
+struct test_key {
+	__u32 pid;
+};
+
+struct test_value {
+	__u64 timestamp_ns;
+	__u32 sm_util_pct;
+	__u32 mem_util_pct;
+	__u64 used_gpu_memory;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct test_key);
+	__type(value, struct test_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} test_iter_map SEC(".maps");
+
+struct test_event {
+	__u32 pid;
+	__u32 sm_util_pct;
+	__u32 mem_util_pct;
+	__u32 _pad;
+	__u64 used_gpu_memory;
+	__u64 timestamp_ns;
+};
+
+GADGET_ITER(map_entries, test_event, dump_test_iter_map);
+GADGET_ITER_TARGET_MAP(dump_test_iter_map, test_iter_map);
+
+SEC("iter/bpf_map_elem")
+int dump_test_iter_map(struct bpf_iter__bpf_map_elem *ctx)
+{
+	struct seq_file *seq = ctx->meta->seq;
+	struct test_key *key = ctx->key;
+	struct test_value *val = ctx->value;
+
+	if (!key || !val)
+		return 0;
+
+	struct test_event ev = {
+		.pid = key->pid,
+		.sm_util_pct = val->sm_util_pct,
+		.mem_util_pct = val->mem_util_pct,
+		.used_gpu_memory = val->used_gpu_memory,
+		.timestamp_ns = val->timestamp_ns,
+	};
+
+	bpf_seq_write(seq, &ev, sizeof(ev));
+	return 0;
+}
+
+char __license[] SEC("license") = "GPL";

--- a/gadgets/ci/test_iter_map_elem/test/integration/test_iter_map_elem_test.go
+++ b/gadgets/ci/test_iter_map_elem/test/integration/test_iter_map_elem_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration test for the test_iter_map_elem CI gadget. Validates that
+// IG can attach a SEC("iter/bpf_map_elem") program to an externally-pinned
+// BPF map via GADGET_ITER_TARGET_MAP, that the gadget emits one event per
+// map entry, and that iteration is non-destructive (entries remain in the
+// map after each run).
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+const (
+	// Must byte-match the declaration in the gadget's program.bpf.c.
+	pinDir        = "/sys/fs/bpf"
+	pinnedMapName = "test_iter_map"
+	mapValueSize  = 24 // sizeof(struct test_value)
+	mapKeySize    = 4  // sizeof(struct test_key)
+	mapMaxEntries = 4096
+)
+
+// testKey/testValue mirror the BPF structs in program.bpf.c. Field order and
+// sizes must match exactly so cilium/ebpf binary-marshals into the same
+// layout the BPF program expects.
+type testKey struct {
+	Pid uint32
+}
+
+type testValue struct {
+	TimestampNs   uint64
+	SmUtilPct     uint32
+	MemUtilPct    uint32
+	UsedGpuMemory uint64
+}
+
+// expectedEvent mirrors the JSON output the iter datasource emits (one
+// object per map entry). Field names follow IG's JSON serialization, which
+// uses the BPF struct field names verbatim.
+type expectedEvent struct {
+	Pid           uint32 `json:"pid"`
+	SmUtilPct     uint32 `json:"sm_util_pct"`
+	MemUtilPct    uint32 `json:"mem_util_pct"`
+	UsedGpuMemory uint64 `json:"used_gpu_memory"`
+	TimestampNs   uint64 `json:"timestamp_ns"`
+}
+
+func TestIterMapElem(t *testing.T) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	// The test creates and pins a BPF map in /sys/fs/bpf on the host
+	// running the test binary, then runs the gadget which is expected
+	// to iterate that map. Under kubectl-gadget the gadget executes
+	// inside the DaemonSet pod on a (mini-)k8s node whose bpffs is
+	// distinct from the test host's, so the map is invisible to the
+	// gadget and the assertion fails. This test therefore only
+	// exercises the ig-local path; feature coverage for the
+	// GADGET_ITER_TARGET_MAP plumbing is provided at that level.
+	if utils.CurrentTestComponent != utils.IgLocalTestComponent {
+		t.Skip("test_iter_map_elem requires the gadget and the map producer to share /sys/fs/bpf; only supported in ig local mode")
+	}
+
+	// Step 1: pre-create and pin the BPF map externally (mimicking a
+	// userspace producer such as gpu-ebpf-bridge).
+	spec := &ebpf.MapSpec{
+		Name:       pinnedMapName,
+		Type:       ebpf.LRUHash,
+		KeySize:    mapKeySize,
+		ValueSize:  mapValueSize,
+		MaxEntries: mapMaxEntries,
+		Pinning:    ebpf.PinByName,
+	}
+	m, err := ebpf.NewMapWithOptions(spec, ebpf.MapOptions{PinPath: pinDir})
+	require.NoError(t, err, "create and pin test map")
+	t.Cleanup(func() {
+		_ = m.Close()
+		_ = os.Remove(filepath.Join(pinDir, pinnedMapName))
+	})
+
+	// Step 2: populate with three deterministic entries.
+	entries := []struct {
+		k testKey
+		v testValue
+	}{
+		{testKey{Pid: 1000}, testValue{TimestampNs: 1, SmUtilPct: 42, MemUtilPct: 17, UsedGpuMemory: 512 * 1024 * 1024}},
+		{testKey{Pid: 2000}, testValue{TimestampNs: 2, SmUtilPct: 88, MemUtilPct: 65, UsedGpuMemory: 8 * 1024 * 1024 * 1024}},
+		{testKey{Pid: 3000}, testValue{TimestampNs: 3, SmUtilPct: 5, MemUtilPct: 2, UsedGpuMemory: 64 * 1024 * 1024}},
+	}
+	for _, e := range entries {
+		err := m.Update(&e.k, &e.v, ebpf.UpdateAny)
+		require.NoError(t, err, "writing entry pid=%d", e.k.Pid)
+	}
+
+	// Step 3: run the gadget and validate the iter datasource output. ig
+	// emits a single JSON array because mapiter/iter datasources are array
+	// datasources (one packet per fetch, n elements per packet).
+	expected := []*expectedEvent{
+		{Pid: 1000, SmUtilPct: 42, MemUtilPct: 17, UsedGpuMemory: 512 * 1024 * 1024, TimestampNs: 1},
+		{Pid: 2000, SmUtilPct: 88, MemUtilPct: 65, UsedGpuMemory: 8 * 1024 * 1024 * 1024, TimestampNs: 2},
+		{Pid: 3000, SmUtilPct: 5, MemUtilPct: 2, UsedGpuMemory: 64 * 1024 * 1024, TimestampNs: 3},
+	}
+
+	runnerOpts := []igrunner.Option{
+		igrunner.WithFlags("--timeout=2"),
+		igrunner.WithValidateOutput(func(t *testing.T, output string) {
+			match.MatchEntries(t, match.JSONSingleArrayMode, output, nil, expected...)
+		}),
+	}
+
+	cmd := igrunner.New("ci/test_iter_map_elem", runnerOpts...)
+	igtesting.RunTestSteps([]igtesting.TestStep{cmd}, t)
+
+	// Step 4: verify the iteration was non-destructive. All three entries
+	// must still be present and unchanged. This is the key property that
+	// distinguishes iter/bpf_map_elem from GADGET_MAPITER (which uses
+	// BPF_MAP_LOOKUP_AND_DELETE_BATCH and drains the map).
+	for _, e := range entries {
+		var got testValue
+		err := m.Lookup(&e.k, &got)
+		require.NoError(t, err, "map entry pid=%d should still exist after iteration", e.k.Pid)
+		require.Equal(t, e.v, got, "map entry pid=%d should be unchanged after iteration", e.k.Pid)
+	}
+}

--- a/include/gadget/macros.h
+++ b/include/gadget/macros.h
@@ -78,4 +78,32 @@
 #define GADGET_MAPITER(name, mapname) \
 	const void *gadget_mapiter_##name##___##mapname __attribute__((unused));
 
+// GADGET_ITER_TARGET_MAP binds a BPF iter program declared with
+// SEC("iter/bpf_map_elem") to the map it should iterate over. The kernel
+// requires the target map FD at attach time; this macro tells IG which map
+// to pass to bpf_link_create's iter_info.map_fd. Use together with
+// GADGET_ITER(name, event_type, prog_name).
+//
+// Example:
+//
+//   struct {
+//       __uint(type, BPF_MAP_TYPE_LRU_HASH);
+//       __uint(max_entries, 4096);
+//       __type(key,   struct mykey);
+//       __type(value, struct myval);
+//       __uint(pinning, LIBBPF_PIN_BY_NAME);
+//   } my_pinned_map SEC(".maps");
+//
+//   GADGET_ITER(my_iter, my_event, dump_my_map);
+//   GADGET_ITER_TARGET_MAP(dump_my_map, my_pinned_map);
+//
+//   SEC("iter/bpf_map_elem")
+//   int dump_my_map(struct bpf_iter__bpf_map_elem *ctx) { ... }
+//
+// - prog_name is the BPF iter program (SEC("iter/bpf_map_elem")).
+// - mapname is the map declared in this object (commonly LIBBPF_PIN_BY_NAME).
+#define GADGET_ITER_TARGET_MAP(prog_name, mapname)                       \
+	const void *gadget_mapelem_iter_target_##prog_name##___##mapname \
+		__attribute__((unused));
+
 #endif /* __MACROS_H */

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -99,6 +99,23 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 				return link.AttachIter(link.IterOptions{
 					Program: prog,
 				})
+			case "bpf_map_elem":
+				mapName, ok := i.iterTargetMaps[p.Name]
+				if !ok {
+					return nil, fmt.Errorf("iter/bpf_map_elem program %q has no target map; declare GADGET_ITER_TARGET_MAP(%s, <map_name>) in the BPF source",
+						p.Name, p.Name)
+				}
+				targetMap, ok := i.collection.Maps[mapName]
+				if !ok {
+					return nil, fmt.Errorf("iter target map %q for program %q not found in loaded collection",
+						mapName, p.Name)
+				}
+				i.logger.Debugf("Attaching iter/bpf_map_elem %q to map %q (fd=%d)",
+					p.Name, mapName, targetMap.FD())
+				return link.AttachIter(link.IterOptions{
+					Program: prog,
+					Map:     targetMap,
+				})
 			}
 			return nil, fmt.Errorf("unsupported iter type %q", attachTo)
 		case strings.HasPrefix(p.SectionName, fentryPrefix):

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -759,6 +759,9 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 	opts := ebpf.CollectionOptions{
 		MapReplacements: mapReplacements,
 		Cache:           i.bpfOperator.btfCache,
+		Maps: ebpf.MapOptions{
+			PinPath: "/sys/fs/bpf",
+		},
 	}
 
 	if seBtfSpecI, ok := gadgetCtx.GetVar("socketEnricherbtf"); ok {

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -126,11 +126,12 @@ func (o *ebpfOperator) InstantiateImageOperator(
 		program: program,
 
 		// Preallocate maps
-		tracers:   make(map[string]*Tracer),
-		structs:   make(map[string]*Struct),
-		iterators: make(map[string]*Iterator),
-		params:    make(map[string]*param),
-		mapIters:  make(map[string]*mapIter),
+		tracers:        make(map[string]*Tracer),
+		structs:        make(map[string]*Struct),
+		iterators:      make(map[string]*Iterator),
+		params:         make(map[string]*param),
+		mapIters:       make(map[string]*mapIter),
+		iterTargetMaps: make(map[string]string),
 
 		containers: make(map[string]*containercollection.Container),
 
@@ -178,12 +179,16 @@ type ebpfInstance struct {
 	collectionSpec *ebpf.CollectionSpec
 	collection     *ebpf.Collection
 
-	tracers     map[string]*Tracer
-	structs     map[string]*Struct
-	iterators   map[string]*Iterator
-	mapIters    map[string]*mapIter
-	params      map[string]*param
-	paramValues map[string]string
+	tracers   map[string]*Tracer
+	structs   map[string]*Struct
+	iterators map[string]*Iterator
+	mapIters  map[string]*mapIter
+	// iterTargetMaps maps a SEC("iter/bpf_map_elem") BPF program name to the
+	// map (by name) it should iterate over. Populated from
+	// GADGET_ITER_TARGET_MAP() declarations in the BPF object.
+	iterTargetMaps map[string]string
+	params         map[string]*param
+	paramValues    map[string]string
 
 	networkTracers map[string]*networktracer.Tracer[api.GadgetData]
 	tcHandlers     map[string]*tchandler.Handler
@@ -239,6 +244,13 @@ func (i *ebpfInstance) analyze(gadgetCtx operators.GadgetContext, paramValues ap
 				gadgetCtx.Logger().Warnf("%s prefix is deprecated; please use %s instead", snapshottersPrefix, iteratorsPrefix)
 				return i.populateIterators(b, s)
 			},
+		},
+		{
+			// Distinct stem from iteratorsPrefix on purpose; see comment
+			// in types.go.
+			prefixFunc:   hasPrefix(iterTargetMapPrefix),
+			validator:    i.validateGlobalConstVoidPtrVar,
+			populateFunc: i.populateIterTargetMap,
 		},
 		{
 			prefixFunc:   hasPrefix(iteratorsPrefix),

--- a/pkg/operators/ebpf/iter.go
+++ b/pkg/operators/ebpf/iter.go
@@ -281,7 +281,7 @@ func isIteratorKindSupported(kind string) bool {
 	//
 	// But at the moment, only a subset is supported by Inspektor Gadget.
 	switch kind {
-	case "task", "task_file", "ksym", "tcp", "udp":
+	case "task", "task_file", "ksym", "tcp", "udp", "bpf_map_elem":
 		return true
 	}
 	return false

--- a/pkg/operators/ebpf/maps.go
+++ b/pkg/operators/ebpf/maps.go
@@ -315,3 +315,48 @@ func (i *ebpfInstance) populateMapIter(t btf.Type, varName string) error {
 	i.mapIters[name] = iter
 	return nil
 }
+
+// populateIterTargetMap handles GADGET_ITER_TARGET_MAP(prog_name, mapname).
+// It binds a SEC("iter/bpf_map_elem") BPF program to the map it should
+// iterate over; the bound map FD is later passed at attach time via
+// link.IterOptions.Map (see attach.go).
+func (i *ebpfInstance) populateIterTargetMap(t btf.Type, varName string) error {
+	i.logger.Debugf("populating iter target map %q", varName)
+
+	info := strings.Split(varName, typeSplitter)
+	if len(info) != 2 {
+		return fmt.Errorf("invalid name for %s type: %q (expected <prog_name>%s<map_name>)",
+			iterTargetMapPrefix, varName, typeSplitter)
+	}
+
+	progName := info[0]
+	mapName := info[1]
+
+	if existing, ok := i.iterTargetMaps[progName]; ok {
+		return fmt.Errorf("duplicate iter target map for program %q (already bound to %q)",
+			progName, existing)
+	}
+
+	// Validate the program exists and is a bpf_map_elem iter.
+	prog, ok := i.collectionSpec.Programs[progName]
+	if !ok {
+		return fmt.Errorf("iter target map references unknown program %q", progName)
+	}
+	if prog.Type != ebpf.Tracing || prog.AttachType != ebpf.AttachTraceIter {
+		return fmt.Errorf("program %q is not a tracing iter (got type=%s attach=%s); use SEC(\"iter/bpf_map_elem\")",
+			progName, prog.Type, prog.AttachType)
+	}
+	if prog.AttachTo != "bpf_map_elem" {
+		return fmt.Errorf("program %q is not iter/bpf_map_elem (got iter/%s); GADGET_ITER_TARGET_MAP only applies to bpf_map_elem iter",
+			progName, prog.AttachTo)
+	}
+
+	// Validate the map exists.
+	if _, ok := i.collectionSpec.Maps[mapName]; !ok {
+		return fmt.Errorf("iter target map references unknown map %q (for program %q)",
+			mapName, progName)
+	}
+
+	i.iterTargetMaps[progName] = mapName
+	return nil
+}

--- a/pkg/operators/ebpf/types.go
+++ b/pkg/operators/ebpf/types.go
@@ -35,6 +35,14 @@ const (
 
 	mapIterPrefix = "gadget_mapiter_"
 
+	// Prefix used by GADGET_ITER_TARGET_MAP to bind a SEC("iter/bpf_map_elem")
+	// BPF program to the map it should iterate over. Deliberately chosen so
+	// it does NOT share a prefix with iteratorsPrefix ("gadget_iter_") —
+	// the prefix-lookup walk in analyze() matches all overlapping prefixes,
+	// so a name like "gadget_iter_target_map_..." would erroneously also be
+	// consumed by populateIterators.
+	iterTargetMapPrefix = "gadget_mapelem_iter_target_"
+
 	// Prefix used to mark variables used by operators
 	varPrefix = "gadget_var_"
 


### PR DESCRIPTION
This PR adds two independent but related eBPF features that make it
possible for gadgets to share and inspect BPF maps across invocations
and with external processes.

## 1. `LIBBPF_PIN_BY_NAME` support in gadget maps

Pass `MapOptions.PinPath = /sys/fs/bpf` to cilium/ebpf so that gadget
maps declared with `__uint(pinning, LIBBPF_PIN_BY_NAME)` can be pinned
to bpffs and reused across gadget invocations.

Previously, libbpf rejected such maps with:

```
creating eBPF collection: map <name>: pin by name: missing
MapOptions.PinPath
```

This enables three independent use-cases:

- Persistent state across `ig run` invocations (e.g. a counter map
  keeps its values between runs).
- Multiple gadgets sharing a map by name.
- Consumer gadgets reading data produced by an external producer
  process (e.g. a userspace daemon writing telemetry into a
  bpffs-pinned map).

If a pinned map already exists at `/sys/fs/bpf/<name>`, libbpf reuses
its FD when the spec (type / key_size / value_size / max_entries /
flags) matches; mismatches fail to load with a clear error from
cilium/ebpf.

## 2. `iter/bpf_map_elem` support via `GADGET_ITER_TARGET_MAP`

Add support for BPF iter programs of type `SEC("iter/bpf_map_elem")`
so gadgets can read entries from an arbitrary BPF map (including
maps pinned externally) non-destructively. This complements the
existing `GADGET_MAPITER`, which is destructive (uses
`BPF_MAP_LOOKUP_AND_DELETE_BATCH`) and restricted to plain HASH maps.

The new macro `GADGET_ITER_TARGET_MAP(prog_name, map_name)` binds the
iter program to the map whose FD should be passed to `bpf_link_create`
via `iter_info.map_fd`. Without this binding, the kernel cannot know
which map a `SEC("iter/bpf_map_elem")` program is iterating over.

### Example

```c
struct {
    __uint(type, BPF_MAP_TYPE_LRU_HASH);
    __uint(pinning, LIBBPF_PIN_BY_NAME);
    __type(key,   struct mykey);
    __type(value, struct myval);
    __uint(max_entries, 4096);
} my_map SEC(".maps");

GADGET_ITER(my_iter, my_event, dump_my_map);
GADGET_ITER_TARGET_MAP(dump_my_map, my_map);

SEC("iter/bpf_map_elem")
int dump_my_map(struct bpf_iter__bpf_map_elem *ctx) {
    /* ... bpf_seq_write(ctx->meta->seq, &ev, sizeof(ev)); */
}
```

### Implementation

- `include/gadget/macros.h`: add `GADGET_ITER_TARGET_MAP` macro that
  emits a `gadget_mapelem_iter_target_<prog>___<map>` variable
  (deliberately distinct stem from `gadget_iter_` to avoid the
  prefix-walk in `analyze()` also matching it as an iterator).
- `pkg/operators/ebpf/types.go`: add `iterTargetMapPrefix` constant.
- `pkg/operators/ebpf/ebpf.go`: add `iterTargetMaps` map to
  `ebpfInstance`, register the parser in `analyze()`.
- `pkg/operators/ebpf/maps.go`: add `populateIterTargetMap` to parse
  the variable name, validate the program is `iter/bpf_map_elem`
  and the map exists.
- `pkg/operators/ebpf/attach.go`: add `case "bpf_map_elem"` that
  resolves the bound map and passes its FD via `link.IterOptions`.
- `pkg/operators/ebpf/iter.go`: allow `"bpf_map_elem"` in
  `isIteratorKindSupported` so `runIterators()` actually reads from
  the link.

## Tests

- `gadgets/ci/test_iter_map_elem/`: minimal CI gadget that iterates
  an externally-pinned `LRU_HASH` map and emits one event per entry.
  Registered in `gadgets/Makefile`.
- `gadgets/ci/test_iter_map_elem/test/integration/`: Go integration
  test that pre-creates + pins the map, runs the gadget, asserts the
  emitted JSON matches the inserted entries, and verifies the map
  is unchanged after iteration (non-destructive).

## Documentation

- `docs/gadget-devel/gadget-ebpf-api.md`: new "Map pinning" section.
- `docs/gadget-devel/program-types.md`: document `iter/bpf_map_elem`
  and the `GADGET_ITER_TARGET_MAP` macro under "Iterators".

## Commits

- `ebpf: support LIBBPF_PIN_BY_NAME in gadget maps`
- `ebpf: support iter/bpf_map_elem with GADGET_ITER_TARGET_MAP`
