### PR TITLE
gadgets/snapshot_socket: Provide human representation of state

### DIFF
--- a/gadgets/snapshot_socket/gadget.yaml
+++ b/gadgets/snapshot_socket/gadget.yaml
@@ -14,9 +14,13 @@ datasources:
         annotations:
           description: Destination address
           template: l4endpoint
+      state_raw:
+        annotations:
+          columns.hidden: true
       state:
         annotations:
-          columns.width: 10
+          description: Socket state
+          columns.width: 12
       ino:
         annotations:
           description: Inode number

--- a/gadgets/snapshot_socket/program.bpf.c
+++ b/gadgets/snapshot_socket/program.bpf.c
@@ -9,7 +9,9 @@
 
 /* This BPF program uses the GPL-restricted function bpf_seq_write(). */
 
+#define UNKNOWN __IGNORE_UNKNOWN
 #include <vmlinux.h>
+#undef UNKNOWN
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
@@ -47,10 +49,28 @@
 #define tw_v6_rcv_saddr __tw_common.skc_v6_rcv_saddr
 #define tw_family __tw_common.skc_family
 
+enum socket_state {
+	UNKNOWN = 0,
+	ESTABLISHED = 1,
+	SYN_SENT = 2,
+	SYN_RECV = 3,
+	FIN_WAIT1 = 4,
+	FIN_WAIT2 = 5,
+	TIME_WAIT = 6,
+	CLOSE = 7,
+	CLOSE_WAIT = 8,
+	LAST_ACK = 9,
+	LISTEN = 10,
+	CLOSING = 11,
+	NEW_SYN_RECV = 12,
+	ACTIVE = 13,
+	INACTIVE = 14,
+};
+
 struct socket_entry {
 	struct gadget_l4endpoint_t src;
 	struct gadget_l4endpoint_t dst;
-	__u32 state;
+	enum socket_state state_raw;
 	__u32 ino;
 	gadget_netns_id netns_id;
 };
@@ -112,7 +132,23 @@ socket_bpf_seq_write(struct seq_file *seq, __u16 family, __u16 proto,
 	entry.src.proto_raw = entry.dst.proto_raw = proto;
 	entry.src.port = bpf_htons(srcp);
 	entry.dst.port = bpf_htons(destp);
-	entry.state = state;
+
+	if (proto == IPPROTO_UDP) {
+		switch (state) {
+		case 1:
+			entry.state_raw = ACTIVE;
+			break;
+		case 7:
+			entry.state_raw = INACTIVE;
+			break;
+		default:
+			entry.state_raw = UNKNOWN;
+			break;
+		}
+	} else {
+		entry.state_raw = (enum socket_state)state;
+	}
+
 	entry.ino = ino;
 	entry.netns_id = netns;
 

--- a/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
@@ -37,7 +37,8 @@ type snapshotSocketEntry struct {
 
 	SrcEndpoint utils.L4Endpoint `json:"src"`
 	DstEndpoint utils.L4Endpoint `json:"dst"`
-	Status      uint64           `json:"status"`
+	State       string           `json:"state"`
+	StateRaw    uint16           `json:"state_raw"`
 }
 
 func TestSnapshotSocket(t *testing.T) {
@@ -100,7 +101,8 @@ func TestSnapshotSocket(t *testing.T) {
 					Port:    0,
 					Proto:   "TCP",
 				},
-				Status:      0,
+				State:       "LISTEN",
+				StateRaw:    10,
 				NetNsID:     utils.NormalizedInt,
 				InodeNumber: utils.NormalizedInt,
 			}


### PR DESCRIPTION
### Description
Updates `gadgets/snapshot_socket` to output human-readable socket states (e.g. `"ESTABLISHED"`, `"LISTEN"`, `"SYN_SENT"`) using Inspektor Gadget's BTF enum formatting.

Fixes #3154