### PR TITLE
Ignore topology.kubernetes.io labels in tests and networkpolicy advisor

### DIFF
--- a/gadgets/advise_networkpolicy/README.mdx
+++ b/gadgets/advise_networkpolicy/README.mdx
@@ -157,3 +157,16 @@ deployment.apps "nginx" deleted
 $ kubectl delete service nginx
 service "nginx" deleted
 ```
+
+## Limitations
+
+The gadget ignores the following non-identity pod labels when generating policy
+selectors:
+
+- `controller-revision-hash`
+- `pod-template-generation`
+- `pod-template-hash`
+- `topology.kubernetes.io/region`
+- `topology.kubernetes.io/zone`
+- `failure-domain.beta.kubernetes.io/region`
+- `failure-domain.beta.kubernetes.io/zone`

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy.go
@@ -40,6 +40,14 @@ var defaultLabelsToIgnore = map[string]struct{}{
 	"controller-revision-hash": {},
 	"pod-template-generation":  {},
 	"pod-template-hash":        {},
+	// Well-known topology labels are derived from the node the pod is scheduled
+	// on, not from the workload identity. Including them in a policy selector
+	// would pin the policy to a region/zone and stop matching the pod once it is
+	// rescheduled elsewhere, so ignore them.
+	"topology.kubernetes.io/region":            {},
+	"topology.kubernetes.io/zone":              {},
+	"failure-domain.beta.kubernetes.io/region": {},
+	"failure-domain.beta.kubernetes.io/zone":   {},
 }
 
 var LabelsToIgnore = defaultLabelsToIgnore

--- a/pkg/operators/generate_networkpolicy/generate_networkpolicy_test.go
+++ b/pkg/operators/generate_networkpolicy/generate_networkpolicy_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate_networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestLabelFilterIgnoresNonIdentityLabels(t *testing.T) {
+	in := map[string]string{
+		"app":                           "backend",
+		"run":                           "backend",
+		"pod-template-hash":             "abc123",
+		"topology.kubernetes.io/region": "us-east1",
+		"topology.kubernetes.io/zone":   "us-east1-c",
+		"failure-domain.beta.kubernetes.io/region": "us-east1",
+		"failure-domain.beta.kubernetes.io/zone":   "us-east1-c",
+	}
+
+	// Only user-defined workload-identity labels must survive; node-derived
+	// topology labels and ephemeral controller labels must be filtered out.
+	assert.Equal(t, map[string]string{"app": "backend", "run": "backend"}, labelFilter(in))
+
+	// labelFilteredKeyList must be consistent with labelFilter.
+	assert.Equal(t, []string{"app", "run"}, labelFilteredKeyList(in))
+}
+
+func TestHandleCiliumEvents_IgnoresTopologyLabels(t *testing.T) {
+	events := []NetworkEvent{
+		makeEvent(false, "prod",
+			map[string]string{
+				"app":                           "backend",
+				"topology.kubernetes.io/region": "us-east1",
+				"topology.kubernetes.io/zone":   "us-east1-c",
+			},
+			types.EndpointKindPod, "prod",
+			map[string]string{
+				"app":                           "frontend",
+				"topology.kubernetes.io/region": "us-east1",
+				"topology.kubernetes.io/zone":   "us-east1-d",
+			},
+			"", 8080, "TCP"),
+	}
+	eventsBySource := map[string][]NetworkEvent{
+		localPodKey(events[0]): events,
+	}
+
+	policies, err := handleCiliumEvents(eventsBySource)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	p := policies[0]
+	// Topology labels must not leak into the generated selectors.
+	assert.Equal(t, map[string]string{"app": "backend"}, p.Spec.EndpointSelector.MatchLabels)
+
+	require.Len(t, p.Spec.Ingress, 1)
+	require.Len(t, p.Spec.Ingress[0].FromEndpoints, 1)
+	assert.Equal(t, map[string]string{"app": "frontend"}, p.Spec.Ingress[0].FromEndpoints[0].MatchLabels)
+}

--- a/pkg/testing/utils/utils.go
+++ b/pkg/testing/utils/utils.go
@@ -122,6 +122,32 @@ func NormalizeCommonData(e *eventtypes.CommonData) {
 		// TODO: Verify container runtime and container name
 		e.Runtime.RuntimeName = ""
 		e.Runtime.ContainerName = ""
+
+		// Managed clusters (e.g. AKS, GKE) asynchronously inject well-known
+		// topology labels onto pods. These are not set by the tests (which only
+		// expect the "run" label from BuildCommonData), so strip them to avoid
+		// flaky mismatches depending on whether the injection landed before the
+		// event was captured.
+		stripCloudInjectedPodLabels(e.K8s.PodLabels)
+	}
+}
+
+// cloudInjectedPodLabelKeys are well-known Kubernetes topology labels that
+// managed clusters inject onto pods. They are not user-defined labels set by
+// the tests, so they must be ignored when matching captured events.
+var cloudInjectedPodLabelKeys = []string{
+	"topology.kubernetes.io/region",
+	"topology.kubernetes.io/zone",
+	// Deprecated equivalents, kept for robustness against older clusters.
+	"failure-domain.beta.kubernetes.io/region",
+	"failure-domain.beta.kubernetes.io/zone",
+}
+
+// stripCloudInjectedPodLabels removes cloud-injected topology labels from the
+// given pod labels map in place.
+func stripCloudInjectedPodLabels(podLabels map[string]string) {
+	for _, key := range cloudInjectedPodLabelKeys {
+		delete(podLabels, key)
 	}
 }
 

--- a/pkg/testing/utils/utils_test.go
+++ b/pkg/testing/utils/utils_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestNormalizeCommonData(t *testing.T) {
+	// NormalizeCommonData behaves differently depending on the current test
+	// component; force the kubectl-gadget (Kubernetes) path and restore it
+	// afterwards.
+	orig := CurrentTestComponent
+	CurrentTestComponent = KubectlGadgetTestComponent
+	t.Cleanup(func() { CurrentTestComponent = orig })
+
+	t.Run("strips cloud-injected topology labels", func(t *testing.T) {
+		e := &eventtypes.CommonData{
+			K8s: eventtypes.K8sMetadata{
+				BasicK8sMetadata: eventtypes.BasicK8sMetadata{
+					PodName:       "test-pod",
+					ContainerName: "test-pod",
+					PodLabels: map[string]string{
+						"run":                           "test-pod",
+						"topology.kubernetes.io/region": "eastus2",
+						"topology.kubernetes.io/zone":   "0",
+						"failure-domain.beta.kubernetes.io/region": "eastus2",
+						"failure-domain.beta.kubernetes.io/zone":   "0",
+					},
+				},
+			},
+		}
+
+		NormalizeCommonData(e)
+
+		assert.Equal(t, map[string]string{"run": "test-pod"}, e.K8s.PodLabels,
+			"cloud-injected topology labels should be stripped, leaving only user labels")
+	})
+
+	t.Run("leaves user labels untouched", func(t *testing.T) {
+		e := &eventtypes.CommonData{
+			K8s: eventtypes.K8sMetadata{
+				BasicK8sMetadata: eventtypes.BasicK8sMetadata{
+					PodLabels: map[string]string{"run": "test-pod"},
+				},
+			},
+		}
+
+		NormalizeCommonData(e)
+
+		assert.Equal(t, map[string]string{"run": "test-pod"}, e.K8s.PodLabels)
+	})
+
+	t.Run("nil pod labels are safe", func(t *testing.T) {
+		e := &eventtypes.CommonData{}
+
+		assert.NotPanics(t, func() { NormalizeCommonData(e) })
+		assert.Nil(t, e.K8s.PodLabels)
+	})
+
+	t.Run("normalizes other non-deterministic fields", func(t *testing.T) {
+		e := &eventtypes.CommonData{
+			Runtime: eventtypes.BasicRuntimeMetadata{
+				RuntimeName:          eventtypes.RuntimeNameContainerd,
+				ContainerName:        "test-pod",
+				ContainerPID:         4242,
+				ContainerImageDigest: "sha256:deadbeef",
+				ContainerStartedAt:   eventtypes.Time(1234567890),
+			},
+			K8s: eventtypes.K8sMetadata{
+				Node: "some-node",
+			},
+		}
+
+		NormalizeCommonData(e)
+
+		assert.Empty(t, e.Runtime.ContainerImageDigest)
+		assert.Zero(t, e.Runtime.ContainerPID)
+		assert.Zero(t, e.Runtime.ContainerStartedAt)
+		assert.Empty(t, e.K8s.Node)
+		assert.Empty(t, string(e.Runtime.RuntimeName))
+		assert.Empty(t, e.Runtime.ContainerName)
+	})
+}


### PR DESCRIPTION
AKS and GKE auto inject labels and we need to strip them in the test and network advisor:

Failure AKS:
```
Error:      	Not equal: 
        	   expected: map[string]interface {}{/***/"podSelector":map[string]interface {}{"matchLabels":map[string]interface {}{"run":"test-advise-networkpolicy-server"}}/***/}}
        	   actual  : map[string]interface {}{/***/"podSelector":map[string]interface {} {"matchLabels":map[string]interface {}{"run":"test-advise-networkpolicy-server", "topology.kubernetes.io/region":"eastus2", "topology.kubernetes.io/zone":"0"}}/***/}}
