### PR TITLE
gadgets/snapshot_file: Support older kernel version

### DIFF
--- a/gadgets/snapshot_file/program.bpf.c
+++ b/gadgets/snapshot_file/program.bpf.c
@@ -112,7 +112,7 @@ int ig_snap_file(struct bpf_iter__task_file *ctx)
 	struct seq_file *seq = ctx->meta->seq;
 	struct task_struct *task = ctx->task;
 	struct file *file = ctx->file;
-	struct gadget_file info;
+	struct gadget_file info = {};
 
 	if (!task || !file)
 		return 0;


### PR DESCRIPTION
Add support for older kernel versions

## Testing done

### w/o this change

```
→ kubectl debug --profile=sysadmin node/aks-nodepool1-35665998-vmss000000 -ti --image=ghcr.io/inspektor-gadget/ig -- ig run snapshot_file
Creating debugging pod node-debugger-aks-nodepool1-35665998-vmss000000-8z6bq with container debugger on node aks-nodepool1-35665998-vmss000000.
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
Error: starting operators: starting operator "oci": starting operator "ebpf": creating eBPF collection: program ig_snap_file: load program: permission denied: invalid indirect read from stack R2 off -408+308 size 312 (348 line(s) omitted)
```

### with this change

```
→ kubectl debug --profile=sysadmin node/aks-nodepool1-35665998-vmss000000 -ti --image=ghcr.io/inspektor-gadget/ig -- ig run ghcr.io/mqasimsarfraz/gadget/snapshot_file:main --verify-image=false
Creating debugging pod node-debugger-aks-nodepool1-35665998-vmss000000-l2twz with container debugger on node aks-nodepool1-35665998-vmss000000.
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
WARN[0004] error pulling signature: pulling signing information with cosign: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/snapshot_file:sha256-6960bb484065599691daca06d0268f310831d0319bcefda8c57efa174aedf5ae.sig: not found
pulling signing information with oci 1.1: failed to perform "FetchReference" on source: ghcr.io/mqasimsarfraz/gadget/snapshot_file:sha256-6960bb484065599691daca06d0268f310831d0319bcefda8c57efa174aedf5ae: not found
pulling signing information with bundle: crafting signing information tag: no referrers found 
WARN[0004] gadget signature verification is disabled due to using corresponding option 
WARN[0004] This gadget was built with ig v0.54.0-22-gb4f746e25 and it's being run with v0.54.0. Gadget could be incompatible 
WARN[0004] gadget signature verification is disabled due to using corresponding option 
WARN[0004] This gadget was built with ig v0.54.0-22-gb4f746e25 and it's being run with v0.54.0. Gadget could be incompatible 
RUNTIME.CONTAINERNAME                       COMM                           PID        TID FD         PATH                    TYPE                    FLAGS                 
azuredisk                                   azurediskplugin               4639       4639 3          cpu.max                 REGULAR                 O_RDONLY|O_LARGEFILE  
azure-ip-masq-agent                         ip-masq-agent-v               4698       4698 3          cpu.max                 REGULAR                 O_RDONLY|O_LARGEFILE  
azfilesrefresh                              python3                       4915       4915 3          azfilesauth.log         REGULAR                 O_WRONLY|O_APPEND|O_L…
azfilesrefresh                              python3                       4915       4915 4          azfilesrefresh.log      REGULAR                 O_WRONLY|O_APPEND|O_L…
cns-container                               azure-cns                     4922       4922 3          azure-cns.log           REGULAR                 O_RDWR|O_APPEND|O_LAR…
azurefile                                   azurefileplugin               5036       5036 3          cpu.max                 REGULAR                 O_RDONLY|O_LARGEFILE  

```
