### PR TITLE
operators/ebpf: Allow changing perf-buffer size

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -830,3 +830,24 @@ on a field according to the `ebpf.rest.name` datasource annotation. The
 field that contains the length of the trailing data. If the gadget doesn't
 provide this annotation, the whole remaining data will be used as the trailing
 data.
+
+### Perf Buffer Size
+
+When running on kernels that do not support eBPF ring buffers (kernel < 5.8),
+gadgets configured with `GADGET_TRACER_MAP()` fall back to using a perf event
+array. By default, the perf reader allocates 64 pages per CPU.
+
+You can override the number of perf buffer pages on a per-datasource basis using
+the `ebpf.tracer.perf-buffer-pages` annotation in `gadget.yaml`:
+
+```yaml
+datasources:
+  events:
+    annotations:
+      ebpf.tracer.perf-buffer-pages: "128"
+```
+
+The annotation value must be a positive integer specifying the number of
+memory pages per CPU. If omitted, invalid, or less than or equal to 0, Inspektor
+Gadget falls back to the default of 64 pages per CPU. This annotation has no
+effect when eBPF ring buffers are supported and in use.

--- a/pkg/operators/ebpf/ebpf.go
+++ b/pkg/operators/ebpf/ebpf.go
@@ -70,10 +70,11 @@ const (
 
 	kernelTypesVar = "kernelTypes"
 
-	AnnotationMapFlushOnStop  = "ebpf.map.flush-on-stop"
-	AnnotationIterFetchOnStop = "ebpf.iter.fetch-on-stop"
-	AnnotationRestName        = "ebpf.rest.name"
-	AnnotationRestLen         = "ebpf.rest.len"
+	AnnotationMapFlushOnStop        = "ebpf.map.flush-on-stop"
+	AnnotationIterFetchOnStop       = "ebpf.iter.fetch-on-stop"
+	AnnotationRestName              = "ebpf.rest.name"
+	AnnotationRestLen               = "ebpf.rest.len"
+	AnnotationTracerPerfBufferPages = "ebpf.tracer.perf-buffer-pages"
 )
 
 type gadgetObjects struct {

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -287,6 +288,23 @@ func (t *Tracer) close() {
 	}
 }
 
+func (i *ebpfInstance) resolvePerfBufferPages(ds datasource.DataSource) int {
+	if ds == nil {
+		return gadgets.PerfBufferPages
+	}
+	val, ok := ds.Annotations()[AnnotationTracerPerfBufferPages]
+	if !ok || val == "" {
+		return gadgets.PerfBufferPages
+	}
+	pages, err := strconv.Atoi(val)
+	if err != nil || pages <= 0 {
+		i.logger.Warnf("invalid value for annotation %q: %q; falling back to default %d",
+			AnnotationTracerPerfBufferPages, val, gadgets.PerfBufferPages)
+		return gadgets.PerfBufferPages
+	}
+	return pages
+}
+
 func (i *ebpfInstance) runTracer(gadgetCtx operators.GadgetContext, tracer *Tracer) error {
 	if tracer.mapName == "" {
 		return fmt.Errorf("tracer map name empty")
@@ -314,7 +332,8 @@ func (i *ebpfInstance) runTracer(gadgetCtx operators.GadgetContext, tracer *Trac
 		tracer.logger = i.logger
 	case ebpf.PerfEventArray:
 		i.logger.Debugf("creating perf reader for map %q", tracer.mapName)
-		tracer.perfReader, err = perf.NewReader(m, gadgets.PerfBufferPages*os.Getpagesize())
+		perfBufferPages := i.resolvePerfBufferPages(tracer.ds)
+		tracer.perfReader, err = perf.NewReader(m, perfBufferPages*os.Getpagesize())
 	default:
 		return fmt.Errorf("unknown type for tracer map %q", tracer.mapName)
 	}

--- a/pkg/operators/ebpf/tracer_test.go
+++ b/pkg/operators/ebpf/tracer_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpfoperator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+)
+
+func TestResolvePerfBufferPages(t *testing.T) {
+	instance := &ebpfInstance{
+		logger: logger.DefaultLogger(),
+	}
+
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		nilDataSource bool
+		expected      int
+	}{
+		{
+			name:          "nil datasource returns default",
+			nilDataSource: true,
+			expected:      gadgets.PerfBufferPages,
+		},
+		{
+			name:        "missing annotation returns default",
+			annotations: map[string]string{},
+			expected:    gadgets.PerfBufferPages,
+		},
+		{
+			name: "empty annotation value returns default",
+			annotations: map[string]string{
+				AnnotationTracerPerfBufferPages: "",
+			},
+			expected: gadgets.PerfBufferPages,
+		},
+		{
+			name: "valid positive integer annotation returns custom value",
+			annotations: map[string]string{
+				AnnotationTracerPerfBufferPages: "128",
+			},
+			expected: 128,
+		},
+		{
+			name: "zero value returns default",
+			annotations: map[string]string{
+				AnnotationTracerPerfBufferPages: "0",
+			},
+			expected: gadgets.PerfBufferPages,
+		},
+		{
+			name: "negative value returns default",
+			annotations: map[string]string{
+				AnnotationTracerPerfBufferPages: "-10",
+			},
+			expected: gadgets.PerfBufferPages,
+		},
+		{
+			name: "invalid non-integer string returns default",
+			annotations: map[string]string{
+				AnnotationTracerPerfBufferPages: "invalid",
+			},
+			expected: gadgets.PerfBufferPages,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ds datasource.DataSource
+			if !tt.nilDataSource {
+				var err error
+				ds, err = datasource.New(datasource.TypeSingle, "test")
+				require.NoError(t, err)
+				for k, v := range tt.annotations {
+					ds.AddAnnotation(k, v)
+				}
+			}
+
+			pages := instance.resolvePerfBufferPages(ds)
+			assert.Equal(t, tt.expected, pages)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When the kernel does not support eBPF ring buffers (kernel < 5.8), the buffer declared by `GADGET_TRACER_MAP()` falls back to a perf event array. Currently, the userspace reader allocates a default per-CPU ring of **64 memory pages**.

This PR adds a new datasource annotation `ebpf.tracer.perf-buffer-pages` allowing gadgets to configure the perf event buffer page count per CPU on a per-datasource basis.

### Changes
- Added constant `AnnotationTracerPerfBufferPages = "ebpf.tracer.perf-buffer-pages"` in `pkg/operators/ebpf/ebpf.go`.
- Implemented `resolvePerfBufferPages()` in `pkg/operators/ebpf/tracer.go` to dynamically resolve perf buffer page count from datasource annotations with fallback to default (`64`) when missing, non-integer, or <= 0.
- Added comprehensive unit tests in `pkg/operators/ebpf/tracer_test.go`.
- Updated documentation in `docs/gadget-devel/gadget-ebpf-api.md`.

Fixes #5579