### PR TITLE
gadgets/trace_mount: Report network namespace in mount gadget

### DIFF
--- a/gadgets/trace_mount/gadget.yaml
+++ b/gadgets/trace_mount/gadget.yaml
@@ -52,3 +52,7 @@ datasources:
       call:
         annotations:
           columns.width: 32
+      netns_id:
+        annotations:
+          description: Network namespace inode id
+          template: ns

--- a/gadgets/trace_mount/program.bpf.c
+++ b/gadgets/trace_mount/program.bpf.c
@@ -67,6 +67,7 @@ struct arg {
 struct event {
 	gadget_timestamp timestamp_raw;
 	struct gadget_process proc;
+	gadget_netns_id netns_id;
 
 	gadget_duration delta_raw;
 	enum flags_set flags_raw;
@@ -132,6 +133,8 @@ static int probe_exit(void *ctx, int ret)
 		goto cleanup;
 
 	gadget_process_populate(&eventp->proc);
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+	eventp->netns_id = BPF_CORE_READ(task, nsproxy, net_ns, ns.inum);
 	eventp->timestamp_raw = bpf_ktime_get_boot_ns();
 	eventp->delta_raw = bpf_ktime_get_ns() - argp->ts;
 	eventp->flags_raw = argp->flags;

--- a/gadgets/trace_mount/test/integration/trace_mount_test.go
+++ b/gadgets/trace_mount/test/integration/trace_mount_test.go
@@ -35,15 +35,16 @@ type traceMountEvent struct {
 	Timestamp string        `json:"timestamp"`
 	Proc      utils.Process `json:"proc"`
 
-	Delta uint64 `json:"delta_raw"`
-	Flags string `json:"flags"`
-	Error string `json:"error"`
-	Fs    string `json:"fs"`
-	Src   string `json:"src"`
-	Dest  string `json:"dest"`
-	Data  string `json:"data"`
-	Op    string `json:"op"`
-	Call  string `json:"call"`
+	Delta   uint64 `json:"delta_raw"`
+	Flags   string `json:"flags"`
+	Error   string `json:"error"`
+	Fs      string `json:"fs"`
+	Src     string `json:"src"`
+	Dest    string `json:"dest"`
+	Data    string `json:"data"`
+	NetnsID uint64 `json:"netns_id"`
+	Op      string `json:"op"`
+	Call    string `json:"call"`
 }
 
 func TestTraceMount(t *testing.T) {
@@ -107,6 +108,7 @@ func TestTraceMount(t *testing.T) {
 				Delta:     utils.NormalizedInt,
 				Fs:        utils.NormalizedStr,
 				Call:      utils.NormalizedStr,
+				NetnsID:   utils.NormalizedInt,
 			}
 
 			normalize := func(e *traceMountEvent) {
@@ -117,6 +119,7 @@ func TestTraceMount(t *testing.T) {
 				utils.NormalizeString(&e.Flags)
 				utils.NormalizeString(&e.Fs)
 				utils.NormalizeString(&e.Call)
+				utils.NormalizeInt(&e.NetnsID)
 			}
 
 			match.MatchEntries(t, match.JSONMultiObjectMode, output, normalize, expectedEntry)


### PR DESCRIPTION
### Description
Adds network namespace ID (`netns_id`) tracking to `gadgets/trace_mount`.

Fixes #1951