### PR TITLE
ci: add non-blocking weekly kernel-compatibility lane for published gadgets

### DIFF
--- a/.github/workflows/gadget-kernel-compatibility.yml
+++ b/.github/workflows/gadget-kernel-compatibility.yml
@@ -1,0 +1,283 @@
+# Weekly kernel-compatibility check for published Inspektor Gadget gadgets.
+#
+# Pulls each published gadget by its OCI reference, extracts the eBPF object,
+# and load/attach-tests it on unmodified vendor distro cloud images in
+# disposable QEMU/KVM VMs. Vendor kernels and cloud images move underneath
+# already-published gadgets, and "kernel version" does not predict eBPF feature
+# support (for example RHEL backports the ring buffer to 4.18 while upstream
+# needs >= 5.8), so this is a drift detector for the shipped artifacts.
+#
+# It is non-blocking (schedule + manual dispatch only, no PR/push trigger),
+# needs no build step or manifest, and consumes the published gadget images
+# directly. Complementary to the existing vimto/ci-kernels tests, not a
+# replacement.
+name: gadget-kernel-compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gadget-kernel-compatibility
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPOSITORY: inspektor-gadget/inspektor-gadget
+  GADGET_REPOSITORY: ghcr.io/inspektor-gadget/gadget
+
+jobs:
+  generate-matrix:
+    name: generate gadget matrix
+    # Skip on forks by default to avoid burning runner minutes; a fork can
+    # opt in by setting the ENABLE_GADGET_KERNEL_COMPATIBILITY repo variable.
+    # Gating only the root job disables the whole lane: gadget-matrix and
+    # compatibility-summary both `needs:` this job, so a skip cascades.
+    if: >-
+      github.repository == 'inspektor-gadget/inspektor-gadget' ||
+      vars.ENABLE_GADGET_KERNEL_COMPATIBILITY == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      baseline-tag: ${{ steps.matrix.outputs.baseline-tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+
+      - name: Generate release comparison matrix
+        id: matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_tag="$(
+            gh api "repos/${UPSTREAM_REPOSITORY}/releases/latest" \
+              --jq '.tag_name'
+          )"
+          matrix="$(
+            make -s -C gadgets list-gadgets |
+              jq -Rsc \
+                --arg baseline "$baseline_tag" \
+                --arg repository "$GADGET_REPOSITORY" \
+                '
+                  (split("\n") | map(select(length > 0))) as $gadgets |
+                  {include: [
+                    $gadgets[] as $gadget |
+                    ($gadget | gsub("/"; "--")) as $key |
+                    {
+                      gadget: $gadget,
+                      version: "baseline",
+                      tag: $baseline,
+                      ref: ($repository + "/" + $gadget + ":" + $baseline),
+                      artifact_key: ($key + "--baseline")
+                    },
+                    {
+                      gadget: $gadget,
+                      version: "current",
+                      tag: "main",
+                      ref: ($repository + "/" + $gadget + ":main"),
+                      artifact_key: ($key + "--current")
+                    }
+                  ]}
+                '
+          )"
+          resolution_dir="$(mktemp -d)"
+          trap 'rm -rf "$resolution_dir"' EXIT
+          resolved='[]'
+          while IFS=$'\t' read -r artifact_key ref; do
+            error_file="${resolution_dir}/${artifact_key}.log"
+            if digest="$(crane digest "$ref" 2>"$error_file")"; then
+              ref_exists=true
+            elif grep -Eiq \
+              'MANIFEST_UNKNOWN|manifest unknown|NAME_UNKNOWN|not found' \
+              "$error_file"; then
+              ref_exists=false
+              digest=""
+            else
+              cat "$error_file" >&2
+              exit 1
+            fi
+            resolved="$(
+              jq -c \
+                --arg artifact_key "$artifact_key" \
+                --arg digest "$digest" \
+                --argjson ref_exists "$ref_exists" \
+                '. + [{
+                  artifact_key: $artifact_key,
+                  ref_exists: $ref_exists,
+                  manifest_digest: (
+                    if $digest == "" then null else $digest end
+                  )
+                }]' <<<"$resolved"
+            )"
+          done < <(
+            jq -r '.include[] | [.artifact_key, .ref] | @tsv' <<<"$matrix"
+          )
+          matrix="$(
+            jq -c --argjson resolved "$resolved" '
+              .include |= map(
+                . as $entry |
+                (
+                  $resolved[] |
+                  select(.artifact_key == $entry.artifact_key)
+                ) as $resolution |
+                $entry + $resolution
+              )
+            ' <<<"$matrix"
+          )"
+          jq -e '
+            (.include | length) > 0 and
+            (.include | length) <= 256 and
+            all(.include[]; has("ref_exists") and has("manifest_digest"))
+          ' \
+            <<<"$matrix" >/dev/null
+          printf 'matrix=%s\n' "$matrix" >>"$GITHUB_OUTPUT"
+          printf 'baseline-tag=%s\n' "$baseline_tag" >>"$GITHUB_OUTPUT"
+
+  gadget-matrix:
+    needs: generate-matrix
+    name: ${{ matrix.gadget }} (${{ matrix.tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Install VM dependencies
+        run: |
+          sudo apt-get update
+          # cloud-image-utils provides cloud-localds: RHEL-family guests only
+          # boot from a genuine cloud-init seed ISO.
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils jq
+
+      - name: Enable KVM on the hosted runner
+        run: |
+          if [[ -e /dev/kvm ]]; then sudo chmod 0666 /dev/kvm || true; ls -l /dev/kvm; fi
+
+      - name: Validate the published gadget across kernels
+        id: compatibility
+        continue-on-error: true
+        # Pinned by commit SHA to a checksum-verified bpfcompat release, so no
+        # toolchain is built on the runner.
+        uses: Kernel-Guard/bpfcompat@179ff612ed2b5d1afb16dd9c282752028d47c415 # v0.3.7
+        with:
+          # An OCI reference: bpfcompat pulls it and extracts the eBPF layer.
+          artifact: ${{ matrix.ref }}
+          # Curated vendor kernels where "kernel version" stops predicting
+          # behaviour (RHEL/Alma/Rocky/CentOS backports, Amazon Linux, Oracle
+          # UEK, openSUSE, Ubuntu, Debian).
+          matrix: quirk-library
+          out: reports/${{ matrix.artifact_key }}/compatibility.json
+          markdown: reports/${{ matrix.artifact_key }}/compatibility.md
+          timeout: 15m
+          concurrency: "2"
+
+      - name: Record comparison metadata
+        if: always()
+        env:
+          ACTION_OUTCOME: ${{ steps.compatibility.outcome }}
+          ARTIFACT_KEY: ${{ matrix.artifact_key }}
+          GADGET: ${{ matrix.gadget }}
+          GADGET_REF: ${{ matrix.ref }}
+          GADGET_TAG: ${{ matrix.tag }}
+          GADGET_VERSION: ${{ matrix.version }}
+          MANIFEST_DIGEST: ${{ matrix.manifest_digest }}
+          REF_EXISTS: ${{ matrix.ref_exists }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          report_dir="reports/${ARTIFACT_KEY}"
+          mkdir -p "$report_dir"
+          jq -n \
+            --arg schema_version \
+              "ig.gadget-kernel-compatibility-metadata.v2" \
+            --arg gadget "$GADGET" \
+            --arg version "$GADGET_VERSION" \
+            --arg tag "$GADGET_TAG" \
+            --arg ref "$GADGET_REF" \
+            --arg action_outcome "$ACTION_OUTCOME" \
+            --arg manifest_digest "$MANIFEST_DIGEST" \
+            --argjson ref_exists "$REF_EXISTS" \
+            --arg run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            '{
+              schema_version: $schema_version,
+              gadget: $gadget,
+              version: $version,
+              tag: $tag,
+              ref: $ref,
+              action_outcome: $action_outcome,
+              ref_exists: $ref_exists,
+              manifest_digest: (
+                if $manifest_digest == "" then null else $manifest_digest end
+              ),
+              run_id: $run_id,
+              run_attempt: $run_attempt
+            }' >"${report_dir}/metadata.json"
+
+      - name: Upload compatibility report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gadget-compatibility-${{ matrix.artifact_key }}
+          path: reports/${{ matrix.artifact_key }}/
+          if-no-files-found: warn
+
+  compatibility-summary:
+    needs:
+      - generate-matrix
+      - gadget-matrix
+    if: ${{ always() && needs.generate-matrix.result == 'success' }}
+    name: aggregate compatibility report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download compatibility reports
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gadget-compatibility-*
+          path: downloaded-reports
+
+      - name: Build release comparison
+        env:
+          EXPECTED_MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
+        run: |
+          set +e
+          python3 tools/gadget_kernel_compatibility_summary.py \
+            --reports-dir downloaded-reports \
+            --matrix-json "$EXPECTED_MATRIX" \
+            --markdown-output reports/gadget-kernel-compatibility.md \
+            --json-output reports/gadget-kernel-compatibility.json \
+            --expected-no-ebpf-gadget bpfstats \
+            --expected-no-ebpf-gadget top_cpu_throttle \
+            --expected-no-ebpf-gadget top_process \
+            --fail-on-regression \
+            --fail-on-unexpected-missing \
+            --fail-on-identical-artifacts
+          status=$?
+          set -e
+          if [[ -f reports/gadget-kernel-compatibility.md ]]; then
+            cat reports/gadget-kernel-compatibility.md \
+              >>"$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      - name: Upload aggregate report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gadget-kernel-compatibility-summary
+          path: reports/
+          if-no-files-found: error

--- a/.github/workflows/gadget-kernel-compatibility.yml
+++ b/.github/workflows/gadget-kernel-compatibility.yml
@@ -1,0 +1,276 @@
+# Weekly kernel-compatibility check for published Inspektor Gadget gadgets.
+#
+# Pulls each published gadget by its OCI reference, extracts the eBPF object,
+# and load/attach-tests it on unmodified vendor distro cloud images in
+# disposable QEMU/KVM VMs. Vendor kernels and cloud images move underneath
+# already-published gadgets, and "kernel version" does not predict eBPF feature
+# support (for example RHEL backports the ring buffer to 4.18 while upstream
+# needs >= 5.8), so this is a drift detector for the shipped artifacts.
+#
+# It is non-blocking (schedule + manual dispatch only, no PR/push trigger),
+# needs no build step or manifest, and consumes the published gadget images
+# directly. Complementary to the existing vimto/ci-kernels tests, not a
+# replacement.
+name: gadget-kernel-compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gadget-kernel-compatibility
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPOSITORY: inspektor-gadget/inspektor-gadget
+  GADGET_REPOSITORY: ghcr.io/inspektor-gadget/gadget
+
+jobs:
+  generate-matrix:
+    name: generate gadget matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      baseline-tag: ${{ steps.matrix.outputs.baseline-tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+
+      - name: Generate release comparison matrix
+        id: matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_tag="$(
+            gh api "repos/${UPSTREAM_REPOSITORY}/releases/latest" \
+              --jq '.tag_name'
+          )"
+          matrix="$(
+            make -s -C gadgets list-gadgets |
+              jq -Rsc \
+                --arg baseline "$baseline_tag" \
+                --arg repository "$GADGET_REPOSITORY" \
+                '
+                  (split("\n") | map(select(length > 0))) as $gadgets |
+                  {include: [
+                    $gadgets[] as $gadget |
+                    ($gadget | gsub("/"; "--")) as $key |
+                    {
+                      gadget: $gadget,
+                      version: "baseline",
+                      tag: $baseline,
+                      ref: ($repository + "/" + $gadget + ":" + $baseline),
+                      artifact_key: ($key + "--baseline")
+                    },
+                    {
+                      gadget: $gadget,
+                      version: "current",
+                      tag: "main",
+                      ref: ($repository + "/" + $gadget + ":main"),
+                      artifact_key: ($key + "--current")
+                    }
+                  ]}
+                '
+          )"
+          resolution_dir="$(mktemp -d)"
+          trap 'rm -rf "$resolution_dir"' EXIT
+          resolved='[]'
+          while IFS=$'\t' read -r artifact_key ref; do
+            error_file="${resolution_dir}/${artifact_key}.log"
+            if digest="$(crane digest "$ref" 2>"$error_file")"; then
+              ref_exists=true
+            elif grep -Eiq \
+              'MANIFEST_UNKNOWN|manifest unknown|NAME_UNKNOWN|not found' \
+              "$error_file"; then
+              ref_exists=false
+              digest=""
+            else
+              cat "$error_file" >&2
+              exit 1
+            fi
+            resolved="$(
+              jq -c \
+                --arg artifact_key "$artifact_key" \
+                --arg digest "$digest" \
+                --argjson ref_exists "$ref_exists" \
+                '. + [{
+                  artifact_key: $artifact_key,
+                  ref_exists: $ref_exists,
+                  manifest_digest: (
+                    if $digest == "" then null else $digest end
+                  )
+                }]' <<<"$resolved"
+            )"
+          done < <(
+            jq -r '.include[] | [.artifact_key, .ref] | @tsv' <<<"$matrix"
+          )
+          matrix="$(
+            jq -c --argjson resolved "$resolved" '
+              .include |= map(
+                . as $entry |
+                (
+                  $resolved[] |
+                  select(.artifact_key == $entry.artifact_key)
+                ) as $resolution |
+                $entry + $resolution
+              )
+            ' <<<"$matrix"
+          )"
+          jq -e '
+            (.include | length) > 0 and
+            (.include | length) <= 256 and
+            all(.include[]; has("ref_exists") and has("manifest_digest"))
+          ' \
+            <<<"$matrix" >/dev/null
+          printf 'matrix=%s\n' "$matrix" >>"$GITHUB_OUTPUT"
+          printf 'baseline-tag=%s\n' "$baseline_tag" >>"$GITHUB_OUTPUT"
+
+  gadget-matrix:
+    needs: generate-matrix
+    name: ${{ matrix.gadget }} (${{ matrix.tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Install VM dependencies
+        run: |
+          sudo apt-get update
+          # cloud-image-utils provides cloud-localds: RHEL-family guests only
+          # boot from a genuine cloud-init seed ISO.
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils jq
+
+      - name: Enable KVM on the hosted runner
+        run: |
+          if [[ -e /dev/kvm ]]; then sudo chmod 0666 /dev/kvm || true; ls -l /dev/kvm; fi
+
+      - name: Validate the published gadget across kernels
+        id: compatibility
+        continue-on-error: true
+        # Pinned by commit SHA to a checksum-verified bpfcompat release, so no
+        # toolchain is built on the runner.
+        uses: Kernel-Guard/bpfcompat@a91b25568563d322220f8fea8fa1ee26d231c8fd # v0.3.3
+        with:
+          # An OCI reference: bpfcompat pulls it and extracts the eBPF layer.
+          artifact: ${{ matrix.ref }}
+          # Curated vendor kernels where "kernel version" stops predicting
+          # behaviour (RHEL/Alma/Rocky/CentOS backports, Amazon Linux, Oracle
+          # UEK, openSUSE, Ubuntu, Debian).
+          matrix: quirk-library
+          out: reports/${{ matrix.artifact_key }}/compatibility.json
+          markdown: reports/${{ matrix.artifact_key }}/compatibility.md
+          timeout: 15m
+          concurrency: "2"
+
+      - name: Record comparison metadata
+        if: always()
+        env:
+          ACTION_OUTCOME: ${{ steps.compatibility.outcome }}
+          ARTIFACT_KEY: ${{ matrix.artifact_key }}
+          GADGET: ${{ matrix.gadget }}
+          GADGET_REF: ${{ matrix.ref }}
+          GADGET_TAG: ${{ matrix.tag }}
+          GADGET_VERSION: ${{ matrix.version }}
+          MANIFEST_DIGEST: ${{ matrix.manifest_digest }}
+          REF_EXISTS: ${{ matrix.ref_exists }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          report_dir="reports/${ARTIFACT_KEY}"
+          mkdir -p "$report_dir"
+          jq -n \
+            --arg schema_version \
+              "ig.gadget-kernel-compatibility-metadata.v2" \
+            --arg gadget "$GADGET" \
+            --arg version "$GADGET_VERSION" \
+            --arg tag "$GADGET_TAG" \
+            --arg ref "$GADGET_REF" \
+            --arg action_outcome "$ACTION_OUTCOME" \
+            --arg manifest_digest "$MANIFEST_DIGEST" \
+            --argjson ref_exists "$REF_EXISTS" \
+            --arg run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            '{
+              schema_version: $schema_version,
+              gadget: $gadget,
+              version: $version,
+              tag: $tag,
+              ref: $ref,
+              action_outcome: $action_outcome,
+              ref_exists: $ref_exists,
+              manifest_digest: (
+                if $manifest_digest == "" then null else $manifest_digest end
+              ),
+              run_id: $run_id,
+              run_attempt: $run_attempt
+            }' >"${report_dir}/metadata.json"
+
+      - name: Upload compatibility report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gadget-compatibility-${{ matrix.artifact_key }}
+          path: reports/${{ matrix.artifact_key }}/
+          if-no-files-found: warn
+
+  compatibility-summary:
+    needs:
+      - generate-matrix
+      - gadget-matrix
+    if: ${{ always() && needs.generate-matrix.result == 'success' }}
+    name: aggregate compatibility report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download compatibility reports
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gadget-compatibility-*
+          path: downloaded-reports
+
+      - name: Build release comparison
+        env:
+          EXPECTED_MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
+        run: |
+          set +e
+          python3 tools/gadget_kernel_compatibility_summary.py \
+            --reports-dir downloaded-reports \
+            --matrix-json "$EXPECTED_MATRIX" \
+            --markdown-output reports/gadget-kernel-compatibility.md \
+            --json-output reports/gadget-kernel-compatibility.json \
+            --expected-no-ebpf-gadget bpfstats \
+            --expected-no-ebpf-gadget top_cpu_throttle \
+            --expected-no-ebpf-gadget top_process \
+            --fail-on-regression \
+            --fail-on-unexpected-missing \
+            --fail-on-identical-artifacts
+          status=$?
+          set -e
+          if [[ -f reports/gadget-kernel-compatibility.md ]]; then
+            cat reports/gadget-kernel-compatibility.md \
+              >>"$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$status"
+
+      - name: Upload aggregate report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gadget-kernel-compatibility-summary
+          path: reports/
+          if-no-files-found: error

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -97,6 +97,10 @@ DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GADGETS_README = $(filter-out ci/%, $(addsuffix /README.mdx, $(GADGETS)))
 GADGETS_README_DEV = $(filter-out ci/%, $(addsuffix /dev.md, $(GADGETS)))
 
+.PHONY: list-gadgets
+list-gadgets:
+	@printf '%s\n' $(GADGETS)
+
 .PHONY: all
 all: build
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -82,6 +82,10 @@ DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GADGETS_README = $(filter-out ci/%, $(addsuffix /README.mdx, $(GADGETS)))
 GADGETS_README_DEV = $(filter-out ci/%, $(addsuffix /dev.md, $(GADGETS)))
 
+.PHONY: list-gadgets
+list-gadgets:
+	@printf '%s\n' $(GADGETS)
+
 .PHONY: all
 all: build
 

--- a/tools/gadget_kernel_compatibility_summary.py
+++ b/tools/gadget_kernel_compatibility_summary.py
@@ -1,0 +1,607 @@
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+PASS = "pass"
+FAIL = "fail"
+INCOMPLETE_STATUSES = {"error", "infra_error", "missing", "skipped", "unknown"}
+STATUS_ICONS = {
+    PASS: "✅",
+    FAIL: "❌",
+    "error": "⚠️",
+    "infra_error": "⚠️",
+    "missing": "—",
+    "skipped": "⏭️",
+    "unknown": "⚠️",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Aggregate bpfcompat gadget reports into a release comparison."
+    )
+    parser.add_argument("--reports-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--matrix-json", required=True)
+    parser.add_argument("--markdown-output", required=True, type=pathlib.Path)
+    parser.add_argument("--json-output", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--expected-no-ebpf-gadget",
+        action="append",
+        default=[],
+        help="Gadget expected to publish no extractable eBPF layer; repeatable.",
+    )
+    parser.add_argument("--fail-on-regression", action="store_true")
+    parser.add_argument("--fail-on-unexpected-missing", action="store_true")
+    parser.add_argument("--fail-on-identical-artifacts", action="store_true")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with path.open(encoding="utf-8") as input_file:
+        return json.load(input_file)
+
+
+def normalize_status(status):
+    normalized = str(status or "unknown").lower()
+    if normalized in STATUS_ICONS:
+        return normalized
+    return "unknown"
+
+
+def missing_result(classification_code="NO_REPORT", expected_missing=False):
+    return {
+        "status": "missing",
+        "classification_code": classification_code,
+        "required": None,
+        "expected_missing": expected_missing,
+    }
+
+
+def load_expected_matrix(matrix_json):
+    matrix = json.loads(matrix_json)
+    entries = matrix.get("include", [])
+    if not entries:
+        raise ValueError("the expected matrix has no include entries")
+
+    gadgets = []
+    versions = {}
+    for entry in entries:
+        gadget = entry["gadget"]
+        version = entry["version"]
+        if gadget not in gadgets:
+            gadgets.append(gadget)
+        versions.setdefault(gadget, {})[version] = entry
+
+    for gadget in gadgets:
+        missing_versions = {"baseline", "current"} - versions[gadget].keys()
+        if missing_versions:
+            missing = ", ".join(sorted(missing_versions))
+            raise ValueError(f"{gadget} is missing matrix versions: {missing}")
+
+    return gadgets, versions
+
+
+def load_reports(reports_dir):
+    reports = {}
+    profiles = []
+    profile_requirements = {}
+
+    for metadata_path in sorted(reports_dir.rglob("metadata.json")):
+        metadata = read_json(metadata_path)
+        key = (metadata["gadget"], metadata["version"])
+        if key in reports:
+            raise ValueError(f"duplicate metadata for {key[0]} ({key[1]})")
+
+        report_path = metadata_path.with_name("compatibility.json")
+        targets = {}
+        artifact = None
+        if report_path.exists():
+            report = read_json(report_path)
+            artifact = report.get("artifact")
+            for target in report.get("targets", []):
+                profile = target.get("profile_id")
+                if not profile:
+                    continue
+                if profile not in profiles:
+                    profiles.append(profile)
+                required = target.get("required")
+                if required is not None and not isinstance(required, bool):
+                    raise ValueError(f"{profile} has a non-boolean required value")
+                known_required = profile_requirements.get(profile)
+                if (
+                    known_required is not None
+                    and required is not None
+                    and known_required != required
+                ):
+                    raise ValueError(f"{profile} has inconsistent required values")
+                if required is not None:
+                    profile_requirements[profile] = required
+                targets[profile] = {
+                    "status": normalize_status(target.get("status")),
+                    "classification_code": target.get("classification_code") or "",
+                    "required": required,
+                    "expected_missing": False,
+                }
+
+        reports[key] = {
+            "metadata": metadata,
+            "artifact": artifact,
+            "targets": targets,
+        }
+
+    return reports, profiles, profile_requirements
+
+
+def classify_change(baseline, current):
+    baseline_status = baseline["status"]
+    current_status = current["status"]
+
+    if baseline_status in INCOMPLETE_STATUSES or current_status in INCOMPLETE_STATUSES:
+        return "incomplete"
+    if baseline_status == PASS and current_status == FAIL:
+        return "regression"
+    if baseline_status == FAIL and current_status == PASS:
+        return "improvement"
+    if baseline_status == FAIL and current_status == FAIL:
+        return "existing_limitation"
+    if baseline_status == PASS and current_status == PASS:
+        return "passing"
+    return "incomplete"
+
+
+def missing_report_result(expected, gadget, expected_no_ebpf_gadgets):
+    if expected.get("ref_exists", True) is False:
+        return missing_result("REFERENCE_NOT_FOUND", expected_missing=True)
+    if gadget in expected_no_ebpf_gadgets:
+        return missing_result("NO_EBPF_LAYER", expected_missing=True)
+    return missing_result()
+
+
+def report_artifact(report):
+    if not report or not isinstance(report["artifact"], dict):
+        return None
+    sha256 = report["artifact"].get("sha256")
+    if not isinstance(sha256, str) or not sha256:
+        return None
+    return report["artifact"]
+
+
+def has_results(report):
+    # A report contributes per-kernel results as long as it carries targets.
+    # This is deliberately independent of the artifact SHA-256: bpfcompat can
+    # emit load/attach results without (or before) recording an artifact hash,
+    # and coupling the two would silently drop real pass/fail data — masking a
+    # regression as "incomplete". The hash is only used for artifact/image
+    # comparison, never to decide whether results exist.
+    return bool(report) and bool(report.get("targets"))
+
+
+def result_for(
+    reports,
+    versions,
+    expected_no_ebpf_gadgets,
+    gadget,
+    version,
+    profile,
+):
+    report = reports.get((gadget, version))
+    if not has_results(report):
+        return missing_report_result(
+            versions[gadget][version],
+            gadget,
+            expected_no_ebpf_gadgets,
+        )
+    return report["targets"].get(
+        profile,
+        missing_result("MISSING_PROFILE_RESULT"),
+    )
+
+
+def empty_counts():
+    return {
+        "regressions": 0,
+        "improvements": 0,
+        "existing_limitations": 0,
+        "passing": 0,
+        "incomplete": 0,
+    }
+
+
+def requirement_name(required):
+    if required is True:
+        return "required"
+    if required is False:
+        return "optional"
+    return "unknown"
+
+
+def build_summary(matrix_json, reports_dir, expected_no_ebpf_gadgets=None):
+    expected_no_ebpf_gadgets = set(expected_no_ebpf_gadgets or [])
+    gadgets, versions = load_expected_matrix(matrix_json)
+    reports, profiles, profile_requirements = load_reports(reports_dir)
+
+    artifacts = []
+    for gadget in gadgets:
+        for version in ("baseline", "current"):
+            expected = versions[gadget][version]
+            report = reports.get((gadget, version))
+            metadata = report["metadata"] if report else {}
+            artifact = report_artifact(report)
+            ref_exists = metadata.get(
+                "ref_exists",
+                expected.get("ref_exists", True),
+            )
+            report_available = has_results(report)
+            expected_missing = False
+            missing_reason = ""
+            if not report_available:
+                missing = missing_report_result(
+                    expected,
+                    gadget,
+                    expected_no_ebpf_gadgets,
+                )
+                expected_missing = missing["expected_missing"]
+                missing_reason = missing["classification_code"]
+            artifacts.append(
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": metadata.get("tag", expected["tag"]),
+                    "ref": metadata.get("ref", expected.get("ref", "")),
+                    "action_outcome": metadata.get("action_outcome", "missing"),
+                    "ref_exists": ref_exists,
+                    "manifest_digest": metadata.get(
+                        "manifest_digest",
+                        expected.get("manifest_digest"),
+                    ),
+                    "report_available": report_available,
+                    "expected_missing": expected_missing,
+                    "missing_reason": missing_reason,
+                    "artifact": artifact,
+                }
+            )
+
+    results = []
+    counts = empty_counts()
+    by_requirement = {
+        "required": empty_counts(),
+        "optional": empty_counts(),
+        "unknown": empty_counts(),
+    }
+    count_keys = {
+        "regression": "regressions",
+        "improvement": "improvements",
+        "existing_limitation": "existing_limitations",
+        "passing": "passing",
+        "incomplete": "incomplete",
+    }
+
+    for profile in profiles:
+        for gadget in gadgets:
+            baseline = result_for(
+                reports,
+                versions,
+                expected_no_ebpf_gadgets,
+                gadget,
+                "baseline",
+                profile,
+            )
+            current = result_for(
+                reports,
+                versions,
+                expected_no_ebpf_gadgets,
+                gadget,
+                "current",
+                profile,
+            )
+            change = classify_change(baseline, current)
+            required = profile_requirements.get(profile)
+            requirement = requirement_name(required)
+            counts[count_keys[change]] += 1
+            by_requirement[requirement][count_keys[change]] += 1
+            results.append(
+                {
+                    "gadget": gadget,
+                    "profile": profile,
+                    "required": required,
+                    "baseline": baseline,
+                    "current": current,
+                    "change": change,
+                }
+            )
+
+    first_gadget = gadgets[0]
+    baseline_tag = versions[first_gadget]["baseline"]["tag"]
+    current_tag = versions[first_gadget]["current"]["tag"]
+    report_completeness = {
+        "available": sum(1 for artifact in artifacts if artifact["report_available"]),
+        "expected_missing": sum(
+            1
+            for artifact in artifacts
+            if not artifact["report_available"] and artifact["expected_missing"]
+        ),
+        "unexpected_missing": sum(
+            1
+            for artifact in artifacts
+            if not artifact["report_available"] and not artifact["expected_missing"]
+        ),
+    }
+    comparable_pairs = 0
+    identical_pairs = 0
+    changed_pairs = 0
+    image_comparable_pairs = 0
+    same_image_pairs = 0
+    artifacts_by_key = {
+        (artifact["gadget"], artifact["version"]): artifact for artifact in artifacts
+    }
+    for gadget in gadgets:
+        baseline_entry = artifacts_by_key[(gadget, "baseline")]
+        current_entry = artifacts_by_key[(gadget, "current")]
+        baseline_artifact = baseline_entry["artifact"]
+        current_artifact = current_entry["artifact"]
+        if baseline_artifact and current_artifact:
+            comparable_pairs += 1
+            if baseline_artifact.get("sha256") == current_artifact.get("sha256"):
+                identical_pairs += 1
+            else:
+                changed_pairs += 1
+        # "Release vs itself" is a mismatch of published images, so detect it
+        # from the OCI manifest digests (resolved in the generator), not from
+        # eBPF-hash equality: in a quiet week the eBPF object can be byte-for-
+        # byte identical while the images legitimately differ, and gating on
+        # the eBPF hash would false-fail that healthy state.
+        baseline_digest = baseline_entry["manifest_digest"]
+        current_digest = current_entry["manifest_digest"]
+        if baseline_digest and current_digest:
+            image_comparable_pairs += 1
+            if baseline_digest == current_digest:
+                same_image_pairs += 1
+
+    return {
+        "schema_version": "ig.gadget-kernel-compatibility-summary.v2",
+        "generated_at": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(),
+        "baseline_tag": baseline_tag,
+        "current_tag": current_tag,
+        "gadgets": gadgets,
+        "profiles": profiles,
+        "profile_requirements": profile_requirements,
+        "artifacts": artifacts,
+        "summary": counts,
+        "summary_by_requirement": by_requirement,
+        "report_completeness": report_completeness,
+        "artifact_comparison": {
+            "comparable_pairs": comparable_pairs,
+            "identical_pairs": identical_pairs,
+            "changed_pairs": changed_pairs,
+            "all_comparable_pairs_identical": (
+                comparable_pairs > 0 and identical_pairs == comparable_pairs
+            ),
+        },
+        "image_comparison": {
+            "comparable_pairs": image_comparable_pairs,
+            "same_image_pairs": same_image_pairs,
+            "all_comparable_pairs_same_image": (
+                image_comparable_pairs > 0
+                and same_image_pairs == image_comparable_pairs
+            ),
+        },
+        "results": results,
+    }
+
+
+def markdown_escape(value):
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def classification_text(baseline, current):
+    baseline_code = baseline.get("classification_code") or ""
+    current_code = current.get("classification_code") or ""
+    if baseline["status"] == FAIL and current["status"] == FAIL:
+        if baseline_code == current_code:
+            return current_code
+        if baseline_code and current_code:
+            return f"{baseline_code} → {current_code}"
+    if current["status"] != PASS and current_code:
+        return current_code
+    if baseline["status"] != PASS and baseline_code:
+        return baseline_code
+    if current["status"] != PASS:
+        return current["status"].upper()
+    if baseline["status"] != PASS:
+        return baseline["status"].upper()
+    return ""
+
+
+def render_cell(result):
+    baseline = result["baseline"]
+    current = result["current"]
+    value = f"{STATUS_ICONS[baseline['status']]} → {STATUS_ICONS[current['status']]}"
+    classification = classification_text(baseline, current)
+    if classification:
+        value += f" ({markdown_escape(classification)})"
+    if result["change"] == "regression":
+        return f"**{value}**"
+    return value
+
+
+def render_markdown(summary):
+    counts = summary["summary"]
+    required_counts = summary["summary_by_requirement"]["required"]
+    optional_counts = summary["summary_by_requirement"]["optional"]
+    completeness = summary["report_completeness"]
+    artifact_comparison = summary["artifact_comparison"]
+    image_comparison = summary["image_comparison"]
+    lines = [
+        "# Gadget kernel compatibility",
+        "",
+        (
+            f"Baseline: `{markdown_escape(summary['baseline_tag'])}` · "
+            f"Current: `{markdown_escape(summary['current_tag'])}`"
+        ),
+        "",
+        (
+            f"Regressions: **{counts['regressions']}** · "
+            f"Required regressions: **{required_counts['regressions']}** · "
+            f"Optional regressions: **{optional_counts['regressions']}**"
+        ),
+        "",
+        (
+            f"Improvements: **{counts['improvements']}** · "
+            f"Existing limitations: **{counts['existing_limitations']}** · "
+            f"Passing: **{counts['passing']}** · "
+            f"Incomplete: **{counts['incomplete']}**"
+        ),
+        "",
+        (
+            f"Reports: **{completeness['available']}** available · "
+            f"**{completeness['expected_missing']}** expected missing · "
+            f"**{completeness['unexpected_missing']}** unexpected missing"
+        ),
+        "",
+        (
+            f"Comparable artifact pairs: "
+            f"**{artifact_comparison['comparable_pairs']}** · "
+            f"Changed: **{artifact_comparison['changed_pairs']}** · "
+            f"Identical eBPF: **{artifact_comparison['identical_pairs']}** · "
+            f"Same published image: "
+            f"**{image_comparison['same_image_pairs']}**/"
+            f"**{image_comparison['comparable_pairs']}**"
+        ),
+        "",
+        (
+            "Each cell is `baseline → current`; bold cells are regressions. "
+            "✅ pass · ❌ incompatible · ⚠️ infrastructure error · "
+            "⏭️ skipped · — missing report"
+        ),
+        "",
+    ]
+
+    gate = summary.get("gate")
+    if gate:
+        lines.append(f"Gate: **{'PASS' if gate['passed'] else 'FAIL'}**")
+        lines.append("")
+        for error in gate["errors"]:
+            lines.append(f"- {markdown_escape(error)}")
+        if gate["errors"]:
+            lines.append("")
+
+    if not summary["profiles"]:
+        lines.extend(
+            [
+                "No kernel-profile results were available.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    by_key = {
+        (result["profile"], result["gadget"]): result for result in summary["results"]
+    }
+    gadgets = summary["gadgets"]
+    lines.append(
+        "| Kernel profile | "
+        + " | ".join(markdown_escape(gadget) for gadget in gadgets)
+        + " |"
+    )
+    lines.append("| --- | " + " | ".join("---" for _ in gadgets) + " |")
+    for profile in summary["profiles"]:
+        cells = [render_cell(by_key[(profile, gadget)]) for gadget in gadgets]
+        requirement = requirement_name(summary["profile_requirements"].get(profile))
+        profile_label = f"{profile} ({requirement})"
+        lines.append(
+            f"| {markdown_escape(profile_label)} | " + " | ".join(cells) + " |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_output(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def evaluate_gates(
+    summary,
+    fail_on_regression=False,
+    fail_on_unexpected_missing=False,
+    fail_on_identical_artifacts=False,
+):
+    errors = []
+    if fail_on_regression and summary["summary"]["regressions"]:
+        errors.append(
+            f"{summary['summary']['regressions']} compatibility regressions found"
+        )
+
+    unexpected_missing = summary["report_completeness"]["unexpected_missing"]
+    if fail_on_unexpected_missing and unexpected_missing:
+        missing = [
+            f"{artifact['gadget']}:{artifact['version']}"
+            for artifact in summary["artifacts"]
+            if not artifact["report_available"] and not artifact["expected_missing"]
+        ]
+        errors.append(
+            f"{unexpected_missing} unexpected missing reports: " + ", ".join(missing)
+        )
+
+    missing_profile_results = [
+        f"{result['gadget']}:{result['profile']}:{version}"
+        for result in summary["results"]
+        for version in ("baseline", "current")
+        if result[version]["classification_code"] == "MISSING_PROFILE_RESULT"
+    ]
+    if fail_on_unexpected_missing and missing_profile_results:
+        errors.append(
+            f"{len(missing_profile_results)} unexpected missing profile results: "
+            + ", ".join(missing_profile_results)
+        )
+
+    image_comparison = summary["image_comparison"]
+    all_same_image = image_comparison["all_comparable_pairs_same_image"]
+    if fail_on_identical_artifacts and all_same_image:
+        errors.append(
+            "all "
+            f"{image_comparison['comparable_pairs']} comparable gadget pairs "
+            "resolve to the same published image (identical manifest digests); "
+            "baseline and current likely point at the same release"
+        )
+    return errors
+
+
+def main():
+    args = parse_args()
+    try:
+        summary = build_summary(
+            args.matrix_json,
+            args.reports_dir,
+            args.expected_no_ebpf_gadget,
+        )
+    except (KeyError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    gate_errors = evaluate_gates(
+        summary,
+        fail_on_regression=args.fail_on_regression,
+        fail_on_unexpected_missing=args.fail_on_unexpected_missing,
+        fail_on_identical_artifacts=args.fail_on_identical_artifacts,
+    )
+    summary["gate"] = {
+        "passed": not gate_errors,
+        "errors": gate_errors,
+    }
+    write_output(args.markdown_output, render_markdown(summary))
+    write_output(
+        args.json_output,
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+    )
+    for error in gate_errors:
+        print(f"error: {error}", file=sys.stderr)
+    return 1 if gate_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gadget_kernel_compatibility_summary.py
+++ b/tools/gadget_kernel_compatibility_summary.py
@@ -1,0 +1,569 @@
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+PASS = "pass"
+FAIL = "fail"
+INCOMPLETE_STATUSES = {"error", "infra_error", "missing", "skipped", "unknown"}
+STATUS_ICONS = {
+    PASS: "✅",
+    FAIL: "❌",
+    "error": "⚠️",
+    "infra_error": "⚠️",
+    "missing": "—",
+    "skipped": "⏭️",
+    "unknown": "⚠️",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Aggregate bpfcompat gadget reports into a release comparison."
+    )
+    parser.add_argument("--reports-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--matrix-json", required=True)
+    parser.add_argument("--markdown-output", required=True, type=pathlib.Path)
+    parser.add_argument("--json-output", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--expected-no-ebpf-gadget",
+        action="append",
+        default=[],
+        help="Gadget expected to publish no extractable eBPF layer; repeatable.",
+    )
+    parser.add_argument("--fail-on-regression", action="store_true")
+    parser.add_argument("--fail-on-unexpected-missing", action="store_true")
+    parser.add_argument("--fail-on-identical-artifacts", action="store_true")
+    return parser.parse_args()
+
+
+def read_json(path):
+    with path.open(encoding="utf-8") as input_file:
+        return json.load(input_file)
+
+
+def normalize_status(status):
+    normalized = str(status or "unknown").lower()
+    if normalized in STATUS_ICONS:
+        return normalized
+    return "unknown"
+
+
+def missing_result(classification_code="NO_REPORT", expected_missing=False):
+    return {
+        "status": "missing",
+        "classification_code": classification_code,
+        "required": None,
+        "expected_missing": expected_missing,
+    }
+
+
+def load_expected_matrix(matrix_json):
+    matrix = json.loads(matrix_json)
+    entries = matrix.get("include", [])
+    if not entries:
+        raise ValueError("the expected matrix has no include entries")
+
+    gadgets = []
+    versions = {}
+    for entry in entries:
+        gadget = entry["gadget"]
+        version = entry["version"]
+        if gadget not in gadgets:
+            gadgets.append(gadget)
+        versions.setdefault(gadget, {})[version] = entry
+
+    for gadget in gadgets:
+        missing_versions = {"baseline", "current"} - versions[gadget].keys()
+        if missing_versions:
+            missing = ", ".join(sorted(missing_versions))
+            raise ValueError(f"{gadget} is missing matrix versions: {missing}")
+
+    return gadgets, versions
+
+
+def load_reports(reports_dir):
+    reports = {}
+    profiles = []
+    profile_requirements = {}
+
+    for metadata_path in sorted(reports_dir.rglob("metadata.json")):
+        metadata = read_json(metadata_path)
+        key = (metadata["gadget"], metadata["version"])
+        if key in reports:
+            raise ValueError(f"duplicate metadata for {key[0]} ({key[1]})")
+
+        report_path = metadata_path.with_name("compatibility.json")
+        targets = {}
+        artifact = None
+        if report_path.exists():
+            report = read_json(report_path)
+            artifact = report.get("artifact")
+            for target in report.get("targets", []):
+                profile = target.get("profile_id")
+                if not profile:
+                    continue
+                if profile not in profiles:
+                    profiles.append(profile)
+                required = target.get("required")
+                if required is not None and not isinstance(required, bool):
+                    raise ValueError(f"{profile} has a non-boolean required value")
+                known_required = profile_requirements.get(profile)
+                if (
+                    known_required is not None
+                    and required is not None
+                    and known_required != required
+                ):
+                    raise ValueError(f"{profile} has inconsistent required values")
+                if required is not None:
+                    profile_requirements[profile] = required
+                targets[profile] = {
+                    "status": normalize_status(target.get("status")),
+                    "classification_code": target.get("classification_code") or "",
+                    "required": required,
+                    "expected_missing": False,
+                }
+
+        reports[key] = {
+            "metadata": metadata,
+            "artifact": artifact,
+            "targets": targets,
+        }
+
+    return reports, profiles, profile_requirements
+
+
+def classify_change(baseline, current):
+    baseline_status = baseline["status"]
+    current_status = current["status"]
+
+    if baseline_status in INCOMPLETE_STATUSES or current_status in INCOMPLETE_STATUSES:
+        return "incomplete"
+    if baseline_status == PASS and current_status == FAIL:
+        return "regression"
+    if baseline_status == FAIL and current_status == PASS:
+        return "improvement"
+    if baseline_status == FAIL and current_status == FAIL:
+        return "existing_limitation"
+    if baseline_status == PASS and current_status == PASS:
+        return "passing"
+    return "incomplete"
+
+
+def missing_report_result(expected, gadget, expected_no_ebpf_gadgets):
+    if expected.get("ref_exists", True) is False:
+        return missing_result("REFERENCE_NOT_FOUND", expected_missing=True)
+    if gadget in expected_no_ebpf_gadgets:
+        return missing_result("NO_EBPF_LAYER", expected_missing=True)
+    return missing_result()
+
+
+def report_artifact(report):
+    if not report or not isinstance(report["artifact"], dict):
+        return None
+    sha256 = report["artifact"].get("sha256")
+    if not isinstance(sha256, str) or not sha256:
+        return None
+    return report["artifact"]
+
+
+def result_for(
+    reports,
+    versions,
+    expected_no_ebpf_gadgets,
+    gadget,
+    version,
+    profile,
+):
+    report = reports.get((gadget, version))
+    if not report_artifact(report):
+        return missing_report_result(
+            versions[gadget][version],
+            gadget,
+            expected_no_ebpf_gadgets,
+        )
+    return report["targets"].get(
+        profile,
+        missing_result("MISSING_PROFILE_RESULT"),
+    )
+
+
+def empty_counts():
+    return {
+        "regressions": 0,
+        "improvements": 0,
+        "existing_limitations": 0,
+        "passing": 0,
+        "incomplete": 0,
+    }
+
+
+def requirement_name(required):
+    if required is True:
+        return "required"
+    if required is False:
+        return "optional"
+    return "unknown"
+
+
+def build_summary(matrix_json, reports_dir, expected_no_ebpf_gadgets=None):
+    expected_no_ebpf_gadgets = set(expected_no_ebpf_gadgets or [])
+    gadgets, versions = load_expected_matrix(matrix_json)
+    reports, profiles, profile_requirements = load_reports(reports_dir)
+
+    artifacts = []
+    for gadget in gadgets:
+        for version in ("baseline", "current"):
+            expected = versions[gadget][version]
+            report = reports.get((gadget, version))
+            metadata = report["metadata"] if report else {}
+            artifact = report_artifact(report)
+            ref_exists = metadata.get(
+                "ref_exists",
+                expected.get("ref_exists", True),
+            )
+            report_available = artifact is not None
+            expected_missing = False
+            missing_reason = ""
+            if not report_available:
+                missing = missing_report_result(
+                    expected,
+                    gadget,
+                    expected_no_ebpf_gadgets,
+                )
+                expected_missing = missing["expected_missing"]
+                missing_reason = missing["classification_code"]
+            artifacts.append(
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": metadata.get("tag", expected["tag"]),
+                    "ref": metadata.get("ref", expected.get("ref", "")),
+                    "action_outcome": metadata.get("action_outcome", "missing"),
+                    "ref_exists": ref_exists,
+                    "manifest_digest": metadata.get(
+                        "manifest_digest",
+                        expected.get("manifest_digest"),
+                    ),
+                    "report_available": report_available,
+                    "expected_missing": expected_missing,
+                    "missing_reason": missing_reason,
+                    "artifact": artifact,
+                }
+            )
+
+    results = []
+    counts = empty_counts()
+    by_requirement = {
+        "required": empty_counts(),
+        "optional": empty_counts(),
+        "unknown": empty_counts(),
+    }
+    count_keys = {
+        "regression": "regressions",
+        "improvement": "improvements",
+        "existing_limitation": "existing_limitations",
+        "passing": "passing",
+        "incomplete": "incomplete",
+    }
+
+    for profile in profiles:
+        for gadget in gadgets:
+            baseline = result_for(
+                reports,
+                versions,
+                expected_no_ebpf_gadgets,
+                gadget,
+                "baseline",
+                profile,
+            )
+            current = result_for(
+                reports,
+                versions,
+                expected_no_ebpf_gadgets,
+                gadget,
+                "current",
+                profile,
+            )
+            change = classify_change(baseline, current)
+            required = profile_requirements.get(profile)
+            requirement = requirement_name(required)
+            counts[count_keys[change]] += 1
+            by_requirement[requirement][count_keys[change]] += 1
+            results.append(
+                {
+                    "gadget": gadget,
+                    "profile": profile,
+                    "required": required,
+                    "baseline": baseline,
+                    "current": current,
+                    "change": change,
+                }
+            )
+
+    first_gadget = gadgets[0]
+    baseline_tag = versions[first_gadget]["baseline"]["tag"]
+    current_tag = versions[first_gadget]["current"]["tag"]
+    report_completeness = {
+        "available": sum(1 for artifact in artifacts if artifact["report_available"]),
+        "expected_missing": sum(
+            1
+            for artifact in artifacts
+            if not artifact["report_available"] and artifact["expected_missing"]
+        ),
+        "unexpected_missing": sum(
+            1
+            for artifact in artifacts
+            if not artifact["report_available"] and not artifact["expected_missing"]
+        ),
+    }
+    comparable_pairs = 0
+    identical_pairs = 0
+    changed_pairs = 0
+    artifacts_by_key = {
+        (artifact["gadget"], artifact["version"]): artifact for artifact in artifacts
+    }
+    for gadget in gadgets:
+        baseline_artifact = artifacts_by_key[(gadget, "baseline")]["artifact"]
+        current_artifact = artifacts_by_key[(gadget, "current")]["artifact"]
+        if not baseline_artifact or not current_artifact:
+            continue
+        comparable_pairs += 1
+        if baseline_artifact.get("sha256") == current_artifact.get("sha256"):
+            identical_pairs += 1
+        else:
+            changed_pairs += 1
+
+    return {
+        "schema_version": "ig.gadget-kernel-compatibility-summary.v2",
+        "generated_at": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(),
+        "baseline_tag": baseline_tag,
+        "current_tag": current_tag,
+        "gadgets": gadgets,
+        "profiles": profiles,
+        "profile_requirements": profile_requirements,
+        "artifacts": artifacts,
+        "summary": counts,
+        "summary_by_requirement": by_requirement,
+        "report_completeness": report_completeness,
+        "artifact_comparison": {
+            "comparable_pairs": comparable_pairs,
+            "identical_pairs": identical_pairs,
+            "changed_pairs": changed_pairs,
+            "all_comparable_pairs_identical": (
+                comparable_pairs > 0 and identical_pairs == comparable_pairs
+            ),
+        },
+        "results": results,
+    }
+
+
+def markdown_escape(value):
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def classification_text(baseline, current):
+    baseline_code = baseline.get("classification_code") or ""
+    current_code = current.get("classification_code") or ""
+    if baseline["status"] == FAIL and current["status"] == FAIL:
+        if baseline_code == current_code:
+            return current_code
+        if baseline_code and current_code:
+            return f"{baseline_code} → {current_code}"
+    if current["status"] != PASS and current_code:
+        return current_code
+    if baseline["status"] != PASS and baseline_code:
+        return baseline_code
+    if current["status"] != PASS:
+        return current["status"].upper()
+    if baseline["status"] != PASS:
+        return baseline["status"].upper()
+    return ""
+
+
+def render_cell(result):
+    baseline = result["baseline"]
+    current = result["current"]
+    value = f"{STATUS_ICONS[baseline['status']]} → {STATUS_ICONS[current['status']]}"
+    classification = classification_text(baseline, current)
+    if classification:
+        value += f" ({markdown_escape(classification)})"
+    if result["change"] == "regression":
+        return f"**{value}**"
+    return value
+
+
+def render_markdown(summary):
+    counts = summary["summary"]
+    required_counts = summary["summary_by_requirement"]["required"]
+    optional_counts = summary["summary_by_requirement"]["optional"]
+    completeness = summary["report_completeness"]
+    artifact_comparison = summary["artifact_comparison"]
+    lines = [
+        "# Gadget kernel compatibility",
+        "",
+        (
+            f"Baseline: `{markdown_escape(summary['baseline_tag'])}` · "
+            f"Current: `{markdown_escape(summary['current_tag'])}`"
+        ),
+        "",
+        (
+            f"Regressions: **{counts['regressions']}** · "
+            f"Required regressions: **{required_counts['regressions']}** · "
+            f"Optional regressions: **{optional_counts['regressions']}**"
+        ),
+        "",
+        (
+            f"Improvements: **{counts['improvements']}** · "
+            f"Existing limitations: **{counts['existing_limitations']}** · "
+            f"Passing: **{counts['passing']}** · "
+            f"Incomplete: **{counts['incomplete']}**"
+        ),
+        "",
+        (
+            f"Reports: **{completeness['available']}** available · "
+            f"**{completeness['expected_missing']}** expected missing · "
+            f"**{completeness['unexpected_missing']}** unexpected missing"
+        ),
+        "",
+        (
+            f"Comparable artifact pairs: "
+            f"**{artifact_comparison['comparable_pairs']}** · "
+            f"Changed: **{artifact_comparison['changed_pairs']}** · "
+            f"Identical: **{artifact_comparison['identical_pairs']}**"
+        ),
+        "",
+        (
+            "Each cell is `baseline → current`; bold cells are regressions. "
+            "✅ pass · ❌ incompatible · ⚠️ infrastructure error · "
+            "⏭️ skipped · — missing report"
+        ),
+        "",
+    ]
+
+    gate = summary.get("gate")
+    if gate:
+        lines.append(f"Gate: **{'PASS' if gate['passed'] else 'FAIL'}**")
+        lines.append("")
+        for error in gate["errors"]:
+            lines.append(f"- {markdown_escape(error)}")
+        if gate["errors"]:
+            lines.append("")
+
+    if not summary["profiles"]:
+        lines.extend(
+            [
+                "No kernel-profile results were available.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    by_key = {
+        (result["profile"], result["gadget"]): result for result in summary["results"]
+    }
+    gadgets = summary["gadgets"]
+    lines.append(
+        "| Kernel profile | "
+        + " | ".join(markdown_escape(gadget) for gadget in gadgets)
+        + " |"
+    )
+    lines.append("| --- | " + " | ".join("---" for _ in gadgets) + " |")
+    for profile in summary["profiles"]:
+        cells = [render_cell(by_key[(profile, gadget)]) for gadget in gadgets]
+        requirement = requirement_name(summary["profile_requirements"].get(profile))
+        profile_label = f"{profile} ({requirement})"
+        lines.append(
+            f"| {markdown_escape(profile_label)} | " + " | ".join(cells) + " |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_output(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def evaluate_gates(
+    summary,
+    fail_on_regression=False,
+    fail_on_unexpected_missing=False,
+    fail_on_identical_artifacts=False,
+):
+    errors = []
+    if fail_on_regression and summary["summary"]["regressions"]:
+        errors.append(
+            f"{summary['summary']['regressions']} compatibility regressions found"
+        )
+
+    unexpected_missing = summary["report_completeness"]["unexpected_missing"]
+    if fail_on_unexpected_missing and unexpected_missing:
+        missing = [
+            f"{artifact['gadget']}:{artifact['version']}"
+            for artifact in summary["artifacts"]
+            if not artifact["report_available"] and not artifact["expected_missing"]
+        ]
+        errors.append(
+            f"{unexpected_missing} unexpected missing reports: " + ", ".join(missing)
+        )
+
+    missing_profile_results = [
+        f"{result['gadget']}:{result['profile']}:{version}"
+        for result in summary["results"]
+        for version in ("baseline", "current")
+        if result[version]["classification_code"] == "MISSING_PROFILE_RESULT"
+    ]
+    if fail_on_unexpected_missing and missing_profile_results:
+        errors.append(
+            f"{len(missing_profile_results)} unexpected missing profile results: "
+            + ", ".join(missing_profile_results)
+        )
+
+    comparison = summary["artifact_comparison"]
+    if fail_on_identical_artifacts and comparison["all_comparable_pairs_identical"]:
+        errors.append(
+            "all "
+            f"{comparison['comparable_pairs']} comparable artifact pairs "
+            "have identical SHA-256 values"
+        )
+    return errors
+
+
+def main():
+    args = parse_args()
+    try:
+        summary = build_summary(
+            args.matrix_json,
+            args.reports_dir,
+            args.expected_no_ebpf_gadget,
+        )
+    except (KeyError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    gate_errors = evaluate_gates(
+        summary,
+        fail_on_regression=args.fail_on_regression,
+        fail_on_unexpected_missing=args.fail_on_unexpected_missing,
+        fail_on_identical_artifacts=args.fail_on_identical_artifacts,
+    )
+    summary["gate"] = {
+        "passed": not gate_errors,
+        "errors": gate_errors,
+    }
+    write_output(args.markdown_output, render_markdown(summary))
+    write_output(
+        args.json_output,
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+    )
+    for error in gate_errors:
+        print(f"error: {error}", file=sys.stderr)
+    return 1 if gate_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gadget_kernel_compatibility_summary_test.py
+++ b/tools/gadget_kernel_compatibility_summary_test.py
@@ -1,0 +1,375 @@
+import json
+import pathlib
+import tempfile
+import unittest
+
+from tools import gadget_kernel_compatibility_summary as summary
+
+
+class GadgetKernelCompatibilitySummaryTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.reports_dir = pathlib.Path(self.temporary_directory.name)
+        self.matrix = {
+            "include": [
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for gadget in ("trace_exec", "trace_open")
+                for version in ("baseline", "current")
+            ]
+        }
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_report(
+        self,
+        gadget,
+        version,
+        targets,
+        sha256=None,
+        manifest_digest=None,
+        include_artifact=True,
+    ):
+        report_dir = self.reports_dir / f"{gadget}-{version}"
+        report_dir.mkdir()
+        metadata = {
+            "gadget": gadget,
+            "version": version,
+            "action_outcome": "success",
+            "ref_exists": True,
+        }
+        if manifest_digest is not None:
+            metadata["manifest_digest"] = manifest_digest
+        (report_dir / "metadata.json").write_text(
+            json.dumps(metadata),
+            encoding="utf-8",
+        )
+        # include_artifact=False models a report that carries real per-kernel
+        # results but no recorded artifact SHA-256 (the F1 regression case).
+        artifact = (
+            {"sha256": sha256 or f"{gadget}-{version}-sha256"}
+            if include_artifact
+            else {}
+        )
+        (report_dir / "compatibility.json").write_text(
+            json.dumps(
+                {
+                    "artifact": artifact,
+                    "targets": targets,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_builds_regression_table_and_counts_changes(self):
+        self.write_report(
+            "trace_exec",
+            "baseline",
+            [
+                {
+                    "profile_id": "kernel-a",
+                    "status": "pass",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-b",
+                    "status": "fail",
+                    "classification_code": "MISSING_BTF",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-c",
+                    "status": "fail",
+                    "classification_code": "UNSUPPORTED_MAP_TYPE",
+                    "required": False,
+                },
+                {
+                    "profile_id": "kernel-d",
+                    "status": "pass",
+                    "required": True,
+                },
+            ],
+        )
+        self.write_report(
+            "trace_exec",
+            "current",
+            [
+                {
+                    "profile_id": "kernel-a",
+                    "status": "fail",
+                    "classification_code": "UNSUPPORTED_HELPER",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-b",
+                    "status": "fail",
+                    "classification_code": "MISSING_BTF",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-c",
+                    "status": "pass",
+                    "required": False,
+                },
+                {
+                    "profile_id": "kernel-d",
+                    "status": "infra_error",
+                    "required": True,
+                },
+            ],
+        )
+
+        result = summary.build_summary(json.dumps(self.matrix), self.reports_dir)
+        markdown = summary.render_markdown(result)
+
+        self.assertEqual(result["summary"]["regressions"], 1)
+        self.assertEqual(result["summary"]["improvements"], 1)
+        self.assertEqual(result["summary"]["existing_limitations"], 1)
+        self.assertEqual(result["summary"]["incomplete"], 5)
+        self.assertEqual(
+            result["summary_by_requirement"]["required"]["regressions"],
+            1,
+        )
+        self.assertEqual(
+            result["summary_by_requirement"]["optional"]["improvements"],
+            1,
+        )
+        self.assertEqual(result["report_completeness"]["available"], 2)
+        self.assertEqual(
+            result["report_completeness"]["unexpected_missing"],
+            2,
+        )
+        self.assertEqual(result["artifact_comparison"]["changed_pairs"], 1)
+        self.assertEqual(len(result["artifacts"]), 4)
+        self.assertEqual(result["artifacts"][0]["action_outcome"], "success")
+        self.assertIn("**✅ → ❌ (UNSUPPORTED_HELPER)**", markdown)
+        self.assertIn("❌ → ❌ (MISSING_BTF)", markdown)
+        self.assertIn("❌ → ✅ (UNSUPPORTED_MAP_TYPE)", markdown)
+        self.assertIn("✅ → ⚠️ (INFRA_ERROR)", markdown)
+        self.assertIn("— → — (NO_REPORT)", markdown)
+        self.assertIn("kernel-a (required)", markdown)
+
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_regression=True,
+            fail_on_unexpected_missing=True,
+            fail_on_identical_artifacts=True,
+        )
+        self.assertEqual(len(errors), 2)
+        self.assertIn("1 compatibility regressions found", errors)
+        self.assertIn("2 unexpected missing reports", errors[1])
+
+    def test_expected_missing_and_identical_artifact_gates(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": not (
+                        gadget == "new_gadget" and version == "baseline"
+                    ),
+                }
+                for gadget in ("trace_exec", "new_gadget", "bpfstats")
+                for version in ("baseline", "current")
+            ]
+        }
+        targets = [
+            {
+                "profile_id": "kernel-a",
+                "status": "pass",
+                "required": True,
+            }
+        ]
+        self.write_report(
+            "trace_exec",
+            "baseline",
+            targets,
+            sha256="same-sha256",
+            manifest_digest="sha256:same-image",
+        )
+        self.write_report(
+            "trace_exec",
+            "current",
+            targets,
+            sha256="same-sha256",
+            manifest_digest="sha256:same-image",
+        )
+        self.write_report("new_gadget", "current", targets)
+
+        result = summary.build_summary(
+            json.dumps(matrix),
+            self.reports_dir,
+            expected_no_ebpf_gadgets=["bpfstats"],
+        )
+        markdown = summary.render_markdown(result)
+
+        self.assertEqual(result["report_completeness"]["available"], 3)
+        self.assertEqual(result["report_completeness"]["expected_missing"], 3)
+        self.assertEqual(result["report_completeness"]["unexpected_missing"], 0)
+        # baseline and current resolve to the same OCI manifest digest ->
+        # release-vs-itself, which is what the gate must catch.
+        self.assertTrue(result["image_comparison"]["all_comparable_pairs_same_image"])
+        self.assertEqual(
+            result["artifacts"][2]["missing_reason"],
+            "REFERENCE_NOT_FOUND",
+        )
+        self.assertEqual(
+            result["artifacts"][4]["missing_reason"],
+            "NO_EBPF_LAYER",
+        )
+        self.assertIn("— → ✅ (REFERENCE_NOT_FOUND)", markdown)
+        self.assertIn("— → — (NO_EBPF_LAYER)", markdown)
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_regression=True,
+            fail_on_unexpected_missing=True,
+            fail_on_identical_artifacts=True,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("same published image", errors[0])
+
+    def test_missing_profile_result_fails_completeness_gate(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": "trace_exec",
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for version in ("baseline", "current")
+            ]
+        }
+        baseline_targets = [
+            {"profile_id": "kernel-a", "status": "pass", "required": True},
+            {"profile_id": "kernel-b", "status": "pass", "required": True},
+        ]
+        current_targets = [
+            {"profile_id": "kernel-a", "status": "pass", "required": True},
+        ]
+        self.write_report("trace_exec", "baseline", baseline_targets)
+        self.write_report("trace_exec", "current", current_targets)
+
+        result = summary.build_summary(json.dumps(matrix), self.reports_dir)
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_unexpected_missing=True,
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("1 unexpected missing profile results", errors[0])
+        self.assertIn("trace_exec:kernel-b:current", errors[0])
+
+    def test_regression_is_detected_without_an_artifact_hash(self):
+        # F1: a report with real per-kernel results but no artifact SHA-256
+        # must still yield its pass/fail data; the ✅ -> ❌ regression cannot be
+        # silently downgraded to "incomplete".
+        self.write_report(
+            "trace_exec",
+            "baseline",
+            [{"profile_id": "kernel-a", "status": "pass", "required": True}],
+        )
+        self.write_report(
+            "trace_exec",
+            "current",
+            [
+                {
+                    "profile_id": "kernel-a",
+                    "status": "fail",
+                    "classification_code": "UNSUPPORTED_HELPER",
+                    "required": True,
+                }
+            ],
+            include_artifact=False,
+        )
+        matrix = {
+            "include": [
+                {
+                    "gadget": "trace_exec",
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for version in ("baseline", "current")
+            ]
+        }
+
+        result = summary.build_summary(json.dumps(matrix), self.reports_dir)
+
+        cell = result["results"][0]
+        self.assertEqual(cell["baseline"]["status"], "pass")
+        self.assertEqual(cell["current"]["status"], "fail")
+        self.assertEqual(cell["change"], "regression")
+        self.assertEqual(result["summary"]["regressions"], 1)
+        self.assertEqual(result["report_completeness"]["available"], 2)
+        self.assertEqual(result["report_completeness"]["unexpected_missing"], 0)
+
+        errors = summary.evaluate_gates(result, fail_on_regression=True)
+        self.assertIn("1 compatibility regressions found", errors)
+
+    def test_identical_ebpf_but_distinct_images_does_not_gate(self):
+        # F2: in a quiet week the eBPF object can be byte-identical between the
+        # release and current while the published images legitimately differ.
+        # The identical-artifacts gate keys on manifest digests, not the eBPF
+        # hash, so this healthy state must not fail the run.
+        matrix = {
+            "include": [
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for gadget in ("trace_exec", "trace_open")
+                for version in ("baseline", "current")
+            ]
+        }
+        targets = [{"profile_id": "kernel-a", "status": "pass", "required": True}]
+        for gadget in ("trace_exec", "trace_open"):
+            self.write_report(
+                gadget,
+                "baseline",
+                targets,
+                sha256=f"{gadget}-unchanged",
+                manifest_digest=f"sha256:{gadget}-release",
+            )
+            self.write_report(
+                gadget,
+                "current",
+                targets,
+                sha256=f"{gadget}-unchanged",
+                manifest_digest=f"sha256:{gadget}-main",
+            )
+
+        result = summary.build_summary(json.dumps(matrix), self.reports_dir)
+
+        # Every eBPF pair is identical (quiet week) ...
+        self.assertTrue(result["artifact_comparison"]["all_comparable_pairs_identical"])
+        # ... but the images differ, so the gate stays silent.
+        self.assertFalse(result["image_comparison"]["all_comparable_pairs_same_image"])
+        errors = summary.evaluate_gates(result, fail_on_identical_artifacts=True)
+        self.assertEqual(errors, [])
+
+    def test_rejects_a_matrix_without_both_versions(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": "trace_exec",
+                    "version": "baseline",
+                    "tag": "v1.0.0",
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(ValueError, "missing matrix versions: current"):
+            summary.build_summary(json.dumps(matrix), self.reports_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gadget_kernel_compatibility_summary_test.py
+++ b/tools/gadget_kernel_compatibility_summary_test.py
@@ -1,0 +1,265 @@
+import json
+import pathlib
+import tempfile
+import unittest
+
+from tools import gadget_kernel_compatibility_summary as summary
+
+
+class GadgetKernelCompatibilitySummaryTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.reports_dir = pathlib.Path(self.temporary_directory.name)
+        self.matrix = {
+            "include": [
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for gadget in ("trace_exec", "trace_open")
+                for version in ("baseline", "current")
+            ]
+        }
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_report(self, gadget, version, targets, sha256=None):
+        report_dir = self.reports_dir / f"{gadget}-{version}"
+        report_dir.mkdir()
+        (report_dir / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "action_outcome": "success",
+                    "ref_exists": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (report_dir / "compatibility.json").write_text(
+            json.dumps(
+                {
+                    "artifact": {"sha256": sha256 or f"{gadget}-{version}-sha256"},
+                    "targets": targets,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_builds_regression_table_and_counts_changes(self):
+        self.write_report(
+            "trace_exec",
+            "baseline",
+            [
+                {
+                    "profile_id": "kernel-a",
+                    "status": "pass",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-b",
+                    "status": "fail",
+                    "classification_code": "MISSING_BTF",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-c",
+                    "status": "fail",
+                    "classification_code": "UNSUPPORTED_MAP_TYPE",
+                    "required": False,
+                },
+                {
+                    "profile_id": "kernel-d",
+                    "status": "pass",
+                    "required": True,
+                },
+            ],
+        )
+        self.write_report(
+            "trace_exec",
+            "current",
+            [
+                {
+                    "profile_id": "kernel-a",
+                    "status": "fail",
+                    "classification_code": "UNSUPPORTED_HELPER",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-b",
+                    "status": "fail",
+                    "classification_code": "MISSING_BTF",
+                    "required": True,
+                },
+                {
+                    "profile_id": "kernel-c",
+                    "status": "pass",
+                    "required": False,
+                },
+                {
+                    "profile_id": "kernel-d",
+                    "status": "infra_error",
+                    "required": True,
+                },
+            ],
+        )
+
+        result = summary.build_summary(json.dumps(self.matrix), self.reports_dir)
+        markdown = summary.render_markdown(result)
+
+        self.assertEqual(result["summary"]["regressions"], 1)
+        self.assertEqual(result["summary"]["improvements"], 1)
+        self.assertEqual(result["summary"]["existing_limitations"], 1)
+        self.assertEqual(result["summary"]["incomplete"], 5)
+        self.assertEqual(
+            result["summary_by_requirement"]["required"]["regressions"],
+            1,
+        )
+        self.assertEqual(
+            result["summary_by_requirement"]["optional"]["improvements"],
+            1,
+        )
+        self.assertEqual(result["report_completeness"]["available"], 2)
+        self.assertEqual(
+            result["report_completeness"]["unexpected_missing"],
+            2,
+        )
+        self.assertEqual(result["artifact_comparison"]["changed_pairs"], 1)
+        self.assertEqual(len(result["artifacts"]), 4)
+        self.assertEqual(result["artifacts"][0]["action_outcome"], "success")
+        self.assertIn("**✅ → ❌ (UNSUPPORTED_HELPER)**", markdown)
+        self.assertIn("❌ → ❌ (MISSING_BTF)", markdown)
+        self.assertIn("❌ → ✅ (UNSUPPORTED_MAP_TYPE)", markdown)
+        self.assertIn("✅ → ⚠️ (INFRA_ERROR)", markdown)
+        self.assertIn("— → — (NO_REPORT)", markdown)
+        self.assertIn("kernel-a (required)", markdown)
+
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_regression=True,
+            fail_on_unexpected_missing=True,
+            fail_on_identical_artifacts=True,
+        )
+        self.assertEqual(len(errors), 2)
+        self.assertIn("1 compatibility regressions found", errors)
+        self.assertIn("2 unexpected missing reports", errors[1])
+
+    def test_expected_missing_and_identical_artifact_gates(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": gadget,
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": not (
+                        gadget == "new_gadget" and version == "baseline"
+                    ),
+                }
+                for gadget in ("trace_exec", "new_gadget", "bpfstats")
+                for version in ("baseline", "current")
+            ]
+        }
+        targets = [
+            {
+                "profile_id": "kernel-a",
+                "status": "pass",
+                "required": True,
+            }
+        ]
+        self.write_report(
+            "trace_exec",
+            "baseline",
+            targets,
+            sha256="same-sha256",
+        )
+        self.write_report(
+            "trace_exec",
+            "current",
+            targets,
+            sha256="same-sha256",
+        )
+        self.write_report("new_gadget", "current", targets)
+
+        result = summary.build_summary(
+            json.dumps(matrix),
+            self.reports_dir,
+            expected_no_ebpf_gadgets=["bpfstats"],
+        )
+        markdown = summary.render_markdown(result)
+
+        self.assertEqual(result["report_completeness"]["available"], 3)
+        self.assertEqual(result["report_completeness"]["expected_missing"], 3)
+        self.assertEqual(result["report_completeness"]["unexpected_missing"], 0)
+        self.assertTrue(result["artifact_comparison"]["all_comparable_pairs_identical"])
+        self.assertEqual(
+            result["artifacts"][2]["missing_reason"],
+            "REFERENCE_NOT_FOUND",
+        )
+        self.assertEqual(
+            result["artifacts"][4]["missing_reason"],
+            "NO_EBPF_LAYER",
+        )
+        self.assertIn("— → ✅ (REFERENCE_NOT_FOUND)", markdown)
+        self.assertIn("— → — (NO_EBPF_LAYER)", markdown)
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_regression=True,
+            fail_on_unexpected_missing=True,
+            fail_on_identical_artifacts=True,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("identical SHA-256", errors[0])
+
+    def test_missing_profile_result_fails_completeness_gate(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": "trace_exec",
+                    "version": version,
+                    "tag": "v1.0.0" if version == "baseline" else "main",
+                    "ref_exists": True,
+                }
+                for version in ("baseline", "current")
+            ]
+        }
+        baseline_targets = [
+            {"profile_id": "kernel-a", "status": "pass", "required": True},
+            {"profile_id": "kernel-b", "status": "pass", "required": True},
+        ]
+        current_targets = [
+            {"profile_id": "kernel-a", "status": "pass", "required": True},
+        ]
+        self.write_report("trace_exec", "baseline", baseline_targets)
+        self.write_report("trace_exec", "current", current_targets)
+
+        result = summary.build_summary(json.dumps(matrix), self.reports_dir)
+        errors = summary.evaluate_gates(
+            result,
+            fail_on_unexpected_missing=True,
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("1 unexpected missing profile results", errors[0])
+        self.assertIn("trace_exec:kernel-b:current", errors[0])
+
+    def test_rejects_a_matrix_without_both_versions(self):
+        matrix = {
+            "include": [
+                {
+                    "gadget": "trace_exec",
+                    "version": "baseline",
+                    "tag": "v1.0.0",
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(ValueError, "missing matrix versions: current"):
+            summary.build_summary(json.dumps(matrix), self.reports_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds an optional weekly/manual workflow that detects kernel-compatibility drift between the latest released Inspektor Gadget artifacts and the artifacts currently published from `main`.

Why: vendor kernels and cloud images move underneath already-published gadgets, and a kernel version does not fully predict eBPF feature support (for example, enterprise kernels backport features). This complements the existing vimto/ci-kernels tests by validating the published OCI artifacts themselves in disposable QEMU/KVM VMs booted from vendor cloud images.

### What it does

- Discovers the full gadget set dynamically with `make -s -C gadgets list-gadgets` (49 gadgets today).
- Resolves the latest GitHub release as the baseline and the `main` OCI tag as the current artifact. The release workflow also moves `latest` to the newest release, so comparing against `latest` would compare the release with itself.
- Preflights all registry references and records manifest digests, so a gadget added after the release is reported as an expected missing baseline rather than silently disappearing.
- Runs the pinned, checksum-verified bpfcompat action against 11 vendor-kernel profiles, retaining both required/optional profile metadata and every per-gadget report.
- Produces one Markdown table and a structured JSON report covering regressions, improvements, existing limitations, infrastructure outcomes, missing reports, and artifact hashes.
- Fails the scheduled/manual run after uploading the aggregate report if it finds a pass→fail regression, an unexpected missing report/profile result, or the suspicious case where every comparable eBPF SHA-256 pair is identical.
- Treats only registry-confirmed absent references and the known no-eBPF-layer gadgets (`bpfstats`, `top_cpu_throttle`, and `top_process`) as expected missing artifacts.
- Uses one non-cancelling workflow concurrency group and an eight-job matrix cap to avoid overlapping weekly/manual runs.

It remains non-blocking for normal development because it has only `schedule` and `workflow_dispatch` triggers—no PR or push trigger—but the drift-detection run itself becomes red when it detects actionable signal.

### Full proof run

Exact head `f659b3ef8f1160acc1b0c1007122e596cc116f2a`:
https://github.com/ErenAri/inspektor-gadget/actions/runs/30472407025

- 100/100 jobs succeeded: generator, 98 gadget/version jobs, and aggregate gate.
- 49 gadgets × 11 profiles = 539 baseline→current comparison cells.
- 0 regressions; 4 improvements; 186 existing limitations; 301 passing; 48 incomplete.
- 45 artifact pairs were comparable: 11 changed eBPF SHA-256 values and 34 identical, proving the comparison is not release-versus-release.
- 91/98 reports available; 7 expected missing; 0 unexpected missing.
- The 48 incomplete cells are 44 expected cells from three no-eBPF-layer gadgets plus one gadget absent from the release, and 4 isolated infrastructure outcomes.
- Runtime: about 92 minutes wall-clock and 665 runner-minutes at max-parallel 8 (median matrix job 6.6 min, p95 11.5 min, max 16.9 min).

Disclosure: I maintain bpfcompat. Inspektor Gadget's OCI gadget distribution is a natural fit for this check, and bpfcompat's OCI-loading support was originally added after discussion with IG maintainers.

Happy to adjust the kernel set, cadence, gating policy, or concurrency based on maintainer preference.
