### PR TITLE
Support OTel/Python stacks from perf_event gadgets

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -411,7 +411,7 @@ Symbolize the kernel stack from `gadget_get_kernel_stack(ctx)` (see [kernel-stac
 
 ### `gadget_user_stack`
 
-Symbolize the user stack from `gadget_get_user_stack(ctx, &event->ustack, collect_ustack)` (see [user-stack-traces](#user-stack-traces)).
+Symbolize the user stack from `gadget_get_user_stack(ctx, &event->ustack)` (see [user-stack-traces](#user-stack-traces)).
 
 ### `gadget_uid` and `gadget_gid`
 
@@ -679,10 +679,25 @@ struct {
 Then, add a field in the event structure with the type of `gadget_user_stack`,
 designated for storing the stack id along with identifiers for the executable
 so that the stack can be symbolised in userspace.
-`gadget_get_user_stack(ctx, &event->ustack, collect_ustack)` could be used
-to populate this field, this helper function will store the kernel stack into
+`gadget_get_user_stack(ctx, &event->ustack)` could be used
+to populate this field, this helper function will store the user stack into
 `ig_ustack` and fill the field passed as parameter. When `collect_ustack` is
 false, `ustack` is initialized to zero and ig will ignore the stack trace.
+
+`gadget_get_user_stack()` dispatches at compile time on the static type of
+`ctx` (using `_Generic`): `struct pt_regs *` selects the
+`kprobe`/`kretprobe`/`uprobe`/`uretprobe` variant, and
+`struct bpf_perf_event_data *` selects the `perf_event` variant. These are the
+program types for which OpenTelemetry eBPF profiler symbolization is available
+(see [Limitations specific to the OpenTelemetry eBPF
+Profiler](../reference/stack-traces.mdx#limitations-specific-to-the-opentelemetry-ebpf-profiler)).
+Passing a `ctx` of any other type is a compile-time error.
+
+For a `tracepoint` gadget, whose program type cannot use OpenTelemetry
+symbolization, call `gadget_get_user_stack_from_tracepoint(ctx, &event->ustack)`
+instead. It collects the plain user stack (still symbolizable by the symtab and
+debuginfod methods); requesting `--collect-otel-stack` with such a gadget makes
+the loader reject the program instead of silently returning an empty stack.
 
 ```C
 struct event {
@@ -699,7 +714,7 @@ GADGET_PARAM(collect_ustack);
 	if (!event)
 		return 0;
 
-	gadget_get_user_stack(ctx, &event->ustack, collect_ustack);
+	gadget_get_user_stack(ctx, &event->ustack);
 ```
 
 ## Map pinning

--- a/docs/reference/stack-traces.mdx
+++ b/docs/reference/stack-traces.mdx
@@ -127,6 +127,23 @@ the OpenTelemetry eBPF profiler library.
 It cannot resolve symbols when it does not know about the process in advance.
 Once the process is noticed, it can resolve the symbols correctly.
 
+The OpenTelemetry eBPF profiler resolves user addresses through a correlation id
+that is computed by an OpenTelemetry entry program reached with a BPF tail call.
+Since a tail call requires the caller and the callee to share the same eBPF
+program type, this symbolization is only available for gadget programs whose type
+has a matching OpenTelemetry entry program:
+
+- `kprobe`, `kretprobe`, `uprobe` and `uretprobe` programs (all
+  `BPF_PROG_TYPE_KPROBE`), for example `trace_capabilities`, `trace_malloc` or
+  `profile_cuda`.
+- `perf_event` programs (`BPF_PROG_TYPE_PERF_EVENT`), for example `profile_cpu`.
+
+Other program types, such as `tracepoint` gadgets (e.g. `trace_open`), cannot use
+the OpenTelemetry symbolization method. Their user stacks are still collected and
+can be symbolized by the other methods (symtab, debuginfod). Requesting
+`--collect-otel-stack` from such a gadget causes the eBPF program to be rejected
+at load time rather than silently returning empty OpenTelemetry stacks.
+
 The OpenTelemetry eBPF profiler requires a minimum Linux kernel version of 5.4.
 See the [upstream documentation](https://github.com/open-telemetry/opentelemetry-ebpf-profiler#supported-linux-kernel-version)
 for details on kernel version requirements.

--- a/gadgets/profile_cpu/gadget.yaml
+++ b/gadgets/profile_cpu/gadget.yaml
@@ -25,6 +25,12 @@ datasources:
       profiles.type: samples
       profiles.unit: count
     fields:
+      user_stack_id:
+        annotations:
+          # Internal aggregation key (equals user_stack_raw.stack_id); hide it
+          # so the output schema is unchanged for consumers.
+          json.skip: "true"
+          columns.hidden: "true"
       runtime.containerName:
         annotations:
           flamegraph.level: 0

--- a/gadgets/profile_cpu/program.bpf.c
+++ b/gadgets/profile_cpu/program.bpf.c
@@ -15,9 +15,17 @@
 
 #define MAX_ENTRIES 10240
 
+/* The aggregation key holds only the sample's *identity*: the user stack is
+ * represented by its stack id (a stable hash of the stack), not by the whole
+ * struct gadget_user_stack. Embedding the full struct here would be wrong
+ * because it carries per-sample fields (boot_timestamp, otel_correlation_id)
+ * that differ on every sample, which would make every sample a unique key and
+ * defeat aggregation. The full struct is stored in the value instead (see
+ * struct values below), mirroring profile_cuda.
+ */
 struct key_t {
 	__u64 kernel_ip;
-	struct gadget_user_stack user_stack_raw;
+	__u32 user_stack_id;
 	gadget_kernel_stack kern_stack_raw;
 	struct gadget_process proc;
 };
@@ -46,8 +54,16 @@ GADGET_PARAM(user_stacks_only);
 const volatile bool include_idle = false;
 GADGET_PARAM(include_idle);
 
+/* The value carries the aggregated sample count plus the full user-stack
+ * metadata. user_stack_raw lives here (not in the key) so that identical
+ * stacks aggregate: its per-sample fields (boot_timestamp, otel_correlation_id)
+ * would otherwise make every sample a unique key. On first insertion the
+ * metadata of that first sample is stored; subsequent identical stacks only
+ * bump samples. This mirrors profile_cuda's alloc_val.
+ */
 struct values {
 	__u64 samples;
+	struct gadget_user_stack user_stack_raw;
 };
 
 struct {
@@ -58,6 +74,23 @@ struct {
 } counts SEC(".maps");
 
 GADGET_MAPITER(samples, counts);
+
+/* Per-CPU temporary storage for the user stack and the value struct, to keep
+ * them off the BPF stack (same rationale as tmp_key above).
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct gadget_user_stack);
+} tmp_gadget_user_stack SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct values);
+} tmp_values SEC(".maps");
 
 /*
  * If PAGE_OFFSET macro is not available in vmlinux.h, determine ip whose MSB
@@ -88,9 +121,6 @@ int ig_prof_cpu(struct bpf_perf_event_data *ctx)
 
 	u32 tid = id;
 	struct values *valp;
-	static const struct values zero = {
-		0,
-	};
 	u32 map_key = 0;
 	bpf_map_update_elem(&tmp_key, &map_key, &empty_key, BPF_ANY);
 	struct key_t *key = bpf_map_lookup_elem(&tmp_key, &map_key);
@@ -108,8 +138,19 @@ int ig_prof_cpu(struct bpf_perf_event_data *ctx)
 		key->kern_stack_raw =
 			bpf_get_stackid(&ctx->regs, &ig_kstack, 0);
 
+	/* Fetch the user stack into per-CPU scratch and key only on its stack
+	 * id, keeping the full metadata (with its per-sample fields) out of the
+	 * aggregation key. See the comments on struct key_t / struct values.
+	 */
+	struct gadget_user_stack *ustack_raw =
+		bpf_map_lookup_elem(&tmp_gadget_user_stack, &map_key);
+	if (!ustack_raw)
+		return 0;
 	if (!kernel_stacks_only)
-		gadget_get_user_stack(ctx, &key->user_stack_raw);
+		gadget_get_user_stack(ctx, ustack_raw);
+	else
+		__builtin_memset(ustack_raw, 0, sizeof(*ustack_raw));
+	key->user_stack_id = ustack_raw->stack_id;
 
 	if (key->kern_stack_raw >= 0) {
 		// populate extras to fix the kernel stack
@@ -119,9 +160,18 @@ int ig_prof_cpu(struct bpf_perf_event_data *ctx)
 			key->kernel_ip = ip;
 	}
 
-	valp = bpf_map_lookup_or_try_init(&counts, key, &zero);
-	if (valp)
+	valp = bpf_map_lookup_elem(&counts, key);
+	if (!valp) {
+		struct values *new_val =
+			bpf_map_lookup_elem(&tmp_values, &map_key);
+		if (!new_val)
+			return 0;
+		new_val->samples = 1;
+		new_val->user_stack_raw = *ustack_raw;
+		bpf_map_update_elem(&counts, key, new_val, BPF_NOEXIST);
+	} else {
 		__sync_fetch_and_add(&valp->samples, 1);
+	}
 
 	return 0;
 }

--- a/gadgets/profile_cpu/test/integration/profile_cpu_stacks_test.go
+++ b/gadgets/profile_cpu/test/integration/profile_cpu_stacks_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+)
+
+// findWorkloadDir locates the profile_cpu/workload directory relative to this
+// test file's source location.
+func findWorkloadDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok, "cannot determine test file path")
+	// This file is at gadgets/profile_cpu/test/integration/profile_cpu_stacks_test.go
+	// Workload is at gadgets/profile_cpu/workload/
+	return filepath.Join(filepath.Dir(filename), "..", "..", "workload")
+}
+
+type userStackRaw struct {
+	Symbols string `json:"symbols"`
+}
+
+type profileCpuEvent struct {
+	Proc         utils.Process `json:"proc"`
+	Samples      uint64        `json:"samples"`
+	UserStackRaw userStackRaw  `json:"user_stack_raw"`
+}
+
+// workloadStep runs the CPU-bound Python workload as a local process. It burns
+// CPU (in recognizable pure-Python frames) for the given duration so that the
+// perf_event sampler + OTel eBPF profiler can capture and symbolize the frames.
+type workloadStep struct {
+	workDir  string
+	duration string
+}
+
+func (w *workloadStep) Run(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("./cpuburn.py", w.duration)
+	cmd.Dir = w.workDir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "running Python workload: %s", string(out))
+}
+
+func (w *workloadStep) Start(t *testing.T)   { t.Helper(); w.Run(t) }
+func (w *workloadStep) Stop(t *testing.T)    {}
+func (w *workloadStep) IsStartAndStop() bool { return false }
+func (w *workloadStep) Running() bool        { return false }
+
+// TestProfileCpuOtelStacks verifies OTel eBPF profiler symbolization of Python
+// stacks from profile_cpu, which is a perf_event gadget. It exercises the
+// perf_event OTel tail-call path (otel_tc_perf / native_tracer_entry).
+//
+// TODO(#5703): Like ci/stacks, this test only runs in --host mode with a local
+// Python workload. Once the python:3.13-slim image is mirrored to
+// ghcr.io/inspektor-gadget/ci/python (inspektor-gadget/inspektor-gadget#5703),
+// switch to running the workload in a container and drop the
+// IgLocalTestComponent skip so it also runs in container/Kubernetes mode.
+func TestProfileCpuOtelStacks(t *testing.T) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	if utils.CurrentTestComponent != utils.IgLocalTestComponent {
+		t.Skip("profile_cpu OTel stacks test only supports ig local mode (requires --host)")
+	}
+
+	workloadSrcDir := findWorkloadDir(t)
+
+	// Burn CPU long enough for the OTel profiler to analyze the process and
+	// collect symbolized samples after it starts (the gadget step waits for
+	// the profiler to initialize before the workload runs).
+	workload := &workloadStep{workDir: workloadSrcDir, duration: "20"}
+
+	var runnerOpts []igrunner.Option
+
+	runnerOpts = append(runnerOpts,
+		igrunner.WithFlags(
+			"--host",
+			"--collect-ustack=true",
+			"--symbolizers=otel-ebpf-profiler",
+			"--collect-otel-stack=true",
+			"--user-stacks-only=true",
+			"--comm=cpuburn.py",
+		),
+		igrunner.WithStartAndStop(),
+		igrunner.WithValidateOutput(func(t *testing.T, output string) {
+			// Assert that at least one sampled stack contains the full
+			// expected pure-Python call chain, proving the perf_event OTel
+			// path symbolized Python frames.
+			expectedEntries := []*profileCpuEvent{
+				{
+					Proc:         utils.BuildProc("cpuburn.py", 0, 0),
+					UserStackRaw: userStackRaw{Symbols: "python-frames-present"},
+				},
+			}
+
+			normalize := func(e *profileCpuEvent) {
+				utils.NormalizeProc(&e.Proc)
+				e.Samples = 0
+
+				s := e.UserStackRaw.Symbols
+				if strings.Contains(s, "compute_fibonacci") &&
+					strings.Contains(s, "burn_cpu") &&
+					strings.Contains(s, "main") {
+					e.UserStackRaw.Symbols = "python-frames-present"
+					return
+				}
+				e.UserStackRaw.Symbols = ""
+			}
+
+			match.MatchEntries(t, match.JSONMultiArrayMode, output, normalize, expectedEntries...)
+		}),
+	)
+
+	profileCpuCmd := igrunner.New("profile_cpu", runnerOpts...)
+
+	steps := []igtesting.TestStep{
+		profileCpuCmd,
+		// OTel eBPF profiler needs ~16s to initialize.
+		utils.Sleep(20 * time.Second),
+		workload,
+	}
+	igtesting.RunTestSteps(steps, t)
+}

--- a/gadgets/profile_cpu/workload/cpuburn.py
+++ b/gadgets/profile_cpu/workload/cpuburn.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+#
+# CPU-bound pure-Python workload for the profile_cpu OTel eBPF profiler test.
+#
+# profile_cpu is a perf_event gadget. To validate OTel/Python stack
+# symbolization from a perf_event program, we need a process that keeps the
+# CPython interpreter busy in recognizable Python frames so that the
+# perf_event sampler can repeatedly land in them and the OTel eBPF profiler
+# can symbolize them (compute_fibonacci / burn_cpu / main).
+
+import sys
+import time
+
+
+def compute_fibonacci(n):
+    if n < 2:
+        return n
+    return compute_fibonacci(n - 1) + compute_fibonacci(n - 2)
+
+
+def burn_cpu(deadline):
+    total = 0
+    while time.time() < deadline:
+        total += compute_fibonacci(20)
+    return total
+
+
+def main():
+    # Default duration is generous: the OTel eBPF profiler needs ~16s to
+    # initialize and a few more seconds to analyze this process before it can
+    # symbolize its Python frames. The test starts the gadget, waits for the
+    # profiler to initialize, then runs this workload.
+    duration = float(sys.argv[1]) if len(sys.argv) > 1 else 15.0
+    burn_cpu(time.time() + duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -126,7 +126,11 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 
 	/* event data */
 	gadget_process_populate(&event->proc);
-	gadget_get_user_stack(ctx, &event->ustack);
+	/* trace_open is a tracepoint gadget: OTel symbolization is not available
+	 * for tracepoint programs, but the plain user stack is still collected
+	 * and symbolized by the symbol-table symbolizer.
+	 */
+	gadget_get_user_stack_from_tracepoint(ctx, &event->ustack);
 
 	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
 	event->flags_raw = ap->flags;

--- a/go.mod
+++ b/go.mod
@@ -230,4 +230,5 @@ replace github.com/notaryproject/notation-go => github.com/inspektor-gadget/nota
 // - correlation ID for stack cache with LRU hash map
 // - u32 key type for generic_params map
 // - GetStackCacheMap() accessor for userspace cleanup
-replace go.opentelemetry.io/ebpf-profiler => github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5
+// - GetPerfEntryEbpfProgram() accessor for perf_event OTel stack correlation
+replace go.opentelemetry.io/ebpf-profiler => github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260715114040-ef6cf29492c8

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inspektor-gadget/notation-go v1.3.3 h1:yygDXeFVU3zvYzaNWwhRkTMiJNq4iWnn7Ssayek00RI=
 github.com/inspektor-gadget/notation-go v1.3.3/go.mod h1:/1kuq5WuLF6Gaer5re0Z6HlkQRlKYO4EbWWT/L7J1Uw=
-github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5 h1:dvYqqM1E3WUn4p/xZTJ4yIvHPtUpwIVJZ7tiS+SDf2Y=
-github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260528153254-79c7c1509ef5/go.mod h1:YcOGWpHl5DRZQxxSLH9P2a4MI51eexSeSWODzPY5FTc=
+github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260715114040-ef6cf29492c8 h1:uAAxfhFJY2k26LvrHwdZdy7gTRo3ZFSTeSrWSPKjirk=
+github.com/inspektor-gadget/opentelemetry-ebpf-profiler v0.0.202611-0.20260715114040-ef6cf29492c8/go.mod h1:YcOGWpHl5DRZQxxSLH9P2a4MI51eexSeSWODzPY5FTc=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=

--- a/include/gadget/user_stack_map.h
+++ b/include/gadget/user_stack_map.h
@@ -11,6 +11,7 @@
 #include <gadget/types.h>
 #include <gadget/macros.h>
 #include <gadget/fnv1a.h>
+#include <gadget/core_fixes.bpf.h>
 
 const volatile bool collect_ustack = false;
 GADGET_PARAM(collect_ustack);
@@ -63,6 +64,14 @@ struct {
 	__type(value, u32);
 	__array(values, int());
 } otel_tc_kprobe SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u32);
+	__array(values, int());
+} otel_tc_perf SEC(".maps");
 
 // Linux v4.0 - v4.17
 struct timespec___obsolete {
@@ -178,11 +187,21 @@ gadget_fetch_otel_stack_from_kprobe(void *ctx)
 	return 0;
 }
 
-/* gadget_get_user_stack gets the user stack into ustack if collect_ustack is
- * true, or initialize ustack to 0 otherwise.
+static __attribute__((noinline)) int
+gadget_fetch_otel_stack_from_perf_event(void *ctx)
+{
+	u32 key = 0;
+	bpf_tail_call(ctx, &otel_tc_perf, key);
+	return 0;
+}
+
+/* __gadget_fill_user_stack fills the user stack into ustack if collect_ustack is
+ * true, or initializes ustack to 0 otherwise. It performs everything except the
+ * OTel correlation-id fetch, which is program-type specific and handled by the
+ * gadget_get_user_stack_from_{kprobe,perf_event} wrappers below.
  */
 static __always_inline void
-gadget_get_user_stack(void *ctx, struct gadget_user_stack *ustack)
+__gadget_fill_user_stack(void *ctx, struct gadget_user_stack *ustack)
 {
 	if (!collect_ustack) {
 		ustack->major = 0;
@@ -242,6 +261,9 @@ gadget_get_user_stack(void *ctx, struct gadget_user_stack *ustack)
 
 	ustack->base_addr_hash = gadget_get_base_addr_hash(task);
 
+	// otel_correlation_id is filled by the program-type specific wrapper.
+	ustack->otel_correlation_id = 0;
+
 	if (collect_build_id && ustack->stack_id >= 0) {
 		int already_exists =
 			bpf_map_update_elem(&ig_build_id, &ustack->stack_id,
@@ -261,18 +283,100 @@ gadget_get_user_stack(void *ctx, struct gadget_user_stack *ustack)
 		if (ret < 0)
 			return;
 	}
+}
 
-	if (collect_otel_stack) {
+// __gadget_read_otel_correlation reads the OTel correlation id that the OTel
+// entry program wrote to the shared otel_generic_params map during the tail
+// call, and stores it in ustack.
+static __always_inline void
+__gadget_read_otel_correlation(struct gadget_user_stack *ustack)
+{
+	struct generic_param *ret_param;
+	int zero = 0;
+	ret_param = bpf_map_lookup_elem(&otel_generic_params, &zero);
+	if (!ret_param)
+		return;
+
+	ustack->otel_correlation_id = ret_param->correlation_id;
+}
+
+/* gadget_get_user_stack_from_kprobe gets the user stack (and, if
+ * collect_otel_stack is set, the OTel correlation id) for a gadget program of
+ * type BPF_PROG_TYPE_KPROBE (kprobe, kretprobe, uprobe, uretprobe).
+ */
+static __always_inline void
+gadget_get_user_stack_from_kprobe(void *ctx, struct gadget_user_stack *ustack)
+{
+	__gadget_fill_user_stack(ctx, ustack);
+
+	if (collect_ustack && collect_otel_stack) {
 		gadget_fetch_otel_stack_from_kprobe(ctx);
-
-		struct generic_param *ret_param;
-		int zero = 0;
-		ret_param = bpf_map_lookup_elem(&otel_generic_params, &zero);
-		if (!ret_param)
-			return;
-
-		ustack->otel_correlation_id = ret_param->correlation_id;
+		__gadget_read_otel_correlation(ustack);
 	}
 }
 
-#endif /* __STACK_MAP_H */
+/* gadget_get_user_stack_from_perf_event gets the user stack (and, if
+ * collect_otel_stack is set, the OTel correlation id) for a gadget program of
+ * type BPF_PROG_TYPE_PERF_EVENT.
+ */
+static __always_inline void
+gadget_get_user_stack_from_perf_event(void *ctx,
+				      struct gadget_user_stack *ustack)
+{
+	__gadget_fill_user_stack(ctx, ustack);
+
+	if (collect_ustack && collect_otel_stack) {
+		gadget_fetch_otel_stack_from_perf_event(ctx);
+		__gadget_read_otel_correlation(ustack);
+	}
+}
+
+/* gadget_get_user_stack_from_tracepoint gets the user stack for a gadget program
+ * whose type cannot use OTel symbolization (e.g. BPF_PROG_TYPE_TRACEPOINT). The
+ * plain user stack is always collected and remains symbolizable by the
+ * symbol-table symbolizer.
+ *
+ * OTel symbolization relies on a correlation id produced by a bpf_tail_call that
+ * requires a matching program type, which a tracepoint program cannot satisfy,
+ * so requesting it here is unsupported. Rather than reference an incompatible
+ * OTel prog-array (or silently return an empty correlation id),
+ * bpf_core_unreachable() makes the loader reject the program if OTel stacks are
+ * requested. Because collect_otel_stack is a const-volatile param, the verifier
+ * prunes this branch entirely when it is unset (the common case), so the guard
+ * is zero-cost and references no OTel prog-array.
+ */
+static __always_inline void
+gadget_get_user_stack_from_tracepoint(void *ctx,
+				      struct gadget_user_stack *ustack)
+{
+	__gadget_fill_user_stack(ctx, ustack);
+
+	if (collect_ustack && collect_otel_stack)
+		bpf_core_unreachable();
+}
+
+/* gadget_get_user_stack dispatches to the program-type-correct variant based on
+ * the static C type of ctx, resolved at compile time by _Generic. Only the
+ * selected variant's bpf_tail_call survives in the program, so each program
+ * references only its own OTel prog-array (otel_tc_kprobe or otel_tc_perf) and
+ * the kernel prog-array type lock (bpf_prog_array_compatible) is never hit.
+ *
+ *   struct bpf_perf_event_data *  -> perf_event variant
+ *   struct pt_regs *              -> kprobe variant (also covers
+ *                                    kretprobe/uprobe/uretprobe, which are all
+ *                                    BPF_PROG_TYPE_KPROBE)
+ *
+ * There is deliberately no default association: a ctx of any other type (e.g. a
+ * tracepoint ctx or a plain void *) is a compile-time error ("controlling
+ * expression type ... not compatible with any generic association type").
+ * Tracepoint gadgets should call gadget_get_user_stack_from_tracepoint() (user
+ * stack only, no OTel symbolization); other program types should call the
+ * matching gadget_get_user_stack_from_{kprobe,perf_event}() helper directly.
+ */
+#define gadget_get_user_stack(ctx, ustack)                                           \
+	_Generic((ctx),                                                              \
+		struct bpf_perf_event_data *: gadget_get_user_stack_from_perf_event, \
+		struct pt_regs *: gadget_get_user_stack_from_kprobe)((ctx),          \
+								     (ustack))
+
+#endif /* __USER_STACK_MAP_H */

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -879,33 +879,62 @@ func (i *ebpfInstance) Start(gadgetCtx operators.GadgetContext) error {
 	}
 	i.collection = collection
 
-	if otelEbpfProgramI, ok := gadgetCtx.GetVar(symbolizer.OtelEbpfProgramKprobe); ok {
+	// Load the OTel entry programs into their type-matching prog-array maps.
+	// OTel symbolization uses BPF tail calls, which require the tail-called
+	// program and the caller to share the same BPF_PROG_TYPE. We therefore
+	// keep two separate prog arrays: otel_tc_kprobe (for kprobe/kretprobe/
+	// uprobe/uretprobe gadget programs) and otel_tc_perf (for perf_event
+	// gadget programs). Each is populated only with its matching-type entry
+	// program.
+	otelTailCalls := []struct {
+		mapName string
+		progVar string
+		want    ebpf.ProgramType
+	}{
+		{symbolizer.OtelTailCallForKprobeMapName, symbolizer.OtelEbpfProgramKprobe, ebpf.Kprobe},
+		{symbolizer.OtelTailCallForPerfMapName, symbolizer.OtelEbpfProgramPerf, ebpf.PerfEvent},
+	}
+	for _, tc := range otelTailCalls {
+		otelEbpfProgramI, ok := gadgetCtx.GetVar(tc.progVar)
+		if !ok {
+			continue
+		}
 		otelEbpfProgram, ok := otelEbpfProgramI.(*ebpf.Program)
 		if !ok {
-			return fmt.Errorf("invalid otel ebpf program: expected *ebpf.Program, got %T", otelEbpfProgramI)
+			return fmt.Errorf("invalid otel ebpf program %q: expected *ebpf.Program, got %T", tc.progVar, otelEbpfProgramI)
 		}
-		if progMap, ok := collection.Maps[symbolizer.OtelTailCallForKprobeMapName]; ok {
-			err := progMap.Update(uint32(0), otelEbpfProgram, ebpf.UpdateAny)
-			if err != nil {
-				return fmt.Errorf("updating %s map: %w", symbolizer.OtelTailCallForKprobeMapName, err)
-			}
+		progMap, ok := collection.Maps[tc.mapName]
+		if !ok {
+			// The gadget does not use this program type's OTel path.
+			continue
+		}
 
-			// Warn if non-kprobe programs reference the otel tail call
-			// map. OTel symbolization uses BPF tail calls which require
-			// matching program types. Only BPF_PROG_TYPE_KPROBE (used by
-			// kprobes, kretprobes, uprobes, uretprobes) is compatible
-			// with the OTel profiler programs.
-			for name, prog := range i.collectionSpec.Programs {
-				if prog.Type == ebpf.Kprobe {
-					continue
-				}
-				refs := prog.Instructions.ReferenceOffsets()
-				if _, ok := refs[symbolizer.OtelTailCallForKprobeMapName]; ok {
-					i.logger.Warnf("program %q (type %s) uses OTel user stack collection, but OTel eBPF Profiler symbolization only supports kprobe/uprobe programs", name, prog.Type)
-				}
+		// A BPF_MAP_TYPE_PROG_ARRAY is locked to the program type of the
+		// first program that references it (kernel
+		// bpf_prog_array_compatible). Only load the entry program if a
+		// gadget program of the matching type actually references this
+		// map; otherwise the update would fail (or the tail call could
+		// never run). Warn about mismatched-type referrers, which cannot
+		// be symbolized with the OTel eBPF Profiler.
+		matched := false
+		for name, prog := range i.collectionSpec.Programs {
+			refs := prog.Instructions.ReferenceOffsets()
+			if _, ok := refs[tc.mapName]; !ok {
+				continue
 			}
-		} else {
-			i.logger.Warnf("%s map not found in gadget collection", symbolizer.OtelTailCallForKprobeMapName)
+			if prog.Type == tc.want {
+				matched = true
+			} else {
+				i.logger.Warnf("program %q (type %s) references OTel tail call map %q (expects %s); OTel eBPF Profiler symbolization only supports matching program types",
+					name, prog.Type, tc.mapName, tc.want)
+			}
+		}
+		if !matched {
+			continue
+		}
+
+		if err := progMap.Update(uint32(0), otelEbpfProgram, ebpf.UpdateAny); err != nil {
+			return fmt.Errorf("updating %s map: %w", tc.mapName, err)
 		}
 	}
 

--- a/pkg/symbolizer/otel/otel.go
+++ b/pkg/symbolizer/otel/otel.go
@@ -193,6 +193,7 @@ func (o *otelResolverInstance) GetEbpfReplacements() map[string]any {
 	}
 	return map[string]any{
 		symbolizer.OtelEbpfProgramKprobe:    o.trc.GetProbeEntryEbpfProgram(),
+		symbolizer.OtelEbpfProgramPerf:      o.trc.GetPerfEntryEbpfProgram(),
 		symbolizer.OtelGenericParamsMapName: o.trc.GetGenericParamsEbpfMap(),
 	}
 }

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -25,6 +25,8 @@ const (
 	OtelGenericParamsMapName     = "otel_generic_params"
 	OtelTailCallForKprobeMapName = "otel_tc_kprobe"
 	OtelEbpfProgramKprobe        = "otel_ebpf_program_kprobe"
+	OtelTailCallForPerfMapName   = "otel_tc_perf"
+	OtelEbpfProgramPerf          = "otel_ebpf_program_perf"
 )
 
 const (


### PR DESCRIPTION
## What this does

OTel eBPF Profiler symbolization — which produces interpreted-language frames,
most importantly Python — previously worked **only** for `kprobe`/`uprobe`
gadgets. This PR adds a `perf_event`-typed path so `perf_event` gadgets, most
importantly **`profile_cpu`** (`SEC("perf_event/profiler")`), can also get
symbolized Python (and other interpreted) stacks.

While enabling this on `profile_cpu`, it also fixes a pre-existing
`profile_cpu` bug (independent of OTel) where identical stacks were never
aggregated — see [Bonus fix](#bonus-fix-profile_cpu-sample-aggregation) below.

## Why it didn't work before

The OTel correlation id is computed by an OTel *entry* program that a gadget
reaches through `bpf_tail_call`. The kernel requires the tail-call caller and
callee to share the same `BPF_PROG_TYPE`. IG only ever loaded the **kprobe**
entry program (into the `otel_tc_kprobe` prog-array), so a `perf_event` gadget
tail-calling into it was type-incompatible: the correlation id was never
produced and the loader logged
`OTel eBPF Profiler symbolization only supports kprobe/uprobe programs`.

## What changed

- **Expose the perf_event entry program.** The OTel profiler already ships a
  `perf_event`-typed entry (`native_tracer_entry`) that writes the correlation
  id to the same shared `generic_params` map as the kprobe entry. The IG fork
  now surfaces it via `GetPerfEntryEbpfProgram()`; `go.mod`/`go.sum` are bumped
  to the fork commit that adds the getter.
- **New symbolizer constants** (`OtelTailCallForPerfMapName = "otel_tc_perf"`,
  `OtelEbpfProgramPerf`) and `GetEbpfReplacements()` now also returns the
  perf_event entry program.
- **Per-type ustack wrappers** (`include/gadget/user_stack_map.h`). Both
  `otel_tc_kprobe` and `otel_tc_perf` prog-arrays are always defined, and the
  fill body is shared in `__gadget_fill_user_stack()`. Two program-type-specific
  wrappers reference their matching prog-array only —
  `gadget_get_user_stack_from_kprobe()` and
  `gadget_get_user_stack_from_perf_event()` — so the kernel prog-array type lock
  is never violated. (A single gadget can contain both a kprobe and a perf_event
  program, so a per-file compile-time switch is not enough — hence per-type
  wrappers.)
- **`gadget_get_user_stack()` stays the single API** most gadgets call: it is now
  a `_Generic` macro that dispatches on the *static C type of `ctx`* at compile
  time (`struct bpf_perf_event_data *` → perf_event, `struct pt_regs *` →
  kprobe/uprobe). Only the selected wrapper's `bpf_tail_call` survives, so each
  program still references only its own prog-array. There is deliberately **no
  default association**, so an unsupported `ctx` type is a compile-time error.
- **Tracepoint variant** `gadget_get_user_stack_from_tracepoint()` for gadgets
  whose program type cannot tail-call into any OTel entry program. It always
  collects the plain user stack (still symbolizable by the symbol-table
  symbolizer) and guards the unsupported OTel path with `bpf_core_unreachable()`:
  with `--collect-otel-stack` unset (the default) the verifier prunes the branch
  at zero cost; when it is explicitly requested the loader rejects the program
  loudly instead of silently returning empty OTel stacks.
- **Loader** (`pkg/operators/ebpf/ebpf.go`) loads each OTel entry program only
  into the prog-array that a gadget program of the matching type actually
  references, and now *warns* (instead of failing) when a mismatched-type
  program references an array.
- **Callers updated:** `profile_cpu` → perf_event variant via
  `gadget_get_user_stack()`; `audit_seccomp`, `profile_cuda`,
  `trace_capabilities`, `trace_malloc`, `ci/stacks` → kprobe variant via
  `gadget_get_user_stack()`; `trace_open` →
  `gadget_get_user_stack_from_tracepoint()`.
- **Docs.** `docs/reference/stack-traces.mdx` documents which program types
  support OTel symbolization (kprobe/uprobe + perf_event) and that other types
  (e.g. tracepoint) don't; `docs/gadget-devel/gadget-ebpf-api.md` documents the
  `_Generic` dispatch and the `gadget_get_user_stack_from_tracepoint()` variant.

## Bonus fix: profile_cpu sample aggregation

While enabling OTel stacks on `profile_cpu`, a separate pre-existing bug became
apparent (last commit, `gadgets/profile_cpu`):

`profile_cpu` embedded the whole `struct gadget_user_stack` in its aggregation
key (`struct key_t`). That struct carries **per-sample** fields set by
`gadget_get_user_stack()` — most notably `boot_timestamp`
(`bpf_ktime_get_boot_ns`) and, after this PR, `otel_correlation_id` — so every
perf sample produced a unique key and the `counts` map **never aggregated**:
each sample became its own `samples:1` entry. With `--collect-ustack` this
yields thousands of rows and a bloated, mis-weighted flamegraph, and can
overflow the map / make the shutdown flush get dropped. The bug is independent
of OTel and also affects native symbol-table stacks.

Fix it the same way `profile_cuda` does: key only on the stack **identity**
(user stack id + kernel stack id/ip + process) and move the full
`struct gadget_user_stack` into the value; the first sample stores the metadata,
subsequent identical stacks only bump `samples` via `__sync_fetch_and_add`. The
user stack and value are staged in per-CPU scratch maps to stay off the BPF
stack.

The output schema is unchanged: `user_stack_raw` keeps the same flattened path
(it just moves from key to value), and the new internal `user_stack_id` scalar
is hidden via `json.skip` / `columns.hidden`. Consumers are unaffected — the
`otel-profiles`/Pyroscope exporter reads the `samples` field (via
`profiles.value-field`) as the per-stack weight, so aggregation preserves
flamegraph weights.

## Dependency

Requires the IG fork of `opentelemetry-ebpf-profiler` that adds
`GetPerfEntryEbpfProgram()` (pinned in `go.mod` as
`v0.0.202611-0.20260715114040-ef6cf29492c8`).

## Testing

- **New integration test** `TestProfileCpuOtelStacks`
  (`gadgets/profile_cpu/test/integration/`) with a pure-Python CPU-bound
  workload (`gadgets/profile_cpu/workload/cpuburn.py`, recognizable
  `compute_fibonacci` → `burn_cpu` → `main` frames). It runs `profile_cpu` with
  the `otel-ebpf-profiler` symbolizer and asserts the full Python call chain is
  symbolized. Like `ci/stacks`, it runs in ig-local/host mode only and skips
  otherwise.

  ```
  make -C gadgets profile_cpu/test-integration \
      IG_PATH=$(pwd)/ig IG_RUNTIME=docker IG_FLAGS="--verify-image=false"
  ```

- **Regression:** the existing `ci/stacks` uprobe OTel test (`TestCiStacks`)
  still passes unchanged (kprobe path via the `_Generic` dispatch).
- **Aggregation fix verified** by running `profile_cpu --collect-ustack` under
  CPU load: identical stacks now aggregate (`samples > 1`) instead of producing
  one `samples:1` row per sample. The generated bytecode was inspected
  (`ig image inspect`) to confirm the `struct gadget_user_stack` zero-init
  compiles to inlined stores (no external `memset` / loop).
- All affected gadgets build (`profile_cpu`, `audit_seccomp`, `profile_cuda`,
  `trace_capabilities`, `trace_malloc`, `trace_open`, `ci/stacks`).
- `make clang-format` and `gofumpt` are clean.

## Checklist

- [x] Commits are signed off (DCO)
- [x] eBPF C formatted with `make clang-format`
- [x] Go formatted (gofumpt/goimports via `make lint`)
- [x] Integration test added and passing
- [x] Existing OTel (uprobe) regression test still passing
