### PR TITLE
pkg/symbolizer/otel: Fix ustack symbolization drops and add profiler debug logging

### DIFF
--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -166,6 +166,15 @@ spec:
                 # Needed to attach qdiscs and filters to network interfaces. See createClsActQdisc()
                 # and addTCFilter() in pkg/gadgets/internal/tcnetworktracer/tc.go
                 - NET_ADMIN
+
+                # Needed by the OTel eBPF profiler (ustack symbolization) to read
+                # the ELF files of profiled processes via /proc/$pid/map_files/*.
+                # These opens go through a ptrace-mode fs-creds check against the
+                # target process, so without this capability the profiler cannot
+                # read libraries of processes running as a different (non-root)
+                # user (e.g. Ray workers running as uid 1000), which leaves their
+                # stack deltas unloaded and breaks symbolization.
+                - DAC_READ_SEARCH
               {{- else }}
               {{- toYaml .Values.capabilities | nindent 14 }}
               {{- end }}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -284,6 +284,15 @@ spec:
                 # Needed to attach qdiscs and filters to network interfaces. See createClsActQdisc()
                 # and addTCFilter() in pkg/gadgets/internal/tcnetworktracer/tc.go
                 - NET_ADMIN
+
+                # Needed by the OTel eBPF profiler (ustack symbolization) to read
+                # the ELF files of profiled processes via /proc/$pid/map_files/*.
+                # These opens go through a ptrace-mode fs-creds check against the
+                # target process, so without this capability the profiler cannot
+                # read libraries of processes running as a different (non-root)
+                # user (e.g. Ray workers running as uid 1000), which leaves their
+                # stack deltas unloaded and breaks symbolization.
+                - DAC_READ_SEARCH
           volumeMounts:
             - mountPath: /host/bin
               name: bin

--- a/pkg/symbolizer/otel/otel.go
+++ b/pkg/symbolizer/otel/otel.go
@@ -17,12 +17,14 @@ package otel
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	otellog "go.opentelemetry.io/ebpf-profiler/log"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	oteltimes "go.opentelemetry.io/ebpf-profiler/times"
 	oteltracer "go.opentelemetry.io/ebpf-profiler/tracer"
