### PR TITLE
gadgets/trace_sni: Add IPv6 support

### DIFF
--- a/gadgets/trace_sni/README.mdx
+++ b/gadgets/trace_sni/README.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # trace_sni
 
-The trace_sni gadget tracks Server Name Indication (SNI) from TLS requests.
+The trace_sni gadget tracks Server Name Indication (SNI) from IPv4 and IPv6 TLS requests.
 
 ## Requirements
 

--- a/gadgets/trace_sni/program.bpf.c
+++ b/gadgets/trace_sni/program.bpf.c
@@ -5,6 +5,7 @@
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/in.h>
 #include <linux/tcp.h>
 
@@ -169,36 +170,42 @@ int ig_trace_sni(struct __sk_buff *skb)
 	struct ethhdr ethh;
 	if (bpf_skb_load_bytes(skb, 0, &ethh, sizeof ethh))
 		return 0;
-	if (bpf_ntohs(ethh.h_proto) != ETH_P_IP)
-		return 0;
 
-	int ip_off = ETH_HLEN;
-	// Read the IP header.
-	struct iphdr iph;
-	if (bpf_skb_load_bytes(skb, ip_off, &iph, sizeof iph))
-		return 0;
+	int tcp_off = 0;
+	__u16 h_proto = bpf_ntohs(ethh.h_proto);
 
-	// Skip packets with IP protocol other than TCP.
-	if (iph.protocol != IPPROTO_TCP)
+	if (h_proto == ETH_P_IP) {
+		int ip_off = ETH_HLEN;
+		struct iphdr iph;
+		if (bpf_skb_load_bytes(skb, ip_off, &iph, sizeof iph))
+			return 0;
+		if (iph.protocol != IPPROTO_TCP)
+			return 0;
+		__u8 ip_header_len = iph.ihl * 4;
+		tcp_off = ip_off + ip_header_len;
+	} else if (h_proto == ETH_P_IPV6) {
+		int ip_off = ETH_HLEN;
+		struct ipv6hdr ip6h;
+		if (bpf_skb_load_bytes(skb, ip_off, &ip6h, sizeof ip6h))
+			return 0;
+		if (ip6h.nexthdr != IPPROTO_TCP)
+			return 0;
+		tcp_off = ip_off + sizeof(struct ipv6hdr);
+	} else {
 		return 0;
-
-	// An IPv4 header doesn't have a fixed size. The IHL field of a packet
-	// represents the size of the IP header in 32-bit words, so we need to
-	// multiply this value by 4 to get the header size in bytes.
-	__u8 ip_header_len = iph.ihl * 4;
-	int tcp_off = ip_off + ip_header_len;
+	}
 
 	// Read the TCP header.
 	struct tcphdr tcph;
 	if (bpf_skb_load_bytes(skb, tcp_off, &tcph, sizeof tcph))
 		return 0;
 
-	if (!tcph.psh)
-		return 0;
-
 	// The data offset field in the header is specified in 32-bit words. We
 	// have to multiply this value by 4 to get the TCP header length in bytes.
 	__u8 tcp_header_len = tcph.doff * 4;
+	if (tcp_header_len < sizeof(struct tcphdr))
+		return 0;
+
 	// TLS data starts at this offset.
 	int payload_off = tcp_off + tcp_header_len;
 


### PR DESCRIPTION
Add IPv6 header parsing (`ETH_P_IPV6`) to `trace_sni` to extract SNI server names from IPv6 TLS Client Hello packets.

Fixes: #5503

## How to test

1. Build the `trace_sni` gadget image:
```bash
sudo ./ig image build -t trace_sni:latest ./gadgets/trace_sni
```

2. Run `trace_sni` on an interface supporting IPv6 container network traffic:
```bash
sudo ./ig run trace_sni:latest --verify-image=false --host iface=br-88ba6cd4e972
```

3. Send a TLS request over IPv6 from a container:
```bash
docker exec sni-ipv6-client curl -k -v --connect-to real-domain.com:443:[2001:db8:1::10]:8443 https://real-domain.com
```

### Verification Output

```text
RUNTIME.CONTAINERNAME          COMM                    PID        TID        NAME                          
sni-ipv6-client                curl                  61489      61489      real-domain.com               
sni-ipv6-app                   openssl               56693      56693      real-domain.com               
```

Signed-off-by: Abhishek Khade <abhishekkhade69@gmail.com>