### PR TITLE
helm: use securityContext.appArmorProfile on Kubernetes >= 1.30

### DIFF
--- a/charts/gadget/templates/_helpers.tpl
+++ b/charts/gadget/templates/_helpers.tpl
@@ -134,3 +134,39 @@ Prometheus scrape port
 {{- $listenAddress := dig "otel-metrics" "otel-metrics-listen-address" "" $operator -}}
 {{- regexFind ":[0-9]+$" (toString $listenAddress) | trimPrefix ":" | default "2224" -}}
 {{- end }}
+
+{{/*
+Returns "true" if the target cluster supports the securityContext.appArmorProfile
+field (Kubernetes >= 1.30), "false" otherwise. Before 1.30, the AppArmor profile
+has to be set via the now-deprecated
+container.apparmor.security.beta.kubernetes.io/<container> annotation instead:
+https://kubernetes.io/docs/tutorials/security/apparmor/#securing-a-pod
+*/}}
+{{- define "gadget.supportsAppArmorField" -}}
+{{- semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version -}}
+{{- end }}
+
+{{/*
+Translates an AppArmor profile string, as accepted by the deprecated
+container.apparmor.security.beta.kubernetes.io/<container> annotation (e.g.
+"unconfined", "runtime/default" or "localhost/my-profile"), into the
+securityContext.appArmorProfile structure introduced in Kubernetes v1.30.
+Mirrors createAppArmorProfile() in cmd/kubectl-gadget/deploy.go.
+*/}}
+{{- define "gadget.appArmorProfile" -}}
+{{- $parts := splitList "/" . -}}
+{{- $type := first $parts -}}
+{{- if eq $type "unconfined" -}}
+type: Unconfined
+{{- else if eq $type "runtime" -}}
+type: RuntimeDefault
+{{- else if eq $type "localhost" -}}
+{{- if ne (len $parts) 2 -}}
+{{- fail (printf "AppArmor profile malformed: localhost/profile expected, got %q" .) -}}
+{{- end -}}
+type: Localhost
+localhostProfile: {{ index $parts 1 }}
+{{- else -}}
+{{- fail (printf "AppArmor profile badly named: expected unconfined, runtime or localhost, got %q" $type) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/gadget/templates/daemonset.yaml
+++ b/charts/gadget/templates/daemonset.yaml
@@ -26,16 +26,29 @@ spec:
         {{- end }}
         k8s-app: {{ include "gadget.fullname" . }}
       annotations:
+        {{- if eq (include "gadget.supportsAppArmorField" .) "false" }}
         # We need to set gadget container as unconfined so it is able to write
         # /sys/fs/bpf as well as /sys/kernel/debug/tracing.
         # Otherwise, we can have error like:
         # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
         # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
+        # This annotation is deprecated since Kubernetes v1.30 in favor of the
+        # securityContext.appArmorProfile field, which is set below instead
+        # when the target cluster is 1.30+.
         container.apparmor.security.beta.kubernetes.io/gadget: {{ default .Values.appArmorProfile .Values.config.appArmorProfile | quote }}
+        {{- end }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ include "gadget.otelMetricsPort" . | quote }}
         prometheus.io/path: "/metrics"
     spec:
+      {{- if eq (include "gadget.supportsAppArmorField" .) "true" }}
+      # We need to set the gadget container as unconfined so it is able to
+      # write /sys/fs/bpf as well as /sys/kernel/debug/tracing. See the
+      # annotation above (used on Kubernetes < 1.30) for more details.
+      securityContext:
+        appArmorProfile:
+          {{- include "gadget.appArmorProfile" (default .Values.appArmorProfile .Values.config.appArmorProfile) | nindent 10 }}
+      {{- end }}
       serviceAccount: {{ include "gadget.fullname" . }}
       hostPID: {{ .Values.hostPID }}
       hostNetwork: {{ .Values.hostNetwork }}

--- a/pkg/resources/manifests/deploy.yaml
+++ b/pkg/resources/manifests/deploy.yaml
@@ -156,16 +156,16 @@ spec:
       labels:
         k8s-app: gadget
       annotations:
-        # We need to set gadget container as unconfined so it is able to write
-        # /sys/fs/bpf as well as /sys/kernel/debug/tracing.
-        # Otherwise, we can have error like:
-        # "failed to create server failed to create folder for pinning bpf maps: mkdir /sys/fs/bpf/gadget: permission denied"
-        # (For reference, see: https://github.com/inspektor-gadget/inspektor-gadget/runs/3966318270?check_suite_focus=true#step:20:221)
-        container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
         prometheus.io/scrape: "true"
         prometheus.io/port: "2224"
         prometheus.io/path: "/metrics"
     spec:
+      # We need to set the gadget container as unconfined so it is able to
+      # write /sys/fs/bpf as well as /sys/kernel/debug/tracing. See the
+      # annotation above (used on Kubernetes < 1.30) for more details.
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
       serviceAccount: gadget
       hostPID: false
       hostNetwork: false


### PR DESCRIPTION
Fixes #5704

## Problem

The Helm chart set the AppArmor profile unconditionally via the
`container.apparmor.security.beta.kubernetes.io/gadget` annotation, which
was deprecated in Kubernetes v1.30 in favor of `securityContext.appArmorProfile`,
causing a deprecation warning on every Helm install against 1.30+ clusters.

`kubectl gadget deploy` already handles this correctly by patching the
manifest based on server version (`deploy.go:766-784`). This PR ports the
same logic into the Helm chart.

## Change

- `_helpers.tpl`: added `gadget.supportsAppArmorField` (version check) and
  `gadget.appArmorProfile` (translates `unconfined`/`runtime`/`localhost/<profile>`
  into the typed `type`/`localhostProfile` structure, mirroring
  `createAppArmorProfile()` in `cmd/kubectl-gadget/deploy.go`).
- `daemonset.yaml`: emits the annotation on Kubernetes < 1.30, and
  `spec.template.spec.securityContext.appArmorProfile` on >= 1.30, using the
  same `appArmorProfile`/`config.appArmorProfile` value as before.

No `values.yaml` changes. `pkg/resources/manifests/deploy.yaml` /
`kubectl gadget deploy` are unaffected — already handled correctly at runtime.

## Testing

`helm lint` passes. Rendered with `--kube-version` against old and new
clusters; diff confirms the AppArmor block is the only thing that changes:

**v1.29.0:**
```yaml
annotations:
  container.apparmor.security.beta.kubernetes.io/gadget: "unconfined"
```

**v1.31.0:**
```yaml
securityContext:
  appArmorProfile:
    type: Unconfined
```

Also verified `localhost/my-profile` → `type: Localhost` /
`localhostProfile: my-profile`, and that a malformed `localhost` value
fails the render with a clear error.