### PR TITLE
feat: add multi-tenancy support (namespace based)

### DIFF
--- a/charts/gadget/templates/clusterrolebinding-auth-delegator.yaml
+++ b/charts/gadget/templates/clusterrolebinding-auth-delegator.yaml
@@ -1,0 +1,20 @@
+{{- if (dig "multiTenancy" "enabled" false .Values.experimental) }}
+# system:auth-delegator grants TokenReview and SubjectAccessReview access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "gadget.fullname" . }}-auth-delegator
+  labels:
+    {{- if not .Values.skipLabels }}
+    {{- include "gadget.labels" . | nindent 4 }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "gadget.fullname" . }}
+    namespace: {{ include "gadget.namespace" . }}
+{{- end }}

--- a/charts/gadget/templates/clusterrolebinding-auth-delegator.yaml
+++ b/charts/gadget/templates/clusterrolebinding-auth-delegator.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.config.multiTenancy.enabled (not .Values.config.experimental) }}
+{{- fail "config.multiTenancy.enabled requires config.experimental=true" }}
+{{- end }}
+{{- if .Values.config.multiTenancy.enabled }}
+# system:auth-delegator grants TokenReview and SubjectAccessReview access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "gadget.fullname" . }}-auth-delegator
+  labels:
+    {{- if not .Values.skipLabels }}
+    {{- include "gadget.labels" . | nindent 4 }}
+    {{- end }}
+    k8s-app: {{ include "gadget.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "gadget.fullname" . }}
+    namespace: {{ include "gadget.namespace" . }}
+{{- end }}

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -18,5 +18,9 @@ data:
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
       gadget-namespace: {{ include "gadget.namespace" . }}
       daemon-log-level: {{ .Values.config.daemonLogLevel }}
+      multi-tenancy: {{ default false (dig "multiTenancy" "enabled" false .Values.experimental) }}
+      multi-tenancy-scope-api-group: {{ default "" (dig "multiTenancy" "scope" "apiGroup" "" .Values.experimental) | quote }}
+      multi-tenancy-scope-resource: {{ default "pods" (dig "multiTenancy" "scope" "resource" "pods" .Values.experimental) }}
+      multi-tenancy-scope-verb: {{ default "create" (dig "multiTenancy" "scope" "verb" "create" .Values.experimental) }}
       operator:
         {{- include "gadget.operatorConfig" . | nindent 8 -}}

--- a/charts/gadget/templates/configmap.yaml
+++ b/charts/gadget/templates/configmap.yaml
@@ -18,5 +18,9 @@ data:
       podman-socketpath: {{ .Values.config.podmanSocketPath }}
       gadget-namespace: {{ include "gadget.namespace" . }}
       daemon-log-level: {{ .Values.config.daemonLogLevel }}
+      multi-tenancy: {{ .Values.config.multiTenancy.enabled }}
+      multi-tenancy-scope-api-group: {{ .Values.config.multiTenancy.scope.apiGroup | quote }}
+      multi-tenancy-scope-resource: {{ .Values.config.multiTenancy.scope.resource }}
+      multi-tenancy-scope-verb: {{ .Values.config.multiTenancy.scope.verb }}
       operator:
         {{- include "gadget.operatorConfig" . | nindent 8 -}}

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -121,6 +121,35 @@
         }
       }
     },
