### PR TITLE
otel-metrics: Introduce snapshot mode

### DIFF
--- a/docs/gadget-devel/metrics.md
+++ b/docs/gadget-devel/metrics.md
@@ -67,6 +67,42 @@ datasources:
 This will increase the counter of that metrics by whatever value the `count` field has. Use `metrics.type: gauge`, if
 you always just want to set the metric to the latest value.
 
+By default, a gauge retains its latest value for every key set. This is useful
+when the last observation remains authoritative until it changes. If an array
+data source instead emits a complete snapshot on every refresh, set
+`metrics.snapshot: "true"` on the data source:
+
+```yaml
+datasources:
+  processes:
+    annotations:
+      metrics.collect: "true"
+      metrics.snapshot: "true"
+      metrics.snapshot-timeout: 5s
+    fields:
+      pid:
+        annotations:
+          metrics.type: key
+      memory:
+        annotations:
+          metrics.type: gauge
+```
+
+Every emitted array then replaces the previous gauge snapshot. Keys absent
+from the new array disappear from the next metrics collection, and an empty
+array removes all gauge series. If the data source stops refreshing, the last
+snapshot expires after `metrics.snapshot-timeout`. When the timeout is omitted,
+it defaults to three times a positive `fetch-interval`. Prefer this derived
+timeout when the fetch interval is configurable. An explicit timeout must be at
+least twice the positive `fetch-interval`.
+
+Snapshot mode only changes gauges. Counters and histograms in the same data
+source continue accumulating normally. Each row in a snapshot must have a
+unique set of metric keys; aggregate rows explicitly before export if several
+rows should contribute to one series. When duplicate keys are present, the
+operator keeps the previous gauge snapshot while other operators and retained
+metrics continue processing the rows.
+
 If you later on want to differentiate the count by their different `name` contents, you can annotate the `name` field
 with key `metrics.type` and value `key`. This creates a key (or label) from that field that is associated with each
 metric afterward - e.g.: this lets you later on filter the values of `count` according to the corresponding `name`

--- a/docs/spec/operators/otel-metrics.md
+++ b/docs/spec/operators/otel-metrics.md
@@ -68,6 +68,60 @@ Together with the `otel-metrics-listen=true` and `otel-metrics-name=<name>`
 flags, this annotation is used to enable the Otel Metrics operator to export the
 data source's output as Prometheus metrics.
 
+#### `metrics.snapshot`
+
+Controls whether gauge series are collected as snapshots. By default, gauges
+are recorded synchronously and retain the latest value for each attribute set.
+
+Set this annotation to `true` when every array emitted by the data source is
+a complete refresh of the currently active entities:
+
+```yaml
+datasources:
+  metrics:
+    annotations:
+      metrics.collect: "true"
+      metrics.snapshot: "true"
+```
+
+Snapshot mode uses observable gauges. Each emitted array atomically replaces
+the previous gauge snapshot, so attribute sets omitted from a later array are
+no longer exported. An empty array removes all gauge series for the data source.
+Snapshot mode is only supported for array data sources.
+
+Counters and histograms in the same data source retain their normal cumulative
+behavior. Snapshot replacement only applies to fields with
+`metrics.type=gauge`.
+
+Rows within one snapshot must have unique values for the fields annotated with
+`metrics.type=key`. The operator rejects a snapshot containing duplicate key
+sets instead of applying an implicit last-write-wins aggregation. A rejected
+snapshot does not replace the previous gauge snapshot; the rows remain
+available to other operators, and counters and histograms still consume them.
+
+#### `metrics.snapshot-timeout`
+
+Sets how long the latest snapshot remains authoritative without another
+completed refresh. When the timeout expires, the observable callback stops
+exporting all gauges from that snapshot.
+
+If omitted, the timeout defaults to three times the data source's positive
+`fetch-interval`. Data sources without a positive fetch interval must configure
+the timeout explicitly. An explicit timeout must be at least twice the positive
+`fetch-interval`. Prefer the derived timeout when users can override the fetch
+interval.
+
+```yaml
+datasources:
+  metrics:
+    annotations:
+      metrics.snapshot: "true"
+      metrics.snapshot-timeout: 5s
+```
+
+An empty snapshot removes series immediately. The timeout instead covers a
+stalled data source that stops emitting refreshes.
+
 #### `metrics.print`
 
 If set to `"true"`, the Otel Metrics operator will render the data source's

--- a/gadgets/gpu_top_per_pid/gadget.yaml
+++ b/gadgets/gpu_top_per_pid/gadget.yaml
@@ -9,10 +9,20 @@ datasources:
       fetch-interval: 1s
       fetch-count: "0"
       cli.clear-screen-before: "true"
