### PR TITLE
docs: Remove traces for legacy way to run gadgets

### DIFF
--- a/docs/reference/ig.md
+++ b/docs/reference/ig.md
@@ -150,7 +150,7 @@ $ sudo ig list-containers -o json --containername kube-proxy
 For example, with `--host`, you can get the following output:
 
 ```bash
-$ sudo ig trace exec --host
+$ sudo ig run trace_exec:latest --host
 RUNTIME.CONTAINERNAME    PID        PPID       COMM             RET ARGS
 
 # Open another terminal.
@@ -173,7 +173,7 @@ The "kubectl debug node" command is documented in
 Examples of commands:
 
 ```bash
-$ kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig trace exec
+$ kubectl debug --profile=sysadmin node/minikube-docker -ti --image=ghcr.io/inspektor-gadget/ig -- ig run trace_exec:latest
 Creating debugging pod node-debugger-minikube-docker-c2wfw with container debugger on node minikube-docker.
 If you don't see a command prompt, try pressing enter.
 RUNTIME.CONTAINERNAME          PID              PPID             COMM             RET ARGS
@@ -367,5 +367,5 @@ Here is an example using a Kubernetes DaemonSet: [ds-ig.yaml](https://github.com
 ```bash
 $ kubectl apply -f https://raw.githubusercontent.com/inspektor-gadget/inspektor-gadget/%IG_BRANCH%/docs/examples/ds-ig.yaml
 $ kubectl exec -ti $(kubectl get pod -o name -l name=example-ig | head -1) -- sh
-/ # ig trace exec
+/ # ig run trace_exec:latest
 ```

--- a/docs/reference/install-kubernetes.md
+++ b/docs/reference/install-kubernetes.md
@@ -114,7 +114,7 @@ $ kubectl gadget deploy --node-selector 'kubernetes.io/hostname in (minikube, mi
 
 By default Inspektor Gadget is deployed to the namespace `gadget`.
 This can be changed with the `--gadget-namespace` flag.
-When using gadgets (e.g. `kubectl gadget trace exec`) the deployed namespace is discovered automatically and no additional flags are needed during the usage.
+When using gadgets (e.g. `kubectl gadget run trace_exec`) the deployed namespace is discovered automatically and no additional flags are needed during the usage.
 For `undeploy` the `--gadget-namespace` flag is mandatory.
 
 ##### Deploying with an AppArmor profile

--- a/gadgets/trace_tcp/README.mdx
+++ b/gadgets/trace_tcp/README.mdx
@@ -113,7 +113,7 @@ Default value: "false"
         The gadget will print that connection on the first terminal
 
         ```bash
-        $ sudo ig trace tcp -c test-trace-tcp
+        $ sudo ig run trace_tcp:%IG_TAG% --containername test-trace-tcp
         RUNTIME.CONTAINERNAME        SRC                                   DST                                   COMM                        PID            TID            UID            GID TYPE
         test-trace-tcp               172.17.0.2:39664                      93.184.215.14:443                     wget                     757178         757178              0              0 connect
         ```


### PR DESCRIPTION
It seems some parts of docs are still using the legacy way to run gadgets. 