### PR TITLE
uprobetracer: Support stripped Go binaries via .gopclntab fallback

### DIFF
--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -77,6 +77,7 @@ GADGETS ?= \
 	ci/image_inspect \
 	ci/container_filtering \
 	ci/stacks \
+	ci/uprobe \
 	ci/gpu \
 	ci/test_iter_map_elem \
 	snapshot_file \
@@ -237,8 +238,26 @@ test-unit: build
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
 	go test -v -exec '$(SUDO)' ./$*/$(INTEGRATION_TEST_DIR)/...
 
+# CI-only gadgets can ship a workload container image built locally from
+# ci/<gadget>/workload/Dockerfile. It is tagged ig-<gadget>:test, e.g.
+# ig-ci-uprobe:test, and is never pushed anywhere.
+CI_WORKLOAD_GADGETS := $(patsubst %/workload/Dockerfile,%,$(wildcard ci/*/workload/Dockerfile))
+
+.PHONY: $(addsuffix /workload-image,$(CI_WORKLOAD_GADGETS))
+$(addsuffix /workload-image,$(CI_WORKLOAD_GADGETS)):
+	$(eval CI_WORKLOAD_GADGET := $(patsubst %/workload-image,%,$@))
+	$(DOCKER) build \
+		-f $(CI_WORKLOAD_GADGET)/workload/Dockerfile \
+		-t ig-$(subst /,-,$(CI_WORKLOAD_GADGET)):test \
+		$(CI_WORKLOAD_GADGET)/workload
+
+define CI_WORKLOAD_INTEGRATION_PREREQUISITE
+$(1)/test-integration: $(1)/workload-image
+endef
+$(foreach gadget,$(CI_WORKLOAD_GADGETS),$(eval $(call CI_WORKLOAD_INTEGRATION_PREREQUISITE,$(gadget))))
+
 .PHONY:
-test-integration: build
+test-integration: build $(addsuffix /workload-image,$(filter $(GADGETS),$(CI_WORKLOAD_GADGETS)))
 	IG_PATH=$(IG_PATH) \
 	GPU_EBPF_BRIDGE_PATH=$(GPU_EBPF_BRIDGE_PATH) \
 	CGO_ENABLED=0 \

--- a/gadgets/ci/uprobe/program.bpf.c
+++ b/gadgets/ci/uprobe/program.bpf.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2026 The Inspektor Gadget authors */
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/filter.h>
+#include <gadget/macros.h>
+#include <gadget/types.h>
+
+#if defined(__TARGET_ARCH_x86)
+#define GO_PARAM1(ctx) ((void *)(ctx)->ax)
+#define GO_PARAM2(ctx) ((void *)(ctx)->bx)
+#elif defined(__TARGET_ARCH_arm64)
+#define GO_PARAM1(ctx) ((void *)((struct pt_regs *)(ctx))->user_regs.regs[0])
+#define GO_PARAM2(ctx) ((void *)((struct pt_regs *)(ctx))->user_regs.regs[1])
+#else
+#error "unsupported architecture"
+#endif
+
+/*
+ * Please keep the Go versions and build modes in sync with:
+ * - workload/Dockerfile
+ * - test/integration/ci_uprobe_test.go
+ */
+#define FOR_EACH_GO_TARGET(F)                                           \
+	F("/opt/ig-tests/ci-uprobe/go1.25/normal/target", GO125_NORMAL) \
+	F("/opt/ig-tests/ci-uprobe/go1.25/pie/target", GO125_PIE)       \
+	F("/opt/ig-tests/ci-uprobe/go1.25/linker/target", GO125_LINKER) \
+	F("/opt/ig-tests/ci-uprobe/go1.25/strip/target", GO125_STRIP)   \
+	F("/opt/ig-tests/ci-uprobe/go1.26/normal/target", GO126_NORMAL) \
+	F("/opt/ig-tests/ci-uprobe/go1.26/pie/target", GO126_PIE)       \
+	F("/opt/ig-tests/ci-uprobe/go1.26/linker/target", GO126_LINKER) \
+	F("/opt/ig-tests/ci-uprobe/go1.26/strip/target", GO126_STRIP)
+
+enum go_target_variant {
+#define DECLARE_GO_TARGET(path, variant) variant,
+	FOR_EACH_GO_TARGET(DECLARE_GO_TARGET)
+#undef DECLARE_GO_TARGET
+};
+
+struct event {
+	struct gadget_process proc;
+	enum go_target_variant variant_raw;
+	char name[128];
+};
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+GADGET_TRACER(go_uprobe, events, event);
+
+static __always_inline int trace_go_target(struct pt_regs *ctx,
+					   enum go_target_variant variant)
+{
+	struct event *event;
+	__u64 len;
+
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		return 0;
+
+	gadget_process_populate(&event->proc);
+	event->variant_raw = variant;
+
+	/*
+	 * Go strings are not NUL terminated: the data pointer is passed in the
+	 * first argument register and the length in the second one.
+	 */
+	len = (__u64)GO_PARAM2(ctx);
+	if (len > sizeof(event->name) - 1)
+		len = sizeof(event->name) - 1;
+	event->name[len] = '\0';
+	if (bpf_probe_read_user(event->name, len, GO_PARAM1(ctx)) < 0)
+		event->name[0] = '\0';
+
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+	return 0;
+}
+
+#define DECLARE_GO_UPROBE(path, variant)                   \
+	SEC("uprobe/" path ":main.target")                 \
+	int trace_go_target_##variant(struct pt_regs *ctx) \
+	{                                                  \
+		return trace_go_target(ctx, variant);      \
+	}
+
+FOR_EACH_GO_TARGET(DECLARE_GO_UPROBE)
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/gadgets/ci/uprobe/test/integration/ci_uprobe_test.go
+++ b/gadgets/ci/uprobe/test/integration/ci_uprobe_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	igtesting "github.com/inspektor-gadget/inspektor-gadget/pkg/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/containers"
+	igrunner "github.com/inspektor-gadget/inspektor-gadget/pkg/testing/ig"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/match"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
+	eventtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+type goUprobeEvent struct {
+	Proc    utils.Process `json:"proc"`
+	Variant string        `json:"variant"`
+	Name    string        `json:"name"`
+}
+
+// workloadImage is built locally by "make -C gadgets ci/uprobe/workload-image".
+const workloadImage = "ig-ci-uprobe:test"
+
+// Please keep the Go versions and build modes in sync with:
+// - ../../workload/Dockerfile
+// - ../../program.bpf.c
+var (
+	goVersions = []string{"1.25", "1.26"}
+	buildModes = []string{"normal", "pie", "linker", "strip"}
+)
+
+func TestCiUprobe(t *testing.T) {
+	gadgettesting.RequireEnvironmentVariables(t)
+	utils.InitTest(t)
+
+	// The workload image is built locally and is not pushed anywhere, so
+	// it is only available to the local Docker daemon. What is tested here
+	// (resolving Go symbols in the target binaries) does not depend on the
+	// container runtime.
+	if utils.Runtime != eventtypes.RuntimeNameDocker.String() {
+		t.Skip("ci/uprobe test only supports the docker runtime (locally built workload image)")
+	}
+
+	containerFactory, err := containers.NewContainerFactory(utils.Runtime)
+	require.NoError(t, err, "new container factory")
+
+	containerName := "test-ci-uprobe"
+	containerOpts := []containers.ContainerOption{
+		containers.WithContainerImage(workloadImage),
+		containers.WithoutContainerImagePull(),
+	}
+
+	commands := make([]string, 0, len(goVersions)*len(buildModes))
+	expectedEntries := make([]*goUprobeEvent, 0, len(goVersions)*len(buildModes))
+	for _, version := range goVersions {
+		for _, mode := range buildModes {
+			path := fmt.Sprintf("/opt/ig-tests/ci-uprobe/go%s/%s/target", version, mode)
+			variant := fmt.Sprintf("GO%s_%s",
+				strings.ReplaceAll(version, ".", ""), strings.ToUpper(mode))
+
+			// The path is passed as an argument so that the gadget
+			// reads it from the traced Go function instead of
+			// relying on os.Args[0].
+			commands = append(commands, path+" "+path)
+			expectedEntries = append(expectedEntries, &goUprobeEvent{
+				Proc:    utils.BuildProc("target", 0, 0),
+				Variant: variant,
+				Name:    path,
+			})
+		}
+	}
+
+	workload := containerFactory.NewContainer(
+		containerName,
+		strings.Join(commands, ";"),
+		containerOpts...,
+	)
+
+	runnerOpts := []igrunner.Option{
+		igrunner.WithStartAndStop(),
+		igrunner.WithValidateOutput(func(t *testing.T, output string) {
+			normalize := func(event *goUprobeEvent) {
+				utils.NormalizeProc(&event.Proc)
+			}
+			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntries...)
+		}),
+	}
+
+	gadgetCmd := igrunner.New("ci/uprobe", runnerOpts...)
+	steps := []igtesting.TestStep{gadgetCmd, workload}
+	igtesting.RunTestSteps(steps, t)
+}

--- a/gadgets/ci/uprobe/workload/Dockerfile
+++ b/gadgets/ci/uprobe/workload/Dockerfile
@@ -1,0 +1,36 @@
+# Build the same Go workload with several Go toolchains and several
+# linking/stripping options, to test uprobe symbol resolution against all of
+# them. A single builder image is used: the additional toolchains are fetched
+# on demand through GOTOOLCHAIN, which is much cheaper than pulling one golang
+# image per Go version.
+FROM golang:1.25.6-bookworm AS builder
+
+# "<directory>:<toolchain>" pairs. The directory only carries the major.minor
+# version, so bumping a patch release does not require updating
+# program.bpf.c and the integration test.
+#
+# Please keep the Go versions and build modes in sync with:
+# - ../program.bpf.c
+# - ../test/integration/ci_uprobe_test.go
+ARG GO_TOOLCHAINS="go1.25:go1.25.6 go1.26:go1.26.4"
+
+WORKDIR /src
+COPY go.mod main.go ./
+
+RUN set -eux; \
+	for pair in $GO_TOOLCHAINS; do \
+		dir="${pair%%:*}"; \
+		GOTOOLCHAIN="${pair#*:}"; \
+		export GOTOOLCHAIN; \
+		mkdir -p "/out/$dir/normal" "/out/$dir/pie" \
+			"/out/$dir/linker" "/out/$dir/strip"; \
+		go build -trimpath -o "/out/$dir/normal/target" .; \
+		go build -trimpath -buildmode=pie -o "/out/$dir/pie/target" .; \
+		go build -trimpath -ldflags='-s -w' -o "/out/$dir/linker/target" .; \
+		go build -trimpath -o /tmp/target .; \
+		strip --strip-all -o "/out/$dir/strip/target" /tmp/target; \
+	done
+
+FROM debian:bookworm-slim
+
+COPY --from=builder /out /opt/ig-tests/ci-uprobe

--- a/gadgets/ci/uprobe/workload/go.mod
+++ b/gadgets/ci/uprobe/workload/go.mod
@@ -1,0 +1,3 @@
+module ci-uprobe-workload
+
+go 1.18

--- a/gadgets/ci/uprobe/workload/main.go
+++ b/gadgets/ci/uprobe/workload/main.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+//go:noinline
+func target(name string) {
+	fmt.Printf("target called from %s\n", name)
+}
+
+func main() {
+	target(os.Args[1])
+}

--- a/pkg/container-utils/testutils/docker.go
+++ b/pkg/container-utils/testutils/docker.go
@@ -66,9 +66,11 @@ func (d *DockerContainer) Run(t *testing.T) {
 
 	_, _ = d.client.ContainerRemove(d.options.ctx, d.name, client.ContainerRemoveOptions{})
 
-	reader, err := d.client.ImagePull(d.options.ctx, d.options.image, client.ImagePullOptions{})
-	require.NoError(t, err, "Failed to pull image container")
-	io.Copy(io.Discard, reader)
+	if d.options.pullImage {
+		reader, err := d.client.ImagePull(d.options.ctx, d.options.image, client.ImagePullOptions{})
+		require.NoError(t, err, "Failed to pull image container")
+		io.Copy(io.Discard, reader)
+	}
 
 	hostConfig := &container.HostConfig{}
 	if d.options.seccompProfile != "" {

--- a/pkg/container-utils/testutils/options.go
+++ b/pkg/container-utils/testutils/options.go
@@ -32,6 +32,7 @@ type containerOptions struct {
 	expectStartError     bool
 	image                string
 	imageTag             string
+	pullImage            bool
 	mounts               []string
 	seccompProfile       string
 	namespace            string
@@ -56,6 +57,7 @@ func defaultContainerOptions() *containerOptions {
 		ctx:                  context.TODO(),
 		image:                DefaultContainerImage,
 		imageTag:             DefaultContainerImageTag,
+		pullImage:            true,
 		logs:                 true,
 		wait:                 true,
 		removal:              true,
@@ -84,6 +86,12 @@ func WithExpectedExitCode(code int) Option {
 func WithImage(image string) Option {
 	return func(opts *containerOptions) {
 		opts.image = image
+	}
+}
+
+func WithoutImagePull() Option {
+	return func(opts *containerOptions) {
+		opts.pullImage = false
 	}
 }
 

--- a/pkg/testing/containers/options.go
+++ b/pkg/testing/containers/options.go
@@ -42,6 +42,12 @@ func WithContainerImage(image string) ContainerOption {
 	}
 }
 
+func WithoutContainerImagePull() ContainerOption {
+	return func(opts *cOptions) {
+		opts.options = append(opts.options, testutils.WithoutImagePull())
+	}
+}
+
 func WithContainerSeccompProfile(profile string) ContainerOption {
 	return func(opts *cOptions) {
 		opts.options = append(opts.options, testutils.WithSeccompProfile(profile))

--- a/pkg/uprobetracer/gosym.go
+++ b/pkg/uprobetracer/gosym.go
@@ -1,0 +1,348 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uprobetracer
+
+import (
+	"debug/elf"
+	"debug/gosym"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/safeelf"
+)
+
+// maxGoSectionSize is the maximum size we'll read for .gopclntab and
+// .gosymtab sections. This prevents a malicious binary inside a container
+// from causing excessive memory allocation in the privileged IG process.
+// 64 MiB is generous: typical Go binaries have .gopclntab well under 32 MiB
+// even for very large programs.
+const maxGoSectionSize = 64 * 1024 * 1024
+
+// maxGoFuncCount is the maximum number of functions we accept in a
+// .gopclntab section. debug/gosym allocates two slices of that many elements
+// (152 bytes per function on amd64) from a function count that is only
+// constrained by the functab fitting in the section, at 8 bytes per function.
+// A crafted section is therefore amplified about 19 times, while a legitimate
+// one uses around 280 bytes of pclntab per function. The limit keeps the
+// worst case at roughly 150 MiB and is generous: kubelet declares about 67000
+// functions and ig about 103000.
+const maxGoFuncCount = 1000 * 1000
+
+// moduledataTextOffset is the pointer-sized field index of moduledata.text
+// in the Go 1.26 moduledata layout. It follows pcHeader, six slices,
+// findfunctab, minpc, and maxpc. Go does not expose this internal layout via
+// the standard library. See:
+// https://github.com/golang/go/blob/go1.26.5/src/runtime/symtab.go#L402-L450.
+const moduledataTextOffset = 22
+
+// goModuleTextStart reads moduledata.text from Go 1.26+'s .go.module
+// section. The section contains the link-time moduledata structure emitted by
+// the Go linker. A false result means that the binary predates this section.
+func goModuleTextStart(f *safeelf.File) (textStart uint64, found bool, err error) {
+	moduleSection := f.Section(".go.module")
+	if moduleSection == nil {
+		return 0, false, nil
+	}
+	if moduleSection.Size > maxGoSectionSize {
+		return 0, true, fmt.Errorf(".go.module too large (%d bytes, max %d)", moduleSection.Size, maxGoSectionSize)
+	}
+
+	data, err := moduleSection.Data()
+	if err != nil {
+		return 0, true, fmt.Errorf("reading .go.module: %w", err)
+	}
+
+	ptrSize := 4
+	if f.Class == elf.ELFCLASS64 {
+		ptrSize = 8
+	} else if f.Class != elf.ELFCLASS32 {
+		return 0, true, fmt.Errorf("unsupported ELF class for .go.module: %v", f.Class)
+	}
+	offset := moduledataTextOffset * ptrSize
+	if len(data) < offset+ptrSize {
+		return 0, true, fmt.Errorf(".go.module too small for moduledata.text: %d bytes", len(data))
+	}
+
+	if ptrSize == 4 {
+		return uint64(f.ByteOrder.Uint32(data[offset:])), true, nil
+	}
+	return f.ByteOrder.Uint64(data[offset:]), true, nil
+}
+
+// pclntabHeaderPtrSize validates the header at the beginning of a .gopclntab
+// section and returns its pointer size.
+func pclntabHeaderPtrSize(data []byte, order binary.ByteOrder) (int, error) {
+	if len(data) < 32 {
+		return 0, fmt.Errorf("pclntab header too short: %d bytes", len(data))
+	}
+
+	// These magic values identify the Go pclntab formats used across Go
+	// releases, including the legacy Go 1.2 and newer formats. See
+	// https://github.com/golang/go/blob/go1.26.5/src/internal/abi/symtab.go#L15-L25.
+	switch order.Uint32(data[0:4]) {
+	case 0xfffffff0, 0xfffffff1, 0xfffffffa, 0xfffffffb:
+	default:
+		return 0, fmt.Errorf("invalid Go pclntab magic: %#x", order.Uint32(data[0:4]))
+	}
+
+	ptrSize := int(data[7])
+	if ptrSize != 4 && ptrSize != 8 {
+		return 0, fmt.Errorf("unsupported Go pclntab pointer size: %d", ptrSize)
+	}
+
+	return ptrSize, nil
+}
+
+// pclntabFuncCount reads the number of functions declared in the header of a
+// .gopclntab section. In every format supported by debug/gosym, it is the
+// first pointer-sized field following the 8-byte header prefix. See
+// https://github.com/golang/go/blob/go1.26.5/src/debug/gosym/pclntab.go#L250-L285.
+func pclntabFuncCount(data []byte, order binary.ByteOrder) (uint64, error) {
+	ptrSize, err := pclntabHeaderPtrSize(data, order)
+	if err != nil {
+		return 0, err
+	}
+
+	if ptrSize == 4 {
+		return uint64(order.Uint32(data[8:])), nil
+	}
+	return order.Uint64(data[8:]), nil
+}
+
+// pclntabTextStart reads the textStart field from Go's runtime metadata
+// header at the beginning of a .gopclntab section. This field contains the
+// link-time virtual address used as the base for Go function offsets. A zero
+// result means that this binary's metadata does not provide a usable Go text
+// base.
+func pclntabTextStart(data []byte, order binary.ByteOrder) (uint64, error) {
+	ptrSize, err := pclntabHeaderPtrSize(data, order)
+	if err != nil {
+		return 0, err
+	}
+
+	textStartOffset := 8 + 2*ptrSize
+	if len(data) < textStartOffset+ptrSize {
+		return 0, errors.New("pclntab header truncated")
+	}
+
+	if ptrSize == 4 {
+		return uint64(order.Uint32(data[textStartOffset:])), nil
+	}
+	return order.Uint64(data[textStartOffset:]), nil
+}
+
+// goTextStart returns the link-time virtual address used as the base for Go
+// pclntab function offsets. It prefers moduledata.text from .go.module, then
+// the textStart field in Go's runtime metadata header, then the runtime.text
+// ELF symbol, and finally .text.Addr for internally linked binaries whose
+// metadata header leaves textStart unset.
+func goTextStart(f *safeelf.File, textSection *elf.Section, pclntabData []byte) (uint64, error) {
+	if textStart, found, err := goModuleTextStart(f); found {
+		if err != nil {
+			return 0, err
+		}
+		if textStart == 0 {
+			return 0, fmt.Errorf(".go.module contains an empty moduledata.text")
+		}
+		return textStart, nil
+	}
+
+	textStart, err := pclntabTextStart(pclntabData, f.ByteOrder)
+	if err != nil {
+		return 0, err
+	}
+	if textStart != 0 {
+		return textStart, nil
+	}
+
+	// runtime.text is an ELF symbol, not executable data. Stripping may remove
+	// it because the loader does not need symbol names to run the program.
+	for _, typ := range []elf.SectionType{elf.SHT_SYMTAB, elf.SHT_DYNSYM} {
+		var runtimeText uint64
+		var found bool
+		err = f.IterateSymbols(typ, func(symbol elf.Symbol) bool {
+			if symbol.Name != "runtime.text" {
+				return false
+			}
+			runtimeText = symbol.Value
+			found = true
+			return true
+		})
+		if err != nil {
+			return 0, fmt.Errorf("reading %s: %w", typ, err)
+		}
+		if found {
+			return runtimeText, nil
+		}
+	}
+
+	// An undefined dynamic symbol indicates external linking (for example,
+	// cgo's libc imports). With no runtime.text symbol and an unset pclntab
+	// textStart, .text.Addr is not reliable, so refuse to guess.
+	var externallyLinked bool
+	err = f.IterateSymbols(elf.SHT_DYNSYM, func(symbol elf.Symbol) bool {
+		if symbol.Section != elf.SHN_UNDEF || symbol.Name == "" {
+			return false
+		}
+		externallyLinked = true
+		return true
+	})
+	if err != nil {
+		return 0, fmt.Errorf("reading .dynsym: %w", err)
+	}
+	if externallyLinked {
+		return 0, errors.New("pclntab textStart unavailable for externally linked binary")
+	}
+
+	// Internally linked binaries may leave textStart unset. In that format,
+	// pclntab function offsets are relative to the ELF .text section.
+	return textSection.Addr, nil
+}
+
+// resolveGoSymbol is the Go symbol resolver. It looks up a function address in
+// a Go binary's .gopclntab section. It works when the standard ELF symbol
+// table (.symtab) is removed, as long as .gopclntab and a usable Go text base
+// remain. For Go 1.16 and later, debug/gosym can resolve names from pclntab
+// alone, so this resolver passes nil when the optional .gosymtab section is
+// absent.
+//
+// This resolver supports ELF Go binaries that retain .gopclntab and a usable
+// Go text base, including stripped pure-Go binaries and Go 1.26+ binaries with
+// .go.module. When .go.module is absent and textStart is unset, it uses
+// runtime.text or .text.Addr only for binaries linked by the Go linker without
+// an external system linker; in that layout, Go function offsets are relative
+// to .text.
+//
+// Binaries whose pclntab data remains only in a PT_LOAD segment after section
+// headers were removed are not supported. Resolving those binaries requires a
+// bounded PT_LOAD scan, which is intentionally not performed here.
+//
+// | Binary layout                                      | Support |
+// |----------------------------------------------------|---------|
+// | .gopclntab and usable Go text base                 | Yes     |
+// | Go 1.26+ with .go.module                           | Yes     |
+// | Stripped pure-Go (-s -w)                           | Yes     |
+// | Older external-linked binary without a text base   | No      |
+// | pclntab section header or data removed             | No      |
+//
+// The caller must pass an already-opened *os.File (typically obtained via
+// secureopen.OpenInContainer) to avoid re-opening untrusted paths.
+//
+// Returns a file offset suitable for use with UprobeOptions.Address.
+func resolveGoSymbol(file *os.File, symbol string) (addr uint64, err error) {
+	// debug/elf and debug/gosym are not hardened against adversarial inputs
+	// and may panic on malformed data. Since we're parsing files from
+	// untrusted containers, recover from panics.
+	defer func() {
+		if r := recover(); r != nil {
+			addr = 0
+			err = fmt.Errorf("panic parsing Go symbol table: %v", r)
+		}
+	}()
+
+	f, err := safeelf.NewFile(file)
+	if err != nil {
+		return 0, fmt.Errorf("reading ELF: %w", err)
+	}
+	defer f.Close()
+
+	pclntab := f.Section(".gopclntab")
+	if pclntab == nil {
+		return 0, fmt.Errorf("no .gopclntab section found (not a Go binary?)")
+	}
+	if pclntab.Size > maxGoSectionSize {
+		return 0, fmt.Errorf(".gopclntab too large (%d bytes, max %d)", pclntab.Size, maxGoSectionSize)
+	}
+
+	// .gosymtab may be absent in stripped binaries. Go 1.16+ embeds all
+	// needed information in .gopclntab, so gosym.NewTable works with nil symtab.
+	var symtabData []byte
+	if symtab := f.Section(".gosymtab"); symtab != nil {
+		if symtab.Size > maxGoSectionSize {
+			return 0, fmt.Errorf(".gosymtab too large (%d bytes, max %d)", symtab.Size, maxGoSectionSize)
+		}
+		symtabData, err = symtab.Data()
+		if err != nil {
+			return 0, fmt.Errorf("reading .gosymtab: %w", err)
+		}
+	}
+
+	textSection := f.Section(".text")
+	if textSection == nil {
+		return 0, fmt.Errorf("no .text section found")
+	}
+
+	pclntabData, err := pclntab.Data()
+	if err != nil {
+		return 0, fmt.Errorf("reading .gopclntab: %w", err)
+	}
+	textStart, err := goTextStart(f, textSection, pclntabData)
+	if err != nil {
+		return 0, fmt.Errorf("reading Go text start: %w", err)
+	}
+
+	// debug/gosym allocates one Func and one Sym per function upfront, from
+	// a count read in the header. Reject implausible counts: a failing
+	// allocation is a fatal runtime error that recover() cannot catch.
+	funcCount, err := pclntabFuncCount(pclntabData, f.ByteOrder)
+	if err != nil {
+		return 0, fmt.Errorf("reading Go function count: %w", err)
+	}
+	if funcCount > maxGoFuncCount {
+		return 0, fmt.Errorf("too many Go functions: %d (max %d)", funcCount, maxGoFuncCount)
+	}
+
+	lineTable := gosym.NewLineTable(pclntabData, textStart)
+	table, err := gosym.NewTable(symtabData, lineTable)
+	if err != nil {
+		return 0, fmt.Errorf("parsing Go symbol table: %w", err)
+	}
+
+	fn := table.LookupFunc(symbol)
+	if fn == nil {
+		return 0, fmt.Errorf("symbol %q not found in .gopclntab", symbol)
+	}
+
+	// Convert virtual address to file offset using the executable LOAD segment.
+	// The uprobe subsystem needs a file offset, not a virtual address.
+	fileSize, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat: %w", err)
+	}
+	for _, prog := range f.Progs {
+		if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
+			continue
+		}
+		// Only the first Filesz bytes of a segment are backed by the
+		// file. The rest (Memsz - Filesz) is zero filled at load time
+		// and has no file offset.
+		if fn.Entry < prog.Vaddr || fn.Entry-prog.Vaddr >= prog.Filesz {
+			continue
+		}
+		offset := fn.Entry - prog.Vaddr
+		if offset > ^uint64(0)-prog.Off {
+			return 0, fmt.Errorf("file offset overflow for symbol %q", symbol)
+		}
+		offset += prog.Off
+		if offset >= uint64(fileSize.Size()) {
+			return 0, fmt.Errorf("file offset 0x%x for symbol %q is past the end of the file", offset, symbol)
+		}
+		return offset, nil
+	}
+
+	return 0, fmt.Errorf("symbol %q (VA 0x%x) not found in any executable LOAD segment", symbol, fn.Entry)
+}

--- a/pkg/uprobetracer/gosym_test.go
+++ b/pkg/uprobetracer/gosym_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uprobetracer
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The linker-built fixture matrix is:
+//
+// | Build variant             | Non-PIE | PIE | Stripped (-s -w)  |
+// |---------------------------|---------|-----|-------------------|
+// | Pure Go                   | Yes     | Yes | Yes               |
+// | cgo/dynamic               | Yes     | Yes | No                |
+//
+// Non-stripped fixtures are cross-checked with go tool nm. External strip
+// variants are tested separately:
+//
+// | Fixture       | --strip-all/unneeded | --strip-debug |
+// |---------------|----------------------|---------------|
+// | Pure Go       | Resolves             | Resolves      |
+// | cgo/dynamic   | Resolves             | Resolves      |
+//
+// Statically linked cgo, actual kubelet/containerd binaries, and sectionless
+// pclntab data are not tested.
+const (
+	goSymbolFixture  = "testdata/gosymbol/main.go"
+	cgoSymbolFixture = "testdata/gosymbol/main_cgo.go"
+)
+
+func TestResolveGoSymbolFixtures(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    []string
+		stripped bool
+	}{
+		{name: "static", flags: nil},
+		{name: "pie", flags: []string{"-buildmode=pie"}},
+		{name: "stripped", flags: nil, stripped: true},
+		{name: "pie-stripped", flags: []string{"-buildmode=pie"}, stripped: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testGoSymbolFixture(t, goSymbolFixture, nil, tt.flags, tt.stripped)
+		})
+	}
+}
+
+func TestResolveGoSymbolCgoFixtures(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("cgo ELF fixture requires Linux")
+	}
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skipf("cgo compiler unavailable: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name  string
+		flags []string
+	}{
+		{name: "non-pie", flags: nil},
+		{name: "pie", flags: []string{"-buildmode=pie"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testGoSymbolFixture(t, cgoSymbolFixture, []string{"CGO_ENABLED=1"}, tt.flags, false)
+		})
+	}
+}
+
+func TestResolveGoSymbolExternalStripFixtures(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("external strip ELF fixture requires Linux")
+	}
+	strip, err := exec.LookPath("strip")
+	if err != nil {
+		t.Skipf("strip unavailable: %v", err)
+	}
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skipf("cgo compiler unavailable: %v", err)
+	}
+
+	for _, fixture := range []struct {
+		name   string
+		source string
+		env    []string
+	}{
+		{name: "go", source: goSymbolFixture},
+		{name: "cgo", source: cgoSymbolFixture, env: []string{"CGO_ENABLED=1"}},
+	} {
+		for _, build := range []struct {
+			name  string
+			flags []string
+		}{
+			{name: "non-pie"},
+			{name: "pie", flags: []string{"-buildmode=pie"}},
+		} {
+			for _, mode := range []string{"--strip-all", "--strip-unneeded", "--strip-debug"} {
+				t.Run(fixture.name+"/"+build.name+"/"+strings.TrimPrefix(mode, "--"), func(t *testing.T) {
+					dir := t.TempDir()
+					target := filepath.Join(dir, "target")
+					buildGoFixture(t, fixture.source, target, fixture.env, build.flags)
+
+					output, err := exec.Command(strip, mode, target).CombinedOutput()
+					require.NoError(t, err, "strip failed: %s", output)
+
+					file, err := os.Open(target)
+					require.NoError(t, err)
+					t.Cleanup(func() { _ = file.Close() })
+
+					got, err := resolveGoSymbol(file, "main.target")
+					require.NoError(t, err)
+
+					output, err = exec.Command(target).CombinedOutput()
+					require.NoError(t, err, "fixture failed: %s", output)
+					want, err := strconv.ParseUint(strings.TrimSpace(string(output)), 10, 64)
+					require.NoError(t, err, "invalid fixture output: %q", output)
+					require.Equal(t, want, got)
+				})
+			}
+		}
+	}
+}
+
+func testGoSymbolFixture(t *testing.T, source string, env, flags []string, stripped bool) {
+	t.Helper()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	targetFlags := append([]string{}, flags...)
+	if stripped {
+		targetFlags = append(targetFlags, "-ldflags=-s -w")
+	}
+	buildGoFixture(t, source, target, env, targetFlags)
+
+	file, err := os.Open(target)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	got, err := resolveGoSymbol(file, "main.target")
+	require.NoError(t, err)
+
+	output, err := exec.Command(target).CombinedOutput()
+	require.NoError(t, err, "fixture failed: %s", output)
+	want, err := strconv.ParseUint(strings.TrimSpace(string(output)), 10, 64)
+	require.NoError(t, err, "invalid fixture output: %q", output)
+	if !stripped {
+		nmWant, err := goToolNMSymbolOffset(target, "main.target")
+		require.NoError(t, err)
+		require.Equal(t, nmWant, want)
+	}
+	require.Equal(t, want, got)
+}
+
+func buildGoFixture(t *testing.T, source, output string, env, flags []string) {
+	t.Helper()
+
+	args := []string{"build", "-o", output}
+	args = append(args, flags...)
+	args = append(args, source, filepath.Join(filepath.Dir(source), "runtime_offset.go"))
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(os.Environ(), env...)
+	outputBytes, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", outputBytes)
+}
+
+func goToolNMSymbolOffset(path, name string) (uint64, error) {
+	output, err := exec.Command("go", "tool", "nm", path).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("running go tool nm: %w: %s", err, output)
+	}
+
+	var virtualAddress uint64
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[2] == name {
+			virtualAddress, err = strconv.ParseUint(fields[0], 16, 64)
+			if err != nil {
+				return 0, fmt.Errorf("parsing symbol address: %w", err)
+			}
+			break
+		}
+	}
+	if virtualAddress == 0 {
+		return 0, fmt.Errorf("symbol %q not found", name)
+	}
+
+	elfFile, err := elf.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("opening ELF: %w", err)
+	}
+	defer elfFile.Close()
+
+	for _, prog := range elfFile.Progs {
+		if prog.Type != elf.PT_LOAD || prog.Flags&elf.PF_X == 0 {
+			continue
+		}
+		if virtualAddress < prog.Vaddr || virtualAddress-prog.Vaddr >= prog.Memsz {
+			continue
+		}
+		return prog.Off + virtualAddress - prog.Vaddr, nil
+	}
+	return 0, fmt.Errorf("symbol %q is not in an executable LOAD segment", name)
+}
+
+// makePclntabHeader builds a minimal pclntab header with the given magic,
+// pointer size and function count.
+func makePclntabHeader(magic uint32, ptrSize byte, funcCount uint64) []byte {
+	data := make([]byte, 64)
+	binary.LittleEndian.PutUint32(data[0:4], magic)
+	data[7] = ptrSize
+	if ptrSize == 4 {
+		binary.LittleEndian.PutUint32(data[8:], uint32(funcCount))
+	} else {
+		binary.LittleEndian.PutUint64(data[8:], funcCount)
+	}
+	return data
+}
+
+func TestPclntabFuncCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		expected  uint64
+		expectErr string
+	}{
+		{
+			name:     "go118_64bit",
+			data:     makePclntabHeader(0xfffffff0, 8, 103189),
+			expected: 103189,
+		},
+		{
+			name:     "go12_32bit",
+			data:     makePclntabHeader(0xfffffffb, 4, 4242),
+			expected: 4242,
+		},
+		{
+			name:      "too_short",
+			data:      makePclntabHeader(0xfffffff0, 8, 1)[:31],
+			expectErr: "too short",
+		},
+		{
+			name:      "bad_magic",
+			data:      makePclntabHeader(0xdeadbeef, 8, 1),
+			expectErr: "invalid Go pclntab magic",
+		},
+		{
+			name:      "bad_pointer_size",
+			data:      makePclntabHeader(0xfffffff0, 3, 1),
+			expectErr: "unsupported Go pclntab pointer size",
+		},
+		{
+			// A crafted section can declare far more functions than
+			// it has room for, which debug/gosym would allocate.
+			name:     "implausible_count",
+			data:     makePclntabHeader(0xfffffff0, 8, ^uint64(0)),
+			expected: ^uint64(0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := pclntabFuncCount(tt.data, binary.LittleEndian)
+			if tt.expectErr != "" {
+				require.ErrorContains(t, err, tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, count)
+			if tt.name == "implausible_count" {
+				require.Greater(t, count, uint64(maxGoFuncCount),
+					"resolveGoSymbol must reject this count")
+			}
+		})
+	}
+}

