### PR TITLE
propose opens fix for fullpath propagation

### DIFF
--- a/gadgets/trace_open/program.bpf.c
+++ b/gadgets/trace_open/program.bpf.c
@@ -21,6 +21,7 @@ struct args_t {
 	const char *fname;
 	int flags;
 	__u16 mode;
+	int dfd;
 };
 
 struct event {
@@ -53,7 +54,7 @@ GADGET_TRACER_MAP(events, 1024 * 256);
 
 GADGET_TRACER(open, events, event);
 
-static __always_inline int trace_enter(const char *filename, int flags,
+static __always_inline int trace_enter(int dfd, const char *filename, int flags,
 				       __u16 mode)
 {
 	__u64 pid = bpf_get_current_pid_tgid();
@@ -65,6 +66,7 @@ static __always_inline int trace_enter(const char *filename, int flags,
 	args.fname = filename;
 	args.flags = flags;
 	args.mode = mode;
+	args.dfd = dfd;
 	bpf_map_update_elem(&start, &pid, &args, 0);
 
 	return 0;
@@ -74,16 +76,16 @@ static __always_inline int trace_enter(const char *filename, int flags,
 SEC("tracepoint/syscalls/sys_enter_open")
 int ig_open_e(struct syscall_trace_enter *ctx)
 {
-	return trace_enter((const char *)ctx->args[0], (int)ctx->args[1],
-			   (__u16)ctx->args[2]);
+	return trace_enter(AT_FDCWD, (const char *)ctx->args[0],
+			   (int)ctx->args[1], (__u16)ctx->args[2]);
 }
 #endif /* !__TARGET_ARCH_arm64 */
 
 SEC("tracepoint/syscalls/sys_enter_openat")
 int ig_openat_e(struct syscall_trace_enter *ctx)
 {
-	return trace_enter((const char *)ctx->args[1], (int)ctx->args[2],
-			   (__u16)ctx->args[3]);
+	return trace_enter((int)ctx->args[0], (const char *)ctx->args[1],
+			   (int)ctx->args[2], (__u16)ctx->args[3]);
 }
 
 static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
@@ -111,6 +113,7 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 
 	fd = 0;
 	errval = 0;
+	event->fpath[0] = '\0';
 	if (ret >= 0) {
 		fd = ret;
 
@@ -122,6 +125,17 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 		}
 	} else {
 		errval = -ret;
+	}
+
+	if (paths && event->fpath[0] == '\0') {
+		char first = 0;
+		bpf_probe_read_user(&first, 1, ap->fname);
+		if (first != 0 && first != '/') {
+			long r = read_full_path_of_dfd_rel(
+				ap->dfd, ap->fname, (char *)event->fpath);
+			if (r <= 0)
+				event->fpath[0] = '\0';
+		}
 	}
 
 	/* event data */

--- a/include/gadget/filesystem.h
+++ b/include/gadget/filesystem.h
@@ -151,7 +151,10 @@ static __always_inline void *get_path_str(struct path *path)
 		// memfd files have no path in the filesystem -> extract their name
 		buf_off = 0;
 		d_name = get_d_name_from_dentry(dentry);
-		bpf_probe_read_str(&(string_p->buf[0]), PATH_MAX, (void *) d_name.name);
+		sz = bpf_probe_read_str(&(string_p->buf[0]), PATH_MAX, (void *) d_name.name);
+		// A failed or empty read must not surface as a valid path.
+		if (sz <= 1)
+			return NULL;
 	} else {
 		// Add leading slash
 		buf_off -= 1;
@@ -203,6 +206,58 @@ static __always_inline long read_full_path_of_open_file_fd(int fd_num, char *buf
 		return -1;
 	}
 	return bpf_probe_read_kernel_str(buf, buf_len, c_path);
+}
+
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+// Resolve the absolute path for a relative filename opened against a dirfd
+// (or AT_FDCWD, i.e. the task's current working directory). buf is always
+// GADGET_PATH_MAX bytes: the verifier needs a compile-time bound for the
+// masked writes below, so the size is not a runtime parameter.
+static __always_inline long read_full_path_of_dfd_rel(int dfd, const char *user_fname,
+						      char *buf)
+{
+	struct path base;
+
+	if (dfd == AT_FDCWD) {
+		struct task_struct *task = (struct task_struct *) bpf_get_current_task();
+		if (!task)
+			return -1;
+		base = BPF_CORE_READ(task, fs, pwd);
+	} else {
+		struct file *f = get_struct_file_for_fd(dfd);
+		if (!f)
+			return -1;
+		base = BPF_CORE_READ(f, f_path);
+	}
+
+	char *bstr = get_path_str(&base);
+	if (!bstr)
+		return -1;
+
+	long n = bpf_probe_read_kernel_str(buf, GADGET_PATH_MAX, bstr);
+	if (n <= 1)
+		return -1;
+
+	u32 off = (u32) (n - 1);
+#define REL_NAME_MAX 256
+	// Base too long to append the name within GADGET_PATH_MAX: fail closed
+	// rather than truncate the base into a plausible but wrong absolute path.
+	if (off >= GADGET_PATH_MAX - REL_NAME_MAX)
+		return -1;
+	// Redundant given the check above, but the verifier needs the constant
+	// mask to prove the REL_NAME_MAX write below stays in bounds.
+	off &= (GADGET_PATH_MAX - REL_NAME_MAX - 1);
+	buf[off & (GADGET_PATH_MAX - 1)] = '/';
+	long m = bpf_probe_read_user_str(&buf[(off + 1) & (GADGET_PATH_MAX - 1)],
+					 REL_NAME_MAX - 1, user_fname);
+	if (m <= 1) {
+		buf[off & (GADGET_PATH_MAX - 1)] = '\0';
+		return -1;
+	}
+	return off + m;
 }
 
 #endif


### PR DESCRIPTION
# [Title: describe the change in one sentence]

Found a bug in node-agent https://github.com/k8sstormcenter/node-agent/issues/81 for mounted paths. 

## How to use
Examples of where the bug shows up is in 

Redis
```
  helm install redis oci://registry-1.docker.io/bitnamicharts/redis --version 27.0.18 \
    --set architecture=standalone --set auth.enabled=false \
    --set image.repository=bitnami/redis \
    --set image.digest=sha256:08863c2c3f4e051fb6139b38fa223e9c13be5033326a59bead182860d899bf98 \
    -n redis --create-namespace
```
and postgres (bitnami chart)
```
  helm install pg-bitnami oci://registry-1.docker.io/bitnamicharts/postgresql \
    --set auth.database=app --set auth.username=app \
    --set auth.password=bobtest --set auth.postgresPassword=bobtest \
    --set primary.persistence.enabled=false \
    -n postgres-bitnami --create-namespace
```

## Testing done

This was tested as part of kubescape-node-agent, **not as standalone gadget yet**, thus draft status. see the issue for more detail
