### PR TITLE
gadgets: Stabilize OTel stack integration tests

### DIFF
--- a/gadgets/ci/stacks/test/integration/ci_stacks_test.go
+++ b/gadgets/ci/stacks/test/integration/ci_stacks_test.go
@@ -20,7 +20,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -110,10 +109,6 @@ func TestCiStacks(t *testing.T) {
 			"--verify-image=false",
 		),
 		igrunner.WithStartAndStop(),
-		// The OTel eBPF profiler does not emit the standard readiness marker and has its own
-		// initialization timing, so it keeps using the explicit sleep below instead of the
-		// readiness gate.
-		igrunner.WithoutReadinessGate(),
 		igrunner.WithValidateOutput(func(t *testing.T, output string) {
 			expectedEntries := []*stacksEvent{
 				{
@@ -151,8 +146,6 @@ func TestCiStacks(t *testing.T) {
 
 	steps := []igtesting.TestStep{
 		stacksCmd,
-		// OTel eBPF profiler needs ~16s to initialize.
-		utils.Sleep(20 * time.Second),
 		workload,
 	}
 	igtesting.RunTestSteps(steps, t)

--- a/gadgets/profile_cpu/test/integration/profile_cpu_stacks_test.go
+++ b/gadgets/profile_cpu/test/integration/profile_cpu_stacks_test.go
@@ -20,7 +20,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -142,8 +141,6 @@ func TestProfileCpuOtelStacks(t *testing.T) {
 
 	steps := []igtesting.TestStep{
 		profileCpuCmd,
-		// OTel eBPF profiler needs ~16s to initialize.
-		utils.Sleep(20 * time.Second),
 		workload,
 	}
 	igtesting.RunTestSteps(steps, t)

--- a/gadgets/profile_cpu/workload/cpuburn.py
+++ b/gadgets/profile_cpu/workload/cpuburn.py
@@ -26,10 +26,9 @@ def burn_cpu(deadline):
 
 
 def main():
-    # Default duration is generous: the OTel eBPF profiler needs ~16s to
-    # initialize and a few more seconds to analyze this process before it can
-    # symbolize its Python frames. The test starts the gadget, waits for the
-    # profiler to initialize, then runs this workload.
+    # The test waits for the OTel eBPF profiler to initialize before starting
+    # this workload. Keep running long enough for the profiler to analyze this
+    # process and collect symbolized samples.
     duration = float(sys.argv[1]) if len(sys.argv) > 1 else 15.0
     burn_cpu(time.time() + duration)
 

--- a/pkg/symbolizer/otel/otel.go
+++ b/pkg/symbolizer/otel/otel.go
@@ -365,7 +365,7 @@ func (o *otelResolverInstance) lookupOrWait(correlationID uint64, eventBootTimes
 }
 
 func bpfVerifierLogLevel() uint32 {
-	if log.IsLevelEnabled(log.DebugLevel) {
+	if log.IsLevelEnabled(log.TraceLevel) {
 		return 2 // full verifier log
 	}
 	return 0
@@ -436,7 +436,7 @@ func (o *otelResolverInstance) startOtelEbpfProfiler(ctx context.Context) error 
 		SamplesPerSecond:       otelSamplesPerSecond,
 		MapScaleFactor:         0,
 		KernelVersionCheck:     false,
-		VerboseMode:            log.IsLevelEnabled(log.DebugLevel),
+		VerboseMode:            log.IsLevelEnabled(log.TraceLevel),
 		BPFVerifierLogLevel:    bpfVerifierLogLevel(),
 		ProbabilisticInterval:  0,
 		ProbabilisticThreshold: 0,

--- a/pkg/testing/ig/ig.go
+++ b/pkg/testing/ig/ig.go
@@ -45,12 +45,6 @@ type runner struct {
 	// before running the workload, instead of relying on a fixed sleep.
 	waitReady    bool
 	readyWatcher *readinessWatcher
-
-	// noReadinessGate disables the readiness gate even for StartAndStop gadgets. It is used by
-	// gadgets that do not emit the standard "running..." readiness marker in a usable way (e.g.
-	// the OTel eBPF profiler, which samples over a window and has its own initialization
-	// timing), so they keep relying on an explicit sleep instead.
-	noReadinessGate bool
 }
 
 func (ig *runner) createCmd() {
@@ -80,15 +74,6 @@ func WithFlags(flags ...string) Option {
 func WithStartAndStop() Option {
 	return func(ig *runner) {
 		ig.StartAndStop = true
-	}
-}
-
-// WithoutReadinessGate disables the readiness gate for a StartAndStop gadget. Use it for gadgets
-// that do not emit the standard "running..." readiness marker in a usable way (e.g. the OTel
-// eBPF profiler), which instead rely on an explicit sleep before the workload.
-func WithoutReadinessGate() Option {
-	return func(ig *runner) {
-		ig.noReadinessGate = true
 	}
 }
 
@@ -150,9 +135,8 @@ func New(image string, opts ...Option) igtesting.TestStep {
 	}
 
 	// StartAndStop gadgets run concurrently with the workload; enable the readiness gate so the
-	// harness waits for the gadget to be capturing before the workload runs (see readiness.go),
-	// unless the gadget opted out (it does not emit a usable readiness marker).
-	if factoryRunner.StartAndStop && !factoryRunner.noReadinessGate {
+	// harness waits for the gadget to be capturing before the workload runs (see readiness.go).
+	if factoryRunner.StartAndStop {
 		factoryRunner.enableReadinessGate()
 	}
 

--- a/pkg/testing/ig/readiness.go
+++ b/pkg/testing/ig/readiness.go
@@ -175,10 +175,10 @@ func parseReadyNode(line string) (string, bool) {
 	return fields[len(fields)-1], true
 }
 
-// isDebugLine reports whether a stderr line is a logrus debug line. Such lines are the verbose
-// noise produced by "-v" and are dropped from the stored stderr to keep test reports readable.
+// isDebugLine reports whether a stderr line is a debug log. Such lines are the verbose noise
+// produced by "-v" and are dropped from the stored stderr to keep test reports readable.
 func isDebugLine(line string) bool {
-	return strings.Contains(line, "level=debug")
+	return strings.Contains(line, "level=debug") || strings.Contains(line, "level=DEBUG")
 }
 
 // enableReadinessGate configures the runner to detect the gadget readiness marker on stderr. It

--- a/pkg/testing/ig/readiness_test.go
+++ b/pkg/testing/ig/readiness_test.go
@@ -145,5 +145,6 @@ func TestReadinessWatcher_UpdatedSignal(t *testing.T) {
 func TestIsDebugLine(t *testing.T) {
 	assert.True(t, isDebugLine(bareMarker))
 	assert.True(t, isDebugLine(nodeAMarker))
+	assert.True(t, isDebugLine(`time=2026-07-08T12:00:00Z level=DEBUG msg="OTel debug output"`))
 	assert.False(t, isDebugLine(`time="2026-07-08T12:00:00Z" level=warning msg="something"`))
 }


### PR DESCRIPTION
Wait for the standard gadget readiness marker before starting OTel stack workloads so image pulls and profiler startup cannot consume a fixed delay.

Remove the redundant post-readiness sleeps and the unused readiness opt-out. Keep readiness logging lightweight by reserving OTel eBPF and verifier debugging for trace level, and filter the profiler uppercase debug lines from stored test output.

Fixes: 34e70dd19dcf