### PR TITLE
cmd: Add --drop-cap-sys-admin to deploy subcommand.

### DIFF
--- a/cmd/kubectl-gadget/deploy.go
+++ b/cmd/kubectl-gadget/deploy.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -112,6 +113,7 @@ var (
 	otelMetricsListenAddr string
 	daemonConfig          string
 	setDaemonConfig       []string
+	dropCapSysAdmin       bool
 )
 
 var clusterImagePolicyKind = schema.GroupVersionKind{
@@ -263,6 +265,10 @@ func init() {
 	deployCmd.PersistentFlags().StringVar(
 		&daemonConfig,
 		"daemon-config", "", "Path to a config file to override the daemon configuration values. The file must be in YAML format")
+	deployCmd.PersistentFlags().BoolVar(
+		&dropCapSysAdmin,
+		"drop-cap-sys-admin", false,
+		"Drop CAP_SYS_ADMIN and use CAP_BPF and CAP_PERFMON instead. This disables fanotify-based container detection and use a non-fanotify hook-mode (podinformer/nri/crio)")
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -271,6 +277,32 @@ func info(format string, args ...any) {
 		return
 	}
 	fmt.Printf(format, args...)
+}
+
+func replaceCapSysAdminWithCapBpfAndCapPerfmon(c *v1.Container) error {
+	if c.SecurityContext == nil || c.SecurityContext.Capabilities == nil {
+		return fmt.Errorf("gadget container has no capabilities to modify")
+	}
+	caps := c.SecurityContext.Capabilities
+
+	filtered := make([]v1.Capability, 0, len(caps.Add))
+	found := false
+	for _, capability := range caps.Add {
+	if capability == "SYS_ADMIN" {
+			found = true
+			continue
+		}
+		filtered = append(filtered, capability)
+	}
+	if !found {
+		return errors.New("--drop-cap-sys-admin used but CAP_SYS_ADMIN was not present in deployment")
+	}
+
+	filtered = append(filtered, "BPF", "PERFMON")
+	caps.Add = filtered
+
+	log.Warn("CAP_SYS_ADMIN dropped: new-container detection via fanotify is disabled")
+	return nil
 }
 
 // parseK8sYaml parses a k8s YAML deployment file content and returns the
@@ -787,6 +819,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			gadgetContainer := &daemonSet.Spec.Template.Spec.Containers[0]
 
 			gadgetContainer.Image = image
+
+			if dropCapSysAdmin {
+				err := replaceCapSysAdminWithCapBpfAndCapPerfmon(gadgetContainer)
+				if err != nil {
+					return err
+				}
+			}
 
 			policy, err := stringToPullPolicy(imagePullPolicy)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -49,12 +49,12 @@ require (
 	go.opentelemetry.io/collector/pdata/pprofile v0.147.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0
 	go.opentelemetry.io/ebpf-profiler v0.0.202536
-	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.64.0
 	go.opentelemetry.io/otel/log v0.18.0
-	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.18.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
@@ -170,7 +170,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,8 @@ go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0 h1:fM78cKITJ2r08cl+n
 go.opentelemetry.io/contrib/instrumentation/runtime v0.67.0/go.mod h1:ybmlzIqGcQzwt5lAfi8TpSnHo/CI3yv1Czodmm+OJa8=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
+go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0 h1:deI9UQMoGFgrg5iLPgzueqFPHevDl+28YKfSpPTI6rY=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0/go.mod h1:PFx9NgpNUKXdf7J4Q3agRxMs3Y07QhTCVipKmLsMKnU=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0 h1:MdKucPl/HbzckWWEisiNqMPhRrAOQX8r4jTuGr636gk=
@@ -475,6 +477,8 @@ go.opentelemetry.io/otel/log v0.18.0 h1:XgeQIIBjZZrliksMEbcwMZefoOSMI1hdjiLEiiB0
 go.opentelemetry.io/otel/log v0.18.0/go.mod h1:KEV1kad0NofR3ycsiDH4Yjcoj0+8206I6Ox2QYFSNgI=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
+go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
+go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
 go.opentelemetry.io/otel/sdk v1.43.0/go.mod h1:P+IkVU3iWukmiit/Yf9AWvpyRDlUeBaRg6Y+C58QHzg=
 go.opentelemetry.io/otel/sdk/log v0.18.0 h1:n8OyZr7t7otkeTnPTbDNom6rW16TBYGtvyy2Gk6buQw=
@@ -485,6 +489,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
+go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.opentelemetry.io/proto/otlp/profiles/v1development v0.2.0 h1:yXinc284C6bmzA1r9jk7MxAhrBIIOH3qwmqwBmylZrA=


### PR DESCRIPTION
This flag drop CAP_SYS_ADMIN and replace it with CAP_BPF and CAP_PERFMON which
are all what is needed to run eBPF programs on modern kernels.
Fanotify will nonetheless not work as it requires CAP_SYS_ADMIN but k8s context
can rely on podinformer.

```bash
$ ./kubectl-gadget deploy --image ghcr.io/inspektor-gadget/inspektor-gadget:latest --drop-cap-sys-admin
WARN[0002] No policy controller found, the container image will not be verified 
Creating Namespace/gadget...
Creating ServiceAccount/gadget...
Creating ConfigMap/gadget...
Creating ClusterRole/gadget-cluster-role...
Creating ClusterRoleBinding/gadget-cluster-role-binding...
Creating Role/gadget-role...
Creating RoleBinding/gadget-role-binding...
WARN[0007] CAP_SYS_ADMIN dropped: new-container detection via fanotify is disabled 
Creating DaemonSet/gadget...
I0727 14:45:22.447779    2708 warnings.go:107] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image ghcr.io/inspektor-gadget
/inspektor-gadget:latest for container gadget has not been allowed."
Waiting for gadget pod(s) to be ready...
1/1 gadget pod(s) ready
Inspektor Gadget successfully deployed
 kubectl get pod -n gadget
NAME           READY   STATUS    RESTARTS   AGE
gadget-mhnkb   1/1     Running   0          58s
$ kubectl logs -n gadget gadget-mhnkb
time="2026-07-27T12:45:26Z" level=info msg="Inspektor Gadget version: 0.54.1"
time="2026-07-27T12:45:26Z" level=info msg="Inspektor Gadget User Agent: gadgettracermanager/v0.54.1 (linux/amd64) kubernetes/v0.35.4"
time="2026-07-27T12:45:26Z" level=info msg="Config: daemon-log-level=info"
time="2026-07-27T12:45:26Z" level=info msg="HostPID=false"
time="2026-07-27T12:45:26Z" level=info msg="HostNetwork=false"
time="2026-07-27T12:45:26Z" level=info msg="HostCgroup=false"
time="2026-07-27T12:45:26Z" level=info msg="OS detected: Ubuntu 24.04.4 LTS"
time="2026-07-27T12:45:26Z" level=info msg="Kernel detected: 6.8.0-1059-azure"
time="2026-07-27T12:45:26Z" level=info msg="Gadget Image: ghcr.io/inspektor-gadget/inspektor-gadget:latest"
time="2026-07-27T12:45:26Z" level=info msg="Starting the Gadget Tracer Manager..."
time="2026-07-27T12:45:26Z" level=info msg="Config: events-buffer-length=16384"
time="2026-07-27T12:45:26Z" level=info msg="Config: gadget-namespace=gadget"
time="2026-07-27T12:45:26Z" level=info msg="initializing ConfigMap store for node \"aks-nodepool1-26628743-vmss000000\""
time="2026-07-27T12:45:26Z" level=info msg="Parsed hook mode: auto"
time="2026-07-27T12:45:26Z" level=warning msg="ContainerNotifier: not supported: fanotify: init error, operation not permitted"
time="2026-07-27T12:45:26Z" level=info msg="KubeManager: hook mode: podinformer (auto)"
time="2026-07-27T12:45:26Z" level=info msg="using the detected container runtime socket path from Kubelet's config: /run/containerd/containerd.sock"
time="2026-07-27T12:45:26Z" level=info msg="Starting Pod controller"
time="2026-07-27T12:45:26Z" level=info msg="Serving hook-service and health-checks on /run/hook-liveness.socket"
$ ./kubectl-gadget run trace_exec -A
K8S.NODE                K8S.NAMESPACE           K8S.PODNAME             K8S.CONTAINERNAME       COMM                 PID        TID TID        TTY ARGS         ER…
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-cleanup-sidec sleep            3910534    3910534 18536      0   sleep\u00a05    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-disk-cleanup  sleep            3910535    3910535 18443      0   sleep\u00a01    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-cleanup-sidec sleep            3910558    3910558 18486      0   sleep\u00a01    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-disk-cleanup  sleep            3910641    3910641 18443      0   sleep\u00a01    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-cleanup-sidec sleep            3910642    3910642 18486      0   sleep\u00a01    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche curl             3910644    3910644 3910643    0   curl\u00a0-…    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche mktemp           3910652    3910652 18540      0   mktemp          
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche sed              3910656    3910656 3910653    0   sed\u00a0s/…    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche tr               3910655    3910655 3910653    0   tr\u00a0-d\…    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche rm               3910657    3910657 18540      0   rm\u00a0-f\…    
aks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 scheduled-events-watche sleep            3910658    3910658 18540      0   sleep\u00a02    
^Caks-nodepoo…-vmss000000 kube-system             azuresecuri…agent-qtl59 azsecpack-disk-cleanup  sleep            3910659    3910659 18443      0   sleep\u00a01
$ kubectl get pod -n gadget gadget-mhnkb -o json | jq .spec.containers[0].securityContext.capabilities
{
  "add": [
    "SYSLOG",
    "SYS_PTRACE",
    "SYS_RESOURCE",
    "IPC_LOCK",
    "NET_RAW",
    "NET_ADMIN",
    "BPF",
    "PERFMON"
  ],
  "drop": [
    "ALL"
  ]
}
```