--- a/pkg/uprobetracer/testdata/gosymbol/main.go
+++ b/pkg/uprobetracer/testdata/gosymbol/main.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+//go:noinline
+func target() {
+}
+
+func main() {
+	target()
+	printTargetOffset()
+}

--- a/pkg/uprobetracer/testdata/gosymbol/main_cgo.go
+++ b/pkg/uprobetracer/testdata/gosymbol/main_cgo.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+//go:noinline
+func target() {
+	C.free(nil)
+}
+
+func main() {
+	target()
+	printTargetOffset()
+}

--- a/pkg/uprobetracer/testdata/gosymbol/runtime_offset.go
+++ b/pkg/uprobetracer/testdata/gosymbol/runtime_offset.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"debug/elf"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func printTargetOffset() {
+	offset, err := targetOffset()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(offset)
+}
+
+func targetOffset() (uint64, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("getting executable path: %w", err)
+	}
+
+	runtimeBase, err := runtimeBaseAddress(executable)
+	if err != nil {
+		return 0, err
+	}
+
+	elfFile, err := elf.Open(executable)
+	if err != nil {
+		return 0, fmt.Errorf("opening ELF: %w", err)
+	}
+	defer elfFile.Close()
+
+	elfBase, err := elfBaseAddress(elfFile)
+	if err != nil {
+		return 0, err
+	}
+
+	runtimeAddress := reflect.ValueOf(target).Pointer()
+	virtualAddress := uint64(runtimeAddress) - runtimeBase + elfBase
+	for _, prog := range elfFile.Progs {
+		if prog.Type != elf.PT_LOAD || prog.Flags&elf.PF_X == 0 {
+			continue
+		}
+		if virtualAddress < prog.Vaddr || virtualAddress-prog.Vaddr >= prog.Memsz {
+			continue
+		}
+		return prog.Off + virtualAddress - prog.Vaddr, nil
+	}
+	return 0, fmt.Errorf("target address 0x%x is not in an executable LOAD segment", virtualAddress)
+}
+
+func runtimeBaseAddress(executable string) (uint64, error) {
+	file, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return 0, fmt.Errorf("opening process maps: %w", err)
+	}
+	defer file.Close()
+
+	var base uint64
+	found := false
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) <= 5 || parts[5] != executable {
+			continue
+		}
+		if parts[1] != "r--p" && parts[1] != "r-xp" {
+			continue
+		}
+		start, _, ok := strings.Cut(parts[0], "-")
+		if !ok {
+			continue
+		}
+		address, err := strconv.ParseUint(start, 16, 64)
+		if err != nil {
+			continue
+		}
+		if !found || address < base {
+			base = address
+			found = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("reading process maps: %w", err)
+	}
+	if !found {
+		return 0, fmt.Errorf("executable mapping not found")
+	}
+	return base, nil
+}
+
+func elfBaseAddress(elfFile *elf.File) (uint64, error) {
+	var base uint64
+	found := false
+	for _, prog := range elfFile.Progs {
+		if prog.Type != elf.PT_LOAD {
+			continue
+		}
+		if !found || prog.Vaddr < base {
+			base = prog.Vaddr
+			found = true
+		}
+	}
+	if !found {
+		return 0, fmt.Errorf("ELF has no LOAD segments")
+	}
+	return base, nil
+}