@@ -100,6 +102,20 @@ type otelResolverInstance struct {
 // The 800ms timeout provides sufficient headroom over the worst case
 // (one full 250ms poll interval + processing time).
 const correlationTimeout = 800 * time.Millisecond
+
+// otelSamplesPerSecond sizes the per-CPU trace_events perf ring buffer that the
+// OTel profiler uses to send unwound stacks to userspace. The buffer is
+// SamplesPerSecond*sizeof(Trace) bytes, or a single page (~4 KiB) when 0 (see
+// startTraceEventMonitor in the profiler's tracer/events.go).
+//
+// We do not use CPU sampling (SetSampleFreq is the only other consumer of this
+// value, via AttachTracer, which we never call), so it purely controls buffer
+// sizing. A 4 KiB buffer overflows during bursts (e.g. profile_cuda tracing a
+// GIL-bound process whose uprobes fire many stacks back-to-back faster than the
+// 250 ms poll interval drains them); dropped traces never reach correlationMap,
+// causing "no frames found" timeouts in Resolve(). A non-zero value enlarges the
+// buffer (~494 KiB per CPU) to absorb these bursts.
+const otelSamplesPerSecond = 20
 
 func (o *otelResolverInstance) IsPruningNeeded() bool {
 	return true
@@ -355,7 +371,27 @@ func bpfVerifierLogLevel() uint32 {
 	return 0
 }
 
+// logrusToSlogLevel maps IG's logrus level to the slog level used by the OTel
+// profiler's internal logger, so the profiler logs at the same verbosity as IG.
+func logrusToSlogLevel(level log.Level) slog.Level {
+	switch level {
+	case log.TraceLevel, log.DebugLevel:
+		return slog.LevelDebug
+	case log.InfoLevel:
+		return slog.LevelInfo
+	case log.WarnLevel:
+		return slog.LevelWarn
+	default: // Error, Fatal, Panic
+		return slog.LevelError
+	}
+}
+
 func (o *otelResolverInstance) startOtelEbpfProfiler(ctx context.Context) error {
+	// Make the OTel profiler's internal logger follow IG's configured log
+	// level, so enabling debug logging in IG also surfaces the profiler's
+	// debug output.
+	otellog.SetLevel(logrusToSlogLevel(log.GetLevel()))
+
 	includeTracers, err := oteltracertypes.Parse("all")
 	if err != nil {
 		return fmt.Errorf("parsing list of OpenTelemetry tracers: %w", err)
@@ -397,7 +433,7 @@ func (o *otelResolverInstance) startOtelEbpfProfiler(ctx context.Context) error 
 		Intervals:              intervals,
 		IncludeTracers:         includeTracers,
 		FilterErrorFrames:      true,
-		SamplesPerSecond:       0,
+		SamplesPerSecond:       otelSamplesPerSecond,
 		MapScaleFactor:         0,
 		KernelVersionCheck:     false,
 		VerboseMode:            log.IsLevelEnabled(log.DebugLevel),


### PR DESCRIPTION
This PR fixes several issues with the OTel eBPF profiler used for userspace stack symbolization, which caused intermittent "no frames found" failures.

## Before the PR

dropped sample symptoms:

```
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25030867731948 after timeout. Give up.","time":"2026-07-24T18:04:44Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25030867955657 after timeout. Give up.","time":"2026-07-24T18:04:44Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25037694721388 after timeout. Give up.","time":"2026-07-24T18:04:50Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25097629751149 after timeout. Give up.","time":"2026-07-24T18:05:50Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25098725445613 after timeout. Give up.","time":"2026-07-24T18:05:51Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25098139846303 after timeout. Give up.","time":"2026-07-24T18:05:51Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25099165420562 after timeout. Give up.","time":"2026-07-24T18:05:52Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25100142786209 after timeout. Give up.","time":"2026-07-24T18:05:53Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25101357519729 after timeout. Give up.","time":"2026-07-24T18:05:54Z"}
{"level":"warning","msg":"OtelResolverInstance.Resolve: no frames found for correlation ID 25101357203397 after timeout. Give up.","time":"2026-07-24T18:05:54Z"}
```

missing capability symptoms:

```
time=2026-07-25T08:00:15.238Z level=DEBUG msg="Failed to get ELF info for PID 301884 file /tmp/ray/session_2026-07-25_00-56-02_077175_1/runtime_resources/pip/4001020c4aa23c890b6a353db3ca5170baf909d0/virtualenv/lib/python3.10/site-packages/cuda/bindings/cydriver.cpython-310-x86_64-linux-gnu.so: open /proc/301884/map_files/7fd01d4e4000-7fd01d4e7000: permission denied"
time=2026-07-25T08:00:15.238Z level=DEBUG msg="Failed to get ELF info for PID 301884 file /tmp/ray/session_2026-07-25_00-56-02_077175_1/runtime_resources/pip/4001020c4aa23c890b6a353db3ca5170baf909d0/virtualenv/lib/python3.10/site-packages/torch/lib/libtorch.so: open /proc/301884/map_files/7fd01d4f8000-7fd01d4fb000: permission denied"
time=2026-07-25T08:00:15.238Z level=DEBUG msg="Failed to get ELF info for PID 301884 file /home/ray/anaconda3/lib/python3.10/site-packages/pyarrow/_json.cpython-310-x86_64-linux-gnu.so: open /proc/301884/map_files/7fd02401b000-7fd02401c000: permission denied"
time=2026-07-25T08:00:15.238Z level=DEBUG msg="Failed to get ELF info for PID 301884 file /home/ray/anaconda3/lib/python3.10/site-packages/pyarrow/_parquet.cpython-310-x86_64-linux-gnu.so: open /proc/301884/map_files/7fd024b81000-7fd024b86000: permission denied"
```

Also, flamegraph w/o fixes:

<img width="3700" height="1781" alt="Screenshot from 2026-07-27 14-33-04" src="https://github.com/user-attachments/assets/3f462642-4647-49b3-96da-15aced572996" />



- Default value for `SamplesPerSecond`: https://github.com/inspektor-gadget/opentelemetry-ebpf-profiler/blob/6d575351a07f0e6d623558a4b23123dfb2a6f80d/collector/factory_linux.go#L42
- Calculation for buffer size: https://github.com/inspektor-gadget/opentelemetry-ebpf-profiler/blob/main/tracer/tracer.go#L627



## Testing Done

Deployed the image from fork and tried running Ray training job:

<img width="3700" height="1781" alt="Screenshot from 2026-07-27 16-12-28" src="https://github.com/user-attachments/assets/ba426126-2fec-49ac-bef9-c1ba238e4d11" />


cc: @alban 