+    "experimental": {
+      "type": "object",
+      "properties": {
+        "multiTenancy": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "scope": {
+              "type": "object",
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "resource": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "verb": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "image": {
       "type": "object",
       "required": [

--- a/charts/gadget/values.schema.json
+++ b/charts/gadget/values.schema.json
@@ -75,6 +75,30 @@
         "experimental": {
           "type": "boolean"
         },
+        "multiTenancy": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "scope": {
+              "type": "object",
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "resource": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "verb": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
         "eventsBufferLength": {
           "type": ["integer", "string"]
         },

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -62,6 +62,17 @@ config:
     #   paramValues: {}
     #     # operator.filter.filter: "fname~/proc.*"
 
+# -- Experimental features (off by default, no compatibility guarantees).
+experimental:
+  # -- Authenticate clients through Kubernetes and enforce namespace access.
+  multiTenancy:
+    enabled: false
+    # -- Kubernetes authorization question used to resolve namespace access.
+    scope:
+      apiGroup: ""
+      resource: pods
+      verb: create
+
 # -- All configurations below are specific to Kubernetes resources created by the gadget chart.
 image:
   # -- Container repository for the container image

--- a/charts/gadget/values.yaml
+++ b/charts/gadget/values.yaml
@@ -16,6 +16,15 @@ config:
   # -- Enable experimental features
   experimental: false
 
+  # -- Authenticate clients through Kubernetes and enforce namespace access.
+  multiTenancy:
+    enabled: false
+    # -- Kubernetes authorization question used to resolve namespace access.
+    scope:
+      apiGroup: ""
+      resource: pods
+      verb: create
+
   # -- Events buffer length. A low value could impact horizontal scaling.
   eventsBufferLength: "16384"
 

--- a/cmd/common/instances.go
+++ b/cmd/common/instances.go
@@ -16,8 +16,8 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -150,20 +150,36 @@ func AddInstanceCommands(
 			if err != nil {
 				return fmt.Errorf("getting gadget instances: %w", err)
 			}
+
+			var retErr error
 			if len(ambiguous) > 0 {
-				fmt.Fprintf(os.Stderr, "ambiguous names/ids: %s\n", strings.Join(ambiguous, ", "))
+				retErr = errors.Join(retErr, fmt.Errorf("ambiguous names/ids: %s", strings.Join(ambiguous, ", ")))
 			}
-			if len(notfound) > 0 {
-				fmt.Fprintf(os.Stderr, "not found names/ids: %s\n", strings.Join(notfound, ", "))
-			}
+			ids := make([]string, 0, len(instances)+len(notfound))
 			for _, instance := range instances {
-				err := runtime.RemoveGadgetInstance(context.Background(), runtimeParams, instance.Id)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "failed to remove gadget instance %q: %v\n", instance.Id, err)
-				}
-				fmt.Printf("%s\n", instance.Id)
+				ids = append(ids, instance.Id)
 			}
-			return nil
+			unresolved := notfound[:0]
+			for _, idOrName := range notfound {
+				if api.IsValidInstanceID(idOrName) {
+					ids = append(ids, idOrName)
+				} else {
+					unresolved = append(unresolved, idOrName)
+				}
+			}
+			if len(unresolved) > 0 {
+				retErr = errors.Join(retErr, fmt.Errorf("not found names/ids: %s", strings.Join(unresolved, ", ")))
+			}
+
+			for _, id := range ids {
+				err := runtime.RemoveGadgetInstance(context.Background(), runtimeParams, id)
+				if err != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("removing gadget instance %q: %w", id, err))
+					continue
+				}
+				fmt.Printf("%s\n", id)
+			}
+			return retErr
 		},
 	}
 	AddFlags(deleteCmd, runtimeParams, nil, runtime)

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -77,7 +77,7 @@ nextName:
 		for _, tmpGadgetInstance := range gadgetInstances {
 			if idOrName == tmpGadgetInstance.Id {
 				instances = append(instances, tmpGadgetInstance)
-				break nextName
+				continue nextName
 			}
 			// match partial ID or full name
 			if tmpGadgetInstance.Name == idOrName || strings.HasPrefix(tmpGadgetInstance.Id, idOrName) {

--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -78,7 +78,7 @@ nextName:
 		for _, tmpGadgetInstance := range gadgetInstances {
 			if idOrName == tmpGadgetInstance.Id {
 				instances = append(instances, tmpGadgetInstance)
-				break nextName
+				continue nextName
 			}
 			// match partial ID or full name
 			if tmpGadgetInstance.Name == idOrName || strings.HasPrefix(tmpGadgetInstance.Id, idOrName) {
@@ -211,15 +211,18 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			if err != nil {
 				return fmt.Errorf("getting gadget instances: %w", err)
 			}
-			if len(notfound) > 0 || len(instances) == 0 {
-				return fmt.Errorf("gadget instance not found")
-			}
 			if len(ambiguous) > 0 {
 				return fmt.Errorf("gadget instance id or name are ambiguous")
 			}
-			imageName = instances[0].Id
+			if len(notfound) > 0 || len(instances) == 0 {
+				if !api.IsValidInstanceID(imageName) {
+					return fmt.Errorf("gadget instance not found")
+				}
+			} else {
+				imageName = instances[0].Id
+			}
 
-			if len(instances[0].Nodes) > 0 {
+			if len(instances) > 0 && len(instances[0].Nodes) > 0 {
 				// GetGadgetInfo can only be run on nodes that know about a gadget instance, so we need
 				// to make sure that the given nodes are valid
 				nodes := runtimeParams.Get(grpcruntime.ParamNode).AsStringSlice()

--- a/cmd/kubectl-gadget/auth/mint.go
+++ b/cmd/kubectl-gadget/auth/mint.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth mints audience-scoped Kubernetes ServiceAccount tokens for
+// authenticating kubectl-gadget to a multi-tenant gadget service.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	serviceauth "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
+	grpcruntime "github.com/inspektor-gadget/inspektor-gadget/pkg/runtime/grpc"
+)
+
+const (
+	flagAuthServiceAccount  = "auth-service-account"
+	flagAuthTokenExpiration = "auth-token-expiration"
+)
+
+type Options struct {
+	ServiceAccount string
+	Expiration     time.Duration
+}
+
+func AddFlags(cmd *cobra.Command) *Options {
+	o := &Options{}
+	cmd.PersistentFlags().StringVar(&o.ServiceAccount, flagAuthServiceAccount, "",
+		"ServiceAccount used to authenticate to the gadget service, in the form <namespace>/<name>.")
+	cmd.PersistentFlags().DurationVar(&o.Expiration, flagAuthTokenExpiration, time.Hour,
+		"Requested lifetime of the audience-scoped token.")
+	return o
+}
+
+func MintToken(ctx context.Context, restCfg *rest.Config, namespace, name string, expiration time.Duration) (string, error) {
+	if expiration <= 0 {
+		return "", fmt.Errorf("--%s must be positive", flagAuthTokenExpiration)
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return "", fmt.Errorf("building Kubernetes client: %w", err)
+	}
+	expirationSeconds := int64(expiration.Seconds())
+	request, err := client.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, name, &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences:         []string{serviceauth.Audience},
+			ExpirationSeconds: &expirationSeconds,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("creating token for ServiceAccount %s/%s: %w", namespace, name, err)
+	}
+	if request.Status.Token == "" {
+		return "", fmt.Errorf("kube-apiserver returned an empty token for %s/%s", namespace, name)
+	}
+	return request.Status.Token, nil
+}
+
+func parseServiceAccount(value string) (string, string, error) {
+	namespace, name, ok := strings.Cut(value, "/")
+	if !ok || namespace == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", fmt.Errorf("--%s=%q is not in the form <namespace>/<name>", flagAuthServiceAccount, value)
+	}
+	return namespace, name, nil
+}
+
+func MaybeMintAndApply(ctx context.Context, restCfg *rest.Config, runtime *grpcruntime.Runtime, o *Options) error {
+	if o.ServiceAccount == "" {
+		return nil
+	}
+	namespace, name, err := parseServiceAccount(o.ServiceAccount)
+	if err != nil {
+		return err
+	}
+	token, err := MintToken(ctx, restCfg, namespace, name, o.Expiration)
+	if err != nil {
+		return err
+	}
+	runtime.SetAuthToken(token)
+	return nil
+}

--- a/cmd/kubectl-gadget/auth/mint_test.go
+++ b/cmd/kubectl-gadget/auth/mint_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseServiceAccount(t *testing.T) {
+	for _, test := range []struct {
+		value     string
+		namespace string
+		name      string
+		wantErr   bool
+	}{
+		{value: "team-a/ig-client", namespace: "team-a", name: "ig-client"},
+		{value: "ig-client", wantErr: true},
+		{value: "/ig-client", wantErr: true},
+		{value: "team-a/", wantErr: true},
+		{value: "team-a/ig/client", wantErr: true},
+	} {
+		namespace, name, err := parseServiceAccount(test.value)
+		if test.wantErr {
+			assert.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		assert.Equal(t, test.namespace, namespace)
+		assert.Equal(t, test.name, name)
+	}
+}

--- a/cmd/kubectl-gadget/main.go
+++ b/cmd/kubectl-gadget/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/common"
 	img "github.com/inspektor-gadget/inspektor-gadget/cmd/common/image"
 	commonutils "github.com/inspektor-gadget/inspektor-gadget/cmd/common/utils"
+	kgauth "github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/auth"
 	"github.com/inspektor-gadget/inspektor-gadget/cmd/kubectl-gadget/utils"
 	igconfig "github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
@@ -80,6 +82,7 @@ func main() {
 	grpcRuntime = grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
 	runtimeGlobalParams = grpcRuntime.GlobalParamDescs().ToParams()
 	common.AddFlags(rootCmd, runtimeGlobalParams, nil, grpcRuntime)
+	mintOptions := kgauth.AddFlags(rootCmd)
 	grpcRuntime.Init(runtimeGlobalParams)
 
 	// evaluate flags early for runtimeGlobalParams; this will make
@@ -106,6 +109,10 @@ func main() {
 		log.Fatalf("Creating RESTConfig: %s", err)
 	}
 	grpcRuntime.SetRestConfig(config)
+
+	if err := kgauth.MaybeMintAndApply(context.Background(), config, grpcRuntime, mintOptions); err != nil {
+		log.Fatalf("minting audience-scoped token: %v", err)
+	}
 
 	namespace, _ := utils.GetNamespace()
 	grpcRuntime.SetDefaultValue(gadgets.K8SNamespace, namespace)

--- a/docs/devel/multitenancy.md
+++ b/docs/devel/multitenancy.md
@@ -1,0 +1,236 @@
+# Kubernetes multi-tenancy
+
+## Status
+
+Kubernetes multi-tenancy is an experimental, opt-in mode. It authenticates
+each `kubectl-gadget` request through Kubernetes and restricts gadgets to the
+namespaces authorized for that identity.
+
+The current identity is an audience-scoped ServiceAccount token minted by
+`kubectl-gadget`. This avoids forwarding the user's reusable kubeconfig
+credential to the privileged gadget pod.
+
+## Security model
+
+Inspektor Gadget has node-wide visibility. Client-side filters are therefore
+not a security boundary: a modified client could remove them. Multi-tenancy
+enforces these invariants in the gadget service:
+
+- every gRPC request requires a token for the `inspektor-gadget` audience;
+- Kubernetes `TokenReview` authenticates the token;
+- Kubernetes `SubjectAccessReview` resolves namespace access;
+- the KubeManager container selector is narrowed before the gadget starts;
+- namespace exclusions and unsupported, host-wide gadgets are rejected;
+- detached instances are filtered and authorized on create, inspect, list,
+  attach, and delete.
+
+Users with access to the same namespace share its security boundary. This mode
+does not provide per-user ownership inside a namespace.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    User["User"] -->|"--auth-service-account=team-a/ig-client"| Client["kubectl-gadget"]
+    Client -->|"TokenRequest<br/>audience: inspektor-gadget"| API["Kubernetes API server"]
+    API -->|"short-lived token"| Client
+    Client -->|"gRPC over Kubernetes port-forward<br/>Authorization: Bearer …"| Daemon["gadget DaemonSet"]
+
+    subgraph Daemon
+        Interceptor["gRPC auth interceptors"]
+        Policy["PolicyScope<br/>allowed namespaces"]
+        Service["Gadget service"]
+        KubeManager["KubeManager<br/>container selector"]
+        Gadget["eBPF gadget"]
+
+        Interceptor --> Policy --> Service --> KubeManager --> Gadget
+    end
+
+    Interceptor -->|"TokenReview"| API
+    Interceptor -->|"list namespaces + SubjectAccessReview per namespace"| API
+    KubeManager -->|"attach only to authorized containers"| Workloads["Tenant workloads"]
+```
+
+### 1. Token minting
+
+`kubectl-gadget` calls the Kubernetes `TokenRequest` subresource for the
+ServiceAccount selected by `--auth-service-account=<namespace>/<name>`. The
+requested token:
+
+- has audience `inspektor-gadget`;
+- defaults to a one-hour lifetime, configurable with
+  `--auth-token-expiration`;
+- remains in memory;
+- is attached to each gRPC call.
+
+The caller must have `create` access to
+`serviceaccounts/token` in that namespace. Kubernetes rejects the command
+before it reaches Inspektor Gadget otherwise.
+
+The credential is allowed over the clear-text inner gRPC connection only when
+the runtime uses Kubernetes port-forward. That inner connection is carried
+inside the authenticated, encrypted Kubernetes API connection. Direct gRPC
+connections do not receive this exception.
+
+### 2. Authentication
+
+Unary and stream interceptors extract the bearer token and submit a
+`TokenReview` with the expected audience. Missing, invalid, or wrong-audience
+tokens fail with `Unauthenticated`.
+
+The audience restriction is important: the token is intended for Inspektor
+Gadget and cannot be replayed as a normal Kubernetes API credential.
+
+### 3. Namespace authorization
+
+After authentication, the daemon lists namespaces and submits a
+`SubjectAccessReview` for the authenticated ServiceAccount in each namespace.
+By default it asks:
+
+```yaml
+apiGroup: ""
+resource: pods
+verb: create
+```
+
+The resulting namespace list is stored in the request context. Authentication
+or authorization API failures fail the request closed.
+
+The checked resource is configurable because installations may want a
+dedicated observability permission instead of granting `create pods`.
+The resource need not have a CRD for Kubernetes RBAC to evaluate a
+`SubjectAccessReview`.
+
+### 4. Gadget enforcement
+
+KubeManager is the existing server-side boundary that selects containers for
+a gadget. Multi-tenancy reuses it instead of adding a second event filter:
+
+| Request | Enforcement |
+| --- | --- |
+| one namespace | accepted only when authorized |
+| comma-separated namespaces | every namespace must be authorized |
+| `--all-namespaces` | replaced with the complete authorized namespace list |
+| exclusion such as `!team-b` | rejected because it could include unauthorized namespaces |
+| no namespace | treated as `default` |
+| gadget without KubeManager isolation | rejected |
+
+The constrained values are copied into KubeManager before it creates mount
+namespace maps or attaches probes. Unauthorized containers are therefore
+excluded before data collection, not merely hidden at output time.
+
+### 5. Detached instances
+
+Creation persists the already-constrained namespace values. Subsequent
+operations authorize those values against the caller's current policy scope:
+
+- list hides instances outside the caller's namespaces;
+- inspect, attach, and delete reject unauthorized instances;
+- permission changes affect the next RPC;
+- an established stream keeps the scope resolved when it was opened.
+
+## Deployment
+
+### Helm
+
+```sh
+helm upgrade --install gadget ./charts/gadget \
+  --namespace gadget --create-namespace \
+  --set experimental.multiTenancy.enabled=true
+```
+
+The chart enables the daemon setting and binds its ServiceAccount to the
+built-in `system:auth-delegator` ClusterRole, which grants both `TokenReview`
+and `SubjectAccessReview`.
+
+To use a dedicated authorization permission:
+
+```sh
+helm upgrade --install gadget ./charts/gadget \
+  --namespace gadget --create-namespace \
+  --set experimental.multiTenancy.enabled=true \
+  --set experimental.multiTenancy.scope.apiGroup=gadget.kinvolk.io \
+  --set experimental.multiTenancy.scope.resource=traces \
+  --set experimental.multiTenancy.scope.verb=get
+```
+
+### `kubectl-gadget deploy`
+
+The embedded default manifest does not grant delegated authentication
+permissions while the feature is disabled. When enabling it through daemon
+configuration, add the binding explicitly:
+
+```sh
+kubectl gadget deploy \
+  --set-daemon-config=multi-tenancy=true
+
+kubectl create clusterrolebinding gadget-auth-delegator \
+  --clusterrole=system:auth-delegator \
+  --serviceaccount=gadget:gadget
+```
+
+## Tenant setup
+
+Create a dedicated identity and grant it the permission used by the configured
+scope:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ig-client
+  namespace: team-a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ig-tenant
+  namespace: team-a
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ig-tenant
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ig-tenant
+subjects:
+  - kind: ServiceAccount
+    name: ig-client
+    namespace: team-a
+```
+
+Separately grant the human or automation running `kubectl-gadget` permission
+to create a token for the selected ServiceAccount.
+
+Run a gadget:
+
+```sh
+kubectl gadget \
+  --auth-service-account=team-a/ig-client \
+  run ghcr.io/inspektor-gadget/gadget/trace_exec:latest \
+  --namespace team-a
+```
+
+## Known limits
+
+- Each RPC performs one `TokenReview`, one namespace list, and one
+  `SubjectAccessReview` per namespace. Add a short-lived cache only when API
+  server load is measurable.
+- Authorization is resolved when a stream opens; long-running streams are not
+  reauthorized until reconnect.
+- The default `create pods` policy couples gadget access to workload creation.
+  Configure a dedicated resource when that distinction matters.
+- Isolation currently requires KubeManager-compatible gadgets. Host-wide or
+  non-namespaced data is denied rather than guessed.
+- Authenticated callers can request metadata for arbitrary gadget images.
+  Image verification and registry policy, not namespace RBAC, define which
+  images are trusted.
+- Tenants in the same namespace can access the same detached instances.
+  Add creator ownership only if namespace-level tenancy is insufficient.

--- a/docs/devel/multitenancy.md
+++ b/docs/devel/multitenancy.md
@@ -1,0 +1,245 @@
+# Kubernetes multi-tenancy
+
+## Status
+
+Kubernetes multi-tenancy is an experimental, opt-in mode. It authenticates
+each `kubectl-gadget` request through Kubernetes and restricts gadgets to the
+namespaces authorized for that identity.
+
+The current identity is an audience-scoped ServiceAccount token minted by
+`kubectl-gadget`. This avoids forwarding the user's reusable kubeconfig
+credential to the privileged gadget pod.
+
+## Security model
+
+Inspektor Gadget has node-wide visibility. Client-side filters are therefore
+not a security boundary: a modified client could remove them. Multi-tenancy
+enforces these invariants in the gadget service:
+
+- every gRPC request requires a token for the `inspektor-gadget` audience;
+- Kubernetes `TokenReview` authenticates the token;
+- Kubernetes `SubjectAccessReview` resolves namespace access;
+- the KubeManager container selector is narrowed before the gadget starts;
+- namespace exclusions and unsupported, host-wide gadgets are rejected;
+- detached instances are filtered and authorized on create, inspect, list,
+  attach, and delete.
+
+Users with access to the same namespace share its security boundary. This mode
+does not provide per-user ownership inside a namespace.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    User["User"] -->|"--auth-service-account=team-a/ig-client"| Client["kubectl-gadget"]
+    Client -->|"TokenRequest<br/>audience: inspektor-gadget"| API["Kubernetes API server"]
+    API -->|"short-lived token"| Client
+    Client -->|"gRPC over Kubernetes port-forward<br/>Authorization: Bearer …"| Daemon["gadget DaemonSet"]
+
+    subgraph Daemon
+        Interceptor["gRPC auth interceptors"]
+        Policy["PolicyScope<br/>allowed namespaces"]
+        Service["Gadget service"]
+        KubeManager["KubeManager<br/>container selector"]
+        Gadget["eBPF gadget"]
+
+        Interceptor --> Policy --> Service --> KubeManager --> Gadget
+    end
+
+    Interceptor -->|"TokenReview"| API
+    Interceptor -->|"list namespaces + SubjectAccessReview per namespace"| API
+    KubeManager -->|"attach only to authorized containers"| Workloads["Tenant workloads"]
+```
+
+### 1. Token minting
+
+`kubectl-gadget` calls the Kubernetes `TokenRequest` subresource for the
+ServiceAccount selected by `--auth-service-account=<namespace>/<name>`. The
+requested token:
+
+- has audience `inspektor-gadget`;
+- defaults to a one-hour lifetime, configurable with
+  `--auth-token-expiration`;
+- remains in memory;
+- is attached to each gRPC call.
+
+The caller must have `create` access to
+`serviceaccounts/token` in that namespace. Kubernetes rejects the command
+before it reaches Inspektor Gadget otherwise.
+
+The credential is allowed over the clear-text inner gRPC connection only when
+the runtime uses Kubernetes port-forward. That inner connection is carried
+inside the authenticated, encrypted Kubernetes API connection. Direct gRPC
+connections do not receive this exception.
+
+### 2. Authentication
+
+Unary and stream interceptors extract the bearer token and submit a
+`TokenReview` with the expected audience. Missing, invalid, or wrong-audience
+tokens fail with `Unauthenticated`.
+
+The audience restriction is important: the token is intended for Inspektor
+Gadget and cannot be replayed as a normal Kubernetes API credential.
+
+### 3. Namespace authorization
+
+After authentication, the daemon lists namespaces and submits a
+`SubjectAccessReview` for the authenticated ServiceAccount in each namespace.
+By default it asks:
+
+```yaml
+apiGroup: ""
+resource: pods
+verb: create
+```
+
+The resulting namespace list is stored in the request context. Authentication
+or authorization API failures fail the request closed.
+
+The checked resource is configurable because installations may want a
+dedicated observability permission instead of granting `create pods`.
+The resource need not have a CRD for Kubernetes RBAC to evaluate a
+`SubjectAccessReview`.
+
+### 4. Gadget enforcement
+
+KubeManager is the existing server-side boundary that selects containers for
+a gadget. Multi-tenancy reuses it instead of adding a second event filter:
+
+| Request | Enforcement |
+| --- | --- |
+| one namespace | accepted only when authorized |
+| comma-separated namespaces | every namespace must be authorized |
+| `--all-namespaces` | all namespaces authorized for the current identity, not all cluster namespaces |
+| exclusion such as `!team-b` | rejected because it could include unauthorized namespaces |
+| no namespace | treated as `default` |
+| gadget without KubeManager isolation | rejected |
+
+The constrained values are copied into KubeManager before it creates mount
+namespace maps or attaches probes. Unauthorized containers are therefore
+excluded before data collection, not merely hidden at output time.
+
+### 5. Detached instances
+
+Creation persists the already-constrained namespace values. Subsequent
+operations authorize those values against the caller's current policy scope:
+
+- list hides instances outside the caller's namespaces;
+- inspect, attach, and delete reject unauthorized instances;
+- permission changes affect the next RPC;
+- an established stream keeps the scope resolved when it was opened.
+
+## Deployment
+
+### Helm
+
+```sh
+helm upgrade --install gadget ./charts/gadget \
+  --namespace gadget --create-namespace \
+  --set config.experimental=true \
+  --set config.multiTenancy.enabled=true
+```
+
+The chart enables the daemon setting and binds its ServiceAccount to the
+built-in `system:auth-delegator` ClusterRole, which grants both `TokenReview`
+and `SubjectAccessReview`.
+
+To use a dedicated authorization permission:
+
+```sh
+helm upgrade --install gadget ./charts/gadget \
+  --namespace gadget --create-namespace \
+  --set config.experimental=true \
+  --set config.multiTenancy.enabled=true \
+  --set config.multiTenancy.scope.apiGroup=authorization.inspektor-gadget.io \
+  --set config.multiTenancy.scope.resource=gadgets \
+  --set config.multiTenancy.scope.verb=use
+```
+
+This is a virtual RBAC marker: `SubjectAccessReview` evaluates the configured
+attributes without requiring a CRD or registered API.
+
+### `kubectl-gadget deploy`
+
+The embedded default manifest does not grant delegated authentication
+permissions while the feature is disabled. When enabling it through daemon
+configuration, add the binding explicitly:
+
+```sh
+kubectl gadget deploy \
+  --experimental \
+  --set-daemon-config=multi-tenancy=true
+
+kubectl create clusterrolebinding gadget-auth-delegator \
+  --clusterrole=system:auth-delegator \
+  --serviceaccount=gadget:gadget
+```
+
+## Tenant setup
+
+Create a dedicated identity and grant it the permission used by the configured
+scope:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ig-client
+  namespace: team-a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ig-tenant
+  namespace: team-a
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ig-tenant
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ig-tenant
+subjects:
+  - kind: ServiceAccount
+    name: ig-client
+    namespace: team-a
+```
+
+Separately grant the human or automation running `kubectl-gadget` permission
+to create a token for the selected ServiceAccount.
+
+Run a gadget:
+
+`kubectl-gadget` establishes the Kubernetes port-forward automatically; no
+manual port-forward is required.
+
+```sh
+kubectl gadget \
+  --auth-service-account=team-a/ig-client \
+  run ghcr.io/inspektor-gadget/gadget/trace_exec:latest \
+  --namespace team-a
+```
+
+## Known limits
+
+- Each RPC performs one `TokenReview`, one namespace list, and one
+  `SubjectAccessReview` per namespace. Add a short-lived cache only when API
+  server load is measurable.
+- Authorization is resolved when a stream opens; long-running streams are not
+  reauthorized until reconnect.
+- The default `create pods` policy couples gadget access to workload creation.
+  Configure a dedicated resource when that distinction matters.
+- Isolation currently requires KubeManager-compatible gadgets. Host-wide or
+  non-namespaced data is denied rather than guessed.
+- Authenticated callers can request metadata for arbitrary gadget images.
+  Image verification and registry policy, not namespace RBAC, define which
+  images are trusted.
+- Tenants in the same namespace can access the same detached instances.
+  Add creator ownership only if namespace-level tenancy is insufficient.

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	// Import this early to set the environment variable before any other package is imported
@@ -232,11 +234,31 @@ func main() {
 		if err != nil {
 			log.Fatalf("invalid service host: %v", err)
 		}
+
+		runConfig := gadgetservice.RunConfig{
+			SocketType: socketType,
+			SocketPath: socketPath,
+		}
+		if config.Config.GetBool(gadgettracermanagerconfig.MultiTenancy) {
+			log.Infof("Config: %s=%t", gadgettracermanagerconfig.MultiTenancy, true)
+			restCfg, err := rest.InClusterConfig()
+			if err != nil {
+				log.Fatalf("building in-cluster config for multi-tenancy: %v", err)
+			}
+			restCfg.UserAgent = version.UserAgent()
+			kc, err := kubernetes.NewForConfig(restCfg)
+			if err != nil {
+				log.Fatalf("building Kubernetes client for multi-tenancy: %v", err)
+			}
+			runConfig.MultiTenancy = true
+			runConfig.KubernetesClient = kc
+			runConfig.MultiTenancyScope.APIGroup = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeAPIGroup)
+			runConfig.MultiTenancyScope.Resource = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeResource)
+			runConfig.MultiTenancyScope.Verb = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeVerb)
+		}
+
 		go func() {
-			err := service.Run(gadgetservice.RunConfig{
-				SocketType: socketType,
-				SocketPath: socketPath,
-			})
+			err := service.Run(runConfig)
 			if err != nil {
 				log.Fatalf("starting gadget service: %v", err)
 			}

--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	// Import this early to set the environment variable before any other package is imported
@@ -232,11 +234,35 @@ func main() {
 		if err != nil {
 			log.Fatalf("invalid service host: %v", err)
 		}
+
+		runConfig := gadgetservice.RunConfig{
+			SocketType: socketType,
+			SocketPath: socketPath,
+		}
+		multiTenancy := config.Config.GetBool(gadgettracermanagerconfig.MultiTenancy)
+		if multiTenancy && !experimental.Enabled() {
+			log.Fatal("multi-tenancy requires experimental features to be enabled")
+		}
+		if multiTenancy {
+			log.Infof("Config: %s=%t", gadgettracermanagerconfig.MultiTenancy, true)
+			restCfg, err := rest.InClusterConfig()
+			if err != nil {
+				log.Fatalf("building in-cluster config for multi-tenancy: %v", err)
+			}
+			restCfg.UserAgent = version.UserAgent()
+			kc, err := kubernetes.NewForConfig(restCfg)
+			if err != nil {
+				log.Fatalf("building Kubernetes client for multi-tenancy: %v", err)
+			}
+			runConfig.MultiTenancy = true
+			runConfig.KubernetesClient = kc
+			runConfig.MultiTenancyScope.APIGroup = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeAPIGroup)
+			runConfig.MultiTenancyScope.Resource = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeResource)
+			runConfig.MultiTenancyScope.Verb = config.Config.GetString(gadgettracermanagerconfig.MultiTenancyScopeVerb)
+		}
+
 		go func() {
-			err := service.Run(gadgetservice.RunConfig{
-				SocketType: socketType,
-				SocketPath: socketPath,
-			})
+			err := service.Run(runConfig)
 			if err != nil {
 				log.Fatalf("starting gadget service: %v", err)
 			}

--- a/integration/k8s/multitenancy_test.go
+++ b/integration/k8s/multitenancy_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestMultiTenancyTokenReviewNamespacePolicy(t *testing.T) {
+	if DefaultTestComponent != InspektorGadgetTestComponent {
+		t.Skip("multi-tenancy TokenReview policy is enforced by the deployed Inspektor Gadget daemon")
+	}
+
+	kubectlGadget := os.Getenv("KUBECTL_GADGET")
+	require.NotEmpty(t, kubectlGadget, "KUBECTL_GADGET is not set")
+
+	teamA := GenerateTestNamespaceName("mt-team-a")
+	teamB := GenerateTestNamespaceName("mt-team-b")
+	instanceName := GenerateTestNamespaceName("mt-snapshot")
+	gadgetImage := fmt.Sprintf("%s/snapshot_process:%s", *gadgetRepository, *gadgetTag)
+
+	cleanupCommands := []TestStep{
+		&Command{
+			Name:    "Delete detached gadget instance",
+			Cmd:     fmt.Sprintf("%s --auth-service-account=%s/ig-client delete %s || true", q(kubectlGadget), teamA, q(instanceName)),
+			Cleanup: true,
+		},
+		&Command{
+			Name: "Restore non-multi-tenant Inspektor Gadget",
+			Cmd: fmt.Sprintf(`ig_image="$(kubectl -n gadget get daemonset gadget -o jsonpath='{.spec.template.spec.containers[0].image}')"
+%[1]s undeploy || true
+%[1]s deploy --experimental --debug \
+  --image="$ig_image" \
+  --image-pull-policy=IfNotPresent \
+  --set-daemon-config=operator.oci.verify-image=false`,
+				q(kubectlGadget),
+			),
+			Cleanup: true,
+		},
+		&Command{
+			Name:    "Delete auth delegator binding",
+			Cmd:     "kubectl delete clusterrolebinding gadget-multitenancy-test-auth-delegator --ignore-not-found",
+			Cleanup: true,
+		},
+		DeleteTestNamespaceCommand(teamA),
+		DeleteTestNamespaceCommand(teamB),
+	}
+	t.Cleanup(func() {
+		RunTestSteps(cleanupCommands, t)
+	})
+
+	commands := []TestStep{
+		&Command{
+			Name: "Deploy Inspektor Gadget with TokenReview",
+			Cmd: fmt.Sprintf(`ig_image="$(kubectl -n gadget get daemonset gadget -o jsonpath='{.spec.template.spec.containers[0].image}')"
+%[1]s undeploy || true
+%[1]s deploy --experimental --debug \
+  --image="$ig_image" \
+  --image-pull-policy=IfNotPresent \
+  --set-daemon-config=operator.oci.verify-image=false \
+  --set-daemon-config=multi-tenancy=true
+kubectl create clusterrolebinding gadget-multitenancy-test-auth-delegator \
+  --clusterrole=system:auth-delegator \
+  --serviceaccount=gadget:gadget \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout status daemonset/gadget -n gadget --timeout=120s`,
+				q(kubectlGadget),
+			),
+		},
+		CreateTestNamespaceCommand(teamA),
+		CreateTestNamespaceCommand(teamB),
+		multiTenancyRBACCommand(teamA),
+		multiTenancyRBACCommand(teamB),
+		&Command{
+			Name: "Team A can run in team A namespace",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s -n %s --timeout=5 -o json",
+				q(kubectlGadget), teamA, q(gadgetImage), q(teamA)),
+		},
+		&Command{
+			Name: "Team A cannot run in team B namespace",
+			Cmd: fmt.Sprintf(`if %s --auth-service-account=%s/ig-client run %s -n %s --timeout=5; then
+  echo "team A unexpectedly ran a gadget in team B namespace"
+  exit 1
+fi`,
+				q(kubectlGadget), teamA, q(gadgetImage), q(teamB)),
+		},
+		&Command{
+			Name: "Team A all-namespaces request is narrowed to team A",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s -A --timeout=5 -o json",
+				q(kubectlGadget), teamA, q(gadgetImage)),
+		},
+		&Command{
+			Name: "Team A can install a detached gadget in team A namespace",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s --detach --name %s -n %s",
+				q(kubectlGadget), teamA, q(gadgetImage), q(instanceName), q(teamA)),
+		},
+		&Command{
+			Name: "Team B cannot list team A detached gadget",
+			Cmd: fmt.Sprintf(`if %s --auth-service-account=%s/ig-client list | grep -F %s; then
+  echo "team B unexpectedly listed team A detached gadget"
+  exit 1
+fi`,
+				q(kubectlGadget), teamB, q(instanceName)),
+		},
+		&Command{
+			Name: "Team B cannot delete team A detached gadget",
+			Cmd: fmt.Sprintf(`instance_id=$(%[1]s --auth-service-account=%[2]s/ig-client show %[3]s | awk '$1 == "ID:" {print $2}')
+if [ -z "$instance_id" ]; then
+  echo "failed to resolve team A gadget instance ID"
+  exit 1
+fi
+set +e
+delete_output=$(%[1]s --auth-service-account=%[4]s/ig-client delete "$instance_id" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "team B unexpectedly deleted team A detached gadget"
+  exit 1
+fi
+if ! printf '%%s\n' "$delete_output" | grep -F "code = PermissionDenied"; then
+  echo "delete failed without PermissionDenied: $delete_output"
+  exit 1
+fi
+%[1]s --auth-service-account=%[2]s/ig-client show "$instance_id" >/dev/null`,
+				q(kubectlGadget), teamA, q(instanceName), teamB),
+		},
+		&Command{
+			Name: "Team A can attach to its detached gadget",
+			Cmd: fmt.Sprintf(`set +e
+timeout 10s %s --auth-service-account=%s/ig-client attach %s
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+  exit "$rc"
+fi`,
+				q(kubectlGadget), teamA, q(instanceName)),
+		},
+		&Command{
+			Name: "Team B cannot attach to team A detached gadget",
+			Cmd: fmt.Sprintf(`set +e
+timeout 10s %s --auth-service-account=%s/ig-client attach %s
+rc=$?
+if [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ]; then
+  echo "team B unexpectedly attached to team A detached gadget"
+  exit 1
+fi`,
+				q(kubectlGadget), teamB, q(instanceName)),
+		},
+	}
+
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn("gadget", teamA, teamB)))
+}
+
+func multiTenancyRBACCommand(namespace string) *Command {
+	cmd := fmt.Sprintf(`kubectl apply -f - <<"EOF"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ig-client
+  namespace: %[1]s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-creator
+  namespace: %[1]s
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ig-client-pod-creator
+  namespace: %[1]s
+subjects:
+- kind: ServiceAccount
+  name: ig-client
+  namespace: %[1]s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-creator
+EOF`, namespace)
+
+	return &Command{
+		Name: fmt.Sprintf("Create team RBAC in %s", namespace),
+		Cmd:  cmd,
+	}
+}
+
+func q(s string) string {
+	return strconv.Quote(s)
+}

