### PR TITLE
docs: Document privileges needed to deploy Inspektor Gadget in k8s.

### DIFF
--- a/docs/reference/install-kubernetes.md
+++ b/docs/reference/install-kubernetes.md
@@ -510,6 +510,16 @@ operator:
 
 For more information about the configuration file, check the [configuration guide](./configuration.md).
 
+### Permissions required to deploy
+
+Deploying Inspektor Gadget creates cluster-scoped RBAC objects (a [ClusterRole](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/charts/gadget/templates/clusterrole.yaml) and a ['ClusterRoleBinding'](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/charts/gadget/templates/clusterrolebinding.yaml)) as well as a namespaced [Role](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/charts/gadget/templates/role.yaml) and [RoleBinding](https://github.com/inspektor-gadget/inspektor-gadget/blob/main/charts/gadget/templates/rolebinding.yaml).
+Kubernetes [privilege escalation prevention](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention) requires that whoever creates these objects already holds every permission being granted, or holds the `escalate`/`bind` verbs on them.
+In practice, this usually means deploying as `cluster-admin`.
+
+It is possible to deploy with a narrower, explicitly enumerated set of permissions instead.
+Such a role must hold the union of everything granted by Inspektor Gadget's own ClusterRole and Role, plus create/delete rights on the objects the deployment creates.
+Note that this is not meaningfully less privileged than `cluster-admin` but it merely makes the permission set auditable.
+
 ## Uninstalling from the cluster
 
 Depending on your installation method, use one of the following command to


### PR DESCRIPTION
I was able to deploy Inspektor Gadget on k8s with the following ClusterRole:

```yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ig-deployer
rules:
  - apiGroups: [""]
    resources: ["nodes/proxy"]
    verbs: ["get"]
  - apiGroups: [""]
    resources: ["namespaces", "nodes", "pods"]
    verbs: ["get", "watch", "list"]
  - apiGroups: [""]
    resources: ["services"]
    verbs: ["list", "watch"]
  - apiGroups: ["gadget.kinvolk.io"]
    resources: ["traces", "traces/status"]
    verbs: ["delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"]
  - apiGroups: ["*"]
    resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "replicationcontrollers"]
    verbs: ["get"]
  - apiGroups: ["security-profiles-operator.x-k8s.io"]
    resources: ["seccompprofiles"]
    verbs: ["list", "watch", "create"]
  - apiGroups: ["security.openshift.io"]
    resources: ["securitycontextconstraints"]
    resourceNames: ["privileged"]
    verbs: ["use"]
  - apiGroups: [""]
    resources: ["namespaces", "serviceaccounts", "configmaps", "secrets"]
    verbs: ["get", "list", "create", "update", "patch", "delete"]
  - apiGroups: ["apps"]
    resources: ["daemonsets"]
    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
  - apiGroups: ["rbac.authorization.k8s.io"]
    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
    verbs: ["get", "list", "create", "update", "patch", "delete"]
  - apiGroups: [""]
    resources: ["configmaps"]
    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

On a fresh AKS cluster, the following command will test it:

```bash
# Create a limited identity
openssl genrsa -out limited.key 2048
openssl req -new -key limited.key -out limited.csr -subj "/CN=limited@example.com"

cat <<EOF | kubectl apply -f -
apiVersion: certificates.k8s.io/v1
kind: CertificateSigningRequest
metadata:
  name: limited
spec:
  request: $(base64 -w0 limited.csr)
  signerName: kubernetes.io/kube-apiserver-client
  usages: ["client auth"]
  expirationSeconds: 86400
EOF

kubectl certificate approve limited
kubectl get csr limited              # MUST say Approved,Issued
kubectl get csr limited -o jsonpath='{.status.certificate}' | base64 -d > limited.crt

# Build the limited kubeconfig.
server=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d > ca.crt

KUBECONFIG=/tmp/limited.kubeconfig kubectl config set-cluster aks --server=$server --certificate-authority=ca.crt --embed-certs
KUBECONFIG=/tmp/limited.kubeconfig kubectl config set-credentials limited --client-certificate=limited.crt --client-key=limited.key --embed-certs
KUBECONFIG=/tmp/limited.kubeconfig kubectl config set-context limited --cluster=aks --user=limited
KUBECONFIG=/tmp/limited.kubeconfig kubectl config use-context limited

KUBECONFIG=/tmp/limited.kubeconfig kubectl auth whoami   # limited@example.com
KUBECONFIG=/tmp/limited.kubeconfig kubectl gadget deploy    # expect Forbidden

# Let's give some rights to limited:
kubectl create clusterrole ig-creator \
  --verb=get,list,create,update,patch,delete \
  --resource=namespaces,serviceaccounts,configmaps,secrets,daemonsets,roles,rolebindings,clusterroles,clusterrolebindings
kubectl create clusterrolebinding ig-creator --clusterrole=ig-creator --user=limited@example.com
KUBECONFIG=/tmp/limited.kubeconfig kubectl gadget deploy # this fails due to missing create verbs on some resources.
kubectl get all -n gadget          
kubectl gadget undeploy

# Let's now use the YAML:
kubectl apply -f ig-deployer.yaml
kubectl create clusterrolebinding ig-deployer --clusterrole=ig-deployer --user=limited@example.com
kubectl delete clusterrolebinding ig-creator     # avoid confusion about which grant did it

KUBECONFIG=/tmp/limited.kubeconfig kubectl gadget deploy   # should succeed 
```

I do not think we should add this ig-deployer.yaml somewhere in our repo, instead we should document someone wanting to deploy Inspektor Gadget needs create verb on all the resources created during Inspektor Gadget deployment.