### PR TITLE
feat(ebpf): add GADGET_MAP_MAX_ENTRIES for dynamic ringbuf size

### DIFF
--- a/docs/gadget-devel/gadget-ebpf-api.md
+++ b/docs/gadget-devel/gadget-ebpf-api.md
@@ -830,3 +830,20 @@ on a field according to the `ebpf.rest.name` datasource annotation. The
 field that contains the length of the trailing data. If the gadget doesn't
 provide this annotation, the whole remaining data will be used as the trailing
 data.
+
+### BPF Map Max Entries
+
+Gadget authors can change the maximum number of entries (`max_entries`) of any BPF map configurable at runtime using the `GADGET_MAP_MAX_ENTRIES` macro defined in `include/gadget/buffer.h`:
+
+```c
+GADGET_MAP_MAX_ENTRIES(my_map, 10240);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u64));
+	__uint(max_entries, 10240);
+} my_map SEC(".maps");
+```
+
+This automatically declares a parameter named `<mapname>_max_entries` (e.g. `--my-map-max-entries`) that users can override at runtime without recompiling the gadget. All tracer maps created via `GADGET_TRACER_MAP(name, size)` automatically support this parameter.

--- a/include/gadget/buffer.h
+++ b/include/gadget/buffer.h
@@ -11,7 +11,13 @@
 #define GADGET_MAX_EVENT_SIZE 10240
 #endif
 
+#define GADGET_MAP_MAX_ENTRIES(mapname, default_size)              \
+	const volatile __u32 mapname##_max_entries = default_size; \
+	const void *gadget_param_##mapname##_max_entries           \
+		__attribute__((unused));
+
 #define GADGET_TRACER_MAP(name, size)                                 \
+	GADGET_MAP_MAX_ENTRIES(name, size)                            \
 	struct {                                                      \
 		__uint(type, BPF_MAP_TYPE_RINGBUF);                   \
 		__uint(max_entries, size);                            \

--- a/include/gadget/user_stack_map.h
+++ b/include/gadget/user_stack_map.h
@@ -32,7 +32,7 @@ GADGET_PARAM(collect_build_id);
 const volatile bool collect_otel_stack = false;
 GADGET_PARAM(collect_otel_stack);
 
-const volatile int ig_build_id_max_entries = 1024;
+const volatile __u32 ig_build_id_max_entries = 1024;
 GADGET_PARAM(ig_build_id_max_entries);
 
 struct {

--- a/pkg/operators/ebpf/tracer.go
+++ b/pkg/operators/ebpf/tracer.go
@@ -72,6 +72,7 @@ func (i *ebpfInstance) fixTracerMap(t btf.Type, varName string) error {
 		bufMap.Type = ebpf.PerfEventArray
 		bufMap.KeySize = 4
 		bufMap.ValueSize = 4
+		bufMap.MaxEntries = 0
 	}
 
 	return nil


### PR DESCRIPTION
This commit resolves #5400 by allowing gadget developers to define dynamic map sizes (especially for ring buffers) that can be overridden at runtime via CLI flags.

- Added GADGET_MAP_MAX_ENTRIES macro in buffer.h.
- Exposed events_max_entries globally via BTF .rodata.
- Updated tracer.go to explicitly reset MaxEntries = 0 when falling back to a PerfEventArray on older kernels (< 5.8), ensuring the user's byte-size request doesn't incorrectly spawn thousands of CPU buffers.
- Fixed a type mismatch in user_stack_map.h (ig_build_id_max_entries).
- Updated gadget-ebpf-api.md with developer documentation.

Fixes #5400

