### PR TITLE
docs: Explain the katacontainers limitation

### DIFF
--- a/docs/reference/requirements.md
+++ b/docs/reference/requirements.md
@@ -32,7 +32,7 @@ project require at least Linux 5.10 with
 | nerdctl           | containerd        | runc              | ✔️                                                                                |
 | Kubernetes        | containerd        | runc              | ✔️                                                                                |
 | Kubernetes        | containerd        | wasm              | ❌ (see [#1899](https://github.com/inspektor-gadget/inspektor-gadget/issues/1899)) |
-| Kubernetes        | containerd        | katacontainers    | ❌                                                                                 |
+| Kubernetes        | containerd        | katacontainers    | ❌ (see [#5743](https://github.com/inspektor-gadget/inspektor-gadget/issues/5743): workloads run in a guest kernel the host gadgets cannot observe) |
 | Kubernetes        | CRI-O             | runc / crun       | Kubernetes v1.20+ (see [below](#cri-o))                                           |
 | Podman (root)     | podman            | runc / crun       | ✔️                                                                                |
 | Podman (rootless) | podman            | runc / crun       | Only with Podman API enabled (see [below](#podman-rootless))                      |


### PR DESCRIPTION
The container runtime table marks `katacontainers` as unsupported with a
bare ❌, while the `wasm` row just above it links to the issue explaining
why. This gives the katacontainers row the same treatment.

Points at #5743, which discusses the limitation: a Kata pod's workload
runs inside a guest kernel, so the tracing gadgets — which attach to the
host kernel — cannot observe its syscalls.

One line changed, nothing else.