+      metrics.collect: "true"
+      metrics.snapshot: "true"
     fields:
+      k8s.node:
+        annotations:
+          metrics.type: key
+      proc.pid:
+        annotations:
+          metrics.type: key
       mem_used_raw:
         annotations:
           description: Total GPU memory in use across all devices (bytes)
+          metrics.type: gauge
+          metrics.unit: By
       mem_used:
         annotations:
           description: Total GPU memory in use across all devices (human-readable)
@@ -21,11 +31,15 @@ datasources:
       sm_util_pct_max:
         annotations:
           description: Peak SM utilization across devices (0-100)
+          metrics.type: gauge
+          metrics.unit: "%"
           columns.width: 8
           columns.alignment: right
       mem_util_pct_max:
         annotations:
           description: Peak memory-bus utilization across devices (0-100)
+          metrics.type: gauge
+          metrics.unit: "%"
           columns.width: 9
           columns.alignment: right
       gpu_device_primary:
@@ -36,6 +50,8 @@ datasources:
       device_count:
         annotations:
           description: Number of devices the PID is using
+          metrics.type: gauge
+          metrics.unit: "{device}"
           columns.width: 8
           columns.alignment: right
       _pad:

--- a/pkg/operators/otel-metrics/otel-metrics.go
+++ b/pkg/operators/otel-metrics/otel-metrics.go
@@ -18,6 +18,7 @@ package otelmetrics
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -64,13 +65,15 @@ const (
 	MetricTypeGauge     = "gauge"
 	MetricTypeHistogram = "histogram"
 
-	AnnotationMetricsCollect     = "metrics.collect"
-	AnnotationMetricsPrint       = "metrics.print"
-	AnnotationMetricsType        = "metrics.type"
-	AnnotationMetricsName        = "metrics.name"
-	AnnotationMetricsDescription = "metrics.description"
-	AnnotationMetricsUnit        = "metrics.unit"
-	AnnotationMetricsBoundaries  = "metrics.boundaries"
+	AnnotationMetricsCollect         = "metrics.collect"
+	AnnotationMetricsSnapshot        = "metrics.snapshot"
+	AnnotationMetricsSnapshotTimeout = "metrics.snapshot-timeout"
+	AnnotationMetricsPrint           = "metrics.print"
+	AnnotationMetricsType            = "metrics.type"
+	AnnotationMetricsName            = "metrics.name"
+	AnnotationMetricsDescription     = "metrics.description"
+	AnnotationMetricsUnit            = "metrics.unit"
+	AnnotationMetricsBoundaries      = "metrics.boundaries"
 
 	AnnotationImplicitCounterName        = "metrics.implicit-counter.name"
 	AnnotationImplicitCounterDescription = "metrics.implicit-counter.description"
@@ -363,14 +366,42 @@ func (m *otelMetricsOperatorInstance) Name() string {
 }
 
 type metricsCollector struct {
-	meter             metric.Meter
-	keys              []func(datasource.Data) attribute.KeyValue
-	values            []func(context.Context, datasource.Data, attribute.Set)
-	mappedName        string
-	output            bool
-	exporter          *otelprometheus.Exporter
-	meterProvider     *sdkmetric.MeterProvider
-	useGlobalProvider bool
+	meter               metric.Meter
+	keys                []func(datasource.Data) attribute.KeyValue
+	values              []func(context.Context, datasource.Data, attribute.Set)
+	snapshotIntValues   []snapshotIntValue
+	snapshotFloatValues []snapshotFloatValue
+	snapshotMode        bool
+	snapshotTimeout     time.Duration
+	snapshotMu          sync.RWMutex
+	snapshot            *metricsSnapshot
+	registration        metric.Registration
+	mappedName          string
+	output              bool
+	exporter            *otelprometheus.Exporter
+	meterProvider       *sdkmetric.MeterProvider
+	useGlobalProvider   bool
+}
+
+type snapshotIntValue struct {
+	instrument metric.Int64ObservableGauge
+	value      func(datasource.Data) int64
+}
+
+type snapshotFloatValue struct {
+	instrument metric.Float64ObservableGauge
+	value      func(datasource.Data) float64
+}
+
+type snapshotPoint struct {
+	attributes  attribute.Set
+	intValues   []int64
+	floatValues []float64
+}
+
+type metricsSnapshot struct {
+	updatedAt time.Time
+	points    []snapshotPoint
 }
 
 func bytesToAttributeValue(b []byte) attribute.Value {
@@ -475,6 +506,60 @@ func (mc *metricsCollector) addValFunc(f datasource.FieldAccessor, metricType st
 				ctr.Record(ctx, asFloatFn(data), metric.WithAttributeSet(set))
 			})
 		}
