### PR TITLE
fix(trace_exec): report the device number of the controlling terminal

### DIFF
--- a/gadgets/trace_exec/gadget.yaml
+++ b/gadgets/trace_exec/gadget.yaml
@@ -104,9 +104,21 @@ datasources:
           columns.hidden: true
       tty:
         annotations:
-          description: The controlling terminal of the process. 0 for processes without a terminal.
+          description: The index of the controlling terminal of the process within its own driver. It does not identify a terminal on its own, as the index is only unique per driver, use tty_major and tty_minor instead. 0 for processes without a controlling terminal, which is indistinguishable from the first terminal of any driver.
           columns.width: 5
           columns.hidden: false
+      tty_major:
+        annotations:
+          description: The major number of the device of the controlling terminal of the process, e.g. 136 for a pseudo terminal or 4 for a virtual console. 0 for processes without a controlling terminal.
+          columns.width: 5
+          columns.hidden: true
+          columns.alignment: right
+      tty_minor:
+        annotations:
+          description: The minor number of the device of the controlling terminal of the process. 0 for processes without a controlling terminal.
+          columns.width: 5
+          columns.hidden: true
+          columns.alignment: right
       from_rootfs:
         annotations:
           description: Whether the executable file of the process (interpreter in case of script) is in the rootfs of the container. Initialized when the execution succeeded or failed with the -ENOEXEC error ("Exec format error"). Notice that to get failed executions, you need to set ignore_failed to false.

