### PR TITLE
gadgets/snapshot_{process,file}: Read __rcu fields with BPF_CORE_READ

### DIFF
--- a/gadgets/snapshot_file/program.bpf.c
+++ b/gadgets/snapshot_file/program.bpf.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2025 Shaheer Ahmad */
 
 #include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 
 #include <gadget/macros.h>
@@ -116,9 +117,12 @@ int ig_snap_file(struct bpf_iter__task_file *ctx)
 	if (!task || !file)
 		return 0;
 
-	if (gadget_should_discard_data(
-		    task->nsproxy->mnt_ns->ns.inum, task->tgid, task->pid,
-		    task->comm, task->cred->uid.val, task->cred->gid.val))
+	__u32 uid = BPF_CORE_READ(task, cred, uid.val);
+	__u32 gid = BPF_CORE_READ(task, cred, gid.val);
+
+	if (gadget_should_discard_data(task->nsproxy->mnt_ns->ns.inum,
+				       task->tgid, task->pid, task->comm, uid,
+				       gid))
 		return 0;
 
 	info.mntns_id = task->nsproxy->mnt_ns->ns.inum;

--- a/gadgets/snapshot_process/program.bpf.c
+++ b/gadgets/snapshot_process/program.bpf.c
@@ -9,6 +9,7 @@
 /* This BPF program uses the GPL-restricted function bpf_seq_write(). */
 
 #include <vmlinux.h>
+#include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 
 #include <gadget/macros.h>
@@ -36,24 +37,28 @@ int ig_snap_proc(struct bpf_iter__task *ctx)
 	if (!show_threads && task->tgid != task->pid)
 		return 0;
 
-	if (gadget_should_discard_data(
-		    task->nsproxy->mnt_ns->ns.inum, task->tgid, task->pid,
-		    task->comm, task->cred->uid.val, task->cred->gid.val))
+	__u32 uid = BPF_CORE_READ(task, cred, uid.val);
+	__u32 gid = BPF_CORE_READ(task, cred, gid.val);
+
+	if (gadget_should_discard_data(task->nsproxy->mnt_ns->ns.inum,
+				       task->tgid, task->pid, task->comm, uid,
+				       gid))
 		return 0;
 
 	process.mntns_id = task->nsproxy->mnt_ns->ns.inum;
 	__builtin_memcpy(process.comm, task->comm, TASK_COMM_LEN);
 	process.pid = task->tgid;
 	process.tid = task->pid;
-	process.creds.uid = task->cred->uid.val;
-	process.creds.gid = task->cred->gid.val;
+	process.creds.uid = uid;
+	process.creds.gid = gid;
 
-	parent = task->real_parent;
+	parent = BPF_CORE_READ(task, real_parent);
 	if (parent) {
-		process.parent.pid = parent->tgid;
-		process.parent.tid = parent->pid;
-		__builtin_memcpy(process.parent.comm, parent->comm,
-				 TASK_COMM_LEN);
+		process.parent.pid = BPF_CORE_READ(parent, tgid);
+		process.parent.tid = BPF_CORE_READ(parent, pid);
+		bpf_probe_read_kernel(&process.parent.comm,
+				      sizeof(process.parent.comm),
+				      parent->comm);
 	}
 
 	bpf_seq_write(seq, &process, sizeof(process));


### PR DESCRIPTION
For snapshot_process and snapshot_file we didn't use `BPF_CORE_READ` and it only failed on the LLVM compiled GKE kernel that actually carries the `rcu` type tag.

## LLM summary

The snapshot_process and snapshot_file gadgets are the only ones that dereference the __rcu-protected task_struct fields task->cred (and, for snapshot_process, task->real_parent) directly. On kernels whose BTF carries the "rcu" btf_type_tag, the verifier tracks such pointers as "rcu_ptr_or_null_" and rejects a direct dereference:

  program ig_snap_proc: load program: permission denied:
  30: (61) r1 = *(u32 *)(r3 +12): R3 invalid mem access 'rcu_ptr_or_null_'

This is why the gadgets fail to load only on GKE. The "rcu" type tag is emitted by __rcu (see include/linux/compiler_types.h, "#define __rcu BTF_TYPE_TAG(rcu)") only when the kernel is built with a toolchain that supports the attribute, i.e. Clang, together with CONFIG_PAHOLE_HAS_BTF_TAG. GKE's Container-Optimized OS is Clang-built and therefore carries the tags and enforces the check, whereas the GCC-built kernels used on the other CI targets (Ubuntu on the GitHub runners, AKS and minikube; Amazon Linux on EKS) do not, so the same program loads there.

Read these fields with BPF_CORE_READ(), which goes through bpf_probe_read_kernel() and is not subject to the RCU pointer check. This matches how every other gadget and the shared helpers (mntns.h, common.h) already read these fields, and works on both Clang- and GCC-built kernels.

Relevant kernel changes: 7472d5a642c9 ("compiler_types: define __user as __attribute__((btf_type_tag("user")))") introduced the btf_type_tag mechanism, and fca1aa75518c ("bpf: Handle MEM_RCU type properly") added the verifier enforcement.