+		return nil
+	}
+}
+
+func (mc *metricsCollector) addSnapshotValFunc(f datasource.FieldAccessor) error {
+	metricName := getMetricName(f)
+
+	var options []metric.InstrumentOption
+	if description := f.Annotations()[AnnotationMetricsDescription]; description != "" {
+		options = append(options, metric.WithDescription(description))
+	}
+	if unit := f.Annotations()[AnnotationMetricsUnit]; unit != "" {
+		options = append(options, metric.WithUnit(unit))
+	}
+
+	switch f.Type() {
+	default:
+		return fmt.Errorf("unsupported field type for snapshot gauge %q: %s", metricName, f.Type())
+	case api.Kind_Uint8,
+		api.Kind_Uint16,
+		api.Kind_Uint32,
+		api.Kind_Uint64,
+		api.Kind_Int8,
+		api.Kind_Int16,
+		api.Kind_Int32,
+		api.Kind_Int64:
+		tOptions := make([]metric.Int64ObservableGaugeOption, len(options))
+		for i, option := range options {
+			tOptions[i] = option
+		}
+		gauge, err := mc.meter.Int64ObservableGauge(metricName, tOptions...)
+		if err != nil {
+			return fmt.Errorf("adding snapshot gauge %q: %w", metricName, err)
+		}
+		asIntFn, _ := datasource.AsInt64(f)
+		mc.snapshotIntValues = append(mc.snapshotIntValues, snapshotIntValue{
+			instrument: gauge,
+			value:      asIntFn,
+		})
+		return nil
+	case api.Kind_Float32, api.Kind_Float64:
+		tOptions := make([]metric.Float64ObservableGaugeOption, len(options))
+		for i, option := range options {
+			tOptions[i] = option
+		}
+		gauge, err := mc.meter.Float64ObservableGauge(metricName, tOptions...)
+		if err != nil {
+			return fmt.Errorf("adding snapshot gauge %q: %w", metricName, err)
+		}
+		asFloatFn, _ := datasource.AsFloat64(f)
+		mc.snapshotFloatValues = append(mc.snapshotFloatValues, snapshotFloatValue{
+			instrument: gauge,
+			value:      asFloatFn,
+		})
 		return nil
 	}
 }
@@ -611,9 +696,130 @@ func (mc *metricsCollector) Collect(ctx context.Context, data datasource.Data) {
 		kvs = append(kvs, kf(data))
 	}
 	kset := attribute.NewSet(kvs...)
