### PR TITLE
pkg/testing: Gate StartAndStop gadget tests on readiness

### DIFF
--- a/gadgets/ci/container_filtering/test/integration/container_filtering_test.go
+++ b/gadgets/ci/container_filtering/test/integration/container_filtering_test.go
@@ -17,7 +17,6 @@ package integration
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -116,7 +115,6 @@ func TestContainerFiltering(t *testing.T) {
 
 	testSteps := []igtesting.TestStep{
 		containerFilteringCmd,
-		utils.Sleep(3 * time.Second),
 	}
 	igtesting.RunTestSteps(testSteps, t, testingOpts...)
 }

--- a/gadgets/ci/datasource-containers/test/integration/datasource_test.go
+++ b/gadgets/ci/datasource-containers/test/integration/datasource_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	ocispec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
@@ -115,8 +114,6 @@ func TestDatasourceContainers(t *testing.T) {
 
 	steps := []igtesting.TestStep{
 		datasourceContainersCmd,
-		// wait to ensure ig or kubectl-gadget has started
-		utils.Sleep(3 * time.Second),
 	}
 	igtesting.RunTestSteps(steps, t, testingOpts...)
 }
@@ -187,8 +184,6 @@ func TestDatasourceContainersPreCreate(t *testing.T) {
 
 	steps := []igtesting.TestStep{
 		datasourceContainersCmd,
-		// wait to ensure ig or kubectl-gadget has started
-		utils.Sleep(5 * time.Second),
 		testContainer,
 	}
 	igtesting.RunTestSteps(steps, t, testingOpts...)

--- a/gadgets/ci/stacks/test/integration/ci_stacks_test.go
+++ b/gadgets/ci/stacks/test/integration/ci_stacks_test.go
@@ -110,6 +110,10 @@ func TestCiStacks(t *testing.T) {
 			"--verify-image=false",
 		),
 		igrunner.WithStartAndStop(),
+		// The OTel eBPF profiler does not emit the standard readiness marker and has its own
+		// initialization timing, so it keeps using the explicit sleep below instead of the
+		// readiness gate.
+		igrunner.WithoutReadinessGate(),
 		igrunner.WithValidateOutput(func(t *testing.T, output string) {
 			expectedEntries := []*stacksEvent{
 				{

--- a/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
+++ b/gadgets/trace_capabilities/test/integration/trace_capabilities_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -233,8 +232,6 @@ int main() {
 
 	steps := []igtesting.TestStep{
 		traceCapabilitiesCmd,
-		// wait to ensure ig or kubectl-gadget has started
-		utils.Sleep(3 * time.Second),
 	}
 	igtesting.RunTestSteps(steps, t, testingOpts...)
 }

--- a/gadgets/trace_exec/test/integration/trace_exec_test.go
+++ b/gadgets/trace_exec/test/integration/trace_exec_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -318,8 +317,6 @@ int main(int argc, char *argv[], char **envp) {
 
 	steps := []igtesting.TestStep{
 		traceExecCmd,
-		// wait to ensure ig or kubectl-gadget has started
-		utils.Sleep(10 * time.Second),
 		testContainer,
 	}
 	igtesting.RunTestSteps(steps, t, testingOpts...)

--- a/gadgets/trace_oomkill/test/integration/trace_oomkill_test.go
+++ b/gadgets/trace_oomkill/test/integration/trace_oomkill_test.go
@@ -17,7 +17,6 @@ package tests
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
@@ -114,7 +113,6 @@ func TestTraceOomKill(t *testing.T) {
 
 	testSteps := []igtesting.TestStep{
 		traceOomkillCmd,
-		utils.Sleep(10 * time.Second),
 		testContainer,
 	}
 

--- a/pkg/testing/command/command.go
+++ b/pkg/testing/command/command.go
@@ -43,6 +43,11 @@ type Command struct {
 	// It's used in situations where we want to process the output on-line without saving it.
 	StdOutWriter io.Writer
 
+	// StdErrLineObserver, if set, is invoked with each complete line of the command's
+	// standard error as it is produced. It allows callers to react to output while the
+	// command is still running (e.g. to detect a readiness marker).
+	StdErrLineObserver func(line string)
+
 	// StartAndStop indicates this command should first be started then stopped.
 	// It corresponds to gadget like execsnoop which wait user to type Ctrl^C.
 	StartAndStop bool
@@ -60,6 +65,38 @@ type Command struct {
 
 	// stderr contains command standard output when started using Startcommand().
 	stderr bytes.Buffer
+
+	// stderrProc is the live stderr line processor, set when StdErrLineObserver is used. It
+	// must be flushed once the process has exited so a final line without a trailing newline
+	// is not lost.
+	stderrProc *stderrLineProcessor
+
+	// trackExit, when set before Start(), makes a background goroutine own Cmd.Wait() so the
+	// command's exit can be observed (via ExitCh) while it is still "running" from the test's
+	// point of view. It is used by the readiness gate to fail fast when a started command exits
+	// before becoming ready, instead of waiting for the readiness timeout. Untracked commands
+	// keep the original Stop()/kill() behaviour.
+	trackExit bool
+	exitCh    chan struct{}
+	exitErr   error
+}
+
+// TrackExit enables background exit tracking (see the trackExit field). It must be called before
+// Start().
+func (c *Command) TrackExit() {
+	c.trackExit = true
+}
+
+// ExitCh returns a channel that is closed once a tracked command's process has exited (and been
+// reaped), or nil if exit tracking is not enabled. ExitErr may be read once it is closed.
+func (c *Command) ExitCh() <-chan struct{} {
+	return c.exitCh
+}
+
+// ExitErr returns the error from Cmd.Wait() for a tracked command. It must only be read after
+// ExitCh() has been closed.
+func (c *Command) ExitErr() error {
+	return c.exitErr
 }
 
 func (c *Command) IsStartAndStop() bool {
@@ -78,6 +115,16 @@ func (c *Command) initExecCmd() {
 
 	if c.StdOutWriter != nil {
 		c.Cmd.Stdout = c.StdOutWriter
+	}
+
+	// When a caller wants to observe stderr lines live, route stderr through a line
+	// processor that feeds the observer while still storing every line.
+	if c.StdErrLineObserver != nil {
+		c.stderrProc = &stderrLineProcessor{
+			observer: c.StdErrLineObserver,
+			store:    &c.stderr,
+		}
+		c.Cmd.Stderr = c.stderrProc
 	}
 
 	// To be able to kill the process of /bin/sh and its child (the process of
@@ -107,12 +154,22 @@ func (c *Command) verifyStderrOutput(t *testing.T) {
 	}
 }
 
+// flushStderr flushes any final stderr line that was not terminated by a newline. It must be
+// called only after the process has exited (so all writes to the processor are done), which is
+// guaranteed after Cmd.Run()/Cmd.Wait() returns.
+func (c *Command) flushStderr() {
+	if c.stderrProc != nil {
+		c.stderrProc.flush()
+	}
+}
+
 // Run runs the Command on the given as parameter test.
 func (c *Command) Run(t *testing.T) {
 	c.initExecCmd()
 
 	t.Logf("[%s] Run command(%s):\n", time.Now().UTC(), c.Name)
 	err := c.Cmd.Run()
+	c.flushStderr()
 	t.Logf("[%s] Command returned(%s):\n%s\n%s\n",
 		time.Now().UTC(), c.Name, c.stderr.String(), c.stdout.String())
 	require.NoError(t, err, "failed to run command(%s)", c.Name)
@@ -136,6 +193,18 @@ func (c *Command) Start(t *testing.T) {
 	require.NoError(t, err, "failed to start command(%s)", c.Name)
 
 	c.started = true
+
+	// When exit tracking is enabled, a background goroutine owns Cmd.Wait() so that the
+	// command's exit (e.g. a gadget that fails to load) can be observed via ExitCh() while the
+	// test is still waiting for it to become ready. kill() then reaps through this goroutine
+	// instead of calling Cmd.Wait() a second time.
+	if c.trackExit {
+		c.exitCh = make(chan struct{})
+		go func() {
+			c.exitErr = c.Cmd.Wait()
+			close(c.exitCh)
+		}()
+	}
 }
 
 // Stop stops a Command previously started with Start().
@@ -150,6 +219,7 @@ func (c *Command) Stop(t *testing.T) {
 
 	t.Logf("[%s] Stop command(%s)\n", time.Now().UTC(), c.Name)
 	err := c.kill()
+	c.flushStderr()
 	t.Logf("[%s] Command returned(%s):\n%s\n%s\n",
 		time.Now().UTC(), c.Name, c.stderr.String(), c.stdout.String())
 	require.NoError(t, err, "failed to kill command(%s)", c.Name)
@@ -164,8 +234,35 @@ func (c *Command) Stop(t *testing.T) {
 func (c *Command) kill() error {
 	const sig syscall.Signal = syscall.SIGKILL
 
+	if c.Cmd == nil {
+		return nil
+	}
+
+	// Tracked commands have a background goroutine that owns Cmd.Wait(). Reap through it
+	// instead of calling Wait() again (which would panic).
+	if c.exitCh != nil {
+		select {
+		case <-c.exitCh:
+			// The process already exited on its own. Report its exit status just like the
+			// untracked path would: a self-exit before readiness is already surfaced by
+			// WaitForReady, but a gadget that becomes ready and then crashes during the
+			// workload window must not be silently treated as a clean stop.
+			return killErrorAllowingSignal(c.exitErr, sig)
+		default:
+		}
+
+		// The process was still running when we checked; kill its group. It may still exit
+		// and be reaped by the background goroutine between the check and here, in which case
+		// the group is already gone (ESRCH); that is not an error for us.
+		if err := syscall.Kill(-c.Cmd.Process.Pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		<-c.exitCh
+		return killErrorAllowingSignal(c.exitErr, sig)
+	}
+
 	// No need to kill, command has not been executed yet or it already exited
-	if c.Cmd == nil || (c.Cmd.ProcessState != nil && c.Cmd.ProcessState.Exited()) {
+	if c.Cmd.ProcessState != nil && c.Cmd.ProcessState.Exited() {
 		return nil
 	}
 
@@ -182,29 +279,81 @@ func (c *Command) kill() error {
 	// with run(), which already waits. On the contrary, in the case it was
 	// executed with start() thus ig.started is true, we need to wait indeed.
 	if c.started {
-		err = c.Cmd.Wait()
-		if err == nil {
-			return nil
-		}
-
-		// Verify if the error is about the signal we just sent. In that case,
-		// do not return error, it is what we were expecting.
-		var exiterr *exec.ExitError
-		if ok := errors.As(err, &exiterr); !ok {
-			return err
-		}
-
-		waitStatus, ok := exiterr.Sys().(syscall.WaitStatus)
-		if !ok {
-			return err
-		}
-
-		if waitStatus.Signal() != sig {
-			return err
-		}
-
-		return nil
+		return killErrorAllowingSignal(c.Cmd.Wait(), sig)
 	}
 
 	return err
+}
+
+// killErrorAllowingSignal returns nil if err is nil or is the process being terminated by sig
+// (which is what we expect when we SIGKILL a still-running command); otherwise it returns err.
+func killErrorAllowingSignal(err error, sig syscall.Signal) error {
+	if err == nil {
+		return nil
+	}
+
+	// Verify if the error is about the signal we just sent. In that case,
+	// do not return error, it is what we were expecting.
+	var exiterr *exec.ExitError
+	if ok := errors.As(err, &exiterr); !ok {
+		return err
+	}
+
+	waitStatus, ok := exiterr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return err
+	}
+
+	if waitStatus.Signal() != sig {
+		return err
+	}
+
+	return nil
+}
+
+// stderrLineProcessor is an io.Writer that splits the incoming bytes into lines and, for each
+// complete line, invokes an optional observer and stores the line in a backing buffer. It's used
+// to observe stderr live (e.g. to detect a readiness marker) without losing it from the command's
+// stored stderr.
+type stderrLineProcessor struct {
+	buf      []byte
+	observer func(line string)
+	store    *bytes.Buffer
+}
+
+func (p *stderrLineProcessor) Write(b []byte) (int, error) {
+	p.buf = append(p.buf, b...)
+	for {
+		i := bytes.IndexByte(p.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(p.buf[:i])
+		p.buf = append(p.buf[:0], p.buf[i+1:]...)
+		p.handle(line, true)
+	}
+	return len(b), nil
+}
+
+func (p *stderrLineProcessor) handle(line string, hasNewline bool) {
+	if p.observer != nil {
+		p.observer(line)
+	}
+	if p.store != nil {
+		p.store.WriteString(line)
+		if hasNewline {
+			p.store.WriteByte('\n')
+		}
+	}
+}
+
+// flush emits any buffered bytes that were not terminated by a newline as a final line. It must
+// be called only after the last Write (i.e. after the process has exited) to avoid data races.
+func (p *stderrLineProcessor) flush() {
+	if len(p.buf) == 0 {
+		return
+	}
+	line := string(p.buf)
+	p.buf = p.buf[:0]
+	p.handle(line, false)
 }

--- a/pkg/testing/command/command.go
+++ b/pkg/testing/command/command.go
@@ -48,6 +48,11 @@ type Command struct {
 	// command is still running (e.g. to detect a readiness marker).
 	StdErrLineObserver func(line string)
 
+	// StdErrStoreFilter, if set and returning true for a given standard error line, causes
+	// that line to be omitted from the stderr buffer used for validation and logging. It's
+	// used to drop verbose/debug noise while still allowing StdErrLineObserver to see it.
+	StdErrStoreFilter func(line string) bool
+
 	// StartAndStop indicates this command should first be started then stopped.
 	// It corresponds to gadget like execsnoop which wait user to type Ctrl^C.
 	StartAndStop bool
@@ -66,9 +71,9 @@ type Command struct {
 	// stderr contains command standard output when started using Startcommand().
 	stderr bytes.Buffer
 
-	// stderrProc is the live stderr line processor, set when StdErrLineObserver is used. It
-	// must be flushed once the process has exited so a final line without a trailing newline
-	// is not lost.
+	// stderrProc is the live stderr line processor, set when StdErrLineObserver or
+	// StdErrStoreFilter is used. It must be flushed once the process has exited so a final
+	// line without a trailing newline is not lost.
 	stderrProc *stderrLineProcessor
 
 	// trackExit, when set before Start(), makes a background goroutine own Cmd.Wait() so the
@@ -117,11 +122,13 @@ func (c *Command) initExecCmd() {
 		c.Cmd.Stdout = c.StdOutWriter
 	}
 
-	// When a caller wants to observe stderr lines live, route stderr through a line
-	// processor that feeds the observer while still storing every line.
-	if c.StdErrLineObserver != nil {
+	// When a caller wants to observe stderr lines live or filter noise out of the stored
+	// stderr, route stderr through a line processor that feeds the observer and only stores
+	// the lines that pass the filter.
+	if c.StdErrLineObserver != nil || c.StdErrStoreFilter != nil {
 		c.stderrProc = &stderrLineProcessor{
 			observer: c.StdErrLineObserver,
+			filter:   c.StdErrStoreFilter,
 			store:    &c.stderr,
 		}
 		c.Cmd.Stderr = c.stderrProc
@@ -312,12 +319,13 @@ func killErrorAllowingSignal(err error, sig syscall.Signal) error {
 }
 
 // stderrLineProcessor is an io.Writer that splits the incoming bytes into lines and, for each
-// complete line, invokes an optional observer and stores the line in a backing buffer. It's used
-// to observe stderr live (e.g. to detect a readiness marker) without losing it from the command's
-// stored stderr.
+// complete line, invokes an optional observer and optionally stores the line in a backing buffer.
+// It's used to observe stderr live (e.g. to detect a readiness marker) while keeping the stored
+// stderr free of verbose/debug noise.
 type stderrLineProcessor struct {
 	buf      []byte
 	observer func(line string)
+	filter   func(line string) bool
 	store    *bytes.Buffer
 }
 
@@ -339,7 +347,7 @@ func (p *stderrLineProcessor) handle(line string, hasNewline bool) {
 	if p.observer != nil {
 		p.observer(line)
 	}
-	if p.store != nil {
+	if p.store != nil && (p.filter == nil || !p.filter(line)) {
 		p.store.WriteString(line)
 		if hasNewline {
 			p.store.WriteByte('\n')

--- a/pkg/testing/command/command_test.go
+++ b/pkg/testing/command/command_test.go
@@ -32,6 +32,7 @@ func TestStderrLineProcessor(t *testing.T) {
 
 	p := &stderrLineProcessor{
 		observer: func(line string) { observed = append(observed, line) },
+		filter:   func(line string) bool { return line == "drop-me" },
 		store:    &store,
 	}
 
@@ -43,20 +44,21 @@ func TestStderrLineProcessor(t *testing.T) {
 		require.Equal(t, len(w), n)
 	}
 
-	// The observer sees every complete line.
+	// The observer sees every complete line, including the filtered one.
 	assert.Equal(t, []string{"keep-1", "drop-me", "keep-2"}, observed)
 
-	// The store keeps every line; the trailing line without a newline is not flushed.
-	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\n", store.String())
+	// The store keeps only the lines that pass the filter; the trailing line without a
+	// newline is not flushed.
+	assert.Equal(t, "keep-1\nkeep-2\n", store.String())
 
 	// After the process exits, flush emits the final unterminated line so it is not lost.
 	p.flush()
 	assert.Equal(t, []string{"keep-1", "drop-me", "keep-2", "partial-no-newline"}, observed)
-	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\npartial-no-newline", store.String())
+	assert.Equal(t, "keep-1\nkeep-2\npartial-no-newline", store.String())
 
 	// A second flush is a no-op.
 	p.flush()
-	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\npartial-no-newline", store.String())
+	assert.Equal(t, "keep-1\nkeep-2\npartial-no-newline", store.String())
 }
 
 func TestKillErrorAllowingSignal(t *testing.T) {

--- a/pkg/testing/command/command_test.go
+++ b/pkg/testing/command/command_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStderrLineProcessor(t *testing.T) {
+	var store bytes.Buffer
+	var observed []string
+
+	p := &stderrLineProcessor{
+		observer: func(line string) { observed = append(observed, line) },
+		store:    &store,
+	}
+
+	// Write in chunks that split lines across Write calls to exercise the line buffering.
+	writes := []string{"keep-1\ndr", "op-me\nke", "ep-2\n", "partial-no-newline"}
+	for _, w := range writes {
+		n, err := p.Write([]byte(w))
+		require.NoError(t, err)
+		require.Equal(t, len(w), n)
+	}
+
+	// The observer sees every complete line.
+	assert.Equal(t, []string{"keep-1", "drop-me", "keep-2"}, observed)
+
+	// The store keeps every line; the trailing line without a newline is not flushed.
+	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\n", store.String())
+
+	// After the process exits, flush emits the final unterminated line so it is not lost.
+	p.flush()
+	assert.Equal(t, []string{"keep-1", "drop-me", "keep-2", "partial-no-newline"}, observed)
+	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\npartial-no-newline", store.String())
+
+	// A second flush is a no-op.
+	p.flush()
+	assert.Equal(t, "keep-1\ndrop-me\nkeep-2\npartial-no-newline", store.String())
+}
+
+func TestKillErrorAllowingSignal(t *testing.T) {
+	const sig = syscall.SIGKILL
+
+	// nil error stays nil.
+	assert.NoError(t, killErrorAllowingSignal(nil, sig))
+
+	// A non-ExitError is returned as-is.
+	sentinel := errors.New("boom")
+	assert.ErrorIs(t, killErrorAllowingSignal(sentinel, sig), sentinel)
+
+	// Being terminated by the signal we sent is expected => nil.
+	killed := exec.Command("/bin/sh", "-c", "kill -KILL $$").Run()
+	require.Error(t, killed)
+	assert.NoError(t, killErrorAllowingSignal(killed, sig))
+
+	// A non-zero exit that is not our signal is a real error and is returned.
+	exited := exec.Command("/bin/sh", "-c", "exit 3").Run()
+	require.Error(t, exited)
+	assert.Error(t, killErrorAllowingSignal(exited, sig))
+}
+
+func TestTrackExit_EarlyExitObservable(t *testing.T) {
+	// A tracked command that exits on its own has its exit observable via ExitCh()/ExitErr()
+	// without a second Wait().
+	c := &Command{Name: "early-exit", Cmd: exec.Command("/bin/sh", "-c", "exit 3")}
+	c.TrackExit()
+	c.Start(t)
+
+	select {
+	case <-c.ExitCh():
+	case <-time.After(10 * time.Second):
+		t.Fatal("tracked command exit was not observed")
+	}
+	assert.Error(t, c.ExitErr(), "expected a non-zero exit error")
+
+	// kill() on an already-exited tracked command does not double-Wait and surfaces the
+	// non-zero exit (a clean/SIGKILL exit would return nil).
+	assert.Error(t, c.kill(), "kill must report a non-zero self-exit")
+}
+
+func TestTrackExit_KillStillRunning(t *testing.T) {
+	// A tracked command that is still running is stopped via kill(), which reaps through the
+	// background goroutine and treats the SIGKILL as expected (no error).
+	c := &Command{Name: "long-running", Cmd: exec.Command("/bin/sh", "-c", "sleep 30")}
+	c.TrackExit()
+	c.Start(t)
+
+	// It should not have exited yet.
+	select {
+	case <-c.ExitCh():
+		t.Fatal("command exited unexpectedly")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	assert.NoError(t, c.kill())
+}
+
+func TestTrackExit_CleanSelfExitNotAnError(t *testing.T) {
+	// A tracked command that exits 0 on its own is not reported as a kill error.
+	c := &Command{Name: "clean-exit", Cmd: exec.Command("/bin/sh", "-c", "exit 0")}
+	c.TrackExit()
+	c.Start(t)
+
+	select {
+	case <-c.ExitCh():
+	case <-time.After(10 * time.Second):
+		t.Fatal("tracked command exit was not observed")
+	}
+	assert.NoError(t, c.ExitErr())
+	assert.NoError(t, c.kill())
+}

--- a/pkg/testing/ig/ig.go
+++ b/pkg/testing/ig/ig.go
@@ -39,6 +39,18 @@ type runner struct {
 	// command.Command contains *exec.Cmd and additional properties and methods for the same.
 	command.Command
 	flags []string
+
+	// waitReady and readyWatcher implement the readiness gate (see readiness.go). They are set
+	// for StartAndStop gadgets so the harness waits for the gadget to actually be capturing
+	// before running the workload, instead of relying on a fixed sleep.
+	waitReady    bool
+	readyWatcher *readinessWatcher
+
+	// noReadinessGate disables the readiness gate even for StartAndStop gadgets. It is used by
+	// gadgets that do not emit the standard "running..." readiness marker in a usable way (e.g.
+	// the OTel eBPF profiler, which samples over a window and has its own initialization
+	// timing), so they keep relying on an explicit sleep instead.
+	noReadinessGate bool
 }
 
 func (ig *runner) createCmd() {
@@ -68,6 +80,15 @@ func WithFlags(flags ...string) Option {
 func WithStartAndStop() Option {
 	return func(ig *runner) {
 		ig.StartAndStop = true
+	}
+}
+
+// WithoutReadinessGate disables the readiness gate for a StartAndStop gadget. Use it for gadgets
+// that do not emit the standard "running..." readiness marker in a usable way (e.g. the OTel
+// eBPF profiler), which instead rely on an explicit sleep before the workload.
+func WithoutReadinessGate() Option {
+	return func(ig *runner) {
+		ig.noReadinessGate = true
 	}
 }
 
@@ -126,6 +147,13 @@ func New(image string, opts ...Option) igtesting.TestStep {
 
 	for _, opt := range opts {
 		opt(factoryRunner)
+	}
+
+	// StartAndStop gadgets run concurrently with the workload; enable the readiness gate so the
+	// harness waits for the gadget to be capturing before the workload runs (see readiness.go),
+	// unless the gadget opted out (it does not emit a usable readiness marker).
+	if factoryRunner.StartAndStop && !factoryRunner.noReadinessGate {
+		factoryRunner.enableReadinessGate()
 	}
 
 	factoryRunner.createCmd()

--- a/pkg/testing/ig/readiness.go
+++ b/pkg/testing/ig/readiness.go
@@ -1,0 +1,239 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ig
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+const (
+	// readinessMarker is the debug message the gadget logs right after all operators
+	// (including the eBPF programs) have been started. Waiting for it lets the harness run
+	// the workload only once the gadget is actually capturing, instead of betting on a fixed
+	// sleep. It is emitted by pkg/gadget-context (see run.go and gadget-context.go); keep this
+	// string in sync with those log messages.
+	//
+	// Beyond this string, the gate also relies on two stable behaviours of the CLI stderr:
+	// the gRPC runtime forwards remote-node logs prefixed with "<node> | " as the raw message
+	// (pkg/runtime/grpc, see parseReadyNode), and logrus uses its non-TTY key=value format
+	// ("level=debug", quoted msg). If either changes, node discrimination or debug filtering
+	// here must be updated accordingly.
+	readinessMarker = "running..."
+
+	// nodeMarkerSep identifies a readiness marker that was forwarded from a remote node by the
+	// gRPC runtime, which prefixes forwarded logs with "<node> | " (see pkg/runtime/grpc).
+	nodeMarkerSep = "| " + readinessMarker
+
+	// dispatchMarker is the debug message the gRPC runtime (kubectl-gadget) logs once for each
+	// node it runs the gadget on, before that node starts (see runGadgetOnTargets in
+	// pkg/runtime/grpc/oci.go). Counting these tells the gate how many nodes to expect a
+	// readiness marker from, honouring --node scoping, without querying the cluster. A node is
+	// always dispatched before it can report ready, so "all dispatched nodes are ready" is
+	// reached exactly when the number of distinct ready nodes equals the dispatched count.
+	dispatchMarker = "running gadget on node "
+
+	// readinessTimeout bounds how long the gate waits for the readiness marker. It only needs to
+	// exceed the worst-case cold start (first-run OCI image pull plus load/attach on a slow
+	// node; heavier gadgets that bundle a WASM module take noticeably longer, especially on the
+	// multi-node minikube runners where the "nodes" share one host). A gadget that fails to
+	// start exits and is caught immediately by exit tracking (see WaitForReady), so this can be
+	// generous without making failing tests hang. If it expires with at least one instance
+	// capturing, the gate proceeds anyway.
+	readinessTimeout = 60 * time.Second
+)
+
+// readinessWatcher tracks gadget readiness on stderr. For the gRPC runtime (kubectl-gadget) it
+// counts the nodes the gadget was dispatched to and the distinct nodes that reported ready (each
+// via a node-prefixed marker); for the local runtime (ig) a single bare marker is expected.
+type readinessWatcher struct {
+	mu         sync.Mutex
+	dispatched int
+	nodes      map[string]struct{}
+	bareSeen   bool
+	updated    chan struct{}
+}
+
+func newReadinessWatcher() *readinessWatcher {
+	return &readinessWatcher{
+		nodes:   make(map[string]struct{}),
+		updated: make(chan struct{}, 1),
+	}
+}
+
+// observe is invoked with each stderr line while the gadget is running.
+func (w *readinessWatcher) observe(line string) {
+	var changed bool
+
+	switch {
+	case strings.Contains(line, dispatchMarker):
+		w.mu.Lock()
+		w.dispatched++
+		changed = true
+		w.mu.Unlock()
+	case strings.Contains(line, readinessMarker):
+		node, isNode := parseReadyNode(line)
+		w.mu.Lock()
+		if isNode {
+			if _, ok := w.nodes[node]; !ok {
+				w.nodes[node] = struct{}{}
+				changed = true
+			}
+		} else if !w.bareSeen {
+			w.bareSeen = true
+			changed = true
+		}
+		w.mu.Unlock()
+	}
+
+	if changed {
+		select {
+		case w.updated <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// ready reports whether every node the gadget was dispatched to has reported ready (gRPC), or a
+// bare marker was seen (local). Because a node is always dispatched before it can report ready,
+// this is true exactly when all expected nodes are capturing.
+//
+// This compares a running count of dispatched nodes against the ready set, which is safe because
+// dispatch lines and readiness markers arrive on the same, in-order stderr stream: a node's
+// dispatch line is logged client-side within microseconds of the run starting (in the goroutine
+// spawn loop of runGadgetOnTargets, pkg/runtime/grpc/oci.go), while its readiness marker is only
+// produced after a full gRPC round trip plus image pull/load/attach (seconds later, forwarded
+// from the node). So by the time observe() sees any readiness marker, every dispatch line that
+// precedes it in the stream has already been counted; the running dispatched count is therefore
+// already final. The dispatch line is logged exactly once per target (no retry), so counting
+// occurrences equals the node count. A hypothetical extra or missing marker cannot cause an early
+// pass: it would only delay the gate until the graceful timeout in WaitForReady.
+func (w *readinessWatcher) ready(nodeMode bool) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if nodeMode {
+		return w.dispatched >= 1 && len(w.nodes) >= w.dispatched
+	}
+	return w.bareSeen
+}
+
+// someReady reports whether at least one instance has reported ready. It's used to decide
+// whether to proceed (with a warning) when not all dispatched nodes are ready before the
+// timeout, so a lagging or unreachable node cannot fail an otherwise-capturing run.
+func (w *readinessWatcher) someReady(nodeMode bool) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if nodeMode {
+		return len(w.nodes) >= 1
+	}
+	return w.bareSeen
+}
+
+func (w *readinessWatcher) summary() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return fmt.Sprintf("%d/%d node(s) ready, bare marker seen: %v", len(w.nodes), w.dispatched, w.bareSeen)
+}
+
+// parseReadyNode extracts a distinct node identifier from a forwarded, node-prefixed readiness
+// marker. It returns (_, false) for a bare (non-forwarded) marker. The gRPC runtime forwards
+// remote logs as `fmt.Sprintf("%-20s | %s", node, msg)`, which the client re-logs (logrus
+// key=value, non-TTY) as `... msg="<node>          | running..."`.
+func parseReadyNode(line string) (string, bool) {
+	i := strings.Index(line, nodeMarkerSep)
+	if i < 0 {
+		return "", false
+	}
+	// Everything up to the separator ends with the padded node name; trim the "%-20s" padding.
+	prefix := strings.TrimRight(line[:i], " ")
+	// The node name is the logrus message value, i.e. what follows the last `msg="`.
+	if j := strings.LastIndex(prefix, `msg="`); j >= 0 {
+		return prefix[j+len(`msg="`):], true
+	}
+	// Fallback: the last whitespace-separated token (node names contain no spaces).
+	fields := strings.Fields(prefix)
+	if len(fields) == 0 {
+		return "", false
+	}
+	return fields[len(fields)-1], true
+}
+
+// enableReadinessGate configures the runner to detect the gadget readiness marker on stderr. It
+// runs the gadget with "-v" so the marker is emitted and observes stderr live.
+func (ig *runner) enableReadinessGate() {
+	ig.waitReady = true
+	ig.readyWatcher = newReadinessWatcher()
+	ig.flags = append(ig.flags, "-v")
+	ig.StdErrLineObserver = ig.readyWatcher.observe
+	// Track the process exit so the gate can fail fast if the gadget exits before it becomes
+	// ready (e.g. image pull, signature, eBPF load/verifier or capability errors), instead of
+	// waiting for readinessTimeout.
+	ig.TrackExit()
+}
+
+// WaitForReady blocks until the gadget has reported that it is running (and thus capturing) on
+// all expected instances, or fails the test after readinessTimeout. It is a no-op when the
+// readiness gate is not enabled.
+func (ig *runner) WaitForReady(t *testing.T) {
+	if !ig.waitReady || ig.readyWatcher == nil {
+		return
+	}
+
+	nodeMode := utils.CurrentTestComponent == utils.KubectlGadgetTestComponent
+
+	deadline := time.NewTimer(readinessTimeout)
+	defer deadline.Stop()
+
+	// exitCh fires if the gadget process exits before becoming ready (nil when exit tracking
+	// is disabled, which blocks forever in the select and is thus a no-op).
+	exitCh := ig.ExitCh()
+
+	for {
+		if ig.readyWatcher.ready(nodeMode) {
+			t.Logf("[%s] gadget ready (%s)", ig.Name, ig.readyWatcher.summary())
+			return
+		}
+		select {
+		case <-ig.readyWatcher.updated:
+		case <-exitCh:
+			// The process exited before all instances reported ready. A StartAndStop gadget
+			// must keep running to capture, so an early exit is always a failure; fail now
+			// instead of waiting for the timeout. The deferred Stop() prints the gadget's
+			// stderr (the actual error).
+			if err := ig.ExitErr(); err != nil {
+				t.Fatalf("[%s] gadget exited before it started capturing: %v (%s)",
+					ig.Name, err, ig.readyWatcher.summary())
+			}
+			t.Fatalf("[%s] gadget exited before it started capturing (%s)",
+				ig.Name, ig.readyWatcher.summary())
+		case <-deadline.C:
+			// If at least one instance is capturing, proceed rather than failing: a lagging
+			// or unreachable node (or an over-counted "want") must not turn an otherwise
+			// capturing run into a hard failure. Only fail if nothing became ready at all.
+			if ig.readyWatcher.someReady(nodeMode) {
+				t.Logf("[%s] gadget readiness timed out after %s; proceeding with partial readiness (%s)",
+					ig.Name, readinessTimeout, ig.readyWatcher.summary())
+				return
+			}
+			t.Fatalf("[%s] gadget did not become ready within %s (%s)",
+				ig.Name, readinessTimeout, ig.readyWatcher.summary())
+		}
+	}
+}

--- a/pkg/testing/ig/readiness.go
+++ b/pkg/testing/ig/readiness.go
@@ -57,7 +57,7 @@ const (
 	// start exits and is caught immediately by exit tracking (see WaitForReady), so this can be
 	// generous without making failing tests hang. If it expires with at least one instance
 	// capturing, the gate proceeds anyway.
-	readinessTimeout = 60 * time.Second
+	readinessTimeout = 120 * time.Second
 )
 
 // readinessWatcher tracks gadget readiness on stderr. For the gRPC runtime (kubectl-gadget) it
@@ -175,13 +175,21 @@ func parseReadyNode(line string) (string, bool) {
 	return fields[len(fields)-1], true
 }
 
+// isDebugLine reports whether a stderr line is a logrus debug line. Such lines are the verbose
+// noise produced by "-v" and are dropped from the stored stderr to keep test reports readable.
+func isDebugLine(line string) bool {
+	return strings.Contains(line, "level=debug")
+}
+
 // enableReadinessGate configures the runner to detect the gadget readiness marker on stderr. It
-// runs the gadget with "-v" so the marker is emitted and observes stderr live.
+// runs the gadget with "-v" so the marker is emitted, observes stderr live and drops the extra
+// debug noise from the stored stderr.
 func (ig *runner) enableReadinessGate() {
 	ig.waitReady = true
 	ig.readyWatcher = newReadinessWatcher()
 	ig.flags = append(ig.flags, "-v")
 	ig.StdErrLineObserver = ig.readyWatcher.observe
+	ig.StdErrStoreFilter = isDebugLine
 	// Track the process exit so the gate can fail fast if the gadget exits before it becomes
 	// ready (e.g. image pull, signature, eBPF load/verifier or capability errors), instead of
 	// waiting for readinessTimeout.

--- a/pkg/testing/ig/readiness_test.go
+++ b/pkg/testing/ig/readiness_test.go
@@ -141,3 +141,9 @@ func TestReadinessWatcher_UpdatedSignal(t *testing.T) {
 	default:
 	}
 }
+
+func TestIsDebugLine(t *testing.T) {
+	assert.True(t, isDebugLine(bareMarker))
+	assert.True(t, isDebugLine(nodeAMarker))
+	assert.False(t, isDebugLine(`time="2026-07-08T12:00:00Z" level=warning msg="something"`))
+}

--- a/pkg/testing/ig/readiness_test.go
+++ b/pkg/testing/ig/readiness_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Realistic logrus-formatted stderr lines (non-TTY text formatter).
+const (
+	// Bare marker emitted by the local runtime, and also by the client itself for the gRPC
+	// runtime (LoadGadgetInfo with run=true). logrus does not quote the message as it has no
+	// spaces (verified against real `ig run -v` output).
+	bareMarker = `time="2026-07-08T12:00:00Z" level=debug msg=running...`
+	// Node-prefixed markers forwarded from remote nodes by the gRPC runtime
+	// (fmt.Sprintf("%-20s | %s", node, "running...")).
+	nodeAMarker = `time="2026-07-08T12:00:01Z" level=debug msg="gke-node-a           | running..."`
+	nodeBMarker = `time="2026-07-08T12:00:02Z" level=debug msg="gke-node-b           | running..."`
+	// Client-side "dispatched to node" lines (one per target, see runGadgetOnTargets). These
+	// tell the gate how many node readiness markers to expect.
+	dispatchAMarker = `time="2026-07-08T12:00:00Z" level=debug msg="running gadget on node \"gke-node-a\""`
+	dispatchBMarker = `time="2026-07-08T12:00:00Z" level=debug msg="running gadget on node \"gke-node-b\""`
+)
+
+func TestParseReadyNode(t *testing.T) {
+	nA, isNodeA := parseReadyNode(nodeAMarker)
+	assert.True(t, isNodeA)
+	assert.Equal(t, "gke-node-a", nA)
+
+	nB, isNodeB := parseReadyNode(nodeBMarker)
+	assert.True(t, isNodeB)
+	assert.Equal(t, "gke-node-b", nB)
+
+	// Distinct nodes yield distinct identifiers; the same line is stable.
+	assert.NotEqual(t, nA, nB)
+	nA2, _ := parseReadyNode(nodeAMarker)
+	assert.Equal(t, nA, nA2)
+
+	// A bare marker is not a node marker.
+	_, isNode := parseReadyNode(bareMarker)
+	assert.False(t, isNode)
+}
+
+func TestReadinessWatcher_LocalMode(t *testing.T) {
+	w := newReadinessWatcher()
+
+	// Not ready before any marker.
+	assert.False(t, w.ready(false))
+
+	// A dispatch line does not make the local runtime ready.
+	w.observe(dispatchAMarker)
+	assert.False(t, w.ready(false))
+
+	// A bare marker makes it ready in local (non-node) mode.
+	w.observe(bareMarker)
+	assert.True(t, w.ready(false))
+}
+
+func TestReadinessWatcher_NodeMode(t *testing.T) {
+	w := newReadinessWatcher()
+
+	// The client's own bare marker must NOT count towards node readiness, and with no
+	// dispatch seen yet the gate is not ready.
+	w.observe(bareMarker)
+	assert.False(t, w.ready(true))
+
+	// Two nodes are dispatched to.
+	w.observe(dispatchAMarker)
+	w.observe(dispatchBMarker)
+	assert.False(t, w.ready(true))
+
+	// First node ready: still waiting for the second.
+	w.observe(nodeAMarker)
+	assert.False(t, w.ready(true))
+
+	// Duplicate marker from the same node must not advance readiness.
+	w.observe(nodeAMarker)
+	assert.False(t, w.ready(true))
+
+	// Second distinct node makes all dispatched nodes ready.
+	w.observe(nodeBMarker)
+	assert.True(t, w.ready(true))
+}
+
+func TestReadinessWatcher_NodeReadyNeedsDispatch(t *testing.T) {
+	// A node marker without a preceding dispatch line (which cannot happen in practice, since a
+	// node is always dispatched before it reports ready) must not by itself satisfy the gate:
+	// readiness requires at least one dispatched node.
+	w := newReadinessWatcher()
+	w.observe(nodeAMarker)
+	assert.False(t, w.ready(true))
+}
+
+func TestReadinessWatcher_SomeReady(t *testing.T) {
+	// Node mode: only a node marker counts as "some ready", not the client's bare marker or a
+	// dispatch line.
+	w := newReadinessWatcher()
+	assert.False(t, w.someReady(true))
+	w.observe(bareMarker)
+	w.observe(dispatchAMarker)
+	assert.False(t, w.someReady(true))
+	w.observe(nodeAMarker)
+	assert.True(t, w.someReady(true))
+
+	// Local mode: the bare marker is enough.
+	wl := newReadinessWatcher()
+	assert.False(t, wl.someReady(false))
+	wl.observe(bareMarker)
+	assert.True(t, wl.someReady(false))
+}
+
+func TestReadinessWatcher_UpdatedSignal(t *testing.T) {
+	w := newReadinessWatcher()
+
+	w.observe(nodeAMarker)
+	select {
+	case <-w.updated:
+	default:
+		t.Fatal("expected an update signal after a new node marker")
+	}
+
+	// A duplicate must not produce a new signal.
+	w.observe(nodeAMarker)
+	select {
+	case <-w.updated:
+		t.Fatal("did not expect an update signal for a duplicate marker")
+	default:
+	}
+}

--- a/pkg/testing/teststeps.go
+++ b/pkg/testing/teststeps.go
@@ -84,9 +84,22 @@ func RunTestSteps(steps []TestStep, t *testing.T, options ...Option) {
 	for _, step := range steps {
 		if step.IsStartAndStop() {
 			step.Start(t)
+			// If the step supports a readiness gate (e.g. a gadget), wait until it is
+			// actually capturing before moving on to the next steps (typically the
+			// workload). This replaces racy fixed sleeps.
+			if rw, ok := step.(readinessWaiter); ok {
+				rw.WaitForReady(t)
+			}
 			continue
 		}
 
 		step.Run(t)
 	}
+}
+
+// readinessWaiter is optionally implemented by TestSteps that can report when they are ready
+// (e.g. a gadget that has started capturing). RunTestSteps waits on it after starting such a
+// step so subsequent steps only run once the step is ready.
+type readinessWaiter interface {
+	WaitForReady(t *testing.T)
 }


### PR DESCRIPTION
For a long time we had flaky CI runs because we couldn't determine when a gadget actually has started or is still at the pulling gadget stage. After a long time discussing with an LLM we came to the conclusion that waiting for the `gadget running...` verbose debug output is the quickest win for our testing harness.

This also doesn't touch much of the code. Even better is that the changes are only inside the testing package - no "production" code needed to be changed.


## LLM description

Problem:  StartAndStop  gadget tests started the gadget, slept a fixed duration as a proxy for "now capturing", then ran the workload. When the sleep was shorter than the gadget's startup (dominated by the first-run image pull, done remotely per-node for  kubectl-gadget ), the workload fired before the eBPF programs attached → empty  captured:  block → flaky test. A top source of integration flakiness and a cause of red multi-node cloud jobs.

Fix: Replace the fixed sleep with a deterministic readiness gate. The gadget already logs  running...  after all operators start; the harness runs  StartAndStop  gadgets with  -v , watches that marker live on stderr, and only runs the workload once every expected instance is ready. Expected count comes from the  running gadget on node  lines (per-node, honours  --node ) — no cluster query; local  ig  uses a single bare marker. Debug noise is filtered from stored stderr.

Extras:

• Fast-fail: a gadget that exits before ready (pull/signature/eBPF-load/verifier errors) fails immediately instead of waiting the timeout.
• Opt-out  WithoutReadinessGate()  for gadgets without a usable marker ( ci/stacks ).
• Marker is on stderr, not stdout — no production code change.
• Removes the redundant sleeps from  trace_oomkill ,  trace_exec ,  trace_capabilities ,  ci/container_filtering ,  ci/datasource-containers .

Testing:  -race  unit tests; CI-validated on ig-local (docker/containerd), minikube  kubectl-gadget  (docker/containerd/cri-o), and EKS.
