### PR TITLE
gadgets/snapshot_socket: Support Unix domain sockets

### DIFF
--- a/gadgets/snapshot_socket/README.md
+++ b/gadgets/snapshot_socket/README.md
@@ -1,5 +1,5 @@
 # snapshot_socket
 
-The snapshot socket gadget gathers information about TCP and UDP sockets.
+The snapshot socket gadget gathers information about TCP, UDP and Unix sockets.
 
 Check the full documentation on https://inspektor-gadget.io/docs/latest/gadgets/snapshot_socket.

--- a/gadgets/snapshot_socket/gadget.yaml
+++ b/gadgets/snapshot_socket/gadget.yaml
@@ -1,5 +1,5 @@
 name: snapshot socket
-description: Show TCP and UDP sockets
+description: Show TCP, UDP and Unix sockets
 homepageURL: https://inspektor-gadget.io/
 documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/snapshot_socket
 sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/snapshot_socket
@@ -26,3 +26,7 @@ datasources:
         annotations:
           description: Network namespace inode id
           template: ns
+      path:
+        annotations:
+          description: Unix domain socket path
+          columns.width: 30

--- a/gadgets/snapshot_socket/program.bpf.c
+++ b/gadgets/snapshot_socket/program.bpf.c
@@ -18,6 +18,9 @@
 #include <gadget/macros.h>
 #include <gadget/types.h>
 
+#define AF_UNIX 1
+#define UNIX_PATH_MAX 108
+
 #define AF_INET 2
 #define AF_INET6 10
 
@@ -53,10 +56,10 @@ struct socket_entry {
 	__u32 state;
 	__u32 ino;
 	gadget_netns_id netns_id;
+	char path[UNIX_PATH_MAX];
 };
 