+	mc.collectWithAttributeSet(ctx, data, kset)
+}
+
+func (mc *metricsCollector) collectWithAttributeSet(ctx context.Context, data datasource.Data, set attribute.Set) {
 	for _, vf := range mc.values {
-		vf(ctx, data, kset)
+		vf(ctx, data, set)
 	}
+}
+
+func (mc *metricsCollector) buildSnapshot(data datasource.DataArray, now time.Time) (*metricsSnapshot, error) {
+	snapshot := &metricsSnapshot{
+		updatedAt: now,
+		points:    make([]snapshotPoint, 0, data.Len()),
+	}
+	seen := make(map[attribute.Distinct]struct{}, data.Len())
+
+	for i := 0; i < data.Len(); i++ {
+		row := data.Get(i)
+		kvs := make([]attribute.KeyValue, 0, len(mc.keys))
+		for _, key := range mc.keys {
+			kvs = append(kvs, key(row))
+		}
+		keySet := attribute.NewSet(kvs...)
+		identity := keySet.Equivalent()
+		if _, ok := seen[identity]; ok {
+			return nil, fmt.Errorf("duplicate metric key set in snapshot: %s", keySet.Encoded(attribute.DefaultEncoder()))
+		}
+		seen[identity] = struct{}{}
+
+		point := snapshotPoint{
+			attributes:  keySet,
+			intValues:   make([]int64, len(mc.snapshotIntValues)),
+			floatValues: make([]float64, len(mc.snapshotFloatValues)),
+		}
+		for j, value := range mc.snapshotIntValues {
+			point.intValues[j] = value.value(row)
+		}
+		for j, value := range mc.snapshotFloatValues {
+			point.floatValues[j] = value.value(row)
+		}
+		snapshot.points = append(snapshot.points, point)
+	}
+
+	return snapshot, nil
+}
+
+func (mc *metricsCollector) replaceSnapshot(snapshot *metricsSnapshot) {
+	mc.snapshotMu.Lock()
+	mc.snapshot = snapshot
+	mc.snapshotMu.Unlock()
+}
+
+func (mc *metricsCollector) registerSnapshotCallback() error {
+	instruments := make([]metric.Observable, 0, len(mc.snapshotIntValues)+len(mc.snapshotFloatValues))
+	for _, value := range mc.snapshotIntValues {
+		instruments = append(instruments, value.instrument)
+	}
+	for _, value := range mc.snapshotFloatValues {
+		instruments = append(instruments, value.instrument)
+	}
+	if len(instruments) == 0 {
+		return nil
+	}
+
+	registration, err := mc.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		mc.snapshotMu.RLock()
+		snapshot := mc.snapshot
+		mc.snapshotMu.RUnlock()
+		if snapshot == nil || time.Since(snapshot.updatedAt) >= mc.snapshotTimeout {
+			return nil
+		}
+
+		for _, point := range snapshot.points {
+			options := metric.WithAttributeSet(point.attributes)
+			for i, value := range point.intValues {
+				observer.ObserveInt64(mc.snapshotIntValues[i].instrument, value, options)
+			}
+			for i, value := range point.floatValues {
+				observer.ObserveFloat64(mc.snapshotFloatValues[i].instrument, value, options)
+			}
+		}
+		return nil
+	}, instruments...)
+	if err != nil {
+		return fmt.Errorf("registering snapshot callback: %w", err)
+	}
+	mc.registration = registration
+	return nil
+}
+
+func snapshotTimeout(ds datasource.DataSource) (time.Duration, error) {
+	annotations := ds.Annotations()
+	if configured := annotations[AnnotationMetricsSnapshotTimeout]; configured != "" {
+		timeout, err := time.ParseDuration(configured)
+		if err != nil {
+			return 0, fmt.Errorf("parsing %s: %w", AnnotationMetricsSnapshotTimeout, err)
+		}
+		if timeout <= 0 {
+			return 0, fmt.Errorf("%s must be greater than zero", AnnotationMetricsSnapshotTimeout)
+		}
+		if configuredInterval := annotations[api.FetchIntervalAnnotation]; configuredInterval != "" {
+			interval, err := time.ParseDuration(configuredInterval)
+			if err != nil {
+				return 0, fmt.Errorf("parsing %s: %w", api.FetchIntervalAnnotation, err)
+			}
+			if interval > 0 && timeout/2 < interval {
+				return 0, fmt.Errorf("%s (%s) must be at least twice %s (%s)",
+					AnnotationMetricsSnapshotTimeout, timeout, api.FetchIntervalAnnotation, interval)
+			}
+		}
+		return timeout, nil
+	}
+
+	fetchInterval := annotations[api.FetchIntervalAnnotation]
+	interval, err := time.ParseDuration(fetchInterval)
+	if err != nil {
+		return 0, fmt.Errorf("snapshot metrics require %s or a valid %s annotation: %w",
+			AnnotationMetricsSnapshotTimeout, api.FetchIntervalAnnotation, err)
+	}
+	if interval <= 0 {
+		return 0, fmt.Errorf("snapshot metrics require %s when %s is not greater than zero",
+			AnnotationMetricsSnapshotTimeout, api.FetchIntervalAnnotation)
+	}
+	return 3 * interval, nil
 }
 
 func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) error {
@@ -626,6 +832,18 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 		// Neither collecting nor printing, do nothing for this data source
 		if !metricsCollect && !metricsPrint {
 			continue
+		}
+
+		snapshot := annotations[AnnotationMetricsSnapshot] == "true"
+		if snapshot {
+			if !metricsCollect {
+				return fmt.Errorf("%s=%s requires %s=true for data source %q",
+					AnnotationMetricsSnapshot, "true", AnnotationMetricsCollect, ds.Name())
+			}
+			if ds.Type() != datasource.TypeArray {
+				return fmt.Errorf("%s=%s requires an array data source, got %q",
+					AnnotationMetricsSnapshot, "true", ds.Name())
+			}
 		}
 
 		if metricsPrint {
@@ -681,6 +899,7 @@ func (m *otelMetricsOperatorInstance) init(gadgetCtx operators.GadgetContext) er
 		m.collectors[ds] = &metricsCollector{
 			output:            metricsPrint,
 			mappedName:        mappedName,
+			snapshotMode:      snapshot,
 			useGlobalProvider: useGlobal,
 		}
 	}
@@ -755,10 +974,23 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 				if err != nil {
 					return fmt.Errorf("adding key for %q: %w", fieldName, err)
 				}
-			case MetricTypeCounter, MetricTypeGauge:
+			case MetricTypeCounter:
 				err := collector.addValFunc(f, metricsType)
 				if err != nil {
 					return fmt.Errorf("adding %s for %q: %w", metricsType, fieldName, err)
+				}
+				hasValueFields = true
+			case MetricTypeGauge:
+				if collector.snapshotMode {
+					err := collector.addSnapshotValFunc(f)
+					if err != nil {
+						return fmt.Errorf("adding %s for %q: %w", metricsType, fieldName, err)
+					}
+				} else {
+					err := collector.addValFunc(f, metricsType)
+					if err != nil {
+						return fmt.Errorf("adding %s for %q: %w", metricsType, fieldName, err)
+					}
 				}
 				hasValueFields = true
 			case MetricTypeHistogram:
@@ -775,12 +1007,46 @@ func (m *otelMetricsOperatorInstance) PreStart(gadgetCtx operators.GadgetContext
 			continue
 		}
 
-		err := ds.Subscribe(func(ds datasource.DataSource, data datasource.Data) error {
-			collector.Collect(gadgetCtx.Context(), data)
-			return nil
-		}, Priority)
-		if err != nil {
-			return err
+		hasSnapshotValues := len(collector.snapshotIntValues)+len(collector.snapshotFloatValues) > 0
+		if hasSnapshotValues {
+			timeout, err := snapshotTimeout(ds)
+			if err != nil {
+				return fmt.Errorf("configuring snapshot metrics for data source %q: %w", ds.Name(), err)
+			}
+			collector.snapshotTimeout = timeout
+			if err := collector.registerSnapshotCallback(); err != nil {
+				return fmt.Errorf("registering snapshot callback for data source %q: %w", ds.Name(), err)
+			}
+			err = ds.SubscribeArray(func(_ datasource.DataSource, data datasource.DataArray) error {
+				snapshot, err := collector.buildSnapshot(data, time.Now())
+				if err != nil {
+					gadgetCtx.Logger().Warnf("rejecting metrics snapshot for data source %q: %v", ds.Name(), err)
+					for i := 0; i < data.Len(); i++ {
+						collector.Collect(gadgetCtx.Context(), data.Get(i))
+					}
+					return nil
+				}
+				for i := 0; i < data.Len(); i++ {
+					collector.collectWithAttributeSet(
+						gadgetCtx.Context(),
+						data.Get(i),
+						snapshot.points[i].attributes,
+					)
+				}
+				collector.replaceSnapshot(snapshot)
+				return nil
+			}, Priority)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := ds.Subscribe(func(_ datasource.DataSource, data datasource.Data) error {
+				collector.Collect(gadgetCtx.Context(), data)
+				return nil
+			}, Priority)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -884,7 +1150,14 @@ func (m *otelMetricsOperatorInstance) Close(gadgetCtx operators.GadgetContext) e
 	gadgetCtx.Logger().Debug("shutting down metrics")
 	close(m.done)
 	ctx := context.Background()
+	var errs []error
 	for _, collector := range m.collectors {
+		if collector.registration != nil {
+			if err := collector.registration.Unregister(); err != nil {
+				errs = append(errs, fmt.Errorf("unregistering snapshot metrics callback: %w", err))
+			}
+			collector.registration = nil
+		}
 		if collector.meterProvider != nil {
 			collector.meterProvider.Shutdown(ctx)
 			collector.meterProvider = nil
@@ -895,7 +1168,7 @@ func (m *otelMetricsOperatorInstance) Close(gadgetCtx operators.GadgetContext) e
 		}
 	}
 	m.wg.Wait()
-	return nil
+	return errors.Join(errs...)
 }
 
 var Operator = &otelMetricsOperator{}

--- a/pkg/operators/otel-metrics/otel-metrics_test.go
+++ b/pkg/operators/otel-metrics/otel-metrics_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
@@ -117,6 +120,379 @@ func TestMetricsCounterAndGauge(t *testing.T) {
 		}
 		assert.True(t, foundCtr)
 		assert.True(t, foundGauge)
+	}
+}
+
+func collectIntMetric(t *testing.T, exporter *otelprometheus.Exporter, name string) map[string]int64 {
+	t.Helper()
+
+	md := &metricdata.ResourceMetrics{}
+	require.NoError(t, exporter.Collect(context.Background(), md))
+	return intMetricValues(t, md, name)
+}
+
+func intMetricValues(t *testing.T, md *metricdata.ResourceMetrics, name string) map[string]int64 {
+	t.Helper()
+
+	values := make(map[string]int64)
+	for _, sm := range md.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Gauge[int64]:
+				for _, point := range data.DataPoints {
+					values[point.Attributes.Encoded(attribute.DefaultEncoder())] = point.Value
+				}
+			case metricdata.Sum[int64]:
+				for _, point := range data.DataPoints {
+					values[point.Attributes.Encoded(attribute.DefaultEncoder())] = point.Value
+				}
+			default:
+				t.Fatalf("unexpected metric data type %T for %q", m.Data, name)
+			}
+		}
+	}
+	return values
+}
+
+type snapshotTestRow struct {
+	key   string
+	gauge uint32
+}
+
+func TestSnapshotMetricsTopTCP(t *testing.T) {
+	o := &otelMetricsOperator{skipListen: true}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	globalParams.Set(ParamOtelMetricsListen, "true")
+	require.NoError(t, o.Init(globalParams))
+
+	var ds datasource.DataSource
+	var key, gauge, counter datasource.FieldAccessor
+	forwardedSnapshots := 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeArray, "tcp")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationMetricsCollect, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshot, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshotTimeout, time.Hour.String())
+
+		key, err = ds.AddField("connection", api.Kind_String, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeKey,
+		}))
+		require.NoError(t, err)
+		gauge, err = ds.AddField("sent_raw", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeGauge,
+		}))
+		require.NoError(t, err)
+		counter, err = ds.AddField("packets", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeCounter,
+		}))
+		require.NoError(t, err)
+		require.NoError(t, ds.SubscribeArray(func(datasource.DataSource, datasource.DataArray) error {
+			forwardedSnapshots++
+			return nil
+		}, Priority+1))
+		return nil
+	}
+
+	newSnapshot := func(rows ...snapshotTestRow) datasource.PacketArray {
+		packet, err := ds.NewPacketArray()
+		require.NoError(t, err)
+		for _, row := range rows {
+			data := packet.New()
+			require.NoError(t, key.PutString(data, row.key))
+			require.NoError(t, gauge.PutUint32(data, row.gauge))
+			require.NoError(t, counter.PutUint32(data, 1))
+			packet.Append(data)
+		}
+		return packet
+	}
+
+	produce := func(operators.GadgetContext) error {
+		require.NoError(t, ds.EmitAndRelease(newSnapshot(
+			snapshotTestRow{key: "A", gauge: 1},
+			snapshotTestRow{key: "B", gauge: 2},
+		)))
+		assert.Equal(t, map[string]int64{"connection=A": 1, "connection=B": 2}, collectIntMetric(t, o.exporter, "sent_raw"))
+
+		require.NoError(t, ds.EmitAndRelease(newSnapshot(
+			snapshotTestRow{key: "A", gauge: 3},
+		)))
+		assert.Equal(t, map[string]int64{"connection=A": 3}, collectIntMetric(t, o.exporter, "sent_raw"))
+
+		require.NoError(t, ds.EmitAndRelease(newSnapshot(
+			snapshotTestRow{key: "A", gauge: 4},
+			snapshotTestRow{key: "A", gauge: 5},
+		)))
+		assert.Equal(t, map[string]int64{"connection=A": 3}, collectIntMetric(t, o.exporter, "sent_raw"))
+		assert.Equal(t, 3, forwardedSnapshots)
+
+		require.NoError(t, ds.EmitAndRelease(newSnapshot()))
+		assert.Empty(t, collectIntMetric(t, o.exporter, "sent_raw"))
+		assert.Equal(t, map[string]int64{"connection=A": 4, "connection=B": 1}, collectIntMetric(t, o.exporter, "packets"))
+		assert.Equal(t, 4, forwardedSnapshots)
+
+		cancel()
+		return nil
+	}
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+	require.NoError(t, gadgetCtx.Run(api.ParamValues{
+		"operator.otel-metrics.otel-metrics-name": "tcp:tcp",
+	}))
+}
+
+func TestSnapshotMetricsExpire(t *testing.T) {
+	o := &otelMetricsOperator{skipListen: true}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	globalParams.Set(ParamOtelMetricsListen, "true")
+	require.NoError(t, o.Init(globalParams))
+
+	var ds datasource.DataSource
+	var gauge datasource.FieldAccessor
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeArray, "expiring")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationMetricsCollect, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshot, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshotTimeout, "25ms")
+		gauge, err = ds.AddField("gauge", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeGauge,
+		}))
+		require.NoError(t, err)
+		return nil
+	}
+	produce := func(operators.GadgetContext) error {
+		packet, err := ds.NewPacketArray()
+		require.NoError(t, err)
+		data := packet.New()
+		require.NoError(t, gauge.PutUint32(data, 1))
+		packet.Append(data)
+		require.NoError(t, ds.EmitAndRelease(packet))
+		require.NotEmpty(t, collectIntMetric(t, o.exporter, "gauge"))
+
+		require.Eventually(t, func() bool {
+			return len(collectIntMetric(t, o.exporter, "gauge")) == 0
+		}, time.Second, 10*time.Millisecond)
+		cancel()
+		return nil
+	}
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+	require.NoError(t, gadgetCtx.Run(api.ParamValues{
+		"operator.otel-metrics.otel-metrics-name": "expiring:expiring",
+	}))
+}
+
+func TestSnapshotMetricsConfiguredProvider(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	o := &otelMetricsOperator{skipListen: true}
+	globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+	require.NoError(t, o.Init(globalParams))
+	o.providers["manual"] = provider
+
+	var ds datasource.DataSource
+	var key, gauge datasource.FieldAccessor
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	prepare := func(gadgetCtx operators.GadgetContext) error {
+		var err error
+		ds, err = gadgetCtx.RegisterDataSource(datasource.TypeArray, "snapshot")
+		require.NoError(t, err)
+		ds.AddAnnotation(AnnotationMetricsCollect, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshot, "true")
+		ds.AddAnnotation(AnnotationMetricsSnapshotTimeout, time.Hour.String())
+		key, err = ds.AddField("key", api.Kind_String, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeKey,
+		}))
+		require.NoError(t, err)
+		gauge, err = ds.AddField("gauge", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+			AnnotationMetricsType: MetricTypeGauge,
+		}))
+		return err
+	}
+	produce := func(operators.GadgetContext) error {
+		packet, err := ds.NewPacketArray()
+		require.NoError(t, err)
+		data := packet.New()
+		require.NoError(t, key.PutString(data, "A"))
+		require.NoError(t, gauge.PutUint32(data, 1))
+		packet.Append(data)
+		require.NoError(t, ds.EmitAndRelease(packet))
+
+		md := &metricdata.ResourceMetrics{}
+		require.NoError(t, reader.Collect(context.Background(), md))
+		assert.Equal(t, map[string]int64{"key=A": 1}, intMetricValues(t, md, "gauge"))
+
+		empty, err := ds.NewPacketArray()
+		require.NoError(t, err)
+		require.NoError(t, ds.EmitAndRelease(empty))
+		md = &metricdata.ResourceMetrics{}
+		require.NoError(t, reader.Collect(context.Background(), md))
+		assert.Empty(t, intMetricValues(t, md, "gauge"))
+
+		cancel()
+		return nil
+	}
+
+	producer := simple.New("producer",
+		simple.WithPriority(Priority-1),
+		simple.OnInit(prepare),
+		simple.OnStart(produce),
+	)
+	gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+	require.NoError(t, gadgetCtx.Run(api.ParamValues{
+		"operator.otel-metrics.otel-metrics-name":     "snapshot:snapshot",
+		"operator.otel-metrics.otel-metrics-exporter": "manual",
+	}))
+}
+
+func TestSnapshotTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		fetchInterval string
+		timeout       string
+		expected      time.Duration
+		errorContains string
+	}{
+		{
+			name:     "configured without fetch interval",
+			timeout:  "5s",
+			expected: 5 * time.Second,
+		},
+		{
+			name:          "configured with fetch interval",
+			fetchInterval: "2s",
+			timeout:       "5s",
+			expected:      5 * time.Second,
+		},
+		{
+			name:          "configured at minimum",
+			fetchInterval: "2s",
+			timeout:       "4s",
+			expected:      4 * time.Second,
+		},
+		{
+			name:          "configured below minimum",
+			fetchInterval: "2s",
+			timeout:       "3999ms",
+			errorContains: "metrics.snapshot-timeout (3.999s) must be at least twice fetch-interval (2s)",
+		},
+		{
+			name:          "derived from fetch interval",
+			fetchInterval: "2s",
+			expected:      6 * time.Second,
+		},
+		{
+			name:          "missing",
+			errorContains: AnnotationMetricsSnapshotTimeout,
+		},
+		{
+			name:          "non-positive",
+			timeout:       "0s",
+			errorContains: "must be greater than zero",
+		},
+		{
+			name:          "invalid",
+			timeout:       "later",
+			errorContains: "parsing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := datasource.New(datasource.TypeArray, "snapshot")
+			require.NoError(t, err)
+			if tt.fetchInterval != "" {
+				ds.AddAnnotation(api.FetchIntervalAnnotation, tt.fetchInterval)
+			}
+			if tt.timeout != "" {
+				ds.AddAnnotation(AnnotationMetricsSnapshotTimeout, tt.timeout)
+			}
+
+			timeout, err := snapshotTimeout(ds)
+			if tt.errorContains != "" {
+				require.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, timeout)
+		})
+	}
+}
+
+func TestSnapshotValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		dataSourceType datasource.Type
+		errorContains  string
+	}{
+		{
+			name:           "requires array data source",
+			dataSourceType: datasource.TypeSingle,
+			errorContains:  "requires an array data source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &otelMetricsOperator{skipListen: true}
+			globalParams := apihelpers.ToParamDescs(o.GlobalParams()).ToParams()
+			require.NoError(t, o.Init(globalParams))
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			producer := simple.New("producer",
+				simple.WithPriority(Priority-1),
+				simple.OnInit(func(gadgetCtx operators.GadgetContext) error {
+					ds, err := gadgetCtx.RegisterDataSource(tt.dataSourceType, "metrics")
+					require.NoError(t, err)
+					ds.AddAnnotation(AnnotationMetricsCollect, "true")
+					ds.AddAnnotation(AnnotationMetricsSnapshot, "true")
+					_, err = ds.AddField("gauge", api.Kind_Uint32, datasource.WithAnnotations(map[string]string{
+						AnnotationMetricsType: MetricTypeGauge,
+					}))
+					return err
+				}),
+			)
+			gadgetCtx := gadgetcontext.New(ctx, "", gadgetcontext.WithDataOperators(o, producer))
+
+			err := gadgetCtx.Run(nil)
+			require.ErrorContains(t, err, tt.errorContains)
+		})
 	}
 }
 