--- a/integration/k8s/multitenancy_test.go
+++ b/integration/k8s/multitenancy_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/inspektor-gadget/inspektor-gadget/integration"
+)
+
+func TestMultiTenancyTokenReviewNamespacePolicy(t *testing.T) {
+	if DefaultTestComponent != InspektorGadgetTestComponent {
+		t.Skip("multi-tenancy TokenReview policy is enforced by the deployed Inspektor Gadget daemon")
+	}
+
+	kubectlGadget := os.Getenv("KUBECTL_GADGET")
+	require.NotEmpty(t, kubectlGadget, "KUBECTL_GADGET is not set")
+
+	teamA := GenerateTestNamespaceName("mt-team-a")
+	teamB := GenerateTestNamespaceName("mt-team-b")
+	instanceName := GenerateTestNamespaceName("mt-snapshot")
+	gadgetImage := fmt.Sprintf("%s/snapshot_process:%s", *gadgetRepository, *gadgetTag)
+
+	cleanupCommands := []TestStep{
+		&Command{
+			Name:    "Delete detached gadget instance",
+			Cmd:     fmt.Sprintf("%s --auth-service-account=%s/ig-client delete %s || true", q(kubectlGadget), teamA, q(instanceName)),
+			Cleanup: true,
+		},
+		&Command{
+			Name: "Restore non-multi-tenant Inspektor Gadget",
+			Cmd: fmt.Sprintf(`ig_image="$(kubectl -n gadget get daemonset gadget -o jsonpath='{.spec.template.spec.containers[0].image}')"
+%[1]s undeploy || true
+%[1]s deploy --experimental --debug \
+  --image="$ig_image" \
+  --image-pull-policy=IfNotPresent \
+  --set-daemon-config=operator.oci.verify-image=false`,
+				q(kubectlGadget),
+			),
+			Cleanup: true,
+		},
+		&Command{
+			Name:    "Delete auth delegator binding",
+			Cmd:     "kubectl delete clusterrolebinding gadget-multitenancy-test-auth-delegator --ignore-not-found",
+			Cleanup: true,
+		},
+		DeleteTestNamespaceCommand(teamA),
+		DeleteTestNamespaceCommand(teamB),
+	}
+	t.Cleanup(func() {
+		RunTestSteps(cleanupCommands, t)
+	})
+
+	commands := []TestStep{
+		&Command{
+			Name: "Deploy Inspektor Gadget with TokenReview",
+			Cmd: fmt.Sprintf(`ig_image="$(kubectl -n gadget get daemonset gadget -o jsonpath='{.spec.template.spec.containers[0].image}')"
+%[1]s undeploy || true
+%[1]s deploy --experimental --debug \
+  --image="$ig_image" \
+  --image-pull-policy=IfNotPresent \
+  --set-daemon-config=operator.oci.verify-image=false \
+  --set-daemon-config=multi-tenancy=true
+kubectl create clusterrolebinding gadget-multitenancy-test-auth-delegator \
+  --clusterrole=system:auth-delegator \
+  --serviceaccount=gadget:gadget \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout status daemonset/gadget -n gadget --timeout=120s`,
+				q(kubectlGadget),
+			),
+		},
+		CreateTestNamespaceCommand(teamA),
+		CreateTestNamespaceCommand(teamB),
+		multiTenancyRBACCommand(teamA),
+		multiTenancyRBACCommand(teamB),
+		&Command{
+			Name: "Team A can run in team A namespace",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s -n %s --timeout=5 -o json",
+				q(kubectlGadget), teamA, q(gadgetImage), q(teamA)),
+		},
+		&Command{
+			Name: "Team A cannot run in team B namespace",
+			Cmd: fmt.Sprintf(`if %s --auth-service-account=%s/ig-client run %s -n %s --timeout=5; then
+  echo "team A unexpectedly ran a gadget in team B namespace"
+  exit 1
+fi`,
+				q(kubectlGadget), teamA, q(gadgetImage), q(teamB)),
+		},
+		&Command{
+			Name: "Team A all-namespaces request is narrowed to team A",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s -A --timeout=5 -o json",
+				q(kubectlGadget), teamA, q(gadgetImage)),
+		},
+		&Command{
+			Name: "Team A can install a detached gadget in team A namespace",
+			Cmd: fmt.Sprintf("%s --auth-service-account=%s/ig-client run %s --detach --name %s -n %s",
+				q(kubectlGadget), teamA, q(gadgetImage), q(instanceName), q(teamA)),
+		},
+		&Command{
+			Name: "Team B cannot list team A detached gadget",
+			Cmd: fmt.Sprintf(`if %s --auth-service-account=%s/ig-client list | grep -F %s; then
+  echo "team B unexpectedly listed team A detached gadget"
+  exit 1
+fi`,
+				q(kubectlGadget), teamB, q(instanceName)),
+		},
+		&Command{
+			Name: "Team B cannot delete team A detached gadget",
+			Cmd: fmt.Sprintf(`instance_id=$(%[1]s --auth-service-account=%[2]s/ig-client show %[3]s | awk '$1 == "ID:" {print $2}')
+if [ -z "$instance_id" ]; then
+  echo "failed to resolve team A gadget instance ID"
+  exit 1
+fi
+set +e
+delete_output=$(%[1]s --auth-service-account=%[4]s/ig-client delete "$instance_id" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "team B unexpectedly deleted team A detached gadget"
+  exit 1
+fi
+if ! printf '%%s\n' "$delete_output" | grep -F "code = PermissionDenied"; then
+  echo "delete failed without PermissionDenied: $delete_output"
+  exit 1
+fi
+%[1]s --auth-service-account=%[2]s/ig-client show "$instance_id" >/dev/null`,
+				q(kubectlGadget), teamA, q(instanceName), teamB),
+		},
+		&Command{
+			Name: "Team A can attach to its detached gadget",
+			Cmd: fmt.Sprintf(`set +e
+timeout 10s %s --auth-service-account=%s/ig-client attach %s
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+  exit "$rc"
+fi`,
+				q(kubectlGadget), teamA, q(instanceName)),
+		},
+		&Command{
+			Name: "Team B cannot attach to team A detached gadget",
+			Cmd: fmt.Sprintf(`instance_id=$(%[1]s --auth-service-account=%[2]s/ig-client show %[3]s | awk '$1 == "ID:" {print $2}')
+if [ -z "$instance_id" ]; then
+  echo "failed to resolve team A gadget instance ID"
+  exit 1
+fi
+set +e
+attach_output=$(timeout 10s %[1]s --auth-service-account=%[4]s/ig-client attach "$instance_id" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ]; then
+  echo "team B unexpectedly attached to team A detached gadget"
+  exit 1
+fi
+if ! printf '%%s\n' "$attach_output" | grep -F "code = PermissionDenied"; then
+  echo "attach failed without PermissionDenied: $attach_output"
+  exit 1
+fi`,
+				q(kubectlGadget), teamA, q(instanceName), teamB),
+		},
+	}
+
+	RunTestSteps(commands, t, WithCbBeforeCleanup(PrintLogsFn("gadget", teamA, teamB)))
+}
+
+func multiTenancyRBACCommand(namespace string) *Command {
+	cmd := fmt.Sprintf(`kubectl apply -f - <<"EOF"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ig-client
+  namespace: %[1]s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-creator
+  namespace: %[1]s
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ig-client-pod-creator
+  namespace: %[1]s
+subjects:
+- kind: ServiceAccount
+  name: ig-client
+  namespace: %[1]s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-creator
+EOF`, namespace)
+
+	return &Command{
+		Name: fmt.Sprintf("Create team RBAC in %s", namespace),
+		Cmd:  cmd,
+	}
+}
+
+func q(s string) string {
+	return strconv.Quote(s)
+}

