### PR TITLE
skills: add Inspektor Gadget agent skills for troubleshooting

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -54,10 +54,10 @@ file.
    symptom→gadget shortlist; `references/gadget-catalog.md` has the full grouped
    list).
 2. **Discover, don't guess** — read the gadget's real flags and fields at run
-   time with `<gadget>:latest --help` (and `-o json | jq keys` on a live sample).
+   time with `<gadget>:latest --help` and inspect a shape-aware JSON sample.
    Never hardcode a field name from memory; gadget images evolve and new gadgets
-   ship. This one rule is what keeps the skills correct against **any future
-   upstream gadget**.
+   ship. This limits interface drift, while the routing catalog still needs
+   periodic updates.
 3. **Run bounded** — always scope (`-n`/`-p`/`-c`/`--host`) and time-box
    (`--timeout`, `--max-entries`) so a trace can't flood context or the cluster.
 4. **Read the columns** — inspect the enriched fields to confirm/refute a

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,85 @@
+# Inspektor Gadget troubleshooting skills
+
+This directory bundles **agent skills** that teach an AI assistant to debug
+systems at the kernel level with **Inspektor Gadget (IG)** — eBPF-based tracing
+that ties every kernel event (syscalls, packets, DNS, capability checks, OOM
+kills) back to the workload that caused it.
+
+## How to choose a skill (dynamic)
+
+**Enumerate, don't hardcode.** This directory is an *open set* — a gadget may add
+its own skill here without editing this file. To pick a skill:
+
+1. **List** every `*/SKILL.md` under this directory (including any skill installed
+   out-of-tree by the agent framework). Do **not** assume the set is fixed.
+2. **Read each skill's `description`** (its YAML frontmatter). Choose the skill
+   whose description best matches the user's symptom / target.
+3. The base skills below are **always present**; gadget-specific skills are
+   present **only when their gadget is installed** (see the next section).
+
+### Base skills (always present)
+
+| Use this skill | When the target is | Launcher |
+|---|---|---|
+| **`kubernetes-troubleshooting`** | a **Kubernetes** pod / Service / workload (cluster-wide, k8s-enriched) | `kubectl gadget run <gadget>:latest` |
+| **`linux-troubleshooting`** | a **single Linux host / VM / container runtime** (no cluster) | `sudo ig run <gadget>:latest` |
+
+Both expose the **same gadgets, flags, and fields** — they differ only in the
+launcher and the enrichment metadata (`k8s.*` vs `runtime.*`). Each skill's
+`references/*-companion.md` explains when to hop to the other.
+
+### Gadget-specific skills (present only when their gadget is installed)
+
+A third-party or add-on gadget may **ship its own skill** alongside its OCI image
+(for example, an add-on gadget may ship a companion debug skill). Such a
+skill is discovered exactly like the base skills — by its `SKILL.md`
+`description` — but before routing to one you **must confirm the gadget is
+actually available** (*discover, don't guess*):
+
+    sudo ig image list --no-trunc | grep <gadget>   # is the gadget present locally?
+    # or: the gadget is exposed as an ig-mcp-server tool
+
+- **Gadget present** → route to its skill for that gadget's specific capability,
+  and use a base skill for the general IG workflow. They are complementary.
+- **Gadget absent** → do **not** route to its skill; fall back to a base skill.
+
+This keeps behavior **identical to the two-skill baseline** whenever no add-on is
+installed, and lets any future gadget become routable with **zero edits** to this
+file.
+
+## The shared mental model
+
+1. **Route** the symptom to a domain (networking / security / process-lifecycle /
+   storage-fs / performance) and a candidate gadget (each skill's SKILL.md has a
+   symptom→gadget shortlist; `references/gadget-catalog.md` has the full grouped
+   list).
+2. **Discover, don't guess** — read the gadget's real flags and fields at run
+   time with `<gadget>:latest --help` (and `-o json | jq keys` on a live sample).
+   Never hardcode a field name from memory; gadget images evolve and new gadgets
+   ship. This one rule is what keeps the skills correct against **any future
+   upstream gadget**.
+3. **Run bounded** — always scope (`-n`/`-p`/`-c`/`--host`) and time-box
+   (`--timeout`, `--max-entries`) so a trace can't flood context or the cluster.
+4. **Read the columns** — inspect the enriched fields to confirm/refute a
+   hypothesis, then narrow and repeat until root cause.
+
+## Progressive disclosure
+
+Keep the entry point small and load depth on demand:
+
+- **SKILL.md** — the always-loaded router: what the skill is for, the 4-step
+  loop, the symptom→gadget shortlist, and pointers. Deliberately thin.
+- **references/** — loaded only when the task needs it: the full gadget catalog,
+  per-domain playbooks (with disambiguation reasoning + verified flags), the
+  discover-don't-guess mechanics, common flags, setup, and companion routing.
+
+A gadget-specific skill follows the same layout: a thin `SKILL.md` router backed
+by `references/` (and optionally `scripts/`, `assets/`, `evals/`) loaded on
+demand.
+
+This mirrors the way IG itself treats each gadget as the single source of truth
+for its own interface: the skill teaches the agent to *ask the gadget*, so the
+docs stay small and never drift.
+
+Read a skill's own `SKILL.md` first; open a `references/*.md` only when you're
+working that domain.

--- a/skills/README.md
+++ b/skills/README.md
@@ -47,9 +47,9 @@ skills/
   from the trigger, and states what it is **not** for (logs, dashboards, cluster
   edits) to prevent mis-fire.
 - **Discover, don't guess.** The skills teach the agent to enumerate a gadget's
-  real flags and fields at run time (`<gadget>:latest --help`, `-o json | jq
-  keys`) rather than hardcoding them. This is what makes the skills correct
-  against **any future upstream gadget** without edits.
+  real flags and fields at run time (`<gadget>:latest --help`, then inspect a
+  shape-aware JSON sample) rather than hardcoding them. This limits drift as
+  gadget interfaces evolve; the routing catalog still needs periodic updates.
 - **Bounded runs.** Every streaming example is scoped and time-boxed
   (`--timeout`, `--max-entries`) to avoid flooding the agent's context or the
   API server.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,93 @@
+# Inspektor Gadget agent skills
+
+Two **progressive-disclosure agent skills** that teach an AI assistant to
+troubleshoot systems at the kernel level with [Inspektor
+Gadget](https://inspektor-gadget.io) (IG). IG runs eBPF programs to trace live
+kernel events — syscalls, network packets, DNS, capability checks, OOM kills —
+and enriches each event with the workload identity (Kubernetes
+namespace/pod/container/node, or container runtime name) that produced it.
+
+## Contents
+
+```
+skills/
+├── AGENTS.md                       # router: which skill, the shared mental model
+├── README.md                       # this file
+├── kubernetes-troubleshooting/     # cluster debugging via `kubectl gadget run`
+│   ├── SKILL.md                    # thin entry point (router + 4-step loop + shortlist)
+│   └── references/                 # loaded on demand
+│       ├── gadget-catalog.md       # all upstream gadgets grouped by domain
+│       ├── discovering-params-and-fields.md   # the golden discover-don't-guess rule
+│       ├── common-flags.md         # scope / output / timeout flags + gotchas
+│       ├── domain-networking.md    # DNS / TCP / drops / retransmits / TLS-SNI / policy
+│       ├── domain-security.md      # capabilities / LSM / seccomp / module loading
+│       ├── domain-process-lifecycle.md   # exec / signals / OOM / snapshots / traceloop
+│       ├── domain-storage-fs.md    # open / slow FS / block I/O / mounts / fd / notify
+│       ├── domain-performance.md   # CPU / throttle / RTT / deadlock / malloc / GPU
+│       ├── install.md              # detect IG, then install plugin / deploy DaemonSet
+│       └── linux-companion.md      # when to switch to standalone `ig`
+└── linux-troubleshooting/          # single-host debugging via `sudo ig run`
+    ├── SKILL.md
+    └── references/
+        ├── gadget-catalog.md
+        ├── discovering-params-and-fields.md
+        ├── common-flags.md
+        ├── install.md
+        └── kubernetes-companion.md
+```
+
+## Design principles
+
+- **Progressive disclosure.** A thin, always-loaded `SKILL.md` routes; deep
+  material lives in `references/` and is opened only when a task needs it. This
+  keeps the working context small and on-topic.
+- **Action-oriented routing descriptions.** Each skill's frontmatter
+  `description` is written around the *symptoms a user reports* ("DNS failing",
+  "CrashLoopBackOff", "permission denied") so the agent selects the right skill
+  from the trigger, and states what it is **not** for (logs, dashboards, cluster
+  edits) to prevent mis-fire.
+- **Discover, don't guess.** The skills teach the agent to enumerate a gadget's
+  real flags and fields at run time (`<gadget>:latest --help`, `-o json | jq
+  keys`) rather than hardcoding them. This is what makes the skills correct
+  against **any future upstream gadget** without edits.
+- **Bounded runs.** Every streaming example is scoped and time-boxed
+  (`--timeout`, `--max-entries`) to avoid flooding the agent's context or the
+  API server.
+- **Two skills, one model.** The k8s and host skills share gadgets/flags/fields
+  and cross-link via companion references, so the agent can route between
+  cluster and single-host targets without relearning.
+
+## Installing
+
+These are plain Markdown skills — no build step, no runtime dependencies. Drop
+the `skills/` tree wherever your agent framework loads skills from:
+
+| Framework | Location |
+|---|---|
+| Skill-aware AI coding assistants | your project or user skills directory (each skill = a folder with `SKILL.md`) |
+| GitHub Copilot | your repo's agent-skills location per the Copilot skills convention |
+| Generic / MCP-based agents | point the agent's skill loader at this `skills/` directory |
+
+The agent reads `AGENTS.md` (or a skill's `SKILL.md`) to route, then pulls a
+`references/*.md` on demand. No secrets, no network calls, no scripts — the
+skills only instruct the agent to run standard upstream `kubectl gadget` / `ig`
+commands directly.
+
+## Requirements (at run time, on the target)
+
+- **Kubernetes skill:** the `kubectl gadget` plugin locally + the IG DaemonSet
+  deployed (`kubectl gadget deploy`). See
+  `kubernetes-troubleshooting/references/install.md`.
+- **Linux skill:** the `ig` binary + root (CAP_BPF/CAP_SYS_ADMIN) + a kernel with
+  BTF (`/sys/kernel/btf/vmlinux`). See `linux-troubleshooting/references/install.md`.
+
+## Scope & safety
+
+All gadgets referenced are **read-only** observers — they trace, they never
+modify a workload or host. The skills are **upstream-generic**: they name only
+gadgets from the public Inspektor Gadget catalog and teach a discovery-first
+method that adapts to new gadgets automatically.
+
+## License
+
+Apache-2.0, matching the Inspektor Gadget project.

--- a/skills/kubernetes-troubleshooting/SKILL.md
+++ b/skills/kubernetes-troubleshooting/SKILL.md
@@ -38,15 +38,13 @@ This skill drives `kubectl gadget`. Confirm it's usable before the loop:
 
 ```bash
 command -v kubectl-gadget >/dev/null 2>&1 || echo "kubectl gadget plugin MISSING"
-kubectl gadget version    # Client version = plugin OK; "Server version: not available" = DaemonSet not deployed
+kubectl gadget version    # "Server version: not available" = inspect the gadget namespace
 ```
 
-If the plugin is **missing**, or a later run errors on connectivity because the
-DaemonSet isn't deployed, **open `references/install.md` and follow it** — don't
-guess an install command. Installing the plugin and running `kubectl gadget deploy`
-need cluster rights and start a **privileged DaemonSet**, so **ask the operator
-before installing**. ("Server version: not available" alone is only a hint — try
-your run anyway; see `references/install.md`.)
+If the plugin is **missing** or the server version is unavailable, **open
+`references/install.md` and follow it** — don't guess an install command.
+Installing the plugin and running `kubectl gadget deploy` need cluster rights and
+start a **privileged DaemonSet**, so **ask the operator before installing**.
 
 ## The one rule: discover, don't guess
 
@@ -55,7 +53,8 @@ evolve and new gadgets ship. Always enumerate the real interface at run time:
 
 ```bash
 kubectl gadget run <gadget>:latest -h          # flags + a "--fields" block listing every data source & field
-kubectl gadget run <gadget>:latest -A --timeout 5 -o json | jq '.[0] | keys'   # real field names in a live sample
+kubectl gadget run <gadget>:latest -A --timeout 5 -o json \
+  | jq -s '(.[0] // {}) | if type == "array" then (.[0] // {}) else . end | keys'
 ```
 
 The gadget's own `-h`/`--fields` output is the source of truth, so this skill
@@ -93,9 +92,9 @@ confirm its flags/fields with `-h` before relying on them. See
 | Slow disk / file I/O | storage-fs | `trace_fsslower` | `profile_blockio`, `top_blockio` |
 | Unexpected mount/umount, or suspicious hardlink/symlink (escape) | storage-fs | `trace_mount` | `trace_link` (`type` = HARDLINK/SYMLINK cuts the noise) |
 | fd leak / "too many open files" / inotify watch storm | storage-fs | `fdpass` | `fsnotify`; `snapshot_file` (unclosed fds in one proc) |
-| Permission denied despite correct RBAC/FS | security | `trace_capabilities` | `trace_lsm`, `audit_seccomp` |
-| Seccomp/AppArmor/SELinux denial | security | `trace_lsm` | `audit_seccomp`, `advise_seccomp` |
-| Syscall blocked by a seccomp profile ("operation not permitted") | security | `audit_seccomp` | the audited syscall = what the profile forbids; `advise_seccomp` to author one |
+| Permission denied despite correct RBAC/FS | security | `trace_capabilities` | `audit_seccomp`; node audit logs for AppArmor/SELinux |
+| Seccomp denial | security | `audit_seccomp` | the `code` + syscall identify the seccomp action; `advise_seccomp` to author a profile |
+| AppArmor/SELinux denial | security | node audit logs | `trace_lsm` can correlate hook activity, but does not expose another LSM's verdict |
 | Kernel module loaded / rootkit / unexpected insmod | security | `trace_init_module` | `trace_capabilities` (CAP_SYS_MODULE) |
 | Harden / author a seccomp or NetworkPolicy profile | security | `advise_seccomp` | `advise_networkpolicy` (policy from observed traffic) |
 | High CPU, or slow despite low CPU% (CFS throttling / cgroup CPU limit) | performance | `profile_cpu` | `top_cpu_throttle` (capped?), `top_process` |
@@ -105,10 +104,10 @@ confirm its flags/fields with `-h` before relying on them. See
 | Quantify eBPF/gadget CPU or memory overhead (self-profiling) | meta | `bpfstats` | needs an active window — use a longer `--timeout` |
 
 This is a deliberately **thin shortlist, not the catalog** — it names the few
-gadgets that fit the most common symptoms so you don't scan all ~42, keeping this
-always-loaded router small. **Symptom not listed here,
+gadgets that fit the most common symptoms so you don't scan the full bundled set,
+keeping this always-loaded router small. **Symptom not listed here,
 or unsure which row fits?** Open `references/gadget-catalog.md` — it groups **all
-42** gadgets by domain with the disambiguation reasoning. The authoritative live
+bundled** gadgets by domain with the disambiguation reasoning. The authoritative live
 list is whatever `kubectl gadget run <name>:latest -h` resolves; always confirm a
 gadget's flags/fields there before relying on them.
 

--- a/skills/kubernetes-troubleshooting/SKILL.md
+++ b/skills/kubernetes-troubleshooting/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: kubernetes-troubleshooting
+description: >-
+  Debug live Kubernetes workloads at the kernel level with Inspektor Gadget via
+  `kubectl gadget run`. Use when a pod or Service is misbehaving and application
+  logs are not enough: DNS resolution failures or slow lookups, TCP connection
+  resets / retransmits / drops / refused connections, CrashLoopBackOff, "no such
+  file or directory", permission / capability / seccomp / LSM denials, OOMKilled,
+  unexpected process execs, slow disk or file I/O, or "which pod/process made
+  this syscall / connection / DNS query". Traces real kernel events with eBPF,
+  auto-enriched with pod / namespace / container / node. Read-only, no workload
+  changes. Not for plain application logs, long-term metrics dashboards, or
+  editing cluster state.
+compatibility: >-
+  Requires the `kubectl gadget` plugin locally and an in-cluster Inspektor Gadget
+  DaemonSet (`kubectl gadget deploy`, namespace `gadget`), on a cluster where you
+  hold troubleshooting RBAC and nodes with BTF for CO-RE. Read-only. If the plugin
+  or DaemonSet is missing, see references/install.md — ask the operator before
+  installing.
+---
+
+# Kubernetes troubleshooting with Inspektor Gadget
+
+Inspektor Gadget (IG) runs **eBPF programs** in the kernel to trace live events —
+syscalls, network packets, DNS, capability checks, OOM kills — and **enriches
+every event with Kubernetes metadata** (namespace, pod, container, node). You
+drive it with `kubectl gadget run <gadget>:latest`. Each **gadget** is an OCI
+image pulled on demand; there is **no built-in list of gadgets to memorize** and
+no `list-gadgets` command.
+
+Use IG when logs/metrics can't answer *"what is the kernel actually doing for
+this workload right now?"* — e.g. a request times out but the app logs nothing,
+a file open fails silently, a connection is reset before the app sees it.
+
+## Prerequisite: confirm IG is available (check first, then route)
+
+This skill drives `kubectl gadget`. Confirm it's usable before the loop:
+
+```bash
+command -v kubectl-gadget >/dev/null 2>&1 || echo "kubectl gadget plugin MISSING"
+kubectl gadget version    # Client version = plugin OK; "Server version: not available" = DaemonSet not deployed
+```
+
+If the plugin is **missing**, or a later run errors on connectivity because the
+DaemonSet isn't deployed, **open `references/install.md` and follow it** — don't
+guess an install command. Installing the plugin and running `kubectl gadget deploy`
+need cluster rights and start a **privileged DaemonSet**, so **ask the operator
+before installing**. ("Server version: not available" alone is only a hint — try
+your run anyway; see `references/install.md`.)
+
+## The one rule: discover, don't guess
+
+**Never hardcode a gadget's flags or field names from memory.** Gadget images
+evolve and new gadgets ship. Always enumerate the real interface at run time:
+
+```bash
+kubectl gadget run <gadget>:latest -h          # flags + a "--fields" block listing every data source & field
+kubectl gadget run <gadget>:latest -A --timeout 5 -o json | jq '.[0] | keys'   # real field names in a live sample
+```
+
+The gadget's own `-h`/`--fields` output is the source of truth, so this skill
+never drifts from the shipped gadgets. If a symptom below names a gadget, still
+confirm its flags/fields with `-h` before relying on them. See
+`references/discovering-params-and-fields.md`.
+
+## The loop (repeat until root cause)
+
+1. **Route.** Map the symptom to a *domain* (networking / security /
+   process-lifecycle / storage-fs / performance), then to a candidate gadget
+   using the table below and the matching `references/domain-*.md`.
+2. **Discover.** Run `<gadget>:latest -h` to read the real flags and fields.
+3. **Run bounded.** Always scope and time-box:
+   `kubectl gadget run <gadget>:latest -n <ns> --timeout <sec> -o json`
+   (`-n`/`-p`/`-c` to filter; **always set `--timeout`** for streaming gadgets;
+   `--max-entries` for `top`/`snapshot`). See `references/common-flags.md`.
+4. **Read the columns.** Inspect the enriched fields (`k8s.*`, `proc.*`, error
+   codes) to confirm or refute a hypothesis, then narrow scope and repeat.
+
+## Symptom → first gadget (confirm flags/fields with `-h`)
+
+| Symptom (what the user reports) | Domain | Start with | Then / disambiguate |
+|---|---|---|---|
+| DNS fails, slow, or NXDOMAIN | networking | `trace_dns` | latency in `latency_ns`; see domain-networking |
+| Connection reset / refused / hangs | networking | `trace_tcp` | `trace_tcpretrans` (retransmits), `trace_tcpdrop` (kernel drops) |
+| Packet loss / high latency between pods | networking | `trace_tcpdrop` | `profile_tcprtt`, `top_tcp`, `tcpdump` |
+| TLS/cert/SNI routing issue | networking | `trace_sni` | `trace_ssl` (plaintext at TLS boundary) |
+| Port bind fails / "address already in use" | networking | `snapshot_socket` | `trace_bind` (the failing bind + errno) |
+| CrashLoopBackOff / unexpected restarts | process-lifecycle | `trace_exec` | `trace_signal` (filter `--signal 9/15` — Go SIGURG / glibc SIGRTMIN async-preempt noise), `trace_oomkill` |
+| Killed / OOMKilled | process-lifecycle | `trace_oomkill` | `top_process`, `profile_cpu` |
+| Container died too fast to trace live (post-mortem) | process-lifecycle | `traceloop` | replays recent syscalls from the ring buffer; empty if it wasn't already recording |
+| Watch an interactive shell / tty / pts / keystrokes | process-lifecycle | `ttysnoop` | no `--tty`/`--pts` selector — scope by `--pid`/`--comm`/pod |
+| "no such file" / missing config / wrong path | storage-fs | `trace_open` | `snapshot_file`, `top_file` |
+| Slow disk / file I/O | storage-fs | `trace_fsslower` | `profile_blockio`, `top_blockio` |
+| Unexpected mount/umount, or suspicious hardlink/symlink (escape) | storage-fs | `trace_mount` | `trace_link` (`type` = HARDLINK/SYMLINK cuts the noise) |
+| fd leak / "too many open files" / inotify watch storm | storage-fs | `fdpass` | `fsnotify`; `snapshot_file` (unclosed fds in one proc) |
+| Permission denied despite correct RBAC/FS | security | `trace_capabilities` | `trace_lsm`, `audit_seccomp` |
+| Seccomp/AppArmor/SELinux denial | security | `trace_lsm` | `audit_seccomp`, `advise_seccomp` |
+| Syscall blocked by a seccomp profile ("operation not permitted") | security | `audit_seccomp` | the audited syscall = what the profile forbids; `advise_seccomp` to author one |
+| Kernel module loaded / rootkit / unexpected insmod | security | `trace_init_module` | `trace_capabilities` (CAP_SYS_MODULE) |
+| Harden / author a seccomp or NetworkPolicy profile | security | `advise_seccomp` | `advise_networkpolicy` (policy from observed traffic) |
+| High CPU, or slow despite low CPU% (CFS throttling / cgroup CPU limit) | performance | `profile_cpu` | `top_cpu_throttle` (capped?), `top_process` |
+| Memory growth / leak (userspace) | performance | `trace_malloc` (libc malloc only — statically-linked Go runtime allocator invisible) | `trace_malloc --collect-ustack` (the leak site) |
+| App hung / mutex deadlock | performance | `deadlock` (pthread only — Go `sync.Mutex` invisible) | `profile_cpu` |
+| GPU / CUDA out-of-memory | performance | `top_cuda_memory` | per-proc device vs pinned; `profile_cuda` = libcuda Driver-API alloc/free |
+| Quantify eBPF/gadget CPU or memory overhead (self-profiling) | meta | `bpfstats` | needs an active window — use a longer `--timeout` |
+
+This is a deliberately **thin shortlist, not the catalog** — it names the few
+gadgets that fit the most common symptoms so you don't scan all ~42, keeping this
+always-loaded router small. **Symptom not listed here,
+or unsure which row fits?** Open `references/gadget-catalog.md` — it groups **all
+42** gadgets by domain with the disambiguation reasoning. The authoritative live
+list is whatever `kubectl gadget run <name>:latest -h` resolves; always confirm a
+gadget's flags/fields there before relying on them.
+
+## References (load only the one you need)
+
+- `references/gadget-catalog.md` — all upstream gadgets grouped by domain, one line each.
+- `references/discovering-params-and-fields.md` — the discover-don't-guess mechanics.
+- `references/common-flags.md` — filters, output modes, timeouts, gotchas.
+- `references/domain-networking.md` — DNS / TCP / drops / retransmits / TLS-SNI / NetworkPolicy.
+- `references/domain-security.md` — capabilities / LSM / seccomp / module loading.
+- `references/domain-process-lifecycle.md` — exec / signals / OOM / snapshots / syscall recording.
+- `references/domain-storage-fs.md` — open / slow FS / block I/O / mounts / fd / fsnotify.
+- `references/domain-performance.md` — CPU / throttle / RTT / deadlock / malloc / GPU.
+- `references/install.md` — detect whether IG is usable; install the `kubectl gadget` plugin and deploy the DaemonSet if missing.
+
+## Safety
+
+Observation is **read-only** — gadgets trace, they never modify workloads. They
+require a privileged in-cluster IG (DaemonSet) or `kubectl gadget`, so use them
+in clusters where you have troubleshooting rights. Always bound streaming
+gadgets with `--timeout` and cap `top`/`snapshot` with `--max-entries` so a
+trace can't flood your context or the API server.

--- a/skills/kubernetes-troubleshooting/references/common-flags.md
+++ b/skills/kubernetes-troubleshooting/references/common-flags.md
@@ -13,7 +13,7 @@ use most, all verified against a live cluster.
 | One pod | `-p <pod>` | `-p api-7d9` |
 | Container name | `-c <name>` | `-c nginx` (comma-list; `!` excludes) |
 | Only a process name | `--comm <name>` | `--comm curl` |
-| A selector/podset | (filter output by `k8s.*` fields) | `-o json | jq 'select(.k8s.namespace=="prod")'` |
+| Label selector | `-l <sel>` / `--selector` | `-l app=api` (k8s label selector, comma-list; `!` excludes) |
 
 Narrow scope = less noise, less context burned, faster root-cause. Start at the
 namespace or pod, not `-A`, unless you're hunting something cluster-wide.
@@ -25,14 +25,39 @@ namespace or pod, not `-A`, unless you're hunting something cluster-wide.
 - **`--max-entries <n>`** — for `top_*` and `snapshot_*` gadgets, to cap rows.
 - Prefer several short, scoped runs over one long unscoped one.
 
+## Filter events with the native filter operator
+
+- **`--filter <field><op><value>`** (short **`-F`**) filters rows before output.
+  Operators: `==`, `!=`, `>=`, `<=`, `>`, `<`, `~` (regex
+  match), `!~` (regex non-match). Combine with commas: `--filter 'comm==curl,error!=0'`.
+  Quote the expression (single quotes) especially with regex.
+- **`--filter-expr <expr>`** (short **`-E`**) is the richer expression-language
+  form for compound logic. Prefer `--filter` for simple field comparisons.
+- The filter operator currently runs in user space, like `jq`, but it is the
+  native interface and can move closer to eBPF without changing your command.
+  Use it when you already know the field/value you want.
+
+## `top_*` gadgets: rank and refresh
+
+- **`--sort <field>`** orders rows; prefix a field with `-` for descending, join
+  multiple with `,` (e.g. `--sort -rbytes,wbytes`). This is how you get "the
+  heaviest N" — combine with `--max-entries <n>`.
+- **`--map-fetch-interval <dur>`** sets how often the gadget snapshots its BPF
+  maps (default `1000ms`); raise it (e.g. `5s`) to sample less often and reduce
+  overhead on a busy host.
+
 ## Output modes
 
 | Mode | When |
 |---|---|
 | `-o json` | machine parsing with `jq`; the default for agents |
 | `-o jsonpretty` | eyeballing nested structure |
-| `-o columns=a,b,c` | compact human table of just the fields you need |
+| `-o columns --fields a,b,c` | compact human table of just the fields you need (the `-o columns=a,b,c` comma form is parsed as separate output modes and prints nothing) |
 | default (no `-o`) | gadget's built-in columns; fine for a quick look |
+
+Streaming datasources produce newline-delimited JSON objects; map-backed
+top/snapshot datasources produce JSON arrays. Match the `jq` expression to the
+shape (see `discovering-params-and-fields.md`).
 
 ## Common enrichment fields (present on most gadgets via kubectl gadget)
 
@@ -46,20 +71,21 @@ namespace or pod, not `-A`, unless you're hunting something cluster-wide.
 
 ## Gotchas (learned from live runs)
 
-- **`:latest` is required.** `run <gadget>` without a tag fails with
-  `invalid reference format`; always `run <gadget>:latest` (or a pinned digest).
+- **Tag defaults to `:latest`.** `run <gadget>` without a tag resolves to
+  `<gadget>:latest` automatically, so both forms work. Use an immutable version
+  tag or digest for reproducibility; `:latest` is mutable.
 - **Path fields need `--paths`.** Fields like `cwd`/`exepath`/`fpath` are only
   populated when you pass `--paths`; otherwise they're empty.
 - **`--failed`/`--failure-only` narrows to errors.** Many trace gadgets have a
   flag to show only failing events (e.g. `trace_open --failed`,
   `trace_tcp --failure-only`) — use it when hunting a failure, it cuts noise hard.
-- **A locally-built gadget image can shadow the upstream one** and fail signature
-  verification. If you hit a cosign/signature error on `:latest`, you likely have
-  a local build with that name; pull by upstream digest or (in a trusted
-  troubleshooting context) use the documented verification override. Prefer the
-  upstream image.
-- **Version skew warning is usually benign.** "gadget built with vX, run with vY"
-  is a warning, not a failure — the run still produces data; note it and proceed.
+- **A locally-built gadget image can shadow the upstream one.** To guarantee a
+  fresh registry copy, use **`--pull always`**; use a pinned digest when exact
+  reproducibility matters.
+- **Treat version skew as a diagnostic signal.** The warning is not itself a
+  failure, but field or protocol skew can change output or produce no useful
+  rows. Prefer matching client, DaemonSet, and gadget versions before concluding
+  that an empty trace means no events occurred.
 - **Bare field vs `*_raw`.** Numeric fields often render as a human-formatted
   string (`latency_ns`="1.2ms", `memoryRSS`="12 MB", `throttledTime`="4ms"); the
   `_raw` sibling (`latency_ns_raw`, `memoryRSS_raw`, `throttledTime_raw`) is the

--- a/skills/kubernetes-troubleshooting/references/common-flags.md
+++ b/skills/kubernetes-troubleshooting/references/common-flags.md
@@ -1,0 +1,70 @@
+# Common flags, output modes, scoping & gotchas (kubectl gadget)
+
+All examples assume `kubectl gadget run <gadget>:latest`. Confirm any flag with
+`-h` (see `discovering-params-and-fields.md`) — this file lists the ones you'll
+use most, all verified against a live cluster.
+
+## Scope the trace (do this first — cluster-wide traces are noisy)
+
+| Goal | Flag | Example |
+|---|---|---|
+| One namespace | `-n <ns>` | `-n prod` |
+| All namespaces | `-A` | `-A` |
+| One pod | `-p <pod>` | `-p api-7d9` |
+| Container name | `-c <name>` | `-c nginx` (comma-list; `!` excludes) |
+| Only a process name | `--comm <name>` | `--comm curl` |
+| A selector/podset | (filter output by `k8s.*` fields) | `-o json | jq 'select(.k8s.namespace=="prod")'` |
+
+Narrow scope = less noise, less context burned, faster root-cause. Start at the
+namespace or pod, not `-A`, unless you're hunting something cluster-wide.
+
+## Always bound the run
+
+- **`--timeout <seconds>`** — for every streaming (`trace_*`) gadget. Without it
+  the gadget streams until interrupted and can flood your context. Start at 5-10s.
+- **`--max-entries <n>`** — for `top_*` and `snapshot_*` gadgets, to cap rows.
+- Prefer several short, scoped runs over one long unscoped one.
+
+## Output modes
+
+| Mode | When |
+|---|---|
+| `-o json` | machine parsing with `jq`; the default for agents |
+| `-o jsonpretty` | eyeballing nested structure |
+| `-o columns=a,b,c` | compact human table of just the fields you need |
+| default (no `-o`) | gadget's built-in columns; fine for a quick look |
+
+## Common enrichment fields (present on most gadgets via kubectl gadget)
+
+- `k8s.namespace`, `k8s.podName`, `k8s.containerName`, `k8s.node` — the
+  Kubernetes identity of the event. This enrichment is the whole point of
+  `kubectl gadget`: every kernel event is tied back to a workload.
+- `proc.comm`, `proc.pid`, `proc.tid`, `proc.creds.uid`/`.gid` — the process.
+- `timestamp` — event time.
+- Endpoints appear as `src`/`dst` with nested `.addr`, `.port`, and their own
+  `.k8s.*` when the peer is in-cluster.
+
+## Gotchas (learned from live runs)
+
+- **`:latest` is required.** `run <gadget>` without a tag fails with
+  `invalid reference format`; always `run <gadget>:latest` (or a pinned digest).
+- **Path fields need `--paths`.** Fields like `cwd`/`exepath`/`fpath` are only
+  populated when you pass `--paths`; otherwise they're empty.
+- **`--failed`/`--failure-only` narrows to errors.** Many trace gadgets have a
+  flag to show only failing events (e.g. `trace_open --failed`,
+  `trace_tcp --failure-only`) — use it when hunting a failure, it cuts noise hard.
+- **A locally-built gadget image can shadow the upstream one** and fail signature
+  verification. If you hit a cosign/signature error on `:latest`, you likely have
+  a local build with that name; pull by upstream digest or (in a trusted
+  troubleshooting context) use the documented verification override. Prefer the
+  upstream image.
+- **Version skew warning is usually benign.** "gadget built with vX, run with vY"
+  is a warning, not a failure — the run still produces data; note it and proceed.
+- **Bare field vs `*_raw`.** Numeric fields often render as a human-formatted
+  string (`latency_ns`="1.2ms", `memoryRSS`="12 MB", `throttledTime`="4ms"); the
+  `_raw` sibling (`latency_ns_raw`, `memoryRSS_raw`, `throttledTime_raw`) is the
+  machine number — use `_raw` for arithmetic/sort/`jq` comparisons, the bare
+  field for display. Both appear under `-h`/`--fields`.
+- **In-cluster IG must be present.** `kubectl gadget run` needs the IG DaemonSet
+  (or `kubectl gadget deploy`). If commands hang or error on connectivity, verify
+  `kubectl get pods -n gadget`.

--- a/skills/kubernetes-troubleshooting/references/discovering-params-and-fields.md
+++ b/skills/kubernetes-troubleshooting/references/discovering-params-and-fields.md
@@ -1,0 +1,64 @@
+# Discovering params and fields — the golden rule
+
+**Never hardcode a gadget's flags or fields from memory. Ask the gadget.**
+Gadget images are versioned OCI artifacts; flags and fields change between
+releases and new gadgets ship. If you rely on a remembered field name it will
+eventually be wrong. The gadget's own `-h` output is the contract, so a skill
+built on discovery never drifts.
+
+## 1. List flags + every field, for any gadget
+
+```bash
+kubectl gadget run <gadget>:latest -h
+```
+
+The help output ends with a **`--fields`** block that enumerates every *data
+source* and every *field* the gadget can emit, each with a short description.
+This is the authoritative field list — richer than any doc, and always current
+for the image you actually pulled. Example (abridged) for `trace_dns`:
+
+```
+--fields string   Available data sources / fields
+                    "dns" (data source):
+                      addresses   Comma-separated IPs from the DNS responses ...
+                      name        The queried domain name
+                      qtype       The query type (A, AAAA, ...)
+                      latency_ns  Time between query and response ...
+                      src / dst   endpoint (+ .k8s.namespace/.k8s.name/.port ...)
+                      ...
+```
+
+## 2. Confirm field names from a real sample
+
+Flags tell you what *can* be emitted; a live sample tells you the exact JSON
+keys you'll parse:
+
+```bash
+kubectl gadget run <gadget>:latest -A --timeout 5 -o json | jq '.[0] | keys'
+```
+
+Use the exact keys from this output in your `jq`/filters. Nested groups appear
+dotted (e.g. `k8s.podName`, `proc.comm`, `dst.port`).
+
+## 3. Select only the fields you need
+
+Long event rows waste context and slow reading. Project fields once you know
+their names:
+
+```bash
+kubectl gadget run trace_dns:latest -n prod --timeout 5 \
+  -o columns=k8s.podName,name,qtype,rcode,latency_ns
+```
+
+`-o json` for machine parsing, `-o columns=<comma-list>` for a compact human
+table, `-o jsonpretty` when eyeballing structure.
+
+## 4. There is no gadget list command — gadgets are images
+
+`kubectl gadget run <name>:latest` pulls the gadget image on demand. There is
+**no `list-gadgets` subcommand**. To know what exists:
+
+- Use the shortlist in `SKILL.md` and the grouped `references/gadget-catalog.md`.
+- Run any candidate with `-h` to confirm it resolves and see its real interface.
+- Browse the upstream catalog at <https://inspektor-gadget.io/docs/latest/gadgets/>
+  (authoritative for the *shipped* set at a given release).

--- a/skills/kubernetes-troubleshooting/references/discovering-params-and-fields.md
+++ b/skills/kubernetes-troubleshooting/references/discovering-params-and-fields.md
@@ -15,7 +15,10 @@ kubectl gadget run <gadget>:latest -h
 The help output ends with a **`--fields`** block that enumerates every *data
 source* and every *field* the gadget can emit, each with a short description.
 This is the authoritative field list — richer than any doc, and always current
-for the image you actually pulled. Example (abridged) for `trace_dns`:
+for the image you actually pulled. Today this block is human-readable text
+only — there is no machine-parseable (`-o json`) form of `-h`, so to feed the
+field list into `jq`/tooling you currently scrape the text or run the gadget
+once with `-o json` and read the keys off a sample event. Example (abridged) for `trace_dns`:
 
 ```
 --fields string   Available data sources / fields
@@ -34,11 +37,15 @@ Flags tell you what *can* be emitted; a live sample tells you the exact JSON
 keys you'll parse:
 
 ```bash
-kubectl gadget run <gadget>:latest -A --timeout 5 -o json | jq '.[0] | keys'
+kubectl gadget run <gadget>:latest -A --timeout 5 -o json \
+  | jq -s '(.[0] // {}) | if type == "array" then (.[0] // {}) else . end | keys'
 ```
 
-Use the exact keys from this output in your `jq`/filters. Nested groups appear
-dotted (e.g. `k8s.podName`, `proc.comm`, `dst.port`).
+Streaming datasources emit one JSON object per line; snapshot/top datasources emit
+JSON arrays. `jq -s` collects the bounded sample, and the expression inspects only
+its first event or first array row. Use the exact keys from this output in your
+`jq`/filters. Nested groups appear dotted (e.g. `k8s.podName`, `proc.comm`,
+`dst.port`).
 
 ## 3. Select only the fields you need
 
@@ -47,11 +54,12 @@ their names:
 
 ```bash
 kubectl gadget run trace_dns:latest -n prod --timeout 5 \
-  -o columns=k8s.podName,name,qtype,rcode,latency_ns
+  -o columns --fields k8s.podName,name,qtype,rcode,latency_ns
 ```
 
-`-o json` for machine parsing, `-o columns=<comma-list>` for a compact human
-table, `-o jsonpretty` when eyeballing structure.
+`-o json` for machine parsing, `-o columns --fields <comma-list>` for a compact
+human table, `-o jsonpretty` when eyeballing structure. (Do **not** write
+`-o columns=<comma-list>` — `-o` comma-splits into output *modes*, so it prints nothing.)
 
 ## 4. There is no gadget list command — gadgets are images
 

--- a/skills/kubernetes-troubleshooting/references/domain-networking.md
+++ b/skills/kubernetes-troubleshooting/references/domain-networking.md
@@ -27,7 +27,7 @@ Rule of thumb: *can't connect* → `trace_tcp`; *connects but slow/lossy* →
 ```bash
 # Watch DNS for one namespace — read fields reliably via json + jq
 kubectl gadget run trace_dns:latest -n <ns> --timeout 10 -o json \
-  | jq -r '.[] | "\(.name)\t\(.qtype)\t\(.rcode)\t\(.latency_ns)"'
+  | jq -r '"\(.name)\t\(.qtype)\t\(.rcode)\t\(.latency_ns)"'
 ```
 
 Read: `rcode` (e.g. NXDOMAIN, SERVFAIL), `latency_ns` (slow resolver), `name`
@@ -37,12 +37,14 @@ resolver / NetworkPolicy / egress problem — pivot to `trace_tcpdrop` or
 `trace_tcp` toward the DNS service IP).
 
 **Gotchas that fake a "no data" result (read before concluding "DNS is fine"):**
-- **`-o columns=…,latency_ns` silently emits ZERO rows.** `latency_ns` is a valid
-  *field* (json / `--fields`) but NOT a valid `-o columns` template — the gadget
-  warns `output mode "latency_ns" … not supported; skipping data source` and prints
-  nothing. Use `-o json | jq` for any latency read (verified live). For **arithmetic/sort**
-  use the raw sibling `latency_ns_raw`; the bare `latency_ns` is a human-formatted
-  string (e.g. "1.2ms") — see the `*_raw` convention in `common-flags.md`.
+- **Never write `-o columns=field,field` — it silently emits ZERO rows.** `-o`
+  takes a comma-separated list of output *modes*, so `-o columns=name,latency_ns`
+  is parsed as the modes `columns=name`, `latency_ns`, … — each an unknown mode
+  (`output mode "latency_ns" … not supported; skipping data source`) and nothing
+  prints. Select columns with **`-o columns --fields name,latency_ns`** instead
+  (verified live, ig v0.54). For **arithmetic/sort** use the raw sibling
+  `latency_ns_raw`; the bare `latency_ns` is a human-formatted string (e.g. "1.2ms")
+  — see the `*_raw` convention in `common-flags.md`. `-o json | jq` also works.
 - **Benign NXDOMAIN is expected.** libc walks the `search`-domain list per `ndots`,
   so short names legitimately return NXDOMAIN for each search suffix before the real
   FQDN resolves — read the `name` column and ignore the suffix misses; only a
@@ -63,7 +65,8 @@ kubectl gadget run trace_tcp:latest -n <ns> --failure-only --timeout 10 -o json
 # Retransmissions toward a suspect upstream
 kubectl gadget run trace_tcpretrans:latest -n <ns> --timeout 15 -o json
 # Kernel drops with reason
-kubectl gadget run trace_tcpdrop:latest -A --timeout 15 -o json | jq '.[].reason' | sort | uniq -c
+kubectl gadget run trace_tcpdrop:latest -A --timeout 15 -o json \
+  | jq -r '.reason' | sort | uniq -c
 ```
 
 Read: `src`/`dst` (+ `.k8s.*` for the peer pod), `error`/errno on failures,
@@ -103,7 +106,7 @@ with `-h` first:
 
 ```bash
 # Who is holding the port right now? (state=LISTEN on that src port = the holder)
-kubectl gadget run snapshot_socket:latest -n <ns> -o columns=k8s.podName,src,dst,state
+kubectl gadget run snapshot_socket:latest -n <ns> -o columns --fields k8s.podName,src,dst,state
 # Catch the failing bind() live — EADDRINUSE surfaces in the error field
 kubectl gadget run trace_bind:latest -n <ns> --timeout 10 -o json
 ```

--- a/skills/kubernetes-troubleshooting/references/domain-networking.md
+++ b/skills/kubernetes-troubleshooting/references/domain-networking.md
@@ -1,0 +1,165 @@
+# Domain: networking (DNS / TCP / drops / retransmits / TLS-SNI / policy)
+
+Route here for: DNS failures or slow lookups, connection resets/refused/hangs,
+packet loss, high latency, TLS/SNI/cert routing issues, "which pod opened this
+connection", NetworkPolicy authoring. Confirm every gadget's flags/fields with
+`kubectl gadget run <gadget>:latest -h` before relying on them.
+
+## Pick the right gadget (don't conflate the TCP trio)
+
+The single most common mis-route is treating the three TCP gadgets as
+interchangeable. They answer different questions:
+
+- **`trace_tcp`** — connection *lifecycle* events: connect / accept / close.
+  Use to see **whether** a connection is established, by whom, and if it's
+  refused. Has `--connect-only`, `--accept-only`, `--failure-only`.
+- **`trace_tcpretrans`** — **retransmissions**. Non-zero retransmits point at
+  loss / congestion / a flaky path even when the connection "works".
+- **`trace_tcpdrop`** — packets the **kernel dropped**, with the drop reason and
+  kernel stack. Use when connections silently stall or reset and you suspect the
+  host/network stack (conntrack, buffer, policy) rather than the app.
+
+Rule of thumb: *can't connect* → `trace_tcp`; *connects but slow/lossy* →
+`trace_tcpretrans`; *silently dropped/stalled* → `trace_tcpdrop`.
+
+## DNS
+
+```bash
+# Watch DNS for one namespace — read fields reliably via json + jq
+kubectl gadget run trace_dns:latest -n <ns> --timeout 10 -o json \
+  | jq -r '.[] | "\(.name)\t\(.qtype)\t\(.rcode)\t\(.latency_ns)"'
+```
+
+Read: `rcode` (e.g. NXDOMAIN, SERVFAIL), `latency_ns` (slow resolver), `name`
+(is the queried FQDN what you expect — search-domain/ndots surprises show here).
+No response row for a query = the request left but nothing came back (upstream
+resolver / NetworkPolicy / egress problem — pivot to `trace_tcpdrop` or
+`trace_tcp` toward the DNS service IP).
+
+**Gotchas that fake a "no data" result (read before concluding "DNS is fine"):**
+- **`-o columns=…,latency_ns` silently emits ZERO rows.** `latency_ns` is a valid
+  *field* (json / `--fields`) but NOT a valid `-o columns` template — the gadget
+  warns `output mode "latency_ns" … not supported; skipping data source` and prints
+  nothing. Use `-o json | jq` for any latency read (verified live). For **arithmetic/sort**
+  use the raw sibling `latency_ns_raw`; the bare `latency_ns` is a human-formatted
+  string (e.g. "1.2ms") — see the `*_raw` convention in `common-flags.md`.
+- **Benign NXDOMAIN is expected.** libc walks the `search`-domain list per `ndots`,
+  so short names legitimately return NXDOMAIN for each search suffix before the real
+  FQDN resolves — read the `name` column and ignore the suffix misses; only a
+  *final fully-qualified* NXDOMAIN is a genuine failure.
+- **Client/server version skew can also yield 0 rows** — see `common-flags.md`
+  ("Version skew"): fall back to default output (drop `-o`) and re-run to confirm.
+
+**Mismatched / spoofed answers** (response doesn't match the query, unexpected extra
+records): pair request↔response by `id`, then check `num_answers` and the `addresses`
+list against `qtype` — an A-query coming back with AAAA/extra records, or a
+`num_answers` higher than asked, is the tell. These fields are json-only.
+
+## TCP connectivity
+
+```bash
+# Only failed connects in a namespace (why is the app getting connection refused?)
+kubectl gadget run trace_tcp:latest -n <ns> --failure-only --timeout 10 -o json
+# Retransmissions toward a suspect upstream
+kubectl gadget run trace_tcpretrans:latest -n <ns> --timeout 15 -o json
+# Kernel drops with reason
+kubectl gadget run trace_tcpdrop:latest -A --timeout 15 -o json | jq '.[].reason' | sort | uniq -c
+```
+
+Read: `src`/`dst` (+ `.k8s.*` for the peer pod), `error`/errno on failures,
+`reason` on drops. A cluster of drops with the same `reason` toward one
+`dst.k8s.name` is your smoking gun. `trace_tcpdrop` also exposes `state`,
+`tcpflags`, and `kernel_stack` — not only `reason`: for a stalled handshake,
+`state=tcp_syn_recv` + `kernel_stack` pinpoint *where* in the stack the SYN-ACK's
+ACK died, and `tcpflags` confirms which packet was dropped.
+
+High-signal drop `reason`s (the full ~70-value `SKB_DROP_REASON_*` enum is
+discoverable via `kubectl gadget run trace_tcpdrop:latest -h`) → usual root cause:
+
+| `reason` | Usual root cause |
+|---|---|
+| `SKB_DROP_REASON_NETFILTER_DROP` | conntrack / iptables / NetworkPolicy dropped it |
+| `SKB_DROP_REASON_IP_RPFILTER` | asymmetric return path (rp_filter) — reply routed differently |
+| `SKB_DROP_REASON_XFRM_POLICY` | IPsec / XFRM policy mismatch (mesh / VPN) |
+| `SKB_DROP_REASON_TCP_INVALID_SEQUENCE` | out-of-window segment (NAT/conntrack rewrite, replay) |
+| `SKB_DROP_REASON_NO_SOCKET` | nothing listening on that port (wrong pod / not bound yet) |
+
+Reading `reason` alone distinguishes a Cilium/conntrack problem
+(`NETFILTER_DROP`) from an asymmetric-routing one (`IP_RPFILTER`) without a
+second run.
+
+## Ports & bind failures ("address already in use")
+
+`bind: address already in use` (EADDRINUSE) means something already holds the
+port. Two complementary gadgets answer *who* and *catch it live* — confirm both
+with `-h` first:
+
+- **`snapshot_socket`** — point-in-time list of open TCP/UDP sockets with
+  `state` (LISTEN / ESTABLISHED / TIME_WAIT) and the owning `src`/`dst`/inode.
+  Use it to see **who currently holds** the port.
+- **`trace_bind`** — live `bind()` calls with `addr` and the errno (`error_raw`).
+  Use it to catch **the failing bind as it happens** and which process/container
+  attempted it.
+
+```bash
+# Who is holding the port right now? (state=LISTEN on that src port = the holder)
+kubectl gadget run snapshot_socket:latest -n <ns> -o columns=k8s.podName,src,dst,state
+# Catch the failing bind() live — EADDRINUSE surfaces in the error field
+kubectl gadget run trace_bind:latest -n <ns> --timeout 10 -o json
+```
+
+Read: `state=LISTEN` on the same `src` port = the current owner; a `TIME_WAIT`
+pileup = recently-closed sockets not yet reaped (missing SO_REUSEADDR / lingering
+connections) rather than a live conflict.
+
+## Latency / throughput
+
+- `profile_tcprtt` — RTT histogram; use to prove/refute "the network is slow".
+- `top_tcp` — live per-connection throughput; find the noisy connection.
+- `profile_qdisc_latency` — scheduler (qdisc) latency if egress shaping is suspected.
+
+## TLS / SNI
+
+- `trace_sni` — the SNI hostname from the **ClientHello** each TLS handshake sends.
+  Use for "traffic is going to the wrong backend / cert mismatch / which host is
+  this pod calling".
+- `trace_ssl` — hooks the OpenSSL/GnuTLS **`SSL_read`/`SSL_write`** boundary
+  (read/recv/write/send). Beyond the plaintext payload it surfaces the **library
+  call itself**, so it also answers "*which* container's TLS library initiated this
+  handshake", not only "what bytes were sent" — don't dismiss it as payload-only.
+
+**Sidecar vs app (same pod, two containers) — the key service-mesh TLS shape.**
+When "curl from the app works but the sidecar's TLS fails", scope by container with
+`-c <container>` to see which one presents which SNI/cert:
+
+```bash
+# What SNI does the app container request vs the istio-proxy sidecar?
+kubectl gadget run trace_sni:latest -n <ns> -p <pod> -c <app-container> --timeout 10 -o json
+kubectl gadget run trace_sni:latest -n <ns> -p <pod> -c istio-proxy     --timeout 10 -o json
+```
+
+`-c` is the discriminator: it isolates the sidecar's handshake from the app's, so
+you can see which container is sending the wrong SNI.
+
+## Raw packets & policy
+
+- `tcpdump` — capture pcap when you need packet-level detail an event trace can't
+  give (flags, options, payload). Bound it hard with `--timeout`. To write a file
+  use the output-mode flag, **`-o pcap-ng >capture.pcapng`** (redirect stdout) —
+  there is **no `-w`** flag like classic tcpdump; `-o pcap-ng` selects the pcap-ng
+  stream and you redirect it yourself.
+- `advise_networkpolicy` — after you understand the traffic, generate a
+  NetworkPolicy from what was actually observed. **`kubectl gadget` only** — it
+  needs Kubernetes pod/label metadata, so it has no useful output under `sudo ig`
+  on a bare host.
+
+## Worked flow: "Service intermittently returns 502"
+
+1. `trace_dns -n <ns>` → is name resolution clean (rcode/ latency)? If not, stop here.
+2. `trace_tcp -n <ns> --failure-only` → are connects to the upstream failing/refused?
+3. `trace_tcpretrans -n <ns>` → retransmits toward the upstream (loss)?
+4. `trace_tcpdrop -A` → kernel drops with a reason (conntrack full, policy)?
+5. Correlate the failing `dst.k8s.name` + `reason`/`error` across steps → root cause.
+
+Each step is a **short, scoped, `--timeout`-bounded** run so you never flood
+context (irrelevant tokens degrade the agent).

--- a/skills/kubernetes-troubleshooting/references/domain-performance.md
+++ b/skills/kubernetes-troubleshooting/references/domain-performance.md
@@ -1,0 +1,110 @@
+# Domain: performance (CPU / throttle / RTT / deadlock / malloc / GPU)
+
+Route here for: high CPU, CPU throttling, latency, memory growth/leaks, hangs
+(deadlock), or GPU memory issues. Confirm flags/fields with
+`kubectl gadget run <gadget>:latest -h`. Flags below are verified against the
+shipped images.
+
+## CPU: where is it going vs who is being capped
+
+- **`profile_cpu`** — samples stack traces → an **on-CPU profile** (flamegraph
+  input). Use to answer "*where* is CPU being spent" (which functions/stacks).
+  Verified flags: `--user-stacks-only`, `--kernel-stacks-only` (scope the stack),
+  `--include-idle`, `--sort`. **Omit BOTH stack flags to get the combined
+  kernel+user stack** — the full flame graph; pass exactly one to halve the volume
+  when you only care about the app (user) or the kernel. To visualise, collapse the
+  sampled stacks to folded format (`func;func;… count`) and render with Brendan
+  Gregg's FlameGraph (`flamegraph.pl`, github.com/brendangregg/FlameGraph) — the
+  folding is a post-process step, `profile_cpu` has no `--fold` flag.
+- **`top_cpu_throttle`** — cgroup **CFS throttling** stats: containers hitting
+  their CPU *limits* and being throttled. Use to answer "is the app slow because
+  it's being **capped**" (a config/limits problem, not a hot-code problem).
+  Verified flags: `--interval`, `--count`, `--sort`. The decisive signal is the
+  throttle counters — a non-zero throttled *count* and throttled *time* mean the
+  app is being paused by CFS. Confirm the exact field names with `-h`/`--fields`
+  before scripting (they are camelCase and can shift by image version — don't
+  hardcode them from memory).
+- **`top_process`** — periodic process CPU/mem ranking — "*who* is hot".
+
+Decision: app is slow → `top_cpu_throttle` (are we being throttled by limits?) →
+if not, `profile_cpu` (where is the CPU actually going?) → `top_process` (which
+process).
+
+```bash
+# Is this workload being CPU-throttled by its limits?
+kubectl gadget run top_cpu_throttle:latest -n <ns> --timeout 15 -o json
+# Where is the CPU going (user stacks only, for an app profile)?
+kubectl gadget run profile_cpu:latest -n <ns> -p <pod> --user-stacks-only --timeout 20 -o json
+```
+
+Read: a non-zero throttled count/time in `top_cpu_throttle` means **raise the CPU
+limit or reduce work** — the app isn't "slow", it's being paused by CFS. If
+throttling is zero, use `profile_cpu` to find the hot stack.
+
+## Memory (userspace)
+
+- **`trace_malloc`** — libc `malloc`/`free` via **uprobe** (it hooks the libc
+  allocator, so it sees only userspace allocations that go through libc — not raw
+  `mmap`/`brk`, nor a musl-static binary; that's the attach caveat). **Scope it** —
+  a uprobe on every process is expensive and noisy — with **`--comm <name>`** or
+  **`--pid <pid>`** to the suspect process. Add **`--collect-ustack`** to capture
+  the **allocation call stack** (the leaking *site*), so `trace_malloc` itself
+  answers "where is the leak". Do **not** hop to `profile_cpu` for allocation stacks
+  — `profile_cpu` is an on-CPU profiler with no allocation-profiling mode (the older
+  "find the alloc site with profile_cpu" pointer was inaccurate). Pair with
+  `trace_oomkill` (process-lifecycle) when the workload is OOM-killed to confirm a
+  userspace leak first.
+
+## Latency
+
+- **`profile_tcprtt`** — TCP RTT histogram (also in networking): use here when
+  "latency" is network-round-trip, not CPU.
+- **`profile_qdisc_latency`** — network scheduler latency (egress shaping).
+
+## Hangs / deadlocks
+
+- **`deadlock`** — builds a per-process **lock graph** from
+  `pthread_mutex_lock`/`unlock` ordering to surface **lock-order inversions**. Use
+  when a multithreaded app hangs with no crash and no CPU (a classic mutex
+  deadlock). Verified flags: **`--pid <pid>`** / **`--comm <name>`** — scope to the
+  **suspect process** (the graph is per-process; an unscoped run is noise). You must
+  **reproduce the hang while the gadget is attached** — it builds the graph from
+  live lock operations, so a mutex acquired before you attached is invisible.
+  Caveat: it instruments **`pthread_mutex` only** — a Go `sync.Mutex` or an async
+  runtime that bypasses pthread won't appear (corroborate a stall with `profile_cpu`
+  stack sampling).
+
+## GPU (CUDA)
+
+- **`top_cuda_memory`** — per-process CUDA memory alloc/free ranking. The decisive
+  field is **`host`** = *Memory class* (**`DEVICE` = GPU VRAM, `HOST` = pinned host
+  memory**) — so you can tell GPU-VRAM exhaustion from a pinned-host-memory balloon
+  at a glance. Scope per process with **`--pid`** / **`--comm`** (the CUDA gadgets
+  are uprobes on the CUDA libraries — scope them). Use for "GPU OOM / who is holding
+  **device** memory".
+- **`profile_cuda`** — CUDA allocation/free behavior over time in libcuda (Driver
+  API) — deeper allocation *profiling*. Like `top_cuda_memory` it's a uprobe on
+  the CUDA libraries, so scope per process with `--pid`/`--comm`; confirm its
+  fields/flags with `-h` (it tracks alloc size/kind over the run).
+
+```bash
+# Who is holding CUDA device memory? (host=DEVICE vs HOST distinguishes VRAM vs pinned)
+kubectl gadget run top_cuda_memory:latest -n <ns> --timeout 15 -o json
+```
+
+**Disambiguate the CUDA question:** `top_cuda_memory` = capacity / top holders (who
+holds how much, `DEVICE` vs `HOST`); `profile_cuda` = alloc/free behavior over time.
+**Neither diagnoses an "illegal memory access" / out-of-bounds CUDA error** — that's
+a kernel-*code* bug (bad pointer/index), not a memory-capacity gadget target; don't
+assume an OOM and an illegal-access share one root cause. For that class, hand
+off to CUDA's own tools — **`compute-sanitizer`** (its `memcheck`/`racecheck`
+tool) or **`cuda-gdb`** — which pinpoint the offending kernel/line; IG's job is
+only to rule OUT a memory-capacity/OOM cause first.
+
+## Notes
+
+- `profile_*` and `top_*` are sampling/periodic — bound with `--timeout` and cap
+  `top_*` with `--max-entries`/`--count`.
+- `profile_cpu` output is stacks; project/aggregate rather than dumping every
+  sample into context. Use `--user-stacks-only` to halve the volume
+  when you only care about the app.

--- a/skills/kubernetes-troubleshooting/references/domain-process-lifecycle.md
+++ b/skills/kubernetes-troubleshooting/references/domain-process-lifecycle.md
@@ -27,20 +27,22 @@ with what argv?).
 
 ```bash
 # 1. What is the container exec-ing? (catch a failing entrypoint/argv)
-kubectl gadget run trace_exec:latest -n <ns> -p <pod> --paths --timeout 15 \
-  -o columns=k8s.podName,proc.comm,args,error
+kubectl gadget run trace_exec:latest -n <ns> -p <pod> --ignore-failed=false \
+  --paths --timeout 15 \
+  -o columns --fields k8s.podName,proc.comm,args,error
 # 2. Is something signalling it?
 kubectl gadget run trace_signal:latest -n <ns> --timeout 15 \
-  -o columns=k8s.podName,proc.comm,sig,tpid
+  -o columns --fields k8s.podName,proc.comm,sig,tpid
 # 3. Is it an OOM kill?
 kubectl gadget run trace_oomkill:latest -A --timeout 20 -o json
 ```
 
-Read: in step 1 a non-zero `error` on the exec (e.g. ENOENT/EACCES) means the
+Read: `trace_exec` ignores failed executions by default, so step 1 explicitly
+sets `--ignore-failed=false`. A non-zero `error` (e.g. ENOENT/EACCES) means the
 binary/path is wrong or not executable — a classic CrashLoop cause the app logs
 never show. In step 2, a `SIGKILL` from a non-kubelet `proc.comm` points at a
 sidecar/supervisor. In step 3, any row = confirmed OOM (raise limits / fix leak;
-pivot to `trace_malloc`/`profile_cpu`).
+pivot to `trace_malloc`).
 
 ## Point-in-time snapshots (state, not stream)
 
@@ -48,10 +50,10 @@ pivot to `trace_malloc`/`profile_cpu`).
   confirm whether a process you expect is actually alive, or spot an unexpected
   one. `--max-entries` to cap. **Also pass `--timeout`** — although snapshots are
   "one-shot", `snapshot_process` can hang waiting on node/DaemonSet responses
-  (observed >2min without one), so always bound it. For **nested** fields like
-  `parent.comm`, `-o columns=…,parent.comm` is silently dropped ("not supported;
-  skipping data source") — use `-o json` + `jq '.[].parent.comm'` for anything
-  nested.
+  (observed >2min without one), so always bound it. For columns, use
+  `-o columns --fields …,parent.comm` (the `-o columns=field,field` comma form is
+  parsed as separate output modes and silently drops everything — see
+  `common-flags.md`); `-o json` + `jq '.[].parent.comm'` also works for nested fields.
 - **`top_process`** — periodic process stats (CPU/mem ranking) — "what's hot
   right now". Verified flags: `--sort` (join with `,`; `-` prefix = descending,
   e.g. `--sort -memoryRSS` for the biggest memory users), `--interval` (default

--- a/skills/kubernetes-troubleshooting/references/domain-process-lifecycle.md
+++ b/skills/kubernetes-troubleshooting/references/domain-process-lifecycle.md
@@ -1,0 +1,84 @@
+# Domain: process lifecycle (exec / signals / OOM / snapshots / recording)
+
+Route here for: CrashLoopBackOff, containers exiting or restarting unexpectedly,
+"who killed my process", OOMKilled, unexpected binaries running, or a
+point-in-time view of what's running. Confirm every gadget's flags/fields with
+`kubectl gadget run <gadget>:latest -h`.
+
+## The three "why did it die / start" gadgets
+
+- **`trace_exec`** — every process execution (argv, uid, cwd with `--paths`).
+  Use for CrashLoopBackOff to see **what the container actually execs** and with
+  which arguments — a wrong entrypoint, a failing init binary, or an unexpected
+  child shows here immediately.
+- **`trace_signal`** — signals delivered between processes. Use for "container
+  got SIGKILL/SIGTERM out of nowhere": see the **sender** (`proc.comm`/pid), the
+  **target** pid (`tpid`), and the `sig` number (`sig_raw` = numeric value).
+- **`trace_oomkill`** — OOM-killer events: victim `tcomm`/`tpid` (the killed process — NOT the
+  trigger `fprocess.comm`/`fprocess.pid`, which is whoever's allocation tripped
+  the OOM) and the memory cgroup. Definitive answer to "was this an OOM kill?" (vs a signal or a clean
+  exit).
+
+Decision order for a dying container: `trace_oomkill` (was it OOM?) →
+`trace_signal` (was it signalled, by whom?) → `trace_exec` (did it even start,
+with what argv?).
+
+## CrashLoopBackOff worked flow
+
+```bash
+# 1. What is the container exec-ing? (catch a failing entrypoint/argv)
+kubectl gadget run trace_exec:latest -n <ns> -p <pod> --paths --timeout 15 \
+  -o columns=k8s.podName,proc.comm,args,error
+# 2. Is something signalling it?
+kubectl gadget run trace_signal:latest -n <ns> --timeout 15 \
+  -o columns=k8s.podName,proc.comm,sig,tpid
+# 3. Is it an OOM kill?
+kubectl gadget run trace_oomkill:latest -A --timeout 20 -o json
+```
+
+Read: in step 1 a non-zero `error` on the exec (e.g. ENOENT/EACCES) means the
+binary/path is wrong or not executable — a classic CrashLoop cause the app logs
+never show. In step 2, a `SIGKILL` from a non-kubelet `proc.comm` points at a
+sidecar/supervisor. In step 3, any row = confirmed OOM (raise limits / fix leak;
+pivot to `trace_malloc`/`profile_cpu`).
+
+## Point-in-time snapshots (state, not stream)
+
+- **`snapshot_process`** — list processes running *right now* in scope. Use to
+  confirm whether a process you expect is actually alive, or spot an unexpected
+  one. `--max-entries` to cap. **Also pass `--timeout`** — although snapshots are
+  "one-shot", `snapshot_process` can hang waiting on node/DaemonSet responses
+  (observed >2min without one), so always bound it. For **nested** fields like
+  `parent.comm`, `-o columns=…,parent.comm` is silently dropped ("not supported;
+  skipping data source") — use `-o json` + `jq '.[].parent.comm'` for anything
+  nested.
+- **`top_process`** — periodic process stats (CPU/mem ranking) — "what's hot
+  right now". Verified flags: `--sort` (join with `,`; `-` prefix = descending,
+  e.g. `--sort -memoryRSS` for the biggest memory users), `--interval` (default
+  `3s`), `--count` (number of reports; `0` = until timeout), `--max-entries`.
+  Memory columns `memoryRSS`/`memoryVirtual`/`memoryShared` (each with a `_raw`
+  numeric sibling); CPU `cpuUsage`/`cpuUsageRelative`.
+
+```bash
+# Top memory consumers in a namespace, refreshed every 5s
+kubectl gadget run top_process:latest -n <ns> --sort -memoryRSS --interval 5 --max-entries 10 -o json
+```
+
+## Flight recorder
+
+- **`traceloop`** — a syscall flight recorder: continuously records recent
+  syscalls per container so you can **replay the last syscalls before a crash**.
+  Invaluable when a container dies too fast to attach a live trace: the ring
+  buffer already holds what it did. Read `-h` for the record/dump workflow.
+
+## `ttysnoop`
+
+- Watch live output from a tty/pts device (e.g. what an interactive debug session
+  is printing). Niche; use when you need to observe a specific terminal.
+
+## Notes
+
+- All of these are **read-only**. `trace_exec`/`trace_signal` are streaming —
+  bound with `--timeout`. `snapshot_*` are one-shot but cap with `--max-entries`.
+- Scope tightly (`-n`/`-p`/`-c`): exec/signal traffic cluster-wide is very noisy
+  and will bloat context.

--- a/skills/kubernetes-troubleshooting/references/domain-security.md
+++ b/skills/kubernetes-troubleshooting/references/domain-security.md
@@ -15,19 +15,19 @@ shipped images.
   `CAP_SYS_PTRACE`).
   Verified flags: `--audit-only` (only audit checks), `--unique` (collapse
   repeats per container), `--filter/-F`, `--pid`, `--uid`, `--gid`.
-- **`trace_lsm`** — decisions at **LSM hooks** — effectively "strace for LSM".
-  Use for AppArmor/SELinux/BPF-LSM denials to see which hook (e.g.
-  `bprm_check_security`, `file_open`, `inode_permission`) returned a denial.
-  Verified: `--trace-all` (default true) or per-hook `--trace-<hook>` flags to
-  scope to a single hook; `--filter/-F`.
-- **`audit_seccomp`** — syscalls **audited/blocked by the seccomp profile**. Use
-  when a container dies or an op fails and you suspect the seccomp profile is too
-  strict — you'll see the offending syscall.
-- **`advise_seccomp`** — after tracing, **suggest a seccomp profile** from the
-  syscalls actually used (least-privilege authoring). It emits the profile on the
-  data stream — capture it with `-o json > profile.json` (redirect stdout), not
-  an in-place file. `audit_seccomp` likewise streams; persist with
-  `-o json > audit.json`. Confirm the exact output flags with `-h`.
+- **`trace_lsm`** — records that an **LSM hook was invoked** (effectively "strace
+  for LSM hooks"). It emits process identity plus the `tracepoint` name, but not
+  another LSM's return value, so it cannot by itself prove that AppArmor or
+  SELinux denied an operation. Use node audit logs for the verdict; use
+  `trace_lsm` only to correlate hook activity. `--trace-all` defaults to false,
+  so pass it or a specific `--trace-<hook>` flag.
+- **`audit_seccomp`** — records seccomp audit events with the syscall and
+  seccomp `code` (for example ERRNO, TRAP, KILL, USER_NOTIF, or LOG). Use the
+  code to distinguish a denial from a logged/notification action.
+- **`advise_seccomp`** — records syscalls during a representative workload and
+  emits suggested profiles when the run stops. Its supported/default output mode
+  is `advise`, not JSON. Redirect the default output to a text file; it can contain
+  one labeled JSON profile per container.
 - **`trace_init_module`** — `init_module`/`finit_module`: **kernel module loads**.
   Use for security auditing ("did anything load a module?") or module-load fails.
   **From inside a container or from the host?** — that is the real security
@@ -40,23 +40,28 @@ shipped images.
 ```bash
 # 1. Which capability is being denied? (EPERM with correct FS perms)
 kubectl gadget run trace_capabilities:latest -n <ns> -p <pod> --timeout 15 \
-  -o columns=k8s.podName,proc.comm,cap,capable,syscall
-# 2. If it's an LSM/AppArmor/SELinux denial, see the hook decision
-kubectl gadget run trace_lsm:latest -n <ns> --timeout 15 -o json
-# 3. If it's a seccomp block, see the audited syscall
+  -o columns --fields k8s.podName,proc.comm,cap,capable,syscall
+# 2. If it's a seccomp action, inspect the audited syscall and return code
 kubectl gadget run audit_seccomp:latest -n <ns> --timeout 15 -o json
+# 3. For AppArmor/SELinux, inspect node audit logs for the verdict.
+# Optional: correlate which LSM hooks the workload reaches (activity only).
+kubectl gadget run trace_lsm:latest -n <ns> --trace-all --timeout 15 -o json
 ```
 
-Read: in step 1, a row where `capable=false` names the missing `cap` — add it to
-the container's `securityContext.capabilities` (or fix why it's requested). In
-step 2, the denied hook + `proc.comm` tells you which action the LSM blocked. In
-step 3, the audited `syscall` is what the seccomp profile forbids.
+Read: in step 1, a row where `capable=false` names the missing `cap`; first fix
+why it is requested, and grant it only when that access is intended. In step 2,
+read both `syscall` and `code`; not every audited action is a denial. In step 3,
+the node's AppArmor/SELinux audit record supplies the actual allow/deny verdict.
+`trace_lsm` only confirms that a named hook ran.
 
 ## Least-privilege authoring (not just debugging)
 
-1. Run the workload under `trace_capabilities` and `audit_seccomp` through a
-   representative workload window (bounded `--timeout`).
-2. Feed observations to `advise_seccomp` to generate a tight seccomp profile.
+1. Run `advise_seccomp` while exercising a representative workload window:
+   `kubectl gadget run advise_seccomp:latest -n <ns> -p <pod> --timeout 30 >
+   seccomp-advice.txt`.
+2. Select and review the labeled profile for the intended container. The advisor
+   only permits syscalls observed during that window, so incomplete workload
+   coverage produces an incomplete profile.
 3. Use `advise_networkpolicy` (networking domain) for the network side.
 
 This turns IG from a debugger into a **hardening** tool — observe real behavior,
@@ -68,14 +73,11 @@ then generate the minimal policy that permits exactly it.
   `--timeout`; scope with `-n`/`-p`/`-c` (security traffic is high-volume).
 - `--audit-only` on `trace_capabilities` cuts to the checks that matter for
   audit; `--unique` stops the same capability spamming once per container.
-- The full LSM hook list is huge — start with `--trace-all` and filter the JSON
-  by the hook you care about, or pass the specific `--trace-<hook>` flag. To
-  **discover which hooks are actually firing** (rather than guessing a hook name),
-  enumerate the live distinct values — find the hook field with `jq keys` first,
-  then tabulate:
+- The full LSM hook list is huge — use a specific `--trace-<hook>` when you know
+  it. To **discover which hooks are actually firing**, run briefly with
+  `--trace-all` and tabulate the `tracepoint` field:
 
   ```bash
-  kubectl gadget run trace_lsm:latest -n <ns> --trace-all --timeout 15 -o json > /tmp/lsm.json
-  jq '.[0] | keys' /tmp/lsm.json                 # locate the hook field (e.g. name)
-  jq -r '.[].name' /tmp/lsm.json | sort | uniq -c | sort -rn
+  kubectl gadget run trace_lsm:latest -n <ns> --trace-all --timeout 15 -o json \
+    | jq -r '.tracepoint' | sort | uniq -c | sort -rn
   ```

--- a/skills/kubernetes-troubleshooting/references/domain-security.md
+++ b/skills/kubernetes-troubleshooting/references/domain-security.md
@@ -1,0 +1,81 @@
+# Domain: security (capabilities / LSM / seccomp / module loading)
+
+Route here for: "permission denied" despite correct file perms/RBAC, seccomp /
+AppArmor / SELinux denials, a container needing an unexpected capability, or
+unexpected kernel-module loads. Confirm flags/fields with
+`kubectl gadget run <gadget>:latest -h`. Flags below are verified against the
+shipped images.
+
+## Which gadget for which denial
+
+- **`trace_capabilities`** — records every kernel **capability check** (the
+  `capable()` LSM hook): which `CAP_*` was tested and whether it was allowed.
+  Use when an operation fails with EPERM but file perms look right — you'll see
+  exactly which capability the workload is missing (e.g. `CAP_NET_ADMIN`,
+  `CAP_SYS_PTRACE`).
+  Verified flags: `--audit-only` (only audit checks), `--unique` (collapse
+  repeats per container), `--filter/-F`, `--pid`, `--uid`, `--gid`.
+- **`trace_lsm`** — decisions at **LSM hooks** — effectively "strace for LSM".
+  Use for AppArmor/SELinux/BPF-LSM denials to see which hook (e.g.
+  `bprm_check_security`, `file_open`, `inode_permission`) returned a denial.
+  Verified: `--trace-all` (default true) or per-hook `--trace-<hook>` flags to
+  scope to a single hook; `--filter/-F`.
+- **`audit_seccomp`** — syscalls **audited/blocked by the seccomp profile**. Use
+  when a container dies or an op fails and you suspect the seccomp profile is too
+  strict — you'll see the offending syscall.
+- **`advise_seccomp`** — after tracing, **suggest a seccomp profile** from the
+  syscalls actually used (least-privilege authoring). It emits the profile on the
+  data stream — capture it with `-o json > profile.json` (redirect stdout), not
+  an in-place file. `audit_seccomp` likewise streams; persist with
+  `-o json > audit.json`. Confirm the exact output flags with `-h`.
+- **`trace_init_module`** — `init_module`/`finit_module`: **kernel module loads**.
+  Use for security auditing ("did anything load a module?") or module-load fails.
+  **From inside a container or from the host?** — that is the real security
+  question. A non-empty `k8s.containerName` (kubectl) / `runtime.containerName`
+  (`ig`) means a container loaded it; an empty one under `--host` means a host
+  process. Always read that column, not just "a module loaded".
+
+## "Permission denied" decision flow
+
+```bash
+# 1. Which capability is being denied? (EPERM with correct FS perms)
+kubectl gadget run trace_capabilities:latest -n <ns> -p <pod> --timeout 15 \
+  -o columns=k8s.podName,proc.comm,cap,capable,syscall
+# 2. If it's an LSM/AppArmor/SELinux denial, see the hook decision
+kubectl gadget run trace_lsm:latest -n <ns> --timeout 15 -o json
+# 3. If it's a seccomp block, see the audited syscall
+kubectl gadget run audit_seccomp:latest -n <ns> --timeout 15 -o json
+```
+
+Read: in step 1, a row where `capable=false` names the missing `cap` — add it to
+the container's `securityContext.capabilities` (or fix why it's requested). In
+step 2, the denied hook + `proc.comm` tells you which action the LSM blocked. In
+step 3, the audited `syscall` is what the seccomp profile forbids.
+
+## Least-privilege authoring (not just debugging)
+
+1. Run the workload under `trace_capabilities` and `audit_seccomp` through a
+   representative workload window (bounded `--timeout`).
+2. Feed observations to `advise_seccomp` to generate a tight seccomp profile.
+3. Use `advise_networkpolicy` (networking domain) for the network side.
+
+This turns IG from a debugger into a **hardening** tool — observe real behavior,
+then generate the minimal policy that permits exactly it.
+
+## Notes
+
+- `trace_capabilities`/`trace_lsm`/`audit_seccomp` are streaming — bound with
+  `--timeout`; scope with `-n`/`-p`/`-c` (security traffic is high-volume).
+- `--audit-only` on `trace_capabilities` cuts to the checks that matter for
+  audit; `--unique` stops the same capability spamming once per container.
+- The full LSM hook list is huge — start with `--trace-all` and filter the JSON
+  by the hook you care about, or pass the specific `--trace-<hook>` flag. To
+  **discover which hooks are actually firing** (rather than guessing a hook name),
+  enumerate the live distinct values — find the hook field with `jq keys` first,
+  then tabulate:
+
+  ```bash
+  kubectl gadget run trace_lsm:latest -n <ns> --trace-all --timeout 15 -o json > /tmp/lsm.json
+  jq '.[0] | keys' /tmp/lsm.json                 # locate the hook field (e.g. name)
+  jq -r '.[].name' /tmp/lsm.json | sort | uniq -c | sort -rn
+  ```

--- a/skills/kubernetes-troubleshooting/references/domain-storage-fs.md
+++ b/skills/kubernetes-troubleshooting/references/domain-storage-fs.md
@@ -23,7 +23,7 @@ Flags below are verified against the shipped images.
 ```bash
 # Which process is writing the most, per file?
 kubectl gadget run top_file:latest -n <ns> --sort -wbytes --max-entries 10 \
-  -o columns=k8s.podName,comm,pid,file,wbytes,rbytes
+  -o columns --fields k8s.podName,comm,pid,file,wbytes,rbytes
 ```
 
 Rule of thumb: *open is failing* → `trace_open --failed`; *what's open now* →
@@ -54,10 +54,12 @@ never appears in app logs.
   never resolves the dentry, so `fpath` comes back **empty** — only `fname` (the raw
   path argument) is populated. Read `fname` when hunting a missing file; trust
   `fpath` only on *successful* opens.
-- **`-o columns=…,error` silently emits ZERO rows.** A column literally named
-  `error` collides with an output-mode name — the gadget warns
-  `output mode "error" … not supported; skipping data source` and prints nothing.
-  Use `-o json` for any read that includes the errno (verified live).
+- **Never write `-o columns=field,field` — it silently emits ZERO rows.** `-o`
+  parses its value as a comma-separated list of output *modes*, so
+  `-o columns=comm,error` becomes the modes `columns=comm`, `error` — both unknown
+  (`output mode "error" … not supported; skipping data source`) and nothing prints.
+  Use **`-o columns --fields comm,error`** to pick columns (verified live, ig v0.54),
+  or `-o json` for any read that includes the errno.
 
 ## Slow disk / file I/O
 

--- a/skills/kubernetes-troubleshooting/references/domain-storage-fs.md
+++ b/skills/kubernetes-troubleshooting/references/domain-storage-fs.md
@@ -1,0 +1,115 @@
+# Domain: storage & filesystem (open / slow I/O / block / mounts / fd / notify)
+
+Route here for: "no such file or directory", missing/wrong config paths, EACCES
+on files, slow disk or file I/O, mount problems, or "which process is hammering
+this file". Confirm flags/fields with `kubectl gadget run <gadget>:latest -h`.
+Flags below are verified against the shipped images.
+
+## The file-access trio (don't conflate)
+
+- **`trace_open`** — the `open`/`openat` **call itself**: filename, flags, and the
+  **error** (errno). This is the first stop for "no such file", wrong path, or
+  permission-denied-on-a-file. Verified flag: **`--failed`** (show only failed
+  opens) — the single best noise-cutter when hunting a missing/denied file.
+- **`snapshot_file`** — point-in-time list of **currently open files** in scope.
+  Use to answer "does this process actually have the file open / which fd". Verified
+  flags: `--type-mask` (filter by file type), `--sort`.
+- **`top_file`** — periodic **read/write activity per file** — "what file is hot".
+  Verified flags: `--all-files` (by default only regular files are traced),
+  `--sort` (e.g. `--sort -wbytes` = busiest writers first; fields
+  `wbytes`/`rbytes`/`writes`/`reads`, each with a `_raw` numeric sibling),
+  `--max-entries`. The `comm`/`pid` columns name the process doing the I/O:
+
+```bash
+# Which process is writing the most, per file?
+kubectl gadget run top_file:latest -n <ns> --sort -wbytes --max-entries 10 \
+  -o columns=k8s.podName,comm,pid,file,wbytes,rbytes
+```
+
+Rule of thumb: *open is failing* → `trace_open --failed`; *what's open now* →
+`snapshot_file`; *what's busy* → `top_file`.
+
+## "No such file / config not found" worked flow
+
+```bash
+# Show only FAILED opens — read fields via json (see the columns pitfall below),
+# filtering out the benign glibc dynamic-loader ENOENT noise
+kubectl gadget run trace_open:latest -n <ns> -p <pod> --failed --paths --timeout 15 -o json \
+  | jq -r 'select(.fname | test("ld\\.so\\.cache|glibc-hwcaps|lib.*\\.so") | not)
+           | "\(.fname)\t\(.error)"'
+```
+
+Read: `fname` is the exact path the process tried; `error` is the errno
+(`ENOENT` = wrong path / missing mount; `EACCES` = perms → pivot to
+`trace_capabilities`). `--paths` populates path fields. This catches the classic
+"app reads /etc/config/foo but the ConfigMap mounted it at /config/foo" bug that
+never appears in app logs.
+
+**Three live-verified gotchas when hunting a missing file:**
+- **Filter the glibc loader noise.** On any glibc image `--failed` floods with
+  benign `ENOENT`s (`ld.so.cache`, `glibc-hwcaps/*`, `libm.so.6` fallbacks) — the
+  dynamic loader probing standard paths. `--failed` alone is not enough; the `jq`
+  `select(… | not)` above drops that noise so the real app-config miss stands out.
+- **`fname` is reliable on failures; `fpath` is not.** On a *failed* open the kernel
+  never resolves the dentry, so `fpath` comes back **empty** — only `fname` (the raw
+  path argument) is populated. Read `fname` when hunting a missing file; trust
+  `fpath` only on *successful* opens.
+- **`-o columns=…,error` silently emits ZERO rows.** A column literally named
+  `error` collides with an output-mode name — the gadget warns
+  `output mode "error" … not supported; skipping data source` and prints nothing.
+  Use `-o json` for any read that includes the errno (verified live).
+
+## Slow disk / file I/O
+
+- **`trace_fsslower`** — open/read/write/fsync operations **slower than a
+  threshold**. Verified flags: **`--min <µs>`** (latency floor — set it so only
+  outliers show), **`--filesystem <fs>`** (btrfs/ext4/fuse/nfs/…; scope to the FS
+  you care about). Use to prove "storage is slow" and see which op/file.
+- **`profile_blockio`** — histogram of **block-device I/O latency** (the layer
+  below the FS). Use to localize slowness to the device vs the filesystem.
+  Verified flags: **`-t`/`--timeout`** — it's a histogram gadget: it accumulates
+  while running and **emits the histogram when `--timeout` expires**, so always set
+  one; plus `--sort` and `--max-entries` (`-1` = unlimited). It has **no**
+  `--interval`/`--count` — the histogram is bounded by `--timeout`, not an interval.
+- **`top_blockio`** — live per-device block I/O ranking — "which device/container
+  is doing the I/O". Verified flags: **`--sort`** (join fields with `,`; prefix a
+  field with `-` for descending, e.g. `--sort -bytes`) and `--max-entries`.
+
+```bash
+# File ops slower than 10ms on ext4 in this namespace
+kubectl gadget run trace_fsslower:latest -n <ns> --filesystem ext4 --min 10000 --timeout 20 -o json
+```
+
+Disambiguate: **`trace_fsslower`** = per-operation FS latency outliers (which
+file/op is slow); **`profile_blockio`** = block-device latency *histogram* (is the
+disk itself slow); **`top_blockio`** = live per-device/container I/O *ranking*
+(who is doing the I/O). FS-slow but device-fast ⇒ look above the block layer.
+
+## Mounts, links, fd passing, notifications
+
+- **`trace_mount`** — `mount`/`umount` syscalls (volume/mount debugging, esp. in
+  init containers or CSI).
+- **`trace_link`** — hardlink/symlink creation (surprising symlink resolution).
+- **`fdpass`** — file descriptors passed over unix sockets (SCM_RIGHTS) — niche,
+  for privilege/fd-leak analysis between processes.
+- **`fsnotify`** — inotify/fanotify events: "who is watching this path" (config
+  reloaders, watchers eating inotify limits). Two event families share one stream
+  — **inotify** rows carry `i_*` fields (`i_wd` watch descriptor, `i_mask` event
+  mask, `i_ino` inode) and **fanotify** rows carry `fa_*` fields; the `type`
+  column tells them apart. Group by `i_wd` to find the busy watch, or by `i_mask`
+  for the dominant event class:
+
+```bash
+# Which inotify watch is the busiest? (group by watch descriptor)
+kubectl gadget run fsnotify:latest -n <ns> --timeout 15 -o json \
+  | jq -r 'select(.type=="inotify") | .i_wd' | sort | uniq -c | sort -rn
+```
+
+## Notes
+
+- `trace_open`/`trace_fsslower`/`trace_mount` are streaming — bound `--timeout`.
+- `snapshot_file` is one-shot but can **block waiting on node/DaemonSet
+  responses** — pair it with **`--timeout`** (not just `--max-entries`/`--sort`),
+  or a run can hang indefinitely.
+- Always prefer `--failed`/`--min` to shrink output to the events that matter —
+  full FS traces are extremely high-volume and will flood the agent's context.

--- a/skills/kubernetes-troubleshooting/references/gadget-catalog.md
+++ b/skills/kubernetes-troubleshooting/references/gadget-catalog.md
@@ -4,7 +4,10 @@ The authoritative live interface for any gadget is `run <gadget>:latest -h`
 (see `discovering-params-and-fields.md`). This catalog is a **routing aid**: it
 groups the shipped upstream gadgets so you can pick the right one for a symptom,
 then confirm its flags/fields with `-h`. One-liners are the gadgets' own
-descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
+descriptions. Gadgets are OCI images; there is no `list-gadgets` command. This
+catalog tracks the upstream `gadgets/` tree at the time it is updated. Recheck
+that tree and the release catalog when editing it; a generated drift check can
+be added separately.
 
 > Run form: `kubectl gadget run <gadget>:latest …` (Kubernetes) or
 > `sudo ig run <gadget>:latest …` (single host). Both accept the same gadgets.
@@ -32,11 +35,11 @@ descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
 | Gadget | What it traces |
 |---|---|
 | `trace_capabilities` | security capability checks (which CAP_* was tested, allowed/denied) |
-| `trace_lsm` | LSM hook decisions — "a strace for LSM" (AppArmor/SELinux/BPF-LSM) |
-| `audit_seccomp` | syscalls audited against the seccomp profile (seccomp denials) |
+| `trace_lsm` | LSM hook invocations (activity only; it does not expose another LSM's verdict) |
+| `audit_seccomp` | seccomp audit events with syscall and return code/action |
 | `advise_seccomp` | suggest a seccomp profile from observed syscalls |
 | `trace_init_module` | `init_module`/`finit_module` — kernel module loads |
-| `trace_lsm`/`trace_capabilities` | pair these when "permission denied" has correct FS perms/RBAC |
+| `trace_lsm`/`trace_capabilities` | capability verdicts plus LSM hook activity; use node audit logs for AppArmor/SELinux verdicts |
 
 ## Process lifecycle (exec / signals / OOM / snapshots / recording)
 

--- a/skills/kubernetes-troubleshooting/references/gadget-catalog.md
+++ b/skills/kubernetes-troubleshooting/references/gadget-catalog.md
@@ -1,0 +1,94 @@
+# Gadget catalog — upstream gadgets grouped by troubleshooting domain
+
+The authoritative live interface for any gadget is `run <gadget>:latest -h`
+(see `discovering-params-and-fields.md`). This catalog is a **routing aid**: it
+groups the shipped upstream gadgets so you can pick the right one for a symptom,
+then confirm its flags/fields with `-h`. One-liners are the gadgets' own
+descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
+
+> Run form: `kubectl gadget run <gadget>:latest …` (Kubernetes) or
+> `sudo ig run <gadget>:latest …` (single host). Both accept the same gadgets.
+
+## Networking
+
+| Gadget | What it traces |
+|---|---|
+| `trace_dns` | DNS requests and responses (query name, qtype, rcode, latency_ns) |
+| `trace_tcp` | connect / accept / close events of TCP connections |
+| `trace_tcpretrans` | TCP retransmissions (congestion / loss symptom) |
+| `trace_tcpdrop` | TCP packets dropped by the kernel (with drop reason / stack) |
+| `trace_sni` | TLS SNI (Server Name Indication) seen on the wire |
+| `trace_ssl` | data on OpenSSL/GnuTLS read/recv/write/send (plaintext at the TLS boundary) |
+| `trace_bind` | socket bind() calls (who bound which port) |
+| `snapshot_socket` | point-in-time list of open TCP/UDP sockets (src, dst, state, inode, netns) |
+| `top_tcp` | periodic per-connection TCP send/receive activity |
+| `profile_tcprtt` | histogram of TCP round-trip time (RTT) |
+| `profile_qdisc_latency` | network scheduler (qdisc) latency |
+| `tcpdump` | capture raw packets — write with `-o pcap-ng >file` (no `-w`) |
+| `advise_networkpolicy` | K8s NetworkPolicies from observed traffic (**`kubectl gadget` only** — needs pod/podIP metadata; no useful output under `sudo ig`) |
+
+## Security (capabilities / LSM / seccomp / module loading)
+
+| Gadget | What it traces |
+|---|---|
+| `trace_capabilities` | security capability checks (which CAP_* was tested, allowed/denied) |
+| `trace_lsm` | LSM hook decisions — "a strace for LSM" (AppArmor/SELinux/BPF-LSM) |
+| `audit_seccomp` | syscalls audited against the seccomp profile (seccomp denials) |
+| `advise_seccomp` | suggest a seccomp profile from observed syscalls |
+| `trace_init_module` | `init_module`/`finit_module` — kernel module loads |
+| `trace_lsm`/`trace_capabilities` | pair these when "permission denied" has correct FS perms/RBAC |
+
+## Process lifecycle (exec / signals / OOM / snapshots / recording)
+
+| Gadget | What it traces |
+|---|---|
+| `trace_exec` | process executions (argv, cwd) — startup crashes, unexpected binaries |
+| `trace_signal` | signals delivered (who SIGKILL'd/SIGTERM'd whom) |
+| `trace_oomkill` | OOM-killer events (victim `tcomm`/`tpid`; trigger `fprocess.*`; memcg) |
+| `snapshot_process` | point-in-time list of running processes |
+| `top_process` | periodic process statistics |
+| `traceloop` | syscalls flight recorder — replay the last syscalls of a container |
+| `ttysnoop` | watch live output from a tty/pts device |
+
+## Storage & filesystem (open / slow I/O / block / mounts / fd / notify)
+
+| Gadget | What it traces |
+|---|---|
+| `trace_open` | file opens (fname, flags, error) — "no such file", wrong path, EACCES |
+| `trace_fsslower` | open/read/write/fsync slower than a threshold (latency outliers) |
+| `snapshot_file` | point-in-time list of open files |
+| `top_file` | periodic per-file read/write activity |
+| `profile_blockio` | histogram of block-device I/O latency |
+| `top_blockio` | periodic block-device I/O activity |
+| `trace_mount` | mount()/umount() syscalls |
+| `trace_link` | hardlink and symlink creation |
+| `fdpass` | file-descriptor passing over unix sockets (SCM_RIGHTS) |
+| `fsnotify` | inotify/fanotify events (who is watching what) |
+
+## Performance (CPU / throttle / memory / deadlock / GPU)
+
+| Gadget | What it traces |
+|---|---|
+| `profile_cpu` | sampled stack traces → on-CPU flamegraph (hot code paths) |
+| `top_cpu_throttle` | cgroup CFS CPU throttling (containers hitting CPU limits) |
+| `trace_malloc` | libc malloc/free via uprobe (userspace allocation churn/leak) |
+| `deadlock` | pthread_mutex lock/unlock ordering → potential deadlock cycles |
+| `profile_cuda` | CUDA memory allocations in libcuda (Driver API) |
+| `top_cuda_memory` | per-process CUDA memory alloc/free (device vs pinned host) |
+
+## Meta / advisory
+
+| Gadget | What it does |
+|---|---|
+| `bpfstats` | per-eBPF-program memory/CPU (`runcount`/`runtime`) — needs `sysctl kernel.bpf_stats_enabled=1`; counters read 0 until stats accumulate, so use a longer `--timeout` |
+| `advise_seccomp` | (see Security) suggest a seccomp profile |
+| `advise_networkpolicy` | (see Networking) suggest NetworkPolicies (`kubectl gadget` only) |
+
+**Disambiguation shortcuts** (see the domain refs for the full reasoning):
+- Connection problem: `trace_tcp` (events) → `trace_tcpretrans` (loss) → `trace_tcpdrop` (kernel dropped it).
+- File problem: `trace_open` (the open call + errno) vs `top_file`/`snapshot_file` (who's using files now).
+- TLS problem: `trace_sni` (which SNI/host) vs `trace_ssl` (the plaintext payload).
+- CPU problem: `profile_cpu` (where CPU goes) vs `top_cpu_throttle` (being capped by limits) vs `top_process` (who).
+
+If a symptom isn't covered here, still pick the closest domain gadget and run
+`-h` — the field list often reveals whether it fits.

--- a/skills/kubernetes-troubleshooting/references/install.md
+++ b/skills/kubernetes-troubleshooting/references/install.md
@@ -1,0 +1,81 @@
+# Install — Inspektor Gadget in a Kubernetes cluster
+
+You need the `kubectl gadget` plugin locally and the Inspektor Gadget DaemonSet
+running in the cluster. Everything here is standard upstream; confirm the exact
+current commands with `kubectl gadget --help`.
+
+## 0. Detect — is IG already usable?
+
+Run these first; only continue with the sections below if a check fails.
+
+```bash
+command -v kubectl-gadget >/dev/null 2>&1 && echo "kubectl gadget plugin: present" || echo "kubectl gadget plugin: MISSING (do section 1)"
+kubectl gadget version    # prints the server version too, once the DaemonSet is deployed (section 2)
+```
+
+- Plugin **present** and a `Server version:` is shown → IG is ready; nothing to install.
+- Plugin **present** but `Server version: not available` → the plugin is fine; the
+  DaemonSet may not be deployed. You can usually still run gadgets — only if a run
+  errors on connectivity do section 2 (`kubectl gadget deploy`).
+- Plugin **missing** → do section 1 (and usually section 2). **Ask the operator
+  before installing** — the DaemonSet is privileged and needs cluster rights.
+
+## 1. Install the `kubectl gadget` plugin
+
+Install via `krew` (the kubectl plugin manager) or download the release binary:
+
+```bash
+# Option A — krew (the recommended kubectl plugin manager, if you have it):
+kubectl krew install gadget
+
+# Option B — release binary (no krew needed):
+IG_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name)
+IG_ARCH=amd64   # or arm64
+curl -sL https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${IG_VERSION}/kubectl-gadget-linux-${IG_ARCH}-${IG_VERSION}.tar.gz | sudo tar -C /usr/local/bin -xzf - kubectl-gadget
+
+kubectl gadget version               # prints client version (and server, once deployed)
+```
+
+## 2. Deploy Inspektor Gadget into the cluster
+
+```bash
+kubectl gadget deploy                # installs the IG DaemonSet (namespace: gadget)
+kubectl get pods -n gadget           # confirm one Running gadget pod per node
+```
+
+`kubectl gadget deploy` starts a privileged DaemonSet that loads the eBPF
+programs on each node and streams enriched events back to your `kubectl gadget
+run` client. To remove it:
+
+```bash
+kubectl gadget undeploy
+```
+
+## 3. Requirements
+
+- **Kernel with BTF** — most modern distros ship it; verify a node has
+  `/sys/kernel/btf/vmlinux`. IG uses CO-RE (Compile Once, Run Everywhere) and
+  needs BTF to relocate against the running kernel.
+- **Privileges** — the DaemonSet runs privileged (CAP_BPF / CAP_SYS_ADMIN) to
+  load eBPF. Deploy it in clusters where you have troubleshooting rights.
+- **Version matching** — keep the `kubectl gadget` client and the deployed
+  DaemonSet on the same IG version. A "built with vX, running vY" message is a
+  **warning**, not a failure; the run still produces data, but match versions
+  when you can to avoid field/flag skew.
+- **"Server version: not available" is not a blocker.** `kubectl gadget version`
+  printing `Server version: not available` only means the version probe didn't
+  answer — **try `kubectl gadget run …` anyway**; it usually still works. Only if
+  the run itself errors on connectivity, check `kubectl get pods -n gadget`; and
+  only if the DaemonSet pod isn't `Running` do you fall back to `sudo ig run` on a
+  single node.
+
+## 4. Sanity check
+
+```bash
+kubectl gadget run trace_exec:latest -A --timeout 5 -o json   # should stream a few exec events
+```
+
+If this hangs or errors on connectivity, re-check `kubectl get pods -n gadget`
+and your kubeconfig context. If it errors on image signature, you likely have a
+locally-built image shadowing the upstream one — pull the upstream image (see
+`common-flags.md` → gotchas).

--- a/skills/kubernetes-troubleshooting/references/install.md
+++ b/skills/kubernetes-troubleshooting/references/install.md
@@ -14,9 +14,10 @@ kubectl gadget version    # prints the server version too, once the DaemonSet is
 ```
 
 - Plugin **present** and a `Server version:` is shown → IG is ready; nothing to install.
-- Plugin **present** but `Server version: not available` → the plugin is fine; the
-  DaemonSet may not be deployed. You can usually still run gadgets — only if a run
-  errors on connectivity do section 2 (`kubectl gadget deploy`).
+- Plugin **present** but `Server version: not available` → no usable server
+  version was discovered, usually because no IG deployment is running. Check
+  `kubectl get pods -n gadget`; repair an existing deployment or, with operator
+  approval, do section 2.
 - Plugin **missing** → do section 1 (and usually section 2). **Ask the operator
   before installing** — the DaemonSet is privileged and needs cluster rights.
 
@@ -62,12 +63,11 @@ kubectl gadget undeploy
   DaemonSet on the same IG version. A "built with vX, running vY" message is a
   **warning**, not a failure; the run still produces data, but match versions
   when you can to avoid field/flag skew.
-- **"Server version: not available" is not a blocker.** `kubectl gadget version`
-  printing `Server version: not available` only means the version probe didn't
-  answer — **try `kubectl gadget run …` anyway**; it usually still works. Only if
-  the run itself errors on connectivity, check `kubectl get pods -n gadget`; and
-  only if the DaemonSet pod isn't `Running` do you fall back to `sudo ig run` on a
-  single node.
+- **"Server version: not available" means no usable server version was
+  discovered.** Usually no IG deployment is running; check the `gadget` namespace
+  before running a gadget. If the DaemonSet is absent, deploy it only with
+  operator approval; if its pods are unhealthy, repair them. Fall back to
+  `sudo ig run` only for intentional single-node work.
 
 ## 4. Sanity check
 
@@ -76,6 +76,6 @@ kubectl gadget run trace_exec:latest -A --timeout 5 -o json   # should stream a 
 ```
 
 If this hangs or errors on connectivity, re-check `kubectl get pods -n gadget`
-and your kubeconfig context. If it errors on image signature, you likely have a
-locally-built image shadowing the upstream one — pull the upstream image (see
-`common-flags.md` → gotchas).
+and your kubeconfig context. For an image-signature error, inspect the exact
+image reference and signer; do not disable verification to bypass an unexplained
+failure.

--- a/skills/kubernetes-troubleshooting/references/linux-companion.md
+++ b/skills/kubernetes-troubleshooting/references/linux-companion.md
@@ -1,0 +1,31 @@
+# Companion: switching to the standalone `ig` (single host)
+
+This skill (`kubernetes-troubleshooting`) drives Inspektor Gadget **in a
+Kubernetes cluster** via `kubectl gadget run`, enriching every event with
+namespace / pod / container / node.
+
+**Switch to the `linux-troubleshooting` skill (standalone `ig` binary) when the
+target is not a cluster:**
+
+- A **bare Linux host**, VM, edge node, or CI runner with no Kubernetes.
+- A **single node's container runtime** directly (Docker / containerd / CRI-O /
+  podman) — e.g. you're SSH'd into one node and want to trace only its local
+  containers without going through the API server.
+- **Host (non-container) processes** — `ig --host` sees processes outside any
+  container, which the cluster path does not target.
+- The cluster's IG DaemonSet isn't (and can't be) deployed, but you can `sudo`
+  on the node.
+
+The **gadgets, flags, fields, and the discover-don't-guess rule are identical** —
+only the launcher and the enrichment metadata differ:
+
+| | `kubernetes-troubleshooting` | `linux-troubleshooting` |
+|---|---|---|
+| Launcher | `kubectl gadget run <g>:latest` | `sudo ig run <g>:latest` |
+| Scope flags | `-n` / `-p` / `-c` | `-c` / `--host` / `--runtimes` |
+| Enrichment | `k8s.namespace/podName/…` | `runtime.containerName/runtimeName` |
+| Needs | in-cluster IG DaemonSet | root on the host |
+
+If you're already at a shell on a node, `ig` is often faster (no DaemonSet, no
+API round-trip). If you need cluster-wide, pod-aware correlation, stay with
+`kubectl gadget`.

--- a/skills/kubernetes-troubleshooting/references/linux-companion.md
+++ b/skills/kubernetes-troubleshooting/references/linux-companion.md
@@ -23,7 +23,7 @@ only the launcher and the enrichment metadata differ:
 |---|---|---|
 | Launcher | `kubectl gadget run <g>:latest` | `sudo ig run <g>:latest` |
 | Scope flags | `-n` / `-p` / `-c` | `-c` / `--host` / `--runtimes` |
-| Enrichment | `k8s.namespace/podName/…` | `runtime.containerName/runtimeName` |
+| Enrichment | `k8s.namespace`, `k8s.podName`, `k8s.containerName`, `k8s.node` | `runtime.containerName`, `runtime.runtimeName` |
 | Needs | in-cluster IG DaemonSet | root on the host |
 
 If you're already at a shell on a node, `ig` is often faster (no DaemonSet, no

--- a/skills/linux-troubleshooting/SKILL.md
+++ b/skills/linux-troubleshooting/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: linux-troubleshooting
+description: >-
+  Debug a single Linux host, VM, or container runtime at the kernel level with
+  Inspektor Gadget via the standalone `ig` binary — no Kubernetes required. Use
+  when something on a bare host, edge node, CI runner, or Docker/containerd/CRI-O
+  box is failing and logs aren't enough: DNS or TCP failures, connection resets /
+  retransmits / drops, processes exiting or being killed (OOM/signal), failed or
+  missing file opens, permission / capability / seccomp / LSM denials, slow disk
+  or file I/O, or "which process made this syscall / connection". Traces real
+  kernel events with eBPF; enriches with container name/runtime when a runtime is
+  present. Read-only. Not for Kubernetes clusters (use kubernetes-troubleshooting
+  for `kubectl gadget`), plain application logs, or metrics dashboards.
+compatibility: >-
+  Requires the standalone `ig` binary on PATH, run as root (CAP_BPF +
+  CAP_SYS_ADMIN), on a BTF-enabled kernel (`/sys/kernel/btf/vmlinux`) for CO-RE. An
+  optional container runtime (containerd/Docker/CRI-O/podman) enriches events;
+  `--host` traces bare-host processes. Read-only. If `ig` is missing, see
+  references/install.md — ask the operator before installing.
+---
+
+# Linux host / container-runtime troubleshooting with Inspektor Gadget
+
+The standalone `ig` binary runs the **same eBPF gadgets** as the Kubernetes
+integration, but against a **single Linux host** and its local container runtime
+(Docker / containerd / CRI-O / podman) — no cluster, no `kubectl`. Use it on
+VMs, edge nodes, CI runners, or any box where you can run `sudo ig`. Events are
+enriched with **container name + runtime** (not pod/namespace) when a runtime is
+present; with `--host` you also see host (non-container) processes.
+
+Reach for `ig` when host logs/metrics can't answer *"what is the kernel doing
+right now?"* — a syscall failing silently, a connection reset before the app
+notices, a file open returning ENOENT.
+
+## Prerequisite: confirm IG is available (check first, then route)
+
+This skill drives the standalone `ig` binary. Confirm it's usable before the loop:
+
+```bash
+command -v ig >/dev/null 2>&1 && ig version || echo "ig MISSING -> references/install.md"
+```
+
+If `ig` is **missing**, **open `references/install.md` and follow it** — don't guess
+an install command. `ig` needs root (CAP_BPF / CAP_SYS_ADMIN) and a BTF-enabled
+kernel; **ask the operator before installing on a host you don't own**.
+
+## The one rule: discover, don't guess
+
+**Never hardcode a gadget's flags or field names from memory.** Enumerate the
+real interface at run time:
+
+```bash
+sudo ig run <gadget>:latest --help       # flags + a "--fields" block listing every data source & field
+sudo ig run <gadget>:latest --timeout 5 -o json | jq '.[0] | keys'   # real field names in a live sample
+```
+
+Each gadget is an OCI image pulled on demand; there is **no `list-gadgets`
+command** and no fixed list to memorize. The gadget's own `--help`/`--fields` is
+the source of truth. See `references/discovering-params-and-fields.md`.
+
+## The loop (repeat until root cause)
+
+1. **Route.** Map the symptom to a *domain* (networking / security /
+   process-lifecycle / storage-fs / performance) and a candidate gadget using
+   the table below + `references/gadget-catalog.md`.
+2. **Discover.** Run `<gadget>:latest --help` to read the real flags and fields.
+3. **Run bounded.** Scope and time-box:
+   `sudo ig run <gadget>:latest --runtimes containerd -c <name> --timeout <sec> -o json`
+   (`-c` filters by container, `--comm`/`--pid` by process; add `--host` for host
+   processes; **always set `--timeout`**; `--max-entries` for `top`/`snapshot`).
+   See `references/common-flags.md`.
+4. **Read the columns.** Inspect the fields (`runtime.*`, `proc.*`, error codes)
+   to confirm or refute, then narrow and repeat.
+
+## Symptom → first gadget (confirm flags/fields with `--help`)
+
+| Symptom | Domain | Start with | Then / disambiguate |
+|---|---|---|---|
+| DNS fails / slow / NXDOMAIN | networking | `trace_dns` | latency in `latency_ns` |
+| Connection reset / refused / hangs | networking | `trace_tcp` | `trace_tcpretrans`, `trace_tcpdrop` |
+| Packet loss / high latency | networking | `trace_tcpdrop` | `profile_tcprtt`, `top_tcp`, `tcpdump` |
+| TLS/cert/SNI issue | networking | `trace_sni` | `trace_ssl` |
+| Port bind fails / "address already in use" | networking | `snapshot_socket` | `trace_bind` (bind + errno) |
+| Process exits / restarts unexpectedly | process-lifecycle | `trace_exec` | `trace_signal` (filter `--signal 9/15` — Go SIGURG / glibc SIGRTMIN async-preempt noise), `trace_oomkill` |
+| Process killed / OOM | process-lifecycle | `trace_oomkill` | `top_process`, `profile_cpu` |
+| Container died too fast to trace live (post-mortem) | process-lifecycle | `traceloop` | replays recent syscalls from the ring buffer; empty if it wasn't already recording |
+| Watch an interactive shell / tty / pts / keystrokes | process-lifecycle | `ttysnoop` | no `--tty`/`--pts` selector — scope by `--pid`/`--comm`/container |
+| "no such file" / missing path | storage-fs | `trace_open --failed` | `snapshot_file`, `top_file` |
+| Slow disk / file I/O | storage-fs | `trace_fsslower` | `profile_blockio`, `top_blockio` |
+| Unexpected mount/umount, or suspicious hardlink/symlink (escape) | storage-fs | `trace_mount` | `trace_link` (`type` = HARDLINK/SYMLINK cuts the noise) |
+| fd leak / "too many open files" / inotify watch storm | storage-fs | `fdpass` | `fsnotify`; `snapshot_file` (unclosed fds in one proc) |
+| Permission denied despite correct FS perms | security | `trace_capabilities` | `trace_lsm`, `audit_seccomp` |
+| Seccomp/AppArmor/SELinux denial | security | `trace_lsm` | `audit_seccomp`, `advise_seccomp` |
+| Syscall blocked by a seccomp profile ("operation not permitted") | security | `audit_seccomp` | the audited syscall = what the profile forbids; `advise_seccomp` to author one |
+| Kernel module loaded / rootkit / unexpected insmod | security | `trace_init_module` | `trace_capabilities` (CAP_SYS_MODULE) |
+| Harden / author a seccomp or NetworkPolicy profile | security | `advise_seccomp` | `advise_networkpolicy` |
+| High CPU, or slow despite low CPU% (CFS throttling / cgroup CPU limit) | performance | `profile_cpu` | `top_cpu_throttle` (capped?), `top_process` |
+| Memory growth / leak (userspace) | performance | `trace_malloc` (libc malloc only — statically-linked Go runtime allocator invisible) | `trace_malloc --collect-ustack` (the leak site) |
+| App hung / mutex deadlock | performance | `deadlock` (pthread only — Go `sync.Mutex` invisible) | `profile_cpu` |
+| GPU / CUDA out-of-memory | performance | `top_cuda_memory` | device vs pinned; `profile_cuda` = libcuda Driver-API |
+| Quantify eBPF/gadget CPU or memory overhead (self-profiling) | meta | `bpfstats` | needs an active window — longer `--timeout` |
+
+This is a deliberately **thin shortlist, not the catalog** — it names the few
+gadgets that fit the most common symptoms so you don't scan all ~42, keeping this
+always-loaded router small. **Symptom not listed, or
+unsure which row fits?** Read `references/gadget-catalog.md` — it groups **all
+42** gadgets by domain with the disambiguation reasoning (which of the
+TCP/file/TLS/CPU gadgets to pick). The authoritative live list is whatever `sudo
+ig run <name>:latest --help` resolves; confirm a gadget's flags/fields there
+before relying on them.
+
+## References (load only the one you need)
+
+- `references/gadget-catalog.md` — all upstream gadgets grouped by domain, with per-domain disambiguation.
+- `references/discovering-params-and-fields.md` — discover-don't-guess mechanics (`ig` variant).
+- `references/common-flags.md` — host/container scope, output, timeouts, gotchas.
+- `references/install.md` — detect whether `ig` is usable; install it + requirements (root, BTF) if missing.
+- `references/kubernetes-companion.md` — when to switch to `kubectl gadget` (clusters).
+
+### Per-domain deep-dive playbooks (shared with the k8s skill)
+
+The five per-domain playbooks (networking, security, process-lifecycle,
+storage-fs, performance) live in the **kubernetes-troubleshooting** skill's
+`references/` tree and apply verbatim here — **the gadgets, flags, and fields are
+identical**; only the launcher and scope flags differ. To use one from this
+single-host skill, swap `kubectl gadget run`→`sudo ig run` and `-n`/`-p`→
+`-c`/`--host` (full mapping in `references/kubernetes-companion.md`):
+
+- `../kubernetes-troubleshooting/references/domain-networking.md` — DNS / TCP / drops / retransmits / TLS-SNI / pcap / NetworkPolicy.
+- `../kubernetes-troubleshooting/references/domain-security.md` — capabilities / LSM / seccomp / kernel-module loading.
+- `../kubernetes-troubleshooting/references/domain-process-lifecycle.md` — exec / signals / OOM / snapshots / traceloop / tty.
+- `../kubernetes-troubleshooting/references/domain-storage-fs.md` — open / slow FS / block I/O / mounts / links / fd / fsnotify.
+- `../kubernetes-troubleshooting/references/domain-performance.md` — CPU / throttle / RTT / deadlock / malloc / GPU.
+
+## Safety
+
+Observation is **read-only** — gadgets never modify the host or containers. `ig`
+needs elevated privileges (typically `sudo`, CAP_BPF/CAP_SYS_ADMIN) to load eBPF.
+Always bound streaming gadgets with `--timeout` and cap `top`/`snapshot` with
+`--max-entries`.

--- a/skills/linux-troubleshooting/SKILL.md
+++ b/skills/linux-troubleshooting/SKILL.md
@@ -51,7 +51,8 @@ real interface at run time:
 
 ```bash
 sudo ig run <gadget>:latest --help       # flags + a "--fields" block listing every data source & field
-sudo ig run <gadget>:latest --timeout 5 -o json | jq '.[0] | keys'   # real field names in a live sample
+sudo ig run <gadget>:latest --timeout 5 -o json \
+  | jq -s '(.[0] // {}) | if type == "array" then (.[0] // {}) else . end | keys'
 ```
 
 Each gadget is an OCI image pulled on demand; there is **no `list-gadgets`
@@ -89,9 +90,9 @@ the source of truth. See `references/discovering-params-and-fields.md`.
 | Slow disk / file I/O | storage-fs | `trace_fsslower` | `profile_blockio`, `top_blockio` |
 | Unexpected mount/umount, or suspicious hardlink/symlink (escape) | storage-fs | `trace_mount` | `trace_link` (`type` = HARDLINK/SYMLINK cuts the noise) |
 | fd leak / "too many open files" / inotify watch storm | storage-fs | `fdpass` | `fsnotify`; `snapshot_file` (unclosed fds in one proc) |
-| Permission denied despite correct FS perms | security | `trace_capabilities` | `trace_lsm`, `audit_seccomp` |
-| Seccomp/AppArmor/SELinux denial | security | `trace_lsm` | `audit_seccomp`, `advise_seccomp` |
-| Syscall blocked by a seccomp profile ("operation not permitted") | security | `audit_seccomp` | the audited syscall = what the profile forbids; `advise_seccomp` to author one |
+| Permission denied despite correct FS perms | security | `trace_capabilities` | `audit_seccomp`; host audit logs for AppArmor/SELinux |
+| Seccomp denial | security | `audit_seccomp` | the `code` + syscall identify the seccomp action; `advise_seccomp` to author a profile |
+| AppArmor/SELinux denial | security | host audit logs | `trace_lsm` can correlate hook activity, but does not expose another LSM's verdict |
 | Kernel module loaded / rootkit / unexpected insmod | security | `trace_init_module` | `trace_capabilities` (CAP_SYS_MODULE) |
 | Harden / author a seccomp or NetworkPolicy profile | security | `advise_seccomp` | `advise_networkpolicy` |
 | High CPU, or slow despite low CPU% (CFS throttling / cgroup CPU limit) | performance | `profile_cpu` | `top_cpu_throttle` (capped?), `top_process` |
@@ -101,10 +102,10 @@ the source of truth. See `references/discovering-params-and-fields.md`.
 | Quantify eBPF/gadget CPU or memory overhead (self-profiling) | meta | `bpfstats` | needs an active window — longer `--timeout` |
 
 This is a deliberately **thin shortlist, not the catalog** — it names the few
-gadgets that fit the most common symptoms so you don't scan all ~42, keeping this
-always-loaded router small. **Symptom not listed, or
+gadgets that fit the most common symptoms so you don't scan the full bundled set,
+keeping this always-loaded router small. **Symptom not listed, or
 unsure which row fits?** Read `references/gadget-catalog.md` — it groups **all
-42** gadgets by domain with the disambiguation reasoning (which of the
+bundled** gadgets by domain with the disambiguation reasoning (which of the
 TCP/file/TLS/CPU gadgets to pick). The authoritative live list is whatever `sudo
 ig run <name>:latest --help` resolves; confirm a gadget's flags/fields there
 before relying on them.

--- a/skills/linux-troubleshooting/references/common-flags.md
+++ b/skills/linux-troubleshooting/references/common-flags.md
@@ -15,7 +15,7 @@ you'll use most.
 | Only a pid | `--pid <n>` | `--pid 1234` |
 
 Without `--host`, `ig` shows **container** events (enriched with
-`runtime.containerName`/`runtimeName`). Add `--host` to also see bare-host
+`runtime.containerName` and `runtime.runtimeName`). Add `--host` to also see bare-host
 processes. Narrow scope = less noise, faster root-cause.
 
 ## Always bound the run
@@ -30,8 +30,31 @@ processes. Narrow scope = less noise, faster root-cause.
 |---|---|
 | `-o json` | machine parsing with `jq`; the default for agents |
 | `-o jsonpretty` | eyeballing nested structure |
-| `-o columns=a,b,c` | compact human table of just the fields you need |
+| `-o columns --fields a,b,c` | compact human table of just the fields you need (the `-o columns=a,b,c` comma form is parsed as separate output modes and prints nothing) |
 | default | gadget's built-in columns; quick look |
+
+Streaming datasources produce newline-delimited JSON objects; map-backed
+top/snapshot datasources produce JSON arrays. Match the `jq` expression to the
+shape (see `discovering-params-and-fields.md`).
+
+## Filter events with the native filter operator
+
+- **`--filter <field><op><value>`** (short **`-F`**) filters rows before output.
+  Operators include `==`, `!=`, `>=`, `<=`, `>`, `<`, `~` (regex match), and
+  `!~` (regex non-match). Combine rules with commas, for example
+  `--filter 'comm==curl,error!=0'`.
+- **`--filter-expr <expr>`** (short **`-E`**) accepts the richer expression
+  language. Confirm datasource-specific forms with the gadget's `--help`.
+- The filter operator currently runs in user space, like `jq`, but it is the
+  native interface and can move closer to eBPF without changing your command.
+
+## `top_*` gadgets: rank and refresh
+
+- **`--sort <field>`** orders rows; prefix a field with `-` for descending and
+  join multiple fields with `,`.
+- **`--map-fetch-interval <dur>`** controls how often map-backed results are
+  fetched (default `1000ms`); raise it to reduce polling frequency.
+- Combine sorting with **`--max-entries <n>`** to keep only the most useful rows.
 
 ## Common enrichment fields (standalone `ig`)
 
@@ -39,14 +62,19 @@ processes. Narrow scope = less noise, faster root-cause.
   the container identity of the event (when a runtime is present).
 - `proc.comm`, `proc.pid`, `proc.tid`, `proc.creds.uid`/`.gid` — the process.
 - `timestamp`; endpoints as `src`/`dst` with nested `.addr`, `.port`.
-- Note: there are **no `k8s.*` fields** here — that enrichment is the Kubernetes
-  path's job (`kubectl gadget`). If you need pod/namespace correlation, use the
-  `kubernetes-troubleshooting` skill instead.
+- Note: `k8s.*` fields are **empty for non-container / host processes**, but `ig`
+  *does* support Kubernetes enrichment on a cluster node — pass
+  **`--enrich-with-k8s-apiserver`** to connect to the API server and populate
+  `k8s.namespace`/`k8s.podName`/`k8s.containerName`/…. Scope local Kubernetes
+  events with the long-form `--k8s-namespace`, `--k8s-podname`,
+  `--k8s-containername`, and `--k8s-selector` flags. Use `kubectl gadget` for
+  cluster-wide tracing; for host-only tracing rely on the `runtime.*` fields.
 
 ## Gotchas
 
-- **`:latest` is required.** `run <gadget>` without a tag fails with
-  `invalid reference format`; always `run <gadget>:latest` (or a pinned digest).
+- **Tag defaults to `:latest`.** `sudo ig run <gadget>` without a tag resolves to
+  `<gadget>:latest` automatically. Use an immutable version tag or digest for
+  reproducibility; `:latest` is mutable.
 - **`ig` needs privileges.** Run with `sudo` (or CAP_BPF/CAP_SYS_ADMIN). Loading
   eBPF fails without them.
 - **BTF required.** The host kernel needs `/sys/kernel/btf/vmlinux` (CO-RE).
@@ -55,10 +83,9 @@ processes. Narrow scope = less noise, faster root-cause.
 - **`--failed`/`--failure-only` narrows to errors** on many trace gadgets
   (`trace_open --failed`, `trace_tcp --failure-only`) — use it when hunting a
   failure; it cuts noise hard.
-- **A locally-built image can shadow the upstream one** and fail signature
-  verification. If you hit a cosign/signature error on `:latest`, pull the
-  upstream image by digest (or use the documented verification override in a
-  trusted context). Prefer the upstream image.
+- **A locally-built image can shadow the upstream one.** To guarantee a fresh
+  registry copy, use **`--pull always`**; use a pinned digest when exact
+  reproducibility matters.
 - **Bare field vs `*_raw`.** Numeric fields often render as a human-formatted
   string (`latency_ns`="1.2ms", `memoryRSS`="12 MB"); the `_raw` sibling
   (`latency_ns_raw`, `memoryRSS_raw`) is the machine number — use `_raw` for

--- a/skills/linux-troubleshooting/references/common-flags.md
+++ b/skills/linux-troubleshooting/references/common-flags.md
@@ -1,0 +1,67 @@
+# Common flags, scoping & gotchas (standalone `ig`)
+
+All examples assume `sudo ig run <gadget>:latest …`. Confirm any flag with
+`--help` (see `discovering-params-and-fields.md`) — this file lists the ones
+you'll use most.
+
+## Scope the trace (do this first)
+
+| Goal | Flag | Example |
+|---|---|---|
+| One container | `-c <name>` | `-c nginx` (comma-list; `!name` excludes) |
+| A container runtime | `--runtimes <r>` | `--runtimes containerd` (docker/cri-o/podman) |
+| Host (non-container) processes | `--host` | include processes outside any container |
+| Only a process name | `--comm <name>` | `--comm curl` |
+| Only a pid | `--pid <n>` | `--pid 1234` |
+
+Without `--host`, `ig` shows **container** events (enriched with
+`runtime.containerName`/`runtimeName`). Add `--host` to also see bare-host
+processes. Narrow scope = less noise, faster root-cause.
+
+## Always bound the run
+
+- **`--timeout <seconds>`** — for every streaming (`trace_*`) gadget; start 5-10s.
+- **`--max-entries <n>`** — for `top_*`/`snapshot_*` to cap rows.
+- Prefer several short, scoped runs over one long unscoped one.
+
+## Output modes
+
+| Mode | When |
+|---|---|
+| `-o json` | machine parsing with `jq`; the default for agents |
+| `-o jsonpretty` | eyeballing nested structure |
+| `-o columns=a,b,c` | compact human table of just the fields you need |
+| default | gadget's built-in columns; quick look |
+
+## Common enrichment fields (standalone `ig`)
+
+- `runtime.containerName`, `runtime.runtimeName`, `runtime.containerImageName` —
+  the container identity of the event (when a runtime is present).
+- `proc.comm`, `proc.pid`, `proc.tid`, `proc.creds.uid`/`.gid` — the process.
+- `timestamp`; endpoints as `src`/`dst` with nested `.addr`, `.port`.
+- Note: there are **no `k8s.*` fields** here — that enrichment is the Kubernetes
+  path's job (`kubectl gadget`). If you need pod/namespace correlation, use the
+  `kubernetes-troubleshooting` skill instead.
+
+## Gotchas
+
+- **`:latest` is required.** `run <gadget>` without a tag fails with
+  `invalid reference format`; always `run <gadget>:latest` (or a pinned digest).
+- **`ig` needs privileges.** Run with `sudo` (or CAP_BPF/CAP_SYS_ADMIN). Loading
+  eBPF fails without them.
+- **BTF required.** The host kernel needs `/sys/kernel/btf/vmlinux` (CO-RE).
+- **Path fields need `--paths`.** Fields like `cwd`/`exepath`/`fpath` are empty
+  unless you pass `--paths`.
+- **`--failed`/`--failure-only` narrows to errors** on many trace gadgets
+  (`trace_open --failed`, `trace_tcp --failure-only`) — use it when hunting a
+  failure; it cuts noise hard.
+- **A locally-built image can shadow the upstream one** and fail signature
+  verification. If you hit a cosign/signature error on `:latest`, pull the
+  upstream image by digest (or use the documented verification override in a
+  trusted context). Prefer the upstream image.
+- **Bare field vs `*_raw`.** Numeric fields often render as a human-formatted
+  string (`latency_ns`="1.2ms", `memoryRSS`="12 MB"); the `_raw` sibling
+  (`latency_ns_raw`, `memoryRSS_raw`) is the machine number — use `_raw` for
+  arithmetic/sort/`jq`, the bare field for display. Both appear under `--fields`.
+- **Daemon mode.** For repeated runs you can start `sudo ig daemon` and connect a
+  client, but one-shot `sudo ig run …` is fine for troubleshooting.

--- a/skills/linux-troubleshooting/references/discovering-params-and-fields.md
+++ b/skills/linux-troubleshooting/references/discovering-params-and-fields.md
@@ -1,0 +1,43 @@
+# Discovering params and fields — the golden rule (`ig` variant)
+
+**Never hardcode a gadget's flags or fields from memory. Ask the gadget.**
+Gadget images are versioned OCI artifacts; flags and fields change between
+releases and new gadgets ship. The gadget's own `--help` output is the contract,
+so a skill built on discovery never drifts.
+
+## 1. List flags + every field, for any gadget
+
+```bash
+sudo ig run <gadget>:latest --help
+```
+
+The help output ends with a **`--fields`** block enumerating every *data source*
+and every *field* the gadget can emit, each with a short description. This is the
+authoritative field list for the image you actually pulled.
+
+## 2. Confirm field names from a real sample
+
+```bash
+sudo ig run <gadget>:latest --timeout 5 -o json | jq '.[0] | keys'
+```
+
+Use the exact keys from this output in your `jq`/filters. Nested groups appear
+dotted (e.g. `runtime.containerName`, `proc.comm`, `dst.port`).
+
+## 3. Select only the fields you need
+
+```bash
+sudo ig run trace_dns:latest --timeout 5 \
+  -o columns=runtime.containerName,name,qtype,rcode,latency_ns
+```
+
+`-o json` for machine parsing, `-o columns=<comma-list>` for a compact table,
+`-o jsonpretty` when eyeballing structure.
+
+## 4. There is no gadget list command — gadgets are images
+
+`sudo ig run <name>:latest` pulls the gadget image on demand. There is **no
+`list-gadgets` subcommand**. To know what exists: use the shortlist in `SKILL.md`
+and `references/gadget-catalog.md`, run any candidate with `--help` to confirm it
+resolves, or browse the upstream catalog at
+<https://inspektor-gadget.io/docs/latest/gadgets/>.

--- a/skills/linux-troubleshooting/references/discovering-params-and-fields.md
+++ b/skills/linux-troubleshooting/references/discovering-params-and-fields.md
@@ -18,21 +18,26 @@ authoritative field list for the image you actually pulled.
 ## 2. Confirm field names from a real sample
 
 ```bash
-sudo ig run <gadget>:latest --timeout 5 -o json | jq '.[0] | keys'
+sudo ig run <gadget>:latest --timeout 5 -o json \
+  | jq -s '(.[0] // {}) | if type == "array" then (.[0] // {}) else . end | keys'
 ```
 
-Use the exact keys from this output in your `jq`/filters. Nested groups appear
-dotted (e.g. `runtime.containerName`, `proc.comm`, `dst.port`).
+Streaming datasources emit one JSON object per line; snapshot/top datasources emit
+JSON arrays. `jq -s` collects the bounded sample, and the expression inspects only
+its first event or first array row. Use the exact keys from this output in your
+`jq`/filters. Nested groups appear dotted (e.g. `runtime.containerName`,
+`proc.comm`, `dst.port`).
 
 ## 3. Select only the fields you need
 
 ```bash
 sudo ig run trace_dns:latest --timeout 5 \
-  -o columns=runtime.containerName,name,qtype,rcode,latency_ns
+  -o columns --fields runtime.containerName,name,qtype,rcode,latency_ns
 ```
 
-`-o json` for machine parsing, `-o columns=<comma-list>` for a compact table,
-`-o jsonpretty` when eyeballing structure.
+`-o json` for machine parsing, `-o columns --fields <comma-list>` for a compact
+table, `-o jsonpretty` when eyeballing structure. (Do **not** write
+`-o columns=<comma-list>` — `-o` comma-splits into output *modes*, so it prints nothing.)
 
 ## 4. There is no gadget list command — gadgets are images
 

--- a/skills/linux-troubleshooting/references/gadget-catalog.md
+++ b/skills/linux-troubleshooting/references/gadget-catalog.md
@@ -5,6 +5,9 @@ The authoritative live interface for any gadget is `sudo ig run <gadget>:latest
 aid**: it groups the shipped upstream gadgets so you can pick the right one for a
 symptom, then confirm its flags/fields with `--help`. One-liners are the gadgets'
 own descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
+This catalog tracks the upstream `gadgets/` tree at the time it is updated.
+Recheck that tree and the release catalog when editing it; a generated drift
+check can be added separately.
 
 > Run form: `sudo ig run <gadget>:latest …`. The same gadgets also run under
 > `kubectl gadget run …` in a cluster (see `kubernetes-companion.md`).
@@ -32,8 +35,8 @@ own descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
 | Gadget | What it traces |
 |---|---|
 | `trace_capabilities` | capability checks (which CAP_* tested, allowed/denied) |
-| `trace_lsm` | LSM hook decisions — "strace for LSM" |
-| `audit_seccomp` | syscalls audited against the seccomp profile |
+| `trace_lsm` | LSM hook invocations (activity only; it does not expose another LSM's verdict) |
+| `audit_seccomp` | seccomp audit events with syscall and return code/action |
 | `advise_seccomp` | suggest a seccomp profile from observed syscalls |
 | `trace_init_module` | init_module/finit_module — kernel module loads |
 
@@ -109,10 +112,10 @@ sudo ig image list --no-trunc     # every locally installed gadget image + diges
 ```
 
 Route to any locally-installed image by its symptom the same way as a bundled
-gadget. Third-party images are often **unsigned by the upstream cosign key**, so
-a manual run needs `--verify-image=false` (and `--pull never` to force the local
-copy). Confirm the real flags/fields at run time with
-`sudo ig run <ref>:latest --help` — do not hardcode them (see
-`discovering-params-and-fields.md`). Examples of security-enforcement add-ons
-seen in the wild: capability/filesystem/ptrace restriction gadgets (BPF-LSM
-enforcers) and userspace-DNS / open-file snapshot tracers.
+gadget. Third-party images are not normally signed by the official Inspektor Gadget key.
+Configure the publisher's trusted public key as documented in the image
+verification guide. Do not disable verification merely to make an unknown image
+run; `--verify-image=false` is a development-only escape hatch after provenance
+has been independently established. Confirm the real flags/fields at run time
+with `sudo ig run <full-ref> --help` — do not hardcode them (see
+`discovering-params-and-fields.md`).

--- a/skills/linux-troubleshooting/references/gadget-catalog.md
+++ b/skills/linux-troubleshooting/references/gadget-catalog.md
@@ -1,0 +1,118 @@
+# Gadget catalog — upstream gadgets grouped by domain (`ig` variant)
+
+The authoritative live interface for any gadget is `sudo ig run <gadget>:latest
+--help` (see `discovering-params-and-fields.md`). This catalog is a **routing
+aid**: it groups the shipped upstream gadgets so you can pick the right one for a
+symptom, then confirm its flags/fields with `--help`. One-liners are the gadgets'
+own descriptions. Gadgets are OCI images; there is no `list-gadgets` command.
+
+> Run form: `sudo ig run <gadget>:latest …`. The same gadgets also run under
+> `kubectl gadget run …` in a cluster (see `kubernetes-companion.md`).
+
+## Networking
+
+| Gadget | What it traces |
+|---|---|
+| `trace_dns` | DNS requests/responses (query name, qtype, rcode, latency_ns) |
+| `trace_tcp` | connect / accept / close of TCP connections |
+| `trace_tcpretrans` | TCP retransmissions (congestion / loss) |
+| `trace_tcpdrop` | TCP packets dropped by the kernel (with drop reason / stack) |
+| `trace_sni` | TLS SNI (Server Name Indication) on the wire |
+| `trace_ssl` | OpenSSL/GnuTLS read/recv/write/send (plaintext at TLS boundary) |
+| `trace_bind` | socket bind() calls (who bound which port) |
+| `snapshot_socket` | point-in-time list of open TCP/UDP sockets (src, dst, state, inode, netns) |
+| `top_tcp` | periodic per-connection TCP activity |
+| `profile_tcprtt` | histogram of TCP round-trip time |
+| `profile_qdisc_latency` | network scheduler (qdisc) latency |
+| `tcpdump` | capture raw packets — write with `-o pcap-ng >file` (no `-w`) |
+| `advise_networkpolicy` | K8s NetworkPolicies from observed traffic (**`kubectl gadget` only** — needs pod/podIP metadata; no useful output under `sudo ig`) |
+
+## Security
+
+| Gadget | What it traces |
+|---|---|
+| `trace_capabilities` | capability checks (which CAP_* tested, allowed/denied) |
+| `trace_lsm` | LSM hook decisions — "strace for LSM" |
+| `audit_seccomp` | syscalls audited against the seccomp profile |
+| `advise_seccomp` | suggest a seccomp profile from observed syscalls |
+| `trace_init_module` | init_module/finit_module — kernel module loads |
+
+## Process lifecycle
+
+| Gadget | What it traces |
+|---|---|
+| `trace_exec` | process executions (argv, cwd) |
+| `trace_signal` | signals delivered (who signalled whom) |
+| `trace_oomkill` | OOM-killer events (victim `tcomm`/`tpid`; trigger `fprocess.*`; memcg) |
+| `snapshot_process` | point-in-time list of running processes |
+| `top_process` | periodic process statistics |
+| `traceloop` | syscall flight recorder — replay a container's last syscalls |
+| `ttysnoop` | watch live output from a tty/pts device |
+
+## Storage & filesystem
+
+| Gadget | What it traces |
+|---|---|
+| `trace_open` | file opens (fname, flags, error) — `--failed` for only failures |
+| `trace_fsslower` | open/read/write/fsync slower than `--min` µs (per `--filesystem`) |
+| `snapshot_file` | point-in-time list of open files |
+| `top_file` | periodic per-file activity (`--all-files` for non-regular) |
+| `profile_blockio` | histogram of block-device I/O latency |
+| `top_blockio` | periodic block-device I/O activity |
+| `trace_mount` | mount()/umount() syscalls |
+| `trace_link` | hardlink / symlink creation |
+| `fdpass` | fd passing over unix sockets (SCM_RIGHTS) |
+| `fsnotify` | inotify/fanotify events |
+
+## Performance
+
+| Gadget | What it traces |
+|---|---|
+| `profile_cpu` | sampled stacks → on-CPU flamegraph (`--user/kernel-stacks-only`) |
+| `top_cpu_throttle` | cgroup CFS CPU throttling (containers hitting CPU limits) |
+| `trace_malloc` | libc malloc/free (userspace allocation churn / leak) |
+| `deadlock` | pthread_mutex lock/unlock ordering → potential deadlocks |
+| `profile_cuda` | CUDA allocations in libcuda (Driver API) |
+| `top_cuda_memory` | per-process CUDA memory alloc/free (device vs pinned host) |
+
+## Meta
+
+| Gadget | What it does |
+|---|---|
+| `bpfstats` | per-eBPF-program memory/CPU (`runcount`/`runtime`) — needs `sysctl kernel.bpf_stats_enabled=1`; counters read 0 until stats accumulate, so use a longer `--timeout` |
+
+## Disambiguation shortcuts
+
+- Connection problem: `trace_tcp` (events) → `trace_tcpretrans` (loss) → `trace_tcpdrop` (kernel dropped it).
+- File problem: `trace_open --failed` (the failing open + errno) vs `top_file`/`snapshot_file` (who's using files now).
+- TLS problem: `trace_sni` (which host/SNI) vs `trace_ssl` (the plaintext payload).
+- CPU problem: `profile_cpu` (where CPU goes) vs `top_cpu_throttle` (capped by limits) vs `top_process` (who).
+- Dying process: `trace_oomkill` (OOM?) → `trace_signal` (signalled, by whom?) → `trace_exec` (did it start, with what argv?).
+
+If a symptom isn't covered here, pick the closest domain gadget and run `--help`
+— the field list often reveals whether it fits.
+
+## Third-party / add-on gadgets (not shipped in this catalog)
+
+This catalog lists only the gadgets bundled with the base image. Operators can
+install **additional third-party gadget images** from public registries (for
+example Artifact Hub — <https://artifacthub.io> — kind "Inspektor Gadget"). Once
+pulled, they run exactly like any other gadget and the router should route to
+them by symptom.
+
+**Never assume an add-on is absent because it is missing from this table.**
+Before concluding a capability is unavailable, DISCOVER what is actually
+installed on the host:
+
+```bash
+sudo ig image list --no-trunc     # every locally installed gadget image + digest
+```
+
+Route to any locally-installed image by its symptom the same way as a bundled
+gadget. Third-party images are often **unsigned by the upstream cosign key**, so
+a manual run needs `--verify-image=false` (and `--pull never` to force the local
+copy). Confirm the real flags/fields at run time with
+`sudo ig run <ref>:latest --help` — do not hardcode them (see
+`discovering-params-and-fields.md`). Examples of security-enforcement add-ons
+seen in the wild: capability/filesystem/ptrace restriction gadgets (BPF-LSM
+enforcers) and userspace-DNS / open-file snapshot tracers.

--- a/skills/linux-troubleshooting/references/install.md
+++ b/skills/linux-troubleshooting/references/install.md
@@ -49,10 +49,10 @@ to run it as a privileged container.)
 sudo ig run trace_exec:latest --host --timeout 5 -o json   # should stream a few exec events
 ```
 
-If it errors on privileges, re-run with `sudo`. If it errors on image signature,
-you likely have a locally-built image shadowing the upstream one — pull the
-upstream image (see `common-flags.md` → gotchas). If it errors on BTF, your
-kernel lacks `/sys/kernel/btf/vmlinux`.
+If it errors on privileges, re-run with `sudo`. For an image-signature error,
+inspect the exact image reference and signer; do not disable verification to
+bypass an unexplained failure. If it errors on BTF, your kernel lacks
+`/sys/kernel/btf/vmlinux`.
 
 ## 4. Optional: daemon mode
 

--- a/skills/linux-troubleshooting/references/install.md
+++ b/skills/linux-troubleshooting/references/install.md
@@ -1,0 +1,66 @@
+# Install — the standalone `ig` binary (no Kubernetes)
+
+`ig` is a single static binary that runs the Inspektor Gadget gadgets against the
+local host and its container runtime. Confirm current commands with `ig --help`.
+
+## 0. Detect — is `ig` already usable?
+
+Run these first; only continue with section 1 if `ig` is missing.
+
+```bash
+command -v ig >/dev/null 2>&1 && ig version || echo "ig: MISSING (do section 1)"
+test -f /sys/kernel/btf/vmlinux && echo "BTF: present" || echo "BTF: MISSING (CO-RE needs it — see section 2)"
+```
+
+- `ig` **present** and prints a version → ready; run it with `sudo` (see section 2).
+- `ig` **missing** → do section 1. **Ask the operator before installing on a host
+  you don't own.**
+
+## 1. Install `ig`
+
+Download the release binary for your arch from the upstream releases and put it
+on `PATH`:
+
+```bash
+# example shape — use the current upstream release asset for your arch
+IG_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name)
+curl -sL -o /tmp/ig.tar.gz \
+  "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${IG_VERSION}/ig-linux-amd64-${IG_VERSION}.tar.gz"
+sudo tar -C /usr/local/bin -xzf /tmp/ig.tar.gz ig
+ig version
+```
+
+(A container image `ghcr.io/inspektor-gadget/ig` is also published if you prefer
+to run it as a privileged container.)
+
+## 2. Requirements
+
+- **Root / privileges** — run with `sudo` (or grant CAP_BPF + CAP_SYS_ADMIN).
+  Loading eBPF fails otherwise.
+- **Kernel with BTF** — verify `/sys/kernel/btf/vmlinux` exists. IG uses CO-RE
+  and needs BTF to relocate against the running kernel.
+- **A container runtime (optional)** — to enrich events with container names,
+  `ig` auto-detects containerd / Docker / CRI-O / podman. Use `--runtimes` to
+  select, or `--host` to trace bare-host processes with no runtime.
+
+## 3. Sanity check
+
+```bash
+sudo ig run trace_exec:latest --host --timeout 5 -o json   # should stream a few exec events
+```
+
+If it errors on privileges, re-run with `sudo`. If it errors on image signature,
+you likely have a locally-built image shadowing the upstream one — pull the
+upstream image (see `common-flags.md` → gotchas). If it errors on BTF, your
+kernel lacks `/sys/kernel/btf/vmlinux`.
+
+## 4. Optional: daemon mode
+
+For many repeated runs, start a local daemon and connect a client:
+
+```bash
+sudo ig daemon &            # exposes a local socket
+ig run trace_dns:latest --timeout 5 -o json
+```
+
+One-shot `sudo ig run …` is perfectly fine for ad-hoc troubleshooting.

--- a/skills/linux-troubleshooting/references/kubernetes-companion.md
+++ b/skills/linux-troubleshooting/references/kubernetes-companion.md
@@ -9,8 +9,9 @@ the target is a Kubernetes cluster:**
 
 - The symptom is about a **pod / Service / Deployment**, not a bare process.
 - You need **cluster-wide** tracing across many nodes from one command.
-- You need events **enriched with `k8s.namespace` / `podName` / `containerName`
-  / `node`** so you can correlate a kernel event back to a workload.
+- You need events enriched with `k8s.namespace`, `k8s.podName`,
+  `k8s.containerName`, and `k8s.node` so you can correlate a kernel event back
+  to a workload.
 - You want to trace **by namespace / pod / label** (`-n` / `-p` / selectors).
 
 The **gadgets, flags, fields, and the discover-don't-guess rule are identical** —
@@ -19,22 +20,22 @@ only the launcher and enrichment differ:
 | | `linux-troubleshooting` | `kubernetes-troubleshooting` |
 |---|---|---|
 | Launcher | `sudo ig run <g>:latest` | `kubectl gadget run <g>:latest` |
-| Scope flags | `-c` / `--host` / `--runtimes` | `-n` / `-p` / `-c` |
-| Enrichment | `runtime.containerName/runtimeName` | `k8s.namespace/podName/…` |
-| Needs | root on the host | in-cluster IG DaemonSet |
+| Kubernetes scope flags | `--k8s-namespace`, `--k8s-podname`, `--k8s-containername`, `--k8s-selector` (long form only) | `-n`, `-p`, `-c`, `-l` |
+| Enrichment | `runtime.*`; local `k8s.*` with Kubernetes API enrichment | `k8s.namespace`, `k8s.podName`, `k8s.containerName`, `k8s.node` |
+| Needs | root on the host; local container runtime | in-cluster IG DaemonSet |
 
 When you follow a `kubectl gadget run …` example from the shared domain playbooks
-(e.g. the security or storage flow), translate it for a host: drop `-n`/`-p`, swap
-the enrichment field `k8s.podName`/`k8s.containerName` → `runtime.containerName`,
-and add `--host` to include non-container processes. Example — the "permission
-denied" capability check on a host:
+(e.g. the security or storage flow), translate Kubernetes short scope flags to
+their long `--k8s-*` forms. Keep `k8s.*` fields when local Kubernetes enrichment
+is available; otherwise use `runtime.containerName`. Add `--host` to include
+non-container processes. Example — the "permission denied" capability check on a
+host:
 
 ```bash
 sudo ig run trace_capabilities:latest -c <container> --timeout 15 \
-  -o columns=runtime.containerName,proc.comm,cap,capable,syscall
+  -o columns --fields runtime.containerName,proc.comm,cap,capable,syscall
 ```
 
-Rule of thumb: **one node, no cluster → `ig`; a Kubernetes workload → `kubectl
-gadget`.** If you're SSH'd into a single node and only care about its local
-containers, `ig` is faster (no DaemonSet, no API round-trip); if you need
-pod-aware, cluster-wide correlation, use `kubectl gadget`.
+Rule of thumb: **one node → `ig`; cluster-wide tracing → `kubectl gadget`.**
+Standalone `ig` can enrich local-runtime events with Kubernetes identity; use
+`kubectl gadget` when one command must cover workloads across nodes.

--- a/skills/linux-troubleshooting/references/kubernetes-companion.md
+++ b/skills/linux-troubleshooting/references/kubernetes-companion.md
@@ -1,0 +1,40 @@
+# Companion: switching to `kubectl gadget` (Kubernetes clusters)
+
+This skill (`linux-troubleshooting`) drives Inspektor Gadget on a **single Linux
+host** via the standalone `sudo ig run` binary, enriching events with container
+name / runtime.
+
+**Switch to the `kubernetes-troubleshooting` skill (`kubectl gadget run`) when
+the target is a Kubernetes cluster:**
+
+- The symptom is about a **pod / Service / Deployment**, not a bare process.
+- You need **cluster-wide** tracing across many nodes from one command.
+- You need events **enriched with `k8s.namespace` / `podName` / `containerName`
+  / `node`** so you can correlate a kernel event back to a workload.
+- You want to trace **by namespace / pod / label** (`-n` / `-p` / selectors).
+
+The **gadgets, flags, fields, and the discover-don't-guess rule are identical** —
+only the launcher and enrichment differ:
+
+| | `linux-troubleshooting` | `kubernetes-troubleshooting` |
+|---|---|---|
+| Launcher | `sudo ig run <g>:latest` | `kubectl gadget run <g>:latest` |
+| Scope flags | `-c` / `--host` / `--runtimes` | `-n` / `-p` / `-c` |
+| Enrichment | `runtime.containerName/runtimeName` | `k8s.namespace/podName/…` |
+| Needs | root on the host | in-cluster IG DaemonSet |
+
+When you follow a `kubectl gadget run …` example from the shared domain playbooks
+(e.g. the security or storage flow), translate it for a host: drop `-n`/`-p`, swap
+the enrichment field `k8s.podName`/`k8s.containerName` → `runtime.containerName`,
+and add `--host` to include non-container processes. Example — the "permission
+denied" capability check on a host:
+
+```bash
+sudo ig run trace_capabilities:latest -c <container> --timeout 15 \
+  -o columns=runtime.containerName,proc.comm,cap,capable,syscall
+```
+
+Rule of thumb: **one node, no cluster → `ig`; a Kubernetes workload → `kubectl
+gadget`.** If you're SSH'd into a single node and only care about its local
+containers, `ig` is faster (no DaemonSet, no API round-trip); if you need
+pod-aware, cluster-wide correlation, use `kubectl gadget`.


### PR DESCRIPTION
Add a self-contained set of AI agent skills under skills/ that teach an assistant to debug systems at the kernel level with Inspektor Gadget (IG), tying every kernel event (syscalls, packets, DNS, capability checks, OOM kills) back to the workload that caused it.

The tree ships two complementary base skills that expose the same gadgets, flags and fields and differ only in launcher and enrichment metadata:

  * kubernetes-troubleshooting - targets Kubernetes pods/nodes via the `kubectl gadget` plugin and an in-cluster DaemonSet (k8s.* enrichment).
  * linux-troubleshooting - targets a Linux host/container via the local `ig` binary (runtime.* enrichment).

Each skill is a thin SKILL.md router backed by on-demand references/ loaded only when needed (progressive disclosure): per-domain playbooks (networking / security / process-lifecycle / performance / storage-fs), a gadget catalog, common-flags, a discover-don't-guess guide for params and fields, a companion note for hopping between the k8s and Linux launchers, and a dedicated install reference. Each SKILL.md carries a thin "confirm IG is available" prerequisite that detects the ig / kubectl gadget binary and, when missing, routes to references/install.md instead of guessing an install command; install/deploy touch privileged surface (root/CAP_BPF, a privileged in-cluster DaemonSet), so every remediation branch defers to operator consent.

skills/AGENTS.md is a dynamic router: rather than hardcoding a fixed skill table it enumerates every */SKILL.md, routes by each skill's own YAML description, and treats the directory as an open set. A third-party or add-on gadget may ship its own skill; before routing to one the agent must confirm the gadget is actually installed (`ig image list`) and otherwise falls back to a base skill (discover, don't guess). The gadget catalog likewise documents discovering locally-installed third-party images with `ig image list --no-trunc` before concluding a capability is unavailable.