### PR TITLE
operators: Add --disable-operators flag to opt-out of operators

### DIFF
--- a/cmd/common/oci.go
+++ b/cmd/common/oci.go
@@ -126,6 +126,8 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		skipParams = append(skipParams, "!attach")
 	}
 
+	var disabledOperators []string
+
 	initializedOperators := false
 
 	preRun := func(cmd *cobra.Command, args []string) error {
@@ -193,7 +195,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 		}
 
 		ops := make([]operators.DataOperator, 0)
-		for _, op := range operators.GetDataOperators() {
+		for _, op := range operators.GetDataOperatorsExcluding(disabledOperators) {
 			// Initialize operator
 			err := op.Init(opGlobalParams[op.Name()])
 			if err != nil {
@@ -242,6 +244,7 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 			context.Background(),
 			imageName,
 			gadgetcontext.WithDataOperators(ops...),
+			gadgetcontext.WithDisabledDataOperators(disabledOperators...),
 			gadgetcontext.WithUseInstance(commandMode == CommandModeAttach),
 			gadgetcontext.WithIsClient(runtime.IsClient()),
 		)
@@ -469,6 +472,8 @@ func NewRunCommand(rootCmd *cobra.Command, runtime runtime.Runtime, hiddenColumn
 	for _, operatorParams := range opGlobalParams {
 		AddOCIFlags(cmd, operatorParams, skipParams, runtime)
 	}
+
+	cmd.PersistentFlags().StringSliceVarP(&disabledOperators, "disable-operators", "d", nil, "Comma-separated list of operators to disable")
 
 	return cmd
 }

--- a/docs/spec/operators/index.mdx
+++ b/docs/spec/operators/index.mdx
@@ -40,9 +40,8 @@ flowchart LR
 
 Operators are enabled automatically based on the gadget that's being run,
 according to the layers present on the OCI image, the types used by the eBPF
-programs, etc. It's currently [not
-possible](https://github.com/inspektor-gadget/inspektor-gadget/issues/1992) to
-explicitly disable an operator. Also, all operators are currently built-in, [we
+programs, etc. Users can explicitly disable specific operators using the
+`--disable-operators` / `-d` CLI flag (for example, `--disable-operators=kubeipresolver,kubenameresolver`). Also, all operators are currently built-in, [we
 however plan](https://github.com/inspektor-gadget/inspektor-gadget/issues/2497)
 to support third-party operators in the future.
 

--- a/pkg/gadget-context/context_test.go
+++ b/pkg/gadget-context/context_test.go
@@ -490,3 +490,10 @@ params:
 		})
 	}
 }
+
+func TestWithDisabledDataOperators(t *testing.T) {
+	disabledOps := []string{"kubeipresolver", "kubenameresolver"}
+	gCtx := New(context.Background(), "test-image", WithDisabledDataOperators(disabledOps...))
+
+	assert.Equal(t, disabledOps, gCtx.DisabledDataOperators())
+}

--- a/pkg/gadget-context/gadget-context.go
+++ b/pkg/gadget-context/gadget-context.go
@@ -64,17 +64,18 @@ type GadgetContext struct {
 	useInstance      bool
 	requestExtraInfo bool
 
-	lock           sync.Mutex
-	dataSources    map[string]datasource.DataSource
-	dataOperators  []operators.DataOperator
-	localOperators []operators.DataOperatorInstance
-	vars           map[string]any
-	params         []*api.Param
-	paramValues    api.ParamValues
-	loaded         bool
-	imageName      string
-	metadata       []byte
-	orasTarget     oras.ReadOnlyTarget
+	lock                  sync.Mutex
+	dataSources           map[string]datasource.DataSource
+	dataOperators         []operators.DataOperator
+	disabledDataOperators []string
+	localOperators        []operators.DataOperatorInstance
+	vars                  map[string]any
+	params                []*api.Param
+	paramValues           api.ParamValues
+	loaded                bool
+	imageName             string
+	metadata              []byte
+	orasTarget            oras.ReadOnlyTarget
 }
 
 func New(
@@ -145,6 +146,10 @@ func (c *GadgetContext) ImageName() string {
 
 func (c *GadgetContext) DataOperators() []operators.DataOperator {
 	return slices.Clone(c.dataOperators)
+}
+
+func (c *GadgetContext) DisabledDataOperators() []string {
+	return slices.Clone(c.disabledDataOperators)
 }
 
 func (c *GadgetContext) IsRemoteCall() bool {

--- a/pkg/gadget-context/options.go
+++ b/pkg/gadget-context/options.go
@@ -98,3 +98,9 @@ func WithName(name string) Option {
 		gadgetCtx.name = name
 	}
 }
+
+func WithDisabledDataOperators(disabledOps ...string) Option {
+	return func(gadgetCtx *GadgetContext) {
+		gadgetCtx.disabledDataOperators = slices.Clone(disabledOps)
+	}
+}

--- a/pkg/gadget-context/run.go
+++ b/pkg/gadget-context/run.go
@@ -34,7 +34,19 @@ import (
 func (c *GadgetContext) instantiateOperators(paramValues api.ParamValues) error {
 	log := c.Logger()
 
-	ops := c.DataOperators()
+	disabledMap := make(map[string]bool, len(c.disabledDataOperators))
+	for _, name := range c.disabledDataOperators {
+		disabledMap[name] = true
+	}
+
+	ops := make([]operators.DataOperator, 0)
+	for _, op := range c.DataOperators() {
+		if disabledMap[op.Name()] {
+			log.Debugf("skipping disabled operator %q", op.Name())
+			continue
+		}
+		ops = append(ops, op)
+	}
 
 	// Sort dataOperators based on their priority and name
 	sort.Slice(ops, func(i, j int) bool {

--- a/pkg/operators/registry.go
+++ b/pkg/operators/registry.go
@@ -15,7 +15,6 @@
 package operators
 
 import (
-	"maps"
 	"sync"
 )
 
@@ -44,9 +43,24 @@ func RegisterDataOperator(operator DataOperator) {
 }
 
 func GetDataOperators() map[string]DataOperator {
+	return GetDataOperatorsExcluding(nil)
+}
+
+// GetDataOperatorsExcluding returns a copy of dataOperators excluding any listed in disabledOperators
+func GetDataOperatorsExcluding(disabledOperators []string) map[string]DataOperator {
 	registryLock.Lock()
 	defer registryLock.Unlock()
-	return maps.Clone(dataOperators)
+	disabledMap := make(map[string]bool, len(disabledOperators))
+	for _, name := range disabledOperators {
+		disabledMap[name] = true
+	}
+	result := make(map[string]DataOperator)
+	for name, op := range dataOperators {
+		if !disabledMap[name] {
+			result[name] = op
+		}
+	}
+	return result
 }
 
 // GetImageOperatorForMediaType returns a copy of the map of operators matching the given


### PR DESCRIPTION
Allows users to disable specific operators (such as `kubeipresolver` or `kubenameresolver`) via the `--disable-operators` / `-d` CLI flag or the `WithDisabledDataOperators(...)` Go API option to reduce overhead in large Kubernetes clusters.

Fixes #1992