### PR TITLE
gadgets: Serialize gadget push/sign on OCI registries and retry flaky errors

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -1952,6 +1952,7 @@ jobs:
           BUILDER_IMAGE: ${{ needs.build-helper-images.outputs.gadget_builder_image }}
           GADGET_REPOSITORY: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
           GADGET_TAG: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+          GADGET_PUSH_RETRIES: 5
           CFLAGS: "-Werror"
         run: |
           make build-gadgets -o install/ig -j$(nproc)
@@ -1960,7 +1961,7 @@ jobs:
           git diff --exit-code HEAD --
 
           # Avoid building the gadgets again
-          make -C gadgets/ push-existing -j$(nproc)
+          make -C gadgets/ push-existing
       - name: Sign the gadgets
         if: needs.check-secrets.outputs.cosign == 'true'
         env:
@@ -1968,8 +1969,9 @@ jobs:
           COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
           GADGET_REPOSITORY: ${{ steps.set-repo-determine-image-tag.outputs.gadget-repository }}
           GADGET_TAG: ${{ steps.set-repo-determine-image-tag.outputs.gadget-tag }}
+          GADGET_PUSH_RETRIES: 5
         run: |
-          make -C gadgets/ sign-existing -j$(nproc)
+          make -C gadgets/ sign-existing
 
   gadgets-unittest:
     name: Gadgets unit tests

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -14,6 +14,11 @@ KUBECTL_GADGET ?= kubectl-gadget
 GPU_EBPF_BRIDGE ?= gpu-ebpf-bridge
 IG_RUNTIME ?= docker
 IG_FLAGS ?=
+# Number of times to retry pushing/signing a gadget after a failure.
+# Defaults to 0 (a single attempt) so interactive users are not slowed
+# down; CI sets this to work around flaky ghcr.io 500s on concurrent
+# manifest PUTs.
+GADGET_PUSH_RETRIES ?= 0
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
 # Force using legacy .sig format.
@@ -158,7 +163,16 @@ push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
+	@n=0; \
+	until sudo -E $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS); do \
+		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
+			echo "Push of $* failed after $$n retries"; \
+			exit 1; \
+		fi; \
+		n=$$((n+1)); \
+		echo "Push of $* failed, retry $$n/$(GADGET_PUSH_RETRIES) in $$((n*5))s..."; \
+		sleep $$((n*5)); \
+	done
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
@@ -172,8 +186,17 @@ sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
-	digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
-	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	@digest=$$(sudo -E $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	n=0; \
+	until $(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest; do \
+		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
+			echo "Signing of $* failed after $$n retries"; \
+			exit 1; \
+		fi; \
+		n=$$((n+1)); \
+		echo "Signing of $* failed, retry $$n/$(GADGET_PUSH_RETRIES) in $$((n*5))s..."; \
+		sleep $$((n*5)); \
+	done
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -14,6 +14,11 @@ KUBECTL_GADGET ?= kubectl-gadget
 GPU_EBPF_BRIDGE ?= gpu-ebpf-bridge
 IG_RUNTIME ?= docker
 IG_FLAGS ?=
+# Number of times to retry pushing/signing a gadget after a failure.
+# Defaults to 0 (a single attempt) so interactive users are not slowed
+# down; CI sets this to work around flaky ghcr.io 500s on concurrent
+# manifest PUTs.
+GADGET_PUSH_RETRIES ?= 0
 IG_DEBUG_LOGS ?= true
 COSIGN ?= cosign
 # Force using legacy .sig format.
@@ -160,7 +165,16 @@ push: $(addsuffix -push,$(GADGETS))
 
 %-push-existing: %
 	@echo "Pushing existing $*"
-	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS)
+	@n=0; \
+	until $(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS); do \
+		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
+			echo "Push of $* failed after $$n retries"; \
+			exit 1; \
+		fi; \
+		n=$$((n+1)); \
+		echo "Push of $* failed, retry $$n/$(GADGET_PUSH_RETRIES) in $$((n*5))s..."; \
+		sleep $$((n*5)); \
+	done
 
 .PHONY:
 push-existing: $(addsuffix -push-existing,$(GADGETS))
@@ -174,8 +188,17 @@ sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing:
 	@echo "Signing existing $*"
-	digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
-	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
+	@digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	n=0; \
+	until $(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest; do \
+		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
+			echo "Signing of $* failed after $$n retries"; \
+			exit 1; \
+		fi; \
+		n=$$((n+1)); \
+		echo "Signing of $* failed, retry $$n/$(GADGET_PUSH_RETRIES) in $$((n*5))s..."; \
+		sleep $$((n*5)); \
+	done
 
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 


### PR DESCRIPTION
Remove the make -j flag: serialize both pushes and signatures. I have
noticed intermittently 500s on concurrent manifest PUTs and "context
deadline exceeded" errors on ttl.sh.

https://github.com/orgs/community/discussions/187118

Also retry each gadget push and signature a few times, gated behind
GADGET_PUSH_RETRIES (default 0 so terminal users get a single attempt;
CI sets it to opt in).


cc @claudiamarcubina @eiffel-fl 