### PR TITLE
pkg/gadget-context: Match paramDefaults keys case-insensitively

### DIFF
--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/attribute"
@@ -103,7 +104,9 @@ func (c *GadgetContext) instantiateOperators(paramValues api.ParamValues) error 
 		if v, ok := cfg.(*viper.Viper); ok {
 			defaults := v.GetStringMapString("paramDefaults")
 			for _, p := range params {
-				fullName := p.Prefix + p.Key
+				// viper lowercases config keys, so match case-insensitively
+				// to support operators whose name is not all-lowercase.
+				fullName := strings.ToLower(p.Prefix + p.Key)
 				if val, ok := defaults[fullName]; ok {
 					p.DefaultValue = val
 				}

--- a/pkg/gadget-context/run_test.go
+++ b/pkg/gadget-context/run_test.go
@@ -312,3 +312,39 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
+
+// TestParamsDefaultCaseInsensitive verifies that a gadget's paramDefaults are
+// applied to operators whose name is not all-lowercase. viper lowercases config
+// keys, so the lookup must match case-insensitively.
+func TestParamsDefaultCaseInsensitive(t *testing.T) {
+	op := &fakeOperator{
+		name:     "FakeOp",
+		priority: 0,
+	}
+
+	ctx := New(t.Context(), "", WithDataOperators(op))
+	metadata := `
+paramDefaults:
+  operator.FakeOp.foo: "123"
+`
+
+	err := ctx.SetMetadata([]byte(metadata))
+	require.NoError(t, err)
+
+	err = ctx.PrepareGadgetInfo(nil)
+	require.NoError(t, err)
+
+	info, err := ctx.SerializeGadgetInfo(false)
+	require.NoError(t, err)
+
+	for _, p := range info.Params {
+		if p.Prefix+p.Key == "operator.FakeOp.foo" {
+			// The operator's built-in default is "567"; the gadget's
+			// paramDefaults override it with "123".
+			require.Equal(t, "123", p.DefaultValue)
+			return
+		}
+	}
+
+	require.Fail(t, "param not found")
+}


### PR DESCRIPTION
A gadget sets defaults for operator instance params via its metadata (`paramDefaults`). These are loaded through viper, which lowercases all config keys. The lookup, however, compared against `p.Prefix+p.Key`, which preserves the operator's declared name. For operators whose name is not all-lowercase (e.g. "KubeManager", "LocalManager"), the lookup never matched and the gadget-configured default was silently ignored.

**Note**: I hit this when trying to work on an operator with containing upper letter characters in the name!

Used the [program here](https://gist.github.com/mqasimsarfraz/51a5a337ca945ec26096be1d17123cad) to verify the viper behavior! 
