### PR TITLE
PoC: Rootless ig run

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -449,6 +449,20 @@ func ensureBuilderImage(ctx context.Context, cli *client.Client, builderImage st
 	return nil
 }
 
+func isRootlessEngine(ctx context.Context, cli *client.Client) (bool, error) {
+	info, err := cli.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return false, fmt.Errorf("getting engine info: %w", err)
+	}
+
+	for _, opt := range info.Info.SecurityOptions {
+		if strings.Contains(opt, "name=rootless") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -532,20 +546,30 @@ func buildInContainer(opts *cmdOpts, conf *buildFile) error {
 		})
 	}
 
-	resp, err := cli.ContainerCreate(
-		ctx,
-		client.ContainerCreateOptions{
-			Config: &container.Config{
-				Image:      opts.builderImage,
-				Cmd:        []string{"sleep", "inf"},
-				WorkingDir: gadgetSourcePath,
-				User:       fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-			},
-			HostConfig: &container.HostConfig{
-				Mounts: mounts,
-			},
+	containerCreateOptions := client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image:      opts.builderImage,
+			Cmd:        []string{"sleep", "inf"},
+			WorkingDir: gadgetSourcePath,
 		},
-	)
+		HostConfig: &container.HostConfig{
+			Mounts: mounts,
+		},
+	}
+
+	isRootless, err := isRootlessEngine(ctx, cli)
+	if err != nil {
+		return fmt.Errorf("getting container engine information: %w", err)
+	}
+	if isRootless {
+		if os.Geteuid() == 0 {
+			return errors.New("running build as root user with rootless container engine is not possible, run build as your user")
+		}
+	} else {
+		containerCreateOptions.Config.User = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	}
+
+	resp, err := cli.ContainerCreate(ctx, containerCreateOptions)
 	if err != nil {
 		return fmt.Errorf("creating builder container: %w", err)
 	}

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -34,6 +34,7 @@ import (
 	gadgetmanifest "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-manifest"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/oci"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	clioperator "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/cli"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/combiner"
@@ -163,6 +164,9 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		if err := utils.ParseEarlyFlags(cmd, args); err != nil {
 			return err
 		}
+
+		ociStoreUser, _ := cmd.PersistentFlags().GetBool("oci-store-user")
+		oci.SetUseUserOciStore(ociStoreUser)
 
 		// Before running the gadget, we need to get the gadget info to be able to set
 		// things (like params) up correctly
@@ -431,6 +435,12 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		"t",
 		0,
 		"Number of seconds that the gadget will run for, 0 to run indefinitely",
+	)
+
+	cmd.PersistentFlags().Bool(
+		"oci-store-user",
+		false,
+		"Use user OCI store (~/.ig/oci-store) instead of system-wide store (/var/lib/ig/oci-store)",
 	)
 
 	if commandMode != CommandModeAttach {

--- a/cmd/ig/main.go
+++ b/cmd/ig/main.go
@@ -20,6 +20,8 @@ import (
 	_ "net/http/pprof"
 	"os"
 
+	"golang.org/x/sys/unix"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -64,6 +66,10 @@ func main() {
 	if experimental.Enabled() {
 		log.Info("Experimental features enabled")
 	}
+
+	// We need this in order to read /proc/self after setting capabilities
+	// manually.
+	_ = unix.Prctl(unix.PR_SET_DUMPABLE, 1, 0, 0, 0)
 
 	rootCmd := &cobra.Command{
 		Use:   "ig",

--- a/docs/rootless-ig-run.md
+++ b/docs/rootless-ig-run.md
@@ -1,0 +1,76 @@
+# Running `ig` Rootless
+
+Run `ig` as a normal (non-root) user with scoped capabilities instead of `sudo`.
+
+## 1. Host setup
+
+These steps require `sudo` **once**. Some are not persistent across reboots (see notes).
+
+### a) Allow your user to read tracefs
+
+`ig` needs to read tracepoint IDs under `/sys/kernel/tracing`.
+
+```bash
+sudo chmod -R o+rX /sys/kernel/tracing
+```
+
+> ⚠️ Resets on reboot (tracefs is a pseudo-filesystem) — re-run after each boot, or
+> persist it with a systemd oneshot. Exposes system-wide tracing data to all local
+> users; acceptable on dev/dedicated hosts, reconsider on multi-tenant machines.
+
+### b) Set `perf_event_paranoid`
+
+```bash
+sudo sysctl -w kernel.perf_event_paranoid=2
+```
+
+### c) Grant capabilities to the `ig` binary
+
+```bash
+sudo setcap cap_sys_ptrace,cap_perfmon,cap_bpf=eip ./ig
+```
+
+| Capability       | Purpose                                              |
+| ---------------- | ---------------------------------------------------- |
+| `cap_bpf`        | Load eBPF programs and create maps                   |
+| `cap_perfmon`    | Open tracepoint perf events                          |
+| `cap_sys_ptrace` | Read `/proc/<pid>/ns/*` for container enrichment     |
+
+> ⚠️ Capabilities are bound to the file inode. **Re-run `setcap` after every rebuild.**
+
+Verify:
+
+```bash
+getcap ./ig   # → ./ig cap_sys_ptrace,cap_perfmon,cap_bpf=eip
+```
+
+## 2. Using `ig` with Podman
+
+Enable the rootless Podman API socket (once):
+
+```bash
+systemctl --user enable --now podman.socket
+ls -l "$XDG_RUNTIME_DIR/podman/podman.sock"
+```
+
+Run `ig`, pointing it at the rootless socket:
+
+```bash
+./ig run trace_exec:built-rootless \
+  --oci-store-user \
+  --verify-image=false \
+  -r podman \
+  --podman-socketpath "$XDG_RUNTIME_DIR/podman/podman.sock"
+```
+
+> Only containers started by **your** user (rootless Podman) are visible.
+
+## 3. Drawbacks
+
+- **No new-container detection.** Rootless `ig` lacks `CAP_SYS_ADMIN`, so fanotify is
+  unavailable. Only containers **already running before `ig` starts** are detected and
+  enriched; containers created afterwards will not appear.
+
+  ```
+  WARN  binary does not have CAP_SYS_ADMIN: new containers will not be detected
+  ```

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -19,6 +19,7 @@ CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
 DOCKER ?= docker
+SUDO ?= sudo -E
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -99,7 +100,7 @@ pull-builder-image:
 .PHONY: $(GADGETS)
 $(GADGETS): pull-builder-image
 	@echo "Building $@"
-	@sudo -E \
+	@$(SUDO) \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -143,34 +144,34 @@ $(GADGETS_README_DEV):
 
 %-push: %-build
 	@echo "Pushing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
+	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
 
 %-sign: %-push
 	@echo "Signing $*"
-	digest=$$(sudo -E $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+	digest=$$($(SUDO) $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
-	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 
 %-clean:
-	sudo -E $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 clean: $(addsuffix -clean,$(GADGETS))
@@ -180,14 +181,14 @@ pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
 	for GADGET in $(GADGETS); do \
-		sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
 	done
 
 .PHONY:
 %/pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	sudo -E $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY:
 test-unit: build
@@ -199,9 +200,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./.../$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./.../$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./.../$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-unit: %
@@ -213,9 +214,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		sudo -E PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./$*/$(UNIT_TEST_DIR)/..., \
-		go test -v -exec 'sudo -E' ./$*/$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO)' ./$*/$(UNIT_TEST_DIR)/...)
 
 .PHONY:
 %/test-integration: %
@@ -225,7 +226,7 @@ test-unit: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./$*/$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./$*/$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-integration: build
@@ -235,7 +236,7 @@ test-integration: build
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec 'sudo -E' ./.../$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO)' ./.../$(INTEGRATION_TEST_DIR)/...
 
 .PHONY:
 test-local: IG_PATH=$(IG)

--- a/go.mod
+++ b/go.mod
@@ -193,6 +193,8 @@ require (
 	sigs.k8s.io/release-utils v0.11.1 // indirect
 )
 
+require github.com/moby/sys/capability v0.4.0
+
 require (
 	cyphar.com/go-pathrs v0.2.5 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,8 @@ github.com/moby/moby/client v0.5.0 h1:5XhyPk2fuOWf6RlSFa3MkIIgDZkF25xToXW8Q/BH7c
 github.com/moby/moby/client v0.5.0/go.mod h1:rcVpF8ncl9vo5gaIBdol6CnbEtSj1uxMvEV/UrykF/s=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/sys/capability v0.4.0 h1:4D4mI6KlNtWMCM1Z/K0i7RV1FkX+DBDHKVJpCndZoHk=
+github.com/moby/sys/capability v0.4.0/go.mod h1:4g9IK291rVkms3LKCDOoYlnV8xKwoDTpIrNEE35Wq0I=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=

--- a/pkg/oci/local_oci_store.go
+++ b/pkg/oci/local_oci_store.go
@@ -16,9 +16,12 @@ package oci
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path"
+	"path/filepath"
 	"reflect"
 
 	"github.com/gofrs/flock"
@@ -34,15 +37,62 @@ type localOciStore struct {
 	indexFlock *flock.Flock
 }
 
+const userOciStoreSubDir = ".ig/oci-store"
+
+var useUserOciStore bool
+
+func SetUseUserOciStore(v bool) {
+	useUserOciStore = v
+}
+
+func getOciStorePath() (string, error) {
+	username := ""
+	if os.Geteuid() == 0 {
+		if useUserOciStore {
+			// Running as root through sudo, with --oci-store-user.
+			username = os.Getenv("SUDO_USER")
+			if username == "" {
+				return "", errors.New("--oci-store-user requires being run with sudo, not as root directly")
+			}
+		} else {
+			// Running as root, without --oci-store-user
+			return rootOciStore, nil
+		}
+	} else {
+		// Running as normal user.
+		u, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("getting current user: %w", err)
+		}
+		username = u.Username
+	}
+
+	return getUserOciStorePath(username)
+}
+
+func getUserOciStorePath(username string) (string, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return "", fmt.Errorf("finding user %q: %w", username, err)
+	}
+
+	return filepath.Join(u.HomeDir, userOciStoreSubDir), nil
+}
+
 // newLocalOciStore returns a localOciStore that is safe when executed
 // concurrently, even from different processes.
 func newLocalOciStore() (*localOciStore, error) {
-	if err := os.MkdirAll(defaultOciStore, 0o700); err != nil {
-		return nil, fmt.Errorf("creating oci store directory %q: %w", defaultOciStore, err)
+	ociStorePath, err := getOciStorePath()
+	if err != nil {
+		return nil, fmt.Errorf("getting OCI store path: %w", err)
 	}
 
-	indexPath := path.Join(defaultOciStore, "index.json")
-	indexLock := flock.New(path.Join(defaultOciStore, "index.json.lock"))
+	if err := os.MkdirAll(ociStorePath, 0o700); err != nil {
+		return nil, fmt.Errorf("creating oci store directory %q: %w", ociStorePath, err)
+	}
+
+	indexPath := path.Join(ociStorePath, "index.json")
+	indexLock := flock.New(path.Join(ociStorePath, "index.json.lock"))
 
 	// lock the file before reading the index below
 	// RLock can't be used since we might create and init an empty index file in oci.New()
@@ -51,7 +101,7 @@ func newLocalOciStore() (*localOciStore, error) {
 	}
 	defer indexLock.Unlock()
 
-	ociStore, err := oci.New(defaultOciStore)
+	ociStore, err := oci.New(ociStorePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -76,7 +76,7 @@ type ImageOptions struct {
 }
 
 const (
-	defaultOciStore = "/var/lib/ig/oci-store"
+	rootOciStore    = "/var/lib/ig/oci-store"
 	DefaultAuthFile = "/var/lib/ig/config.json"
 
 	PullImageAlways  = "always"

--- a/pkg/operators/localmanager/localmanager.go
+++ b/pkg/operators/localmanager/localmanager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/constants"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
+	"github.com/moby/sys/capability"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
@@ -259,6 +260,17 @@ func (l *localManager) Init(operatorParams *params.Params) error {
 	return nil
 }
 
+func hasEffectiveCap(cap capability.Cap) (bool, error) {
+	caps, err := capability.NewPid2(0)
+	if err != nil {
+		return false, err
+	}
+	if err := caps.Load(); err != nil {
+		return false, err
+	}
+	return caps.Get(capability.EFFECTIVE, cap), nil
+}
+
 // initCollections initializes the container collection and tracer collection.
 func (l *localManager) initCollections(rc []*containerutilsTypes.RuntimeConfig, kubeconfig string, enrichWithK8s bool) error {
 	var cc containercollection.ContainerCollection
@@ -289,10 +301,20 @@ func (l *localManager) initCollections(rc []*containerutilsTypes.RuntimeConfig, 
 		containercollection.WithLinuxNamespaceEnrichment(),
 		containercollection.WithMultipleContainerRuntimesEnrichment(rc),
 		containercollection.WithOCIConfigForInitialContainer(),
-		containercollection.WithContainerFanotifyEbpf(),
 		containercollection.WithTracerCollection(l.tracerCollection),
 		containercollection.WithProcEnrichment(),
 	}...)
+
+	ok, err := hasEffectiveCap(capability.CAP_SYS_ADMIN)
+	if err != nil {
+		log.Warnf("checking if binary has CAP_SYS_ADMIN: %v", err)
+	}
+
+	if ok {
+		ccOpts = append(ccOpts, containercollection.WithContainerFanotifyEbpf())
+	} else {
+		log.Warn("binary does not have CAP_SYS_ADMIN: new containers will not be detected")
+	}
 
 	if kubeconfig != "" {
 		ccOpts = append(ccOpts, containercollection.WithKubeconfigPath(kubeconfig))

--- a/pkg/runtime/local/local.go
+++ b/pkg/runtime/local/local.go
@@ -15,10 +15,6 @@
 package local
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 )
@@ -30,10 +26,6 @@ func New() *Runtime {
 }
 
 func (r *Runtime) Init(globalRuntimeParams *params.Params) error {
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("%s must be run as root to be able to run eBPF programs", filepath.Base(os.Args[0]))
-	}
-
 	err := host.Init(host.Config{})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR enables running gadgets without being root and without CAP_SYS_ADMIN, only the 3 following capabilities are needed:
1. `cap_bpf`       
1. `cap_perfmon`   
1. `cap_sys_ptrace`

Unfortunately, this is not possible to get fanotify running, as it requires CAP_SYS_ADMIN, so ig will report events coming from already running containers.

This PR needs commits from #5578 in order to have the normal user reading the oci store, so only https://github.com/inspektor-gadget/inspektor-gadget/pull/5637/commits/38bd7aface5a246b5dd002f6f27e3567ff78cb08 is exclusive to this PR and feature.