--- a/pkg/config/gadgettracermanagerconfig/config.go
+++ b/pkg/config/gadgettracermanagerconfig/config.go
@@ -39,6 +39,11 @@ const (
 
 	OtelMetricsListen        = "otel-metrics-listen"
 	OtelMetricsListenAddress = "otel-metrics-listen-address"
+
+	MultiTenancy              = "multi-tenancy"
+	MultiTenancyScopeAPIGroup = "multi-tenancy-scope-api-group"
+	MultiTenancyScopeResource = "multi-tenancy-scope-resource"
+	MultiTenancyScopeVerb     = "multi-tenancy-scope-verb"
 )
 
 func Init() error {
@@ -46,6 +51,10 @@ func Init() error {
 
 	config.Config.SetDefault(EventsBufferLengthKey, 16384)
 	config.Config.SetDefault(DaemonLogLevel, "info")
+	config.Config.SetDefault(MultiTenancy, false)
+	config.Config.SetDefault(MultiTenancyScopeAPIGroup, "")
+	config.Config.SetDefault(MultiTenancyScopeResource, "pods")
+	config.Config.SetDefault(MultiTenancyScopeVerb, "create")
 
 	err := config.Config.ReadInConfig()
 	if err != nil {
@@ -77,7 +86,8 @@ func FullKeyPath(key string) string {
 func isRootKey(key string) bool {
 	switch key {
 	case EventsBufferLengthKey, ContainerdSocketPath, CrioSocketPath, DockerSocketPath,
-		PodmanSocketPath, GadgetNamespace, DaemonLogLevel:
+		PodmanSocketPath, GadgetNamespace, DaemonLogLevel, MultiTenancy,
+		MultiTenancyScopeAPIGroup, MultiTenancyScopeResource, MultiTenancyScopeVerb:
 		return true
 	default:
 		return false

--- a/pkg/gadget-service/auth/tokenreview.go
+++ b/pkg/gadget-service/auth/tokenreview.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth authenticates gadget service requests with Kubernetes.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	authv1 "k8s.io/api/authentication/v1"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+const Audience = "inspektor-gadget"
+
+const authorizationHeader = "authorization"
+
+type ScopeConfig struct {
+	APIGroup string
+	Resource string
+	Verb     string
+}
+
+func DefaultScopeConfig() ScopeConfig {
+	return ScopeConfig{Resource: "pods", Verb: "create"}
+}
+
+type PolicyScope struct {
+	// A nil slice means namespace policy is disabled. A non-nil empty slice
+	// means the caller is authenticated but has no authorized namespaces.
+	AllowedNamespaces []string
+}
+
+type policyScopeContextKey struct{}
+
+func ContextWithPolicyScope(ctx context.Context, scope PolicyScope) context.Context {
+	return context.WithValue(ctx, policyScopeContextKey{}, scope)
+}
+
+func WithoutPolicyScope(ctx context.Context) context.Context {
+	// Shadow any scope inherited from ctx while gadget metadata is inspected.
+	return context.WithValue(ctx, policyScopeContextKey{}, PolicyScope{})
+}
+
+func PolicyScopeFromContext(ctx context.Context) (PolicyScope, bool) {
+	scope, ok := ctx.Value(policyScopeContextKey{}).(PolicyScope)
+	return scope, ok && scope.AllowedNamespaces != nil
+}
+
+func extractBearer(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	for _, value := range md.Get(authorizationHeader) {
+		scheme, token, ok := strings.Cut(value, " ")
+		if ok && strings.EqualFold(scheme, "bearer") && token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func allowedNamespaces(ctx context.Context, client kubernetes.Interface, user authv1.UserInfo, scope ScopeConfig) ([]string, error) {
+	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing namespaces: %w", err)
+	}
+
+	// Kubernetes has no bulk SubjectAccessReview, so resolve the configured
+	// permission independently for each namespace and fail closed on errors.
+	allowed := make([]string, 0, len(namespaces.Items))
+	for _, namespace := range namespaces.Items {
+		review, err := client.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User:   user.Username,
+				UID:    user.UID,
+				Groups: user.Groups,
+				Extra:  convertExtra(user.Extra),
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Namespace: namespace.Name,
+					Verb:      scope.Verb,
+					Group:     scope.APIGroup,
+					Resource:  scope.Resource,
+				},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("reviewing namespace %q: %w", namespace.Name, err)
+		}
+		if review.Status.Allowed {
+			allowed = append(allowed, namespace.Name)
+		}
+	}
+	return allowed, nil
+}
+
+func convertExtra(extra map[string]authv1.ExtraValue) map[string]authzv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	converted := make(map[string]authzv1.ExtraValue, len(extra))
+	for key, value := range extra {
+		converted[key] = authzv1.ExtraValue(value)
+	}
+	return converted
+}
+
+func authenticate(ctx context.Context, client kubernetes.Interface, log logger.Logger, method string, scope ScopeConfig) (context.Context, error) {
+	token := extractBearer(ctx)
+	if token == "" {
+		return ctx, status.Error(codes.Unauthenticated, "missing bearer token")
+	}
+	// Restrict TokenReview to the gadget audience so ordinary ServiceAccount
+	// tokens cannot be replayed against this service.
+	review, err := client.AuthenticationV1().TokenReviews().Create(ctx, &authv1.TokenReview{
+		Spec: authv1.TokenReviewSpec{
+			Token:     token,
+			Audiences: []string{Audience},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return ctx, status.Errorf(codes.Unavailable, "token review failed: %v", err)
+	}
+	if !review.Status.Authenticated {
+		return ctx, status.Error(codes.Unauthenticated, "token was not authenticated")
+	}
+
+	allowed, err := allowedNamespaces(ctx, client, review.Status.User, scope)
+	if err != nil {
+		return ctx, status.Errorf(codes.Unavailable, "resolving namespace access: %v", err)
+	}
+	log.Debugf("auth: %s: user=%q allowedNamespaces=%v", method, review.Status.User.Username, allowed)
+	return ContextWithPolicyScope(ctx, PolicyScope{AllowedNamespaces: allowed}), nil
+}
+
+func UnaryInterceptor(client kubernetes.Interface, log logger.Logger, scope ScopeConfig) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx, err := authenticate(ctx, client, log, info.FullMethod, scope)
+		if err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func StreamInterceptor(client kubernetes.Interface, log logger.Logger, scope ScopeConfig) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx, err := authenticate(stream.Context(), client, log, info.FullMethod, scope)
+		if err != nil {
+			return err
+		}
+		return handler(srv, &serverStreamWithContext{ServerStream: stream, ctx: ctx})
+	}
+}
+
+type serverStreamWithContext struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *serverStreamWithContext) Context() context.Context {
+	// gRPC stream handlers read their context from the stream rather than from
+	// a separate argument, so preserve the authenticated scope in this wrapper.
+	return s.ctx
+}

--- a/pkg/gadget-service/auth/tokenreview_test.go
+++ b/pkg/gadget-service/auth/tokenreview_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	authv1 "k8s.io/api/authentication/v1"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+func TestExtractBearer(t *testing.T) {
+	for _, test := range []struct {
+		header string
+		want   string
+	}{
+		{"Bearer token", "token"},
+		{"bEaReR token", "token"},
+		{"Basic token", ""},
+		{"Bearer ", ""},
+	} {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(authorizationHeader, test.header))
+		assert.Equal(t, test.want, extractBearer(ctx))
+	}
+}
+
+func TestAuthenticateAddsPolicyScope(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-b"}},
+	)
+	client.PrependReactor("create", "tokenreviews", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenReview{Status: authv1.TokenReviewStatus{
+			Authenticated: true,
+			User:          authv1.UserInfo{Username: "tenant"},
+		}}, nil
+	})
+	client.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authzv1.SubjectAccessReview)
+		assert.Equal(t, "create", review.Spec.ResourceAttributes.Verb)
+		return true, &authzv1.SubjectAccessReview{Status: authzv1.SubjectAccessReviewStatus{
+			Allowed: review.Spec.ResourceAttributes.Namespace == "team-a",
+		}}, nil
+	})
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(authorizationHeader, "Bearer token"))
+	ctx, err := authenticate(ctx, client, logger.DefaultLogger(), "test", DefaultScopeConfig())
+	require.NoError(t, err)
+	scope, ok := PolicyScopeFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, []string{"team-a"}, scope.AllowedNamespaces)
+}
+
+func TestAuthenticateRequiresToken(t *testing.T) {
+	_, err := authenticate(context.Background(), fake.NewSimpleClientset(), logger.DefaultLogger(), "test", DefaultScopeConfig())
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}

