### PR TITLE
grpc: Use NewClient instead of deprecated Dial

### DIFF
--- a/gadget-container/gadgettracermanager/main.go
+++ b/gadget-container/gadgettracermanager/main.go
@@ -112,8 +112,7 @@ func main() {
 		var conn *grpc.ClientConn
 
 		var err error
-		//nolint:staticcheck
-		conn, err = grpc.Dial("unix://"+socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err = grpc.NewClient("unix://"+socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			fmt.Printf("Gadget Tracer Manager health check failed to dial: %v", err)
 			os.Exit(1)

--- a/gadget-container/hooks/nri/main.go
+++ b/gadget-container/hooks/nri/main.go
@@ -94,8 +94,7 @@ func processContainer(r *types.Request, conf *igHookConf) error {
 	var client pb.HookServiceClient
 	var ctx context.Context
 	var cancel context.CancelFunc
-	//nolint:staticcheck
-	conn, err := grpc.Dial("unix://"+conf.Socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("unix://"+conf.Socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}

--- a/gadget-container/hooks/oci/main.go
+++ b/gadget-container/hooks/oci/main.go
@@ -81,8 +81,7 @@ func main() {
 	var client pb.HookServiceClient
 	var ctx context.Context
 	var cancel context.CancelFunc
-	//nolint:staticcheck
-	conn, err := grpc.Dial("unix://"+socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("unix://"+socketfile, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/container-utils/containerd/containerd.go
+++ b/pkg/container-utils/containerd/containerd.go
@@ -70,11 +70,7 @@ func NewContainerdClient(socketPath string, protocol string, config *containerut
 		namespace = config.Namespace
 	}
 
-	dialCtx, cancelFunc := context.WithTimeout(context.TODO(), DefaultTimeout)
-	defer cancelFunc()
-	//nolint:staticcheck
-	grpcConn, err := grpc.DialContext(
-		dialCtx,
+	grpcConn, err := grpc.NewClient(
 		"unix:"+socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/pkg/container-utils/cri/cri.go
+++ b/pkg/container-utils/cri/cri.go
@@ -53,9 +53,8 @@ type CRIClient struct {
 }
 
 func NewCRIClient(name types.RuntimeName, socketPath string, timeout time.Duration) (*CRIClient, error) {
-	//nolint:staticcheck
-	conn, err := grpc.Dial(
-		socketPath,
+	conn, err := grpc.NewClient(
+		"passthrough:///"+socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			d := net.Dialer{Timeout: timeout}

--- a/pkg/runtime/grpc/grpc-runtime.go
+++ b/pkg/runtime/grpc/grpc-runtime.go
@@ -443,14 +443,9 @@ All these options should be set at the same time to enable TLS connection`,
 			gadgetNamespace := r.globalParams.Get(ParamGadgetNamespace).AsString()
 			return NewK8SPortFwdConn(ctx, r.restConfig, gadgetNamespace, target, port, timeout)
 		}))
-	} else {
-		newCtx, cancel := context.WithTimeout(dialCtx, timeout)
-		defer cancel()
-		dialCtx = newCtx
 	}
 
-	//nolint:staticcheck
-	conn, err := grpc.DialContext(dialCtx, "passthrough:///"+target.addressOrPod, opts...)
+	conn, err := grpc.NewClient("passthrough:///"+target.addressOrPod, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("dialing %q (%q): %w", target.addressOrPod, target.node, err)
 	}


### PR DESCRIPTION
### Description
Refactors all deprecated calls to `grpc.Dial` and `grpc.DialContext` to use `grpc.NewClient` across the codebase, removing `//nolint:staticcheck` directives.

Fixes #3127

### Changes
- `pkg/runtime/grpc/grpc-runtime.go`: Use `grpc.NewClient`
- `pkg/container-utils/cri/cri.go`: Use `grpc.NewClient`
- `pkg/container-utils/containerd/containerd.go`: Use `grpc.NewClient` and remove unused `dialCtx`
- `gadget-container/gadgettracermanager/main.go`: Use `grpc.NewClient`
- `gadget-container/hooks/oci/main.go`: Use `grpc.NewClient`
- `gadget-container/hooks/nri/main.go`: Use `grpc.NewClient`