### PR TITLE
.github: Mirror python:3.13-slim image for CI tests

### DIFF
--- a/.github/workflows/dockerhub-mirror.yml
+++ b/.github/workflows/dockerhub-mirror.yml
@@ -28,6 +28,12 @@ jobs:
             repo: docker.io/library
           - image: nginx:latest
             repo: docker.io/library
+          # Pinned to 3.13 (not the floating "3" tag): the OTel eBPF profiler
+          # only symbolizes CPython up to 3.14, so a newer default would break
+          # stack-symbolization tests. See maxVer in:
+          # https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/1de801e979a36561ea1308533388dc61d1290150/interpreter/python/python.go#L796-L797
+          - image: python:3.13-slim
+            repo: docker.io/library
           - image: registry:2
             repo: docker.io/library
           - image: network-multitool:latest


### PR DESCRIPTION
## What this does

Adds the `python:3.13-slim` image to the Dockerhub mirror matrix so it is
available at `ghcr.io/inspektor-gadget/ci/python` for gadget integration tests,
avoiding Docker Hub pull rate limits.

## Why

Stack-symbolization tests (e.g. `profile_cpu`, `ci/stacks`) currently run their
Python workload only in `--host`/ig-local mode against a `python3` interpreter
that must be present on the host. Mirroring a Python image lets those tests run
the workload in a container like other gadget tests (e.g. `trace_dns`), so they
can also run in container/Kubernetes test components.

## Why pin to `3.13-slim` (not the floating `3` tag)

The OTel eBPF profiler only symbolizes CPython **up to 3.14** (`maxVer`), so
letting the mirrored image drift to a newer default would silently break
symbolization tests once CPython 3.15 ships:

https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/1de801e979a36561ea1308533388dc61d1290150/interpreter/python/python.go#L796-L797

`slim` (Debian/glibc, shared libpython) is used deliberately — the profiler's
interpreter unwinder reads `Py_Version`/`_PyRuntime` from `.dynsym` (which
survive stripping); musl/alpine would not be a good fit.

## Follow-up

Once this is merged and the mirror job has run (daily `cron`, or a manual
`workflow_dispatch`), a follow-up will convert the `profile_cpu` OTel stacks
test to run the Python workload in a container using this image.