--- a/pkg/gadget-service/instance-manager/instance.go
+++ b/pkg/gadget-service/instance-manager/instance.go
@@ -17,6 +17,7 @@ package instancemanager
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -78,6 +79,12 @@ func (p *GadgetInstance) GadgetInfo() (*api.GadgetInfo, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.gadgetInfo, p.error
+}
+
+func (p *GadgetInstance) ParamValues() api.ParamValues {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return maps.Clone(p.request.ParamValues)
 }
 
 func (p *GadgetInstance) AddClient(client api.GadgetManager_RunGadgetServer) chan struct{} {

--- a/pkg/gadget-service/service-oci.go
+++ b/pkg/gadget-service/service-oci.go
@@ -30,8 +30,10 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
+	kubemanagerpolicy "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/policy"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/simple"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 )
@@ -79,6 +81,9 @@ func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoReque
 		if gi == nil {
 			return nil, fmt.Errorf("instance %s not found", req.ImageName)
 		}
+		if err := kubemanagerpolicy.AuthorizeParamValues(ctx, gi.ParamValues()); err != nil {
+			return nil, err
+		}
 		gadgetInfo, err := gi.GadgetInfo()
 		if err != nil {
 			return nil, err
@@ -92,8 +97,10 @@ func (s *Service) GetGadgetInfo(ctx context.Context, req *api.GetGadgetInfoReque
 		ops = append(ops, op)
 	}
 
+	// Image metadata is not namespace-scoped, and final namespace parameters are
+	// unavailable while the client discovers the gadget's parameters.
 	gadgetCtx := gadgetcontext.New(
-		ctx,
+		auth.WithoutPolicyScope(ctx),
 		req.ImageName,
 		gadgetcontext.WithDataOperators(ops...),
 		gadgetcontext.WithAsRemoteCall(true),
@@ -120,6 +127,13 @@ func (s *Service) RunGadget(runGadget api.GadgetManager_RunGadgetServer) error {
 		}
 		if s.instanceMgr == nil {
 			return errors.New("instance manager not initialized")
+		}
+		gi := s.instanceMgr.LookupInstance(attachRequest.Id)
+		if gi == nil {
+			return fmt.Errorf("instance %s not found", attachRequest.Id)
+		}
+		if err := kubemanagerpolicy.AuthorizeParamValues(runGadget.Context(), gi.ParamValues()); err != nil {
+			return err
 		}
 
 		s.ctrAttachGadget.Add(context.Background(), 1)

--- a/pkg/gadget-service/service-store.go
+++ b/pkg/gadget-service/service-store.go
@@ -20,9 +20,20 @@ import (
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/namesgenerator"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	kubemanagerpolicy "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/policy"
 )
 
 func (s *Service) CreateGadgetInstance(ctx context.Context, request *api.CreateGadgetInstanceRequest) (*api.CreateGadgetInstanceResponse, error) {
+	if request.GadgetInstance == nil || request.GadgetInstance.GadgetConfig == nil {
+		return nil, fmt.Errorf("missing gadget instance configuration")
+	}
+	if request.GadgetInstance.GadgetConfig.ParamValues == nil {
+		request.GadgetInstance.GadgetConfig.ParamValues = api.ParamValues{}
+	}
+	if err := kubemanagerpolicy.EnforcePolicyScopeOnParamValues(ctx, request.GadgetInstance.GadgetConfig.ParamValues); err != nil {
+		return nil, err
+	}
+
 	// Create random ID if not set by the client
 	if request.GadgetInstance.Id == "" {
 		var err error
@@ -49,13 +60,19 @@ func (s *Service) ListGadgetInstances(ctx context.Context, request *api.ListGadg
 	if err != nil {
 		return nil, fmt.Errorf("listing gadget instances: %w", err)
 	}
+	visible := resp.GadgetInstances[:0]
 	for _, gi := range resp.GadgetInstances {
+		if err := authorizeGadgetInstance(ctx, gi); err != nil {
+			continue
+		}
 		st, err := s.instanceMgr.InstanceState(gi.Id)
 		if err != nil {
 			return nil, fmt.Errorf("getting instance status for %q: %w", gi.Id, err)
 		}
 		gi.State = st
+		visible = append(visible, gi)
 	}
+	resp.GadgetInstances = visible
 	return resp, nil
 }
 
@@ -66,6 +83,9 @@ func (s *Service) GetGadgetInstance(ctx context.Context, id *api.GadgetInstanceI
 	gi, err := s.store.GetGadgetInstance(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting gadget instance from store: %w", err)
+	}
+	if err := authorizeGadgetInstance(ctx, gi); err != nil {
+		return nil, err
 	}
 	st, err := s.instanceMgr.InstanceState(gi.Id)
 	if err != nil {
@@ -79,5 +99,19 @@ func (s *Service) RemoveGadgetInstance(ctx context.Context, id *api.GadgetInstan
 	if !api.IsValidInstanceID(id.Id) {
 		return nil, fmt.Errorf("invalid gadget instance id: %s", id.Id)
 	}
+	gi, err := s.store.GetGadgetInstance(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("getting gadget instance from store: %w", err)
+	}
+	if err := authorizeGadgetInstance(ctx, gi); err != nil {
+		return nil, err
+	}
 	return s.store.RemoveGadgetInstance(ctx, id)
+}
+
+func authorizeGadgetInstance(ctx context.Context, instance *api.GadgetInstance) error {
+	if instance == nil || instance.GadgetConfig == nil {
+		return fmt.Errorf("missing gadget instance configuration")
+	}
+	return kubemanagerpolicy.AuthorizeParamValues(ctx, instance.GadgetConfig.ParamValues)
 }

--- a/pkg/gadget-service/service.go
+++ b/pkg/gadget-service/service.go
@@ -26,11 +26,13 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/inspektor-gadget/inspektor-gadget/internal/version"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
 	instancemanager "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/instance-manager"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/store"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
@@ -53,6 +55,15 @@ type RunConfig struct {
 	// If SocketGID != 0 and a unix socket is used, the ownership of that socket
 	// will be changed to the given SocketGID
 	SocketGID int
+
+	// MultiTenancy enables Kubernetes authentication and namespace isolation.
+	MultiTenancy bool
+
+	// KubernetesClient is used for TokenReview and SubjectAccessReview.
+	KubernetesClient kubernetes.Interface
+
+	// MultiTenancyScope defines the namespace permission checked by Kubernetes.
+	MultiTenancyScope auth.ScopeConfig
 }
 
 type Service struct {
@@ -211,6 +222,24 @@ func (s *Service) Run(runConfig RunConfig, serverOptions ...grpc.ServerOption) e
 		s.listener = listener
 	default:
 		return fmt.Errorf("invalid socket type: %s", runConfig.SocketType)
+	}
+
+	if runConfig.MultiTenancy {
+		if runConfig.KubernetesClient == nil {
+			return fmt.Errorf("multi-tenancy enabled but no Kubernetes client provided")
+		}
+		scope := runConfig.MultiTenancyScope
+		if scope.Resource == "" {
+			scope = auth.DefaultScopeConfig()
+		}
+		if scope.Verb == "" {
+			return fmt.Errorf("multi-tenancy scope verb cannot be empty")
+		}
+		s.logger.Infof("multi-tenancy enabled (audience=%q, scope=%s/%s/%s)", auth.Audience, scope.APIGroup, scope.Resource, scope.Verb)
+		serverOptions = append(serverOptions,
+			grpc.UnaryInterceptor(auth.UnaryInterceptor(runConfig.KubernetesClient, s.logger, scope)),
+			grpc.StreamInterceptor(auth.StreamInterceptor(runConfig.KubernetesClient, s.logger, scope)),
+		)
 	}
 
 	server := grpc.NewServer(serverOptions...)

--- a/pkg/operators/kubemanager/kubemanager.go
+++ b/pkg/operators/kubemanager/kubemanager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cilium/ebpf"
@@ -27,20 +28,24 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource/compat"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	apihelpers "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api-helpers"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
 	hookservice "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/hook-service"
 	hookserviceapi "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/hook-service/api"
+	kubemanagerpolicy "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/policy"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/params"
 	tracercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/tracer-collection"
@@ -55,8 +60,10 @@ const (
 	ParamHookLivenessSocketFile = "hook-liveness-socketfile"
 
 	// Instance parameter keys
-	ParamAllNamespaces = "all-namespaces"
+	ParamAllNamespaces = kubemanagerpolicy.ParamAllNamespaces
 )
+
+const paramPolicyScope = kubemanagerpolicy.ParamPolicyScope
 
 type MountNsMapSetter interface {
 	SetMountNsMap(*ebpf.Map)
@@ -460,8 +467,21 @@ func (k *KubeManager) InstantiateDataOperator(gadgetCtx operators.GadgetContext,
 		activate = true
 	}
 
+	_, hasPolicyScope := auth.PolicyScopeFromContext(gadgetCtx.Context())
+	policyRequired := hasPolicyScope || strings.EqualFold(paramValues[paramPolicyScope], "true")
 	if !activate {
+		if policyRequired {
+			return nil, status.Error(codes.PermissionDenied, "gadget does not support Kubernetes namespace isolation")
+		}
 		return nil, nil
+	}
+
+	if err := kubemanagerpolicy.EnforcePolicyScopeFromContext(gadgetCtx.Context(), paramValues); err != nil {
+		return nil, err
+	}
+	delete(paramValues, paramPolicyScope)
+	if err := params.CopyFromMap(paramValues, ""); err != nil {
+		return nil, err
 	}
 
 	return traceInstance, nil

--- a/pkg/operators/kubemanager/policy/policy.go
+++ b/pkg/operators/kubemanager/policy/policy.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
+)
+
+const (
+	ParamAllNamespaces  = "all-namespaces"
+	ParamPolicyScope    = "multi-tenancy-policy"
+	operatorParamPrefix = "operator.KubeManager."
+)
+
+func requestedNamespaces(values api.ParamValues, prefix string) ([]string, bool, error) {
+	if strings.EqualFold(values[prefix+ParamAllNamespaces], "true") {
+		return nil, true, nil
+	}
+	namespace := values[prefix+common.ParamNamespace]
+	if namespace == "" {
+		namespace = values[prefix+common.ParamK8sNamespace]
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	if strings.Contains(namespace, "!") {
+		return nil, false, status.Errorf(codes.InvalidArgument, "namespace exclusions are not supported in multi-tenancy mode: %q", namespace)
+	}
+	namespaces := strings.Split(namespace, ",")
+	for i := range namespaces {
+		namespaces[i] = strings.TrimSpace(namespaces[i])
+		if namespaces[i] == "" {
+			return nil, false, status.Errorf(codes.InvalidArgument, "invalid namespace filter %q", namespace)
+		}
+	}
+	return namespaces, false, nil
+}
+
+func authorizeNamespaces(scope auth.PolicyScope, namespaces []string) error {
+	if len(scope.AllowedNamespaces) == 0 {
+		return status.Error(codes.PermissionDenied, "no Kubernetes namespaces are authorized for this request")
+	}
+	for _, namespace := range namespaces {
+		if !slices.Contains(scope.AllowedNamespaces, namespace) {
+			return status.Error(codes.PermissionDenied, "requested Kubernetes namespace is not authorized")
+		}
+	}
+	return nil
+}
+
+func enforcePolicyScope(scope auth.PolicyScope, values api.ParamValues, prefix string) error {
+	namespaces, all, err := requestedNamespaces(values, prefix)
+	if err != nil {
+		return err
+	}
+	if all {
+		namespaces = scope.AllowedNamespaces
+	}
+	if err := authorizeNamespaces(scope, namespaces); err != nil {
+		return err
+	}
+	values[prefix+ParamAllNamespaces] = "false"
+	values[prefix+common.ParamNamespace] = strings.Join(namespaces, ",")
+	values[prefix+ParamPolicyScope] = "true"
+	delete(values, prefix+common.ParamK8sNamespace)
+	return nil
+}
+
+func EnforcePolicyScopeOnParamValues(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return enforcePolicyScope(scope, values, operatorParamPrefix)
+}
+
+func EnforcePolicyScopeFromContext(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return enforcePolicyScope(scope, values, "")
+}
+
+func AuthorizeParamValues(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	namespaces, all, err := requestedNamespaces(values, operatorParamPrefix)
+	if err != nil {
+		return err
+	}
+	if all {
+		return status.Error(codes.PermissionDenied, "all-namespaces gadget instances are not allowed in multi-tenancy mode")
+	}
+	return authorizeNamespaces(scope, namespaces)
+}

--- a/pkg/operators/kubemanager/policy/policy.go
+++ b/pkg/operators/kubemanager/policy/policy.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/operators/common"
+)
+
+const (
+	ParamAllNamespaces  = "all-namespaces"
+	ParamPolicyScope    = "multi-tenancy-policy"
+	operatorParamPrefix = "operator.KubeManager."
+)
+
+func requestedNamespaces(values api.ParamValues, prefix string) ([]string, bool, error) {
+	if strings.EqualFold(values[prefix+ParamAllNamespaces], "true") {
+		return nil, true, nil
+	}
+	namespace := values[prefix+common.ParamNamespace]
+	if namespace == "" {
+		namespace = values[prefix+common.ParamK8sNamespace]
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	if strings.Contains(namespace, "!") {
+		return nil, false, status.Errorf(codes.InvalidArgument, "namespace exclusions are not supported in multi-tenancy mode: %q", namespace)
+	}
+	namespaces := strings.Split(namespace, ",")
+	for i := range namespaces {
+		namespaces[i] = strings.TrimSpace(namespaces[i])
+		if namespaces[i] == "" {
+			return nil, false, status.Errorf(codes.InvalidArgument, "invalid namespace filter %q", namespace)
+		}
+	}
+	return namespaces, false, nil
+}
+
+func authorizeNamespaces(scope auth.PolicyScope, namespaces []string) error {
+	if len(scope.AllowedNamespaces) == 0 {
+		return status.Error(codes.PermissionDenied, "no Kubernetes namespaces are authorized for this request")
+	}
+	for _, namespace := range namespaces {
+		if !slices.Contains(scope.AllowedNamespaces, namespace) {
+			return status.Errorf(codes.PermissionDenied, "requested Kubernetes namespace %q is not authorized", namespace)
+		}
+	}
+	return nil
+}
+
+func enforcePolicyScope(scope auth.PolicyScope, values api.ParamValues, prefix string) error {
+	namespaces, all, err := requestedNamespaces(values, prefix)
+	if err != nil {
+		return err
+	}
+	if all {
+		namespaces = scope.AllowedNamespaces
+	}
+	if err := authorizeNamespaces(scope, namespaces); err != nil {
+		return err
+	}
+	values[prefix+ParamAllNamespaces] = "false"
+	values[prefix+common.ParamNamespace] = strings.Join(namespaces, ",")
+	values[prefix+ParamPolicyScope] = "true"
+	delete(values, prefix+common.ParamK8sNamespace)
+	return nil
+}
+
+func EnforcePolicyScopeOnParamValues(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return enforcePolicyScope(scope, values, operatorParamPrefix)
+}
+
+func EnforcePolicyScopeFromContext(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return enforcePolicyScope(scope, values, "")
+}
+
+func AuthorizeParamValues(ctx context.Context, values api.ParamValues) error {
+	scope, ok := auth.PolicyScopeFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	namespaces, all, err := requestedNamespaces(values, operatorParamPrefix)
+	if err != nil {
+		return err
+	}
+	if all {
+		return status.Error(codes.PermissionDenied, "all-namespaces gadget instances are not allowed in multi-tenancy mode")
+	}
+	if err := authorizeNamespaces(scope, namespaces); err != nil {
+		return status.Error(codes.PermissionDenied, "gadget instance is not authorized")
+	}
+	return nil
+}

--- a/pkg/operators/kubemanager/policy_test.go
+++ b/pkg/operators/kubemanager/policy_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/auth"
+	kubemanagerpolicy "github.com/inspektor-gadget/inspektor-gadget/pkg/operators/kubemanager/policy"
+)
+
+func policyContext(namespaces ...string) context.Context {
+	return auth.ContextWithPolicyScope(context.Background(), auth.PolicyScope{AllowedNamespaces: namespaces})
+}
+
+func TestEnforcePolicyScopeOnParamValues(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		allowed  []string
+		values   api.ParamValues
+		want     string
+		wantErr  bool
+		noPolicy bool
+	}{
+		{
+			name:    "all namespaces becomes allowed namespaces",
+			allowed: []string{"team-a", "team-b"},
+			values:  api.ParamValues{"operator.KubeManager.all-namespaces": "true"},
+			want:    "team-a,team-b",
+		},
+		{
+			name:    "allowed list is preserved",
+			allowed: []string{"team-a", "team-b"},
+			values:  api.ParamValues{"operator.KubeManager.namespace": "team-b,team-a"},
+			want:    "team-b,team-a",
+		},
+		{
+			name:    "unauthorized namespace",
+			allowed: []string{"team-a"},
+			values:  api.ParamValues{"operator.KubeManager.namespace": "team-b"},
+			want:    "team-b",
+			wantErr: true,
+		},
+		{
+			name:    "exclusion is rejected",
+			allowed: []string{"team-a"},
+			values:  api.ParamValues{"operator.KubeManager.namespace": "!team-b"},
+			want:    "!team-b",
+			wantErr: true,
+		},
+		{
+			name:     "disabled policy preserves values",
+			values:   api.ParamValues{},
+			noPolicy: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := policyContext(test.allowed...)
+			if test.noPolicy {
+				ctx = context.Background()
+			}
+			err := kubemanagerpolicy.EnforcePolicyScopeOnParamValues(ctx, test.values)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.want, test.values["operator.KubeManager.namespace"])
+			if !test.wantErr && !test.noPolicy {
+				assert.Equal(t, "true", test.values["operator.KubeManager."+kubemanagerpolicy.ParamPolicyScope])
+			}
+		})
+	}
+}
+
+func TestAuthorizeParamValues(t *testing.T) {
+	values := api.ParamValues{"operator.KubeManager.namespace": "team-a"}
+	require.NoError(t, kubemanagerpolicy.AuthorizeParamValues(policyContext("team-a"), values))
+	err := kubemanagerpolicy.AuthorizeParamValues(policyContext("team-b"), values)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.NotContains(t, err.Error(), "team-a")
+}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -31,6 +31,10 @@ data:
       podman-socketpath: /run/podman/podman.sock
       gadget-namespace: gadget
       daemon-log-level: info
+      multi-tenancy: false
+      multi-tenancy-scope-api-group: ""
+      multi-tenancy-scope-resource: pods
+      multi-tenancy-scope-verb: create
       operator:
         kubemanager:
           fallback-podinformer: true

--- a/pkg/runtime/grpc/auth.go
+++ b/pkg/runtime/grpc/auth.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcruntime
+
+import "context"
+
+type bearerCreds struct {
+	token         string
+	allowInsecure bool
+}
+
+func (b *bearerCreds) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + b.token}, nil
+}
+
+func (b *bearerCreds) RequireTransportSecurity() bool { return !b.allowInsecure }

--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -87,6 +87,7 @@ type Runtime struct {
 	globalParams   *params.Params
 	restConfig     *rest.Config
 	connectionMode ConnectionMode
+	authToken      string
 }
 
 type RunClient interface {
@@ -370,12 +371,23 @@ func (r *Runtime) getConnFromTarget(ctx context.Context, runtimeParams *params.P
 	return conn, nil
 }
 
+func (r *Runtime) SetAuthToken(token string) {
+	r.authToken = token
+}
+
 func (r *Runtime) dialContext(dialCtx context.Context, target target, timeout time.Duration) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
 		//nolint:staticcheck
 		grpc.WithBlock(),
 		//nolint:staticcheck
 		grpc.WithReturnConnectionError(),
+	}
+
+	if r.authToken != "" {
+		opts = append(opts, grpc.WithPerRPCCredentials(&bearerCreds{
+			token:         r.authToken,
+			allowInsecure: r.connectionMode == ConnectionModeKubernetesProxy,
+		}))
 	}
 
 	tlsKey := r.globalParams.Get(ParamTLSKey).String()


### PR DESCRIPTION
This adds Kubernetes-authenticated namespace isolation so tenants can run and manage
gadgets only in namespaces authorized by RBAC.

## Summary

- mint audience-scoped ServiceAccount tokens in `kubectl-gadget`
- authenticate with TokenReview and resolve namespace access with SubjectAccessReview
- constrain KubeManager before collection and protect every detached-instance operation
- add opt-in Helm configuration, RBAC, an end-to-end test, and architecture documentation

## Security model

The namespace is the tenant boundary. Unsupported host-wide gadgets and
namespace exclusions fail closed. Users in the same namespace can share
detached instances.

## Validation

- targeted Go tests and daemon/integration compilation
- `kubectl-gadget` build
- Helm rendering with multi-tenancy disabled and enabled
- minikube end-to-end coverage for allowed, denied, all-namespace, and
  detached list/delete/attach paths

## Manual testing

Set `IG_IMAGE` to a gadget container image built from this branch. The commands
below assume the current kubeconfig identity can deploy Inspektor Gadget,
create RBAC resources, and mint ServiceAccount tokens.

```sh
KG=./kubectl-gadget
IG_IMAGE=<registry>/inspektor-gadget:<branch-tag>
GADGET_IMAGE=ghcr.io/inspektor-gadget/gadget/snapshot_process:latest

make kubectl-gadget

"$KG" deploy --experimental \
  --image="$IG_IMAGE" \
  --image-pull-policy=IfNotPresent \
  --set-daemon-config=operator.oci.verify-image=false \
  --set-daemon-config=multi-tenancy=true

kubectl create clusterrolebinding gadget-manual-auth-delegator \
  --clusterrole=system:auth-delegator \
  --serviceaccount=gadget:gadget \
  --dry-run=client -o yaml | kubectl apply -f -
```

Create Team A and Team B. Each identity can create pods only in its own
namespace:

```sh
kubectl create namespace team-a
kubectl create namespace team-b

kubectl -n team-a create serviceaccount ig-client
kubectl -n team-a create role ig-tenant --verb=create --resource=pods
kubectl -n team-a create rolebinding ig-client \
  --role=ig-tenant \
  --serviceaccount=team-a:ig-client

kubectl -n team-b create serviceaccount ig-client
kubectl -n team-b create role ig-tenant --verb=create --resource=pods
kubectl -n team-b create rolebinding ig-client \
  --role=ig-tenant \
  --serviceaccount=team-b:ig-client

kubectl -n team-a run workload --image=busybox:1.36 --restart=Never \
  -- sh -c 'sleep 3600'
kubectl -n team-b run workload --image=busybox:1.36 --restart=Never \
  -- sh -c 'sleep 3600'
kubectl wait -n team-a --for=condition=Ready pod/workload --timeout=60s
kubectl wait -n team-b --for=condition=Ready pod/workload --timeout=60s
```

Team A can inspect its namespace. Access to Team B is denied, and
`--all-namespaces` is narrowed to Team A's authorized namespace:

```sh
"$KG" --auth-service-account=team-a/ig-client \
  run "$GADGET_IMAGE" -n team-a --timeout=5

# Expected: PermissionDenied.
"$KG" --auth-service-account=team-a/ig-client \
  run "$GADGET_IMAGE" -n team-b --timeout=5

# Expected: output from team-a only.
"$KG" --auth-service-account=team-a/ig-client \
  run "$GADGET_IMAGE" --all-namespaces --timeout=5
```

Create a detached Team A gadget and verify Team B cannot discover, attach to,
or delete it:

```sh
"$KG" --auth-service-account=team-a/ig-client \
  run "$GADGET_IMAGE" --detach --name team-a-snapshot -n team-a

INSTANCE_ID=$("$KG" --auth-service-account=team-a/ig-client \
  show team-a-snapshot | awk '$1 == "ID:" {print $2}')

# Expected: team-a-snapshot is absent.
"$KG" --auth-service-account=team-b/ig-client list

# Expected: both commands fail; delete returns PermissionDenied.
"$KG" --auth-service-account=team-b/ig-client attach "$INSTANCE_ID"
"$KG" --auth-service-account=team-b/ig-client delete "$INSTANCE_ID"

# Team A still owns the instance and can remove it.
"$KG" --auth-service-account=team-a/ig-client show "$INSTANCE_ID"
"$KG" --auth-service-account=team-a/ig-client delete "$INSTANCE_ID"
```

Clean up:

```sh
kubectl delete namespace team-a team-b
kubectl delete clusterrolebinding gadget-manual-auth-delegator
"$KG" undeploy
```

The integration test automates the same story and reuses the daemon image from
the existing deployment:

```sh
INTEGRATION_TESTS_PARAMS="-run '^TestMultiTenancyTokenReviewNamespacePolicy$'" make integration-tests
```

Focused unit tests can be run with:

```sh
go test ./cmd/kubectl-gadget/auth ./pkg/gadget-service/auth ./pkg/operators/kubemanager/...
```

## Known limits

- authorization performs one SAR per namespace on each RPC
- long-running streams retain the scope resolved when they opened
- isolation currently requires KubeManager-compatible gadgets