--- a/gadgets/trace_exec/program.bpf.c
+++ b/gadgets/trace_exec/program.bpf.c
@@ -42,6 +42,8 @@ struct event {
 	gadget_errno error_raw;
 	int args_count;
 	int tty;
+	unsigned int tty_major;
+	unsigned int tty_minor;
 	bool from_rootfs;
 	bool file_from_rootfs;
 	bool upper_layer;
@@ -115,6 +117,32 @@ GADGET_TRACER_MAP(events, 1024 * 256);
 
 GADGET_TRACER(exec, events, event);
 
+// read_tty fills in the controlling terminal of the task, if any.
+//
+// tty->index alone does not identify a terminal: it is only the index of the
+// terminal within its own driver, so /dev/pts/0 and /dev/tty0 both have index
+// 0, which is also the value reported for a task without a controlling
+// terminal. The device number is what identifies the terminal unambiguously, so
+// report it as well and leave it at 0:0 when there is no controlling terminal.
+//
+// The device number is computed the same way as the kernel's tty_devnum():
+// MKDEV(tty->driver->major, tty->driver->minor_start) + tty->index
+static __always_inline void read_tty(struct event *event,
+				     struct task_struct *task)
+{
+	struct tty_struct *tty = BPF_CORE_READ(task, signal, tty);
+	if (!tty)
+		return;
+
+	struct tty_driver *driver = BPF_CORE_READ(tty, driver);
+	if (!driver)
+		return;
+
+	event->tty = BPF_CORE_READ(tty, index);
+	event->tty_major = BPF_CORE_READ(driver, major);
+	event->tty_minor = BPF_CORE_READ(driver, minor_start) + event->tty;
+}
+
 static __always_inline int enter_execve(const char **args)
 {
 	u64 id;
@@ -148,7 +176,7 @@ static __always_inline int enter_execve(const char **args)
 	if (bpf_core_field_exists(task->sessionid))
 		event->sessionid = BPF_CORE_READ(task, sessionid);
 
-	event->tty = BPF_CORE_READ(task, signal, tty, index);
+	read_tty(event, task);
 
 	if (paths) {
 		struct fs_struct *fs = BPF_CORE_READ(task, fs);

--- a/gadgets/trace_exec/test/unit/trace_exec_test.go
+++ b/gadgets/trace_exec/test/unit/trace_exec_test.go
@@ -25,7 +25,9 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/creack/pty"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
 	traceexec "github.com/inspektor-gadget/inspektor-gadget/gadgets/trace_exec/consts"
@@ -36,12 +38,15 @@ import (
 )
 
 type ExpectedTraceExecEvent struct {
-	Proc   utils.Process `json:"proc"`
-	Error  string        `json:"error"`
-	Args   string        `json:"args"`
-	Ctime  uint64        `json:"ctime"`
-	Fctime uint64        `json:"fctime"`
-	Pctime uint64        `json:"pctime"`
+	Proc     utils.Process `json:"proc"`
+	Error    string        `json:"error"`
+	Args     string        `json:"args"`
+	Ctime    uint64        `json:"ctime"`
+	Fctime   uint64        `json:"fctime"`
+	Pctime   uint64        `json:"pctime"`
+	Tty      int32         `json:"tty"`
+	TtyMajor uint32        `json:"tty_major"`
+	TtyMinor uint32        `json:"tty_minor"`
 }
 
 type testDef struct {
@@ -220,6 +225,88 @@ func TestTraceExecGadget(t *testing.T) {
 			testCase.validate(t, runner.Info, gadgetRunner.CapturedEvents, testCase.argv)
 		})
 	}
+}
+
+// TestTraceExecTty checks the controlling terminal reported for a process that
+// has one and for a process that has none. Both processes are started in their
+// own session so that the controlling terminal does not depend on the one of
+// the process running the test.
+func TestTraceExecTty(t *testing.T) {
+	gadgettesting.InitUnitTest(t)
+
+	// Open the pty outside of the runner: the file descriptors are inherited by
+	// the child regardless of the namespaces it is started in.
+	ptmx, pts, err := pty.Open()
+	require.NoError(t, err, "Opening pty")
+	defer ptmx.Close()
+	defer pts.Close()
+
+	var stat unix.Stat_t
+	err = unix.Fstat(int(pts.Fd()), &stat)
+	require.NoError(t, err, "Getting the device number of %s", pts.Name())
+	expectedMajor := unix.Major(uint64(stat.Rdev))
+	expectedMinor := unix.Minor(uint64(stat.Rdev))
+
+	runner := utils.NewRunnerWithTest(t, &utils.RunnerConfig{})
+	onGadgetRun := func(gadgetCtx operators.GadgetContext) error {
+		utils.RunWithRunner(t, runner, func() error {
+			// First event: the pty is made the controlling terminal of the new
+			// session, i.e. it is the controlling terminal of the process.
+			argv := []string{"/bin/echo", "with-tty"}
+			p, err := os.StartProcess(argv[0], argv, &os.ProcAttr{
+				Files: []*os.File{pts, pts, pts},
+				Sys: &syscall.SysProcAttr{
+					Setsid:  true,
+					Setctty: true,
+					Ctty:    0,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			if _, err := p.Wait(); err != nil {
+				return err
+			}
+
+			// Second event: a new session without a controlling terminal.
+			argv = []string{"/bin/echo", "without-tty"}
+			p, err = os.StartProcess(argv[0], argv, &os.ProcAttr{
+				Sys: &syscall.SysProcAttr{Setsid: true},
+			})
+			if err != nil {
+				return err
+			}
+			_, err = p.Wait()
+			return err
+		})
+		return nil
+	}
+
+	opts := gadgetrunner.GadgetRunnerOpts[ExpectedTraceExecEvent]{
+		Image:          "trace_exec",
+		Timeout:        5 * time.Second,
+		MntnsFilterMap: utils.CreateMntNsFilterMap(t, runner.Info.MountNsID),
+		OnGadgetRun:    onGadgetRun,
+	}
+	gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+
+	gadgetRunner.RunGadget()
+
+	events := gadgetRunner.CapturedEvents
+	require.Len(t, events, 2, "Expected 2 events but got %d", len(events))
+
+	withTty := events[0]
+	require.Contains(t, withTty.Args, "with-tty")
+	require.Equal(t, expectedMajor, withTty.TtyMajor,
+		"tty_major should be the major number of %s", pts.Name())
+	require.Equal(t, expectedMinor, withTty.TtyMinor,
+		"tty_minor should be the minor number of %s", pts.Name())
+
+	withoutTty := events[1]
+	require.Contains(t, withoutTty.Args, "without-tty")
+	require.Zero(t, withoutTty.Tty, "tty should be 0 without a controlling terminal")
+	require.Zero(t, withoutTty.TtyMajor, "tty_major should be 0 without a controlling terminal")
+	require.Zero(t, withoutTty.TtyMinor, "tty_minor should be 0 without a controlling terminal")
 }
 
 func generateEventFromThread(t *testing.T, argv []string) {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

The `tty` field of `trace_exec` reports `tty->index`, which does not identify a terminal: the index is only unique per driver, and `0` means both "no controlling terminal" and "the first terminal of any driver"; so a process on `/dev/pts/0` is indistinguishable from a process with no terminal. This adds `tty_major`/`tty_minor` with the terminal's device number so consumers can tell terminals apart, and corrects the `tty` description.

### Problem

`trace_exec` exposes the controlling terminal of a process as a single `tty` field, read from `tty->index`:

```c
event->tty = BPF_CORE_READ(task, signal, tty, index);
```

`tty->index` is the index of the terminal **within its own driver**, not an identifier of the terminal. That makes the field hard to use for two reasons:

1. **The value is meaningless without knowing the driver.** The index is only unique per driver, so `/dev/pts/0`, `/dev/tty0` and `/dev/ttyS0` are all reported as `0`. A consumer that sees `tty: 3` cannot tell whether the process is on a pseudo terminal, a virtual console or a serial console.

2. **"No controlling terminal" is indistinguishable from "the first terminal of a driver".** When a process has no controlling terminal, `task->signal->tty` is NULL, the chained read fails, and the field ends up as `0`: exactly the same value reported for a process on `/dev/pts/0`. The field is currently documented as:

   > The controlling terminal of the process. 0 for processes without a terminal.

   which does not hold: the common case of the first pseudo terminal on the system collides with it. Any consumer testing `tty == 0` to mean "not attached to a terminal" gets a wrong answer for processes on `pts/0`, and any consumer testing `tty != 0` to mean "attached to a terminal" misses them.

The information that identifies a terminal unambiguously is its device number, and it is available right next to the index.

### Change

Add `tty_major` and `tty_minor`, the device number of the controlling terminal, computed the same way as the kernel's `tty_devnum()`:

```
MKDEV(tty->driver->major, tty->driver->minor_start) + tty->index
```

They are left at `0:0` when the process has no controlling terminal, which is unambiguous since no terminal driver uses major 0. The driver becomes explicit (major `136` for a pseudo terminal, `4` for a virtual console), and `tty_minor` combined with `tty_major` maps directly onto the device under `/dev`.

Both fields are hidden columns by default, matching the existing `dev_major`/`dev_minor` fields in this gadget, so the default CLI output is unchanged.

The existing `tty` field is **kept as is** to avoid breaking existing consumers; only its description is corrected to state what it actually contains and to point at the new fields. If maintainers would rather repurpose or drop `tty` instead of keeping a field that cannot be used on its own, I'm happy to do that in this PR: it would be a breaking change, hence the conservative default here.

A `tty_name` field (from `tty->name`, e.g. `pts/0`) would be a friendlier column for humans reading CLI output; I left it out to keep this focused on the correctness fix, and can add it here or in a follow-up if it's wanted.

### Testing

New unit test `TestTraceExecTty` in `gadgets/trace_exec/test/unit`. It starts two processes, each in its own session so the result does not depend on the controlling terminal of the test process itself:

- one with a pty made its controlling terminal (`Setsid` + `Setctty`): asserts `tty_major`/`tty_minor` equal the device number obtained by `fstat()`ing the pts file, rather than hardcoding 136, so it holds regardless of how the pts driver is registered;
- one with `Setsid` only, i.e. no controlling terminal: asserts `tty`, `tty_major` and `tty_minor` are all 0.

The second case is what the current field cannot express: without this change the two processes are only distinguishable when the pty happens not to be `pts/0`.

Also verified that the eBPF program builds for both `amd64` and `arm64` with the `gadget-builder` image, and that `struct event` carries the new fields in BTF.