### PR DESCRIPTION
Previously, OTel gauges retained the latest value for every observed key set,                                                                                                                                                                                                                                              so iterator-based gadgets could not remove metrics for entities that                                                                                                                                                                                                                                                          disappeared. This change adds an opt-in snapshot mode where each emitted array                                                                                                                                                                                                                                               replaces the previous gauge snapshot, removing stale series while preserving                                                                                                                                                                                                                                                 normal gauge updates for entities that remain present. This allows gadgets such as `gpu_top_per_pid` / `top_process` etc, to stop exporting metrics for processes or other                                                                                                                                                                                                                                               
entities that no longer exist. 

Users could check running pod/container state to filter for stale series but I believe it makes sense to support it out of the box! 

## Testing Done

```bash
# start the gadget
sudo ./ig run top_process --host --interval 10s --output none --otel-metrics-listen --otel-metrics-name processes:top_process --annotate 'processes:metrics.collect=true,processes:metrics.snapshot=true,processes:metrics.snapshot-timeout=30s,processes.pid:metrics.type=key,processes.comm:metrics.type=key,processes.uid:metrics.type=key,processes.ppid:metrics.type=gauge,processes.priority:metrics.type=gauge,processes.nice:metrics.type=gauge,processes.cpuUsage:metrics.type=gauge,processes.cpuUsage:metrics.unit=%,processes.cpuUsageRelative:metrics.type=gauge,processes.cpuUsageRelative:metrics.unit=%,processes.cpuTime:metrics.type=gauge,processes.memoryRSS_raw:metrics.type=gauge,processes.memoryRSS_raw:metrics.unit=By,processes.memoryVirtual_raw:metrics.type=gauge,processes.memoryVirtual_raw:metrics.unit=By,processes.memoryShared_raw:metrics.type=gauge,processes.memoryShared_raw:metrics.unit=By,processes.memoryRelative:metrics.type=gauge,processes.memoryRelative:metrics.unit=%,processes.threadCount:metrics.type=gauge,processes.startTime:metrics.type=gauge'
# start a test process
python3 -c 'import os, time; memory = bytearray(500 * 1024 * 1024); print(f"allocated 500 MiB; PID={os.getpid()}", flush=True); time.sleep(10)'
# make sure you can get metrics
curl -s localhost:2224/metrics | grep python3
cpuTime{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 14
cpuUsageRelative_percent{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 0
cpuUsage_percent{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 0
memoryRSS_raw_bytes{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 5.35126016e+08
memoryRelative_percent{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 1.6048739542663868
memoryShared_raw_bytes{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 6.811648e+06
memoryVirtual_raw_bytes{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 5.45845248e+08
nice{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 0
ppid{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 2.728616e+06
priority{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 20
startTime{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 2.6194768e+07
threadCount{comm="python3",otel_scope_name="top_process",otel_scope_schema_url="",otel_scope_version="",pid="2730521",uid="1000"} 1
# try again after another fetch interval (nothing printed)
curl -s localhost:2224/metrics | grep python3
```

