### PR TITLE
charts: point the Prometheus scrape annotation to the otel-metrics listener port

### DIFF
--- a/charts/gadget/templates/_helpers.tpl
+++ b/charts/gadget/templates/_helpers.tpl
@@ -125,3 +125,12 @@ Operator configuration
 {{- end }}
 {{- toYaml $operator }}
 {{- end }}
+
+{{/*
+Prometheus scrape port
+*/}}
+{{- define "gadget.otelMetricsPort" -}}
+{{- $operator := include "gadget.operatorConfig" . | fromYaml -}}
+{{- $listenAddress := dig "otel-metrics" "otel-metrics-listen-address" "" $operator -}}
+{{- regexFind ":[0-9]+$" (toString $listenAddress) | trimPrefix ":" | default "2224" -}}
+{{- end }}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -32,9 +32,8 @@ spec:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
         container.apparmor.security.beta.kubernetes.io/gadget: {{ default .Values.appArmorProfile .Values.config.appArmorProfile | quote }}
-        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
         prometheus.io/scrape: "true"
-        prometheus.io/port: "2224"
+        prometheus.io/port: {{ include "gadget.otelMetricsPort" . | quote }}
         prometheus.io/path: "/metrics"
     spec:
       serviceAccount: {{ include "gadget.fullname" . }}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -32,9 +32,9 @@ spec:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
         container.apparmor.security.beta.kubernetes.io/gadget: {{ default .Values.appArmorProfile .Values.config.appArmorProfile | quote }}
-        # keep aligned with values in pkg/operators/prometheus/prometheus.go
+        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
         prometheus.io/scrape: "true"
-        prometheus.io/port: "2223"
+        prometheus.io/port: "2224"
         prometheus.io/path: "/metrics"
     spec:
       serviceAccount: {{ include "gadget.fullname" . }}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -162,9 +162,9 @@ spec:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
         container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
-        # keep aligned with values in pkg/operators/prometheus/prometheus.go
+        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
         prometheus.io/scrape: "true"
-        prometheus.io/port: "2223"
+        prometheus.io/port: "2224"
         prometheus.io/path: "/metrics"
     spec:
       serviceAccount: gadget

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -162,7 +162,6 @@ spec:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
         container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
-        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
         prometheus.io/scrape: "true"
         prometheus.io/port: "2224"
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
The `prometheus.io/*` annotations on the gadget DaemonSet were added for the
legacy Prometheus implementation, which served metrics on port 2223, and that
port is hardcoded in the chart template. Metrics now come from the otel-metrics
operator, whose default listen address is `0.0.0.0:2224`, set by
`config.operator.otel-metrics.otel-metrics-listen-address`. Prometheus service
discovery was therefore scraping a port nothing listens on.

This sets the annotation to 2224 so scraping works with the default
configuration, and regenerates `pkg/resources/manifests/deploy.yaml` so
`kubectl gadget deploy` produces the same value. The comment above the
annotation is refreshed too: it referenced
`pkg/operators/prometheus/prometheus.go`, which no longer exists, rather than
the config key the value has to stay aligned with.

Overriding `otel-metrics-listen-address` with another port still leaves the
annotation at 2224. Deriving it from the configuration would need a helper in
`_helpers.tpl` plus the same resolution in `deploy.go` for `--daemon-config`;
happy to do that here instead if you would prefer it in one go.

Fixes #4371

## How to use

Nothing to do for users on the default configuration. After deploying, the
gadget pods carry `prometheus.io/port: "2224"` and Prometheus service discovery
finds the metrics endpoint once `otel-metrics-listen` is enabled.

Reviewers can check both deployment paths:

```bash
# helm
make -C charts template && grep 'prometheus.io/' charts/bin/deploy.yaml

# kubectl-gadget
kubectl gadget deploy --print-only | grep 'prometheus.io/'
```

## Testing done

Regenerated the manifest with the real target, helm v3.14.3:

```console
$ make generate-manifests
echo "---" > pkg/resources/manifests/deploy.yaml
echo "# This file is generated by 'make generate-manifests'; DO NOT EDIT." >> pkg/resources/manifests/deploy.yaml
cat pkg/resources/manifests/namespace.yaml >> pkg/resources/manifests/deploy.yaml
HELM_PARAMS="--set skipLabels=true" make -C charts APP_VERSION=latest template
make[1]: Entering directory '/work/charts'
rm -rf bin
Building chart:
mkdir -p bin
cp -r gadget bin
mv bin/gadget/Chart.yaml.tmpl bin/gadget/Chart.yaml
Using GNU sed
sed -i "s/%VERSION%/"1.0.0-dev"/g" bin/gadget/Chart.yaml
sed -i "s/%APP_VERSION%/latest/g" bin/gadget/Chart.yaml
Preparing docs
Charts available at: bin/gadget
helm template gadget bin/gadget --namespace gadget --skip-crds $HELM_PARAMS | tee bin/deploy.yaml
[...]
make[1]: Leaving directory '/work/charts'
cat charts/bin/deploy.yaml >> pkg/resources/manifests/deploy.yaml
```

The DaemonSet annotations in the rendered output:

```yaml
        container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
        prometheus.io/scrape: "true"
        prometheus.io/port: "2224"
        prometheus.io/path: "/metrics"
```

The regenerated file came out identical to the one committed here, so the
checked-in manifest is in sync with the chart:

```console
$ git status --porcelain pkg/resources/manifests/deploy.yaml
$
```

The whole change is the port plus the stale comment, in the template and in the
generated manifest:

```console
$ git diff --stat main..HEAD
 charts/gadget/templates/daemonset.yaml | 4 ++--
 pkg/resources/manifests/deploy.yaml    | 4 ++--
 2 files changed, 4 insertions(+), 4 deletions(-)

$ git diff -U1 main..HEAD -- pkg/resources/manifests/deploy.yaml
@@ -164,5 +164,5 @@ spec:
         container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
-        # keep aligned with values in pkg/operators/prometheus/prometheus.go
+        # keep aligned with config.operator.otel-metrics.otel-metrics-listen-address
         prometheus.io/scrape: "true"
-        prometheus.io/port: "2223"
+        prometheus.io/port: "2224"
         prometheus.io/path: "/metrics"
```