--- a/pkg/uprobetracer/tracer.go
+++ b/pkg/uprobetracer/tracer.go
@@ -52,6 +52,8 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/secureopen"
 )
 
+var errSymbolNotFound = errors.New("symbol not found")
+
 type ProgType uint32
 
 const (
@@ -190,19 +192,37 @@ func (t *Tracer[Event]) attachUprobe(file *os.File) (link.Link, error) {
 		return nil, fmt.Errorf("opening %q: %w", attachPath, err)
 	}
 	switch t.progType {
-	case ProgUprobe, ProgUretprobe:
+	case ProgUprobe:
 		// Resolve symbol in IG's hardened code, then pass the file offset
 		// to cilium/ebpf. This bypasses cilium/ebpf's Symbols()/
 		// DynamicSymbols() path which doesn't limit memory consumption.
 		offset, err := resolveSymbolOffset(file, t.attachSymbol)
+		if err == nil {
+			return ex.Uprobe("", t.prog, &link.UprobeOptions{Address: offset})
+		}
+		if !errors.Is(err, errSymbolNotFound) {
+			return nil, fmt.Errorf("resolving symbol %q: %w", t.attachSymbol, err)
+		}
+		// If the symbol was not found in the ELF symbol table, try
+		// resolving it from Go's .gopclntab section. This allows
+		// attaching uprobes to stripped Go binaries.
+		t.logger.Debugf("uprobe attach by symbol failed (%s), trying .gopclntab fallback", err)
+		offset, goErr := resolveGoSymbol(file, t.attachSymbol)
+		if goErr != nil {
+			return nil, fmt.Errorf("attaching uprobe (ELF: %w; gopclntab: %w)", err, goErr)
+		}
+		t.logger.Debugf("resolved %q from .gopclntab at offset 0x%x", t.attachSymbol, offset)
+		return ex.Uprobe("", t.prog, &link.UprobeOptions{Address: offset})
+	case ProgUretprobe:
+		// Go uretprobes need Go-aware return handling because goroutine stacks can move.
+		// See https://github.com/inspektor-gadget/inspektor-gadget/pull/3552
+		// Resolve the ELF symbol ourselves to avoid cilium/ebpf's unbounded
+		// symbol table parsing.
+		offset, err := resolveSymbolOffset(file, t.attachSymbol)
 		if err != nil {
 			return nil, fmt.Errorf("resolving symbol %q: %w", t.attachSymbol, err)
 		}
-		opts := &link.UprobeOptions{Address: offset}
-		if t.progType == ProgUprobe {
-			return ex.Uprobe("", t.prog, opts)
-		}
-		return ex.Uretprobe("", t.prog, opts)
+		return ex.Uretprobe("", t.prog, &link.UprobeOptions{Address: offset})
 	case ProgUSDT:
 		attachInfo, err := getUsdtInfo(attachPath, t.attachSymbol)
 		if err != nil {
@@ -247,7 +267,7 @@ func resolveSymbolOffset(file *os.File, symbol string) (uint64, error) {
 			return 0, iterErr
 		}
 	}
-	return 0, fmt.Errorf("symbol %q not found", symbol)
+	return 0, fmt.Errorf("symbol %q: %w", symbol, errSymbolNotFound)
 }
 
 // try attaching to a container, will update `containerPid2Inodes`


### PR DESCRIPTION
When attaching a uprobe and the symbol is not found in the standard ELF symbol table (.symtab), fall back to resolving it from Go's .gopclntab section. This section is preserved even in stripped Go binaries (built with -ldflags="-s -w") because the Go runtime needs it for stack traces.

The .gopclntab contains all Go function names and their virtual addresses. We convert the virtual address to a file offset using the executable LOAD segment, then attach via UprobeOptions.Address.

Use the shared panic-safe ELF parser and reject overflowing virtual-address to file-offset conversions while resolving symbols.

This enables tracing stripped Go binaries like the production kubelet.

This patch was initially introduced in #5493.

cc @vfalico @mqasimsarfraz 