-GADGET_ITER(sockets, socket_entry, ig_snap_tcp, ig_snap_udp);
-
+GADGET_ITER(sockets, socket_entry, ig_snap_tcp, ig_snap_udp, ig_snap_unix);
 /**
  * sock_i_ino - Returns the inode identifier associated to a socket.
  * @sk: The socket whom inode identifier will be returned.
@@ -227,6 +230,39 @@ int ig_snap_udp(struct bpf_iter__udp *ctx)
 		BPF_CORE_READ(sp, __sk_common.skc_net.net, ns.inum));
 
 	return 0;
+}
+
+
+
+static int dump_unix_sock(struct seq_file *seq, __u32 netns, struct unix_sock *unix_sk)
+{
+	struct socket_entry entry = {};
+	struct sock *sk = &unix_sk->sk;
+	struct unix_address *addr;
+	entry.src.proto_raw = AF_UNIX;
+	entry.dst.proto_raw = AF_UNIX;
+	entry.state = BPF_CORE_READ(sk, __sk_common.skc_state);
+	entry.ino = sock_i_ino(sk);
+	entry.netns_id = netns;
+	// Read socket path if bound
+	addr = BPF_CORE_READ(unix_sk, addr);
+	if (addr) {
+		bpf_probe_read_kernel_str(&entry.path, sizeof(entry.path), &addr->name[0].sun_path);
+	}
+	bpf_seq_write(seq, &entry, sizeof(entry));
+	return 0;
+}
+
+SEC("iter/unix")
+int ig_snap_unix(struct bpf_iter__unix *ctx)
+{
+	struct seq_file *seq = ctx->meta->seq;
+	struct unix_sock *unix_sk = ctx->unix_sk;
+	__u32 netns;
+	if (unix_sk == (void *)0)
+		return 0;
+	BPF_CORE_READ_INTO(&netns, &unix_sk->sk, __sk_common.skc_net.net, ns.inum);
+	return dump_unix_sock(seq, netns, unix_sk);
 }
 
 char _license[] SEC("license") = "GPL";

--- a/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/integration/snapshot_socket_test.go
@@ -38,6 +38,7 @@ type snapshotSocketEntry struct {
 	SrcEndpoint utils.L4Endpoint `json:"src"`
 	DstEndpoint utils.L4Endpoint `json:"dst"`
 	Status      uint64           `json:"status"`
+	Path        string           `json:"path"`
 }
 
 func TestSnapshotSocket(t *testing.T) {

--- a/gadgets/snapshot_socket/test/unit/snapshot_socket_test.go
+++ b/gadgets/snapshot_socket/test/unit/snapshot_socket_test.go
@@ -15,15 +15,54 @@
 package tests
 
 import (
+	"net"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	gadgettesting "github.com/inspektor-gadget/inspektor-gadget/gadgets/testing"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/gadgetrunner"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/testing/utils"
 )
+
+type ExpectedSnapshotSocketEvent struct {
+	NetNsID     uint64           `json:"netns_id"`
+	InodeNumber uint64           `json:"ino"`
+	SrcEndpoint utils.L4Endpoint `json:"src"`
+	DstEndpoint utils.L4Endpoint `json:"dst"`
+	Status      uint64           `json:"status"`
+	Path        string           `json:"path"`
+}
 
 func TestSnapshotSocket(t *testing.T) {
 	gadgettesting.MinimumKernelVersion(t, "5.8")
+	gadgettesting.InitUnitTest(t)
 
-	// TODO: This is a dummy test to check that the gadget runs without errors.
-	// It should be extended to check that the gadget produces correct data.
-	gadgettesting.DummyGadgetTest(t, "snapshot_socket")
+	socketPath := "/tmp/test-ig-snapshot-unix.sock"
+	os.Remove(socketPath)
+
+	l, err := net.Listen("unix", socketPath)
+	require.NoError(t, err, "failed to create unix socket listener")
+	defer l.Close()
+	defer os.Remove(socketPath)
+
+	opts := gadgetrunner.GadgetRunnerOpts[ExpectedSnapshotSocketEvent]{
+		Image:   "snapshot_socket",
+		Timeout: 3 * time.Second,
+	}
+
+	gadgetRunner := gadgetrunner.NewGadgetRunner(t, opts)
+	gadgetRunner.RunGadget()
+
+	found := false
+	for _, event := range gadgetRunner.CapturedEvents {
+		if event.Path == socketPath {
+			found = true
+			break
+		}
+	}
+
+	require.True(t, found, "expected unix socket path %s to be captured by snapshot_socket", socketPath)
 }

--- a/pkg/operators/common/datasource.go
+++ b/pkg/operators/common/datasource.go
@@ -37,6 +37,8 @@ func GetIPForVersion(data datasource.Data, version, ipAddr datasource.FieldAcces
 
 	var ipStr string
 	switch v {
+	case 0:
+		return "", nil
 	case 4:
 		ipStr, err = net.IP(ip[:4]).String(), nil
 	case 6:

--- a/pkg/operators/ebpf/attach.go
+++ b/pkg/operators/ebpf/attach.go
@@ -96,7 +96,7 @@ func (i *ebpfInstance) attachProgram(gadgetCtx operators.GadgetContext, p *ebpf.
 		case strings.HasPrefix(p.SectionName, iterPrefix):
 			i.logger.Debugf("Attaching iter %q to %q", p.Name, attachTo)
 			switch attachTo {
-			case "task", "task_file", "tcp", "udp", "ksym":
+			case "task", "task_file", "tcp", "udp", "ksym", "unix":
 				return link.AttachIter(link.IterOptions{
 					Program: prog,
 				})

--- a/pkg/operators/ebpf/iter.go
+++ b/pkg/operators/ebpf/iter.go
@@ -306,7 +306,7 @@ func isIteratorKindSupported(kind string) bool {
 	//
 	// But at the moment, only a subset is supported by Inspektor Gadget.
 	switch kind {
-	case "task", "task_file", "ksym", "tcp", "udp", "bpf_map_elem":
+	case "task", "task_file", "ksym", "tcp", "udp", "bpf_map_elem", "unix":
 		return true
 	}
 	return false


### PR DESCRIPTION
## What

Adds support for Unix domain sockets (`AF_UNIX`) to the `snapshot_socket` gadget.

- Adds `SEC("iter/unix")` BPF iterator and `dump_unix_sock` in `gadgets/snapshot_socket/program.bpf.c` to extract Unix socket filesystem paths.
- Extends `gadget.yaml` schema with the `path` column.
- Adds `unix` iterator support to `pkg/operators/ebpf/attach.go` and `pkg/operators/ebpf/iter.go`.
- Handles non-IP endpoints (`version == 0`) gracefully in `pkg/operators/common/datasource.go`.
- Adds automated unit test in `gadgets/snapshot_socket/test/unit/snapshot_socket_test.go` to verify Unix domain socket capture.

## How to test

```bash
sudo IG_VERIFY_IMAGE=false GADGET_TAG=main go test -v ./gadgets/snapshot_socket/test/unit/...
```

Closes #360