```
Failure GKE:
```
Error:      	Not equal: 
        	   expected: map[string]interface {}{/***/"podSelector":map[string]interface {}{"matchLabels":map[string]interface {}{"run":"test-advise-networkpolicy-server"}}/***/}}
        	   actual  : map[string]interface {}{/***/"podSelector":map[string]interface {}{"matchLabels":map[string]interface {}{"run":"test-advise-networkpolicy-server", "topology.kubernetes.io/region":"us-east1", "topology.kubernetes.io/zone":"us-east1-d"}}/***/}}}
```

Citest run: https://github.com/inspektor-gadget/inspektor-gadget/actions/runs/28860826135

## LLM summary

Ignore node topology labels on managed clusters

What

On managed Kubernetes clusters (AKS, GKE), pods carry the well-known topology labels  topology.kubernetes.io/region  and  topology.kubernetes.io/zone . These are derived from the node a pod is scheduled on — not the workload identity — and are populated asynchronously. This made several gadget integration tests flaky, through two different code paths, both fixed here.

1. Event matching (test framework)

Integration tests build their expected event with only the  run  pod label ( BuildCommonData ) and compare captured events with a strict  reflect.DeepEqual  ( MatchUnmarshalledEntries ). When the topology labels landed before the event was captured, the captured  podLabels  map contained extra keys and the comparison failed; otherwise it passed — a race. This affected  TestSnapshotProcess ,  TestSnapshotSocket ,  TestTopTcp ,  TestContainerFiltering , and many others.

A gadget event should faithfully report the pod's real labels, so this is a test-only concern: strip the topology labels in  NormalizeCommonData  (the single helper all gadget integration tests run captured data through) so only user-defined labels are compared.

2. Network policy advisor (production)

The  advise_networkpolicy  gadget builds pod selectors from observed pod labels and already filters non-identity labels ( controller-revision-hash ,  pod-template-generation ,  pod-template-hash ) via  LabelsToIgnore . Emitting the topology labels in a NetworkPolicy  podSelector  is incorrect: it pins the policy to a region/zone, so once the pod is rescheduled elsewhere the selector no longer matches it and the policy silently stops applying. This also made  TestAdviseNetworkpolicyGadget  flaky on managed clusters.

Add the topology labels (and the deprecated  failure-domain.beta.kubernetes.io  equivalents) to the default ignore list. Both the Kubernetes and Cilium generators share  labelFilter() , so this covers both.

Testing

• New unit tests for both changes ( pkg/testing/utils ,  pkg/operators/generate_networkpolicy ).
• Verified on CI run  28860826135 : after the framework fix,  match.go  mismatches dropped to 0 on all four AKS jobs; the only remaining AKS failure was  TestAdviseNetworkpolicyGadget , addressed by the advisor fix.