### PR TITLE
profile_cpu: discard invalid stack IDs

### DIFF
--- a/gadgets/profile_cpu/program.bpf.c
+++ b/gadgets/profile_cpu/program.bpf.c
@@ -246,6 +246,12 @@ int ig_prof_cpu(struct bpf_perf_event_data *ctx)
 		gadget_get_user_stack(ctx, ustack_raw);
 	else
 		__builtin_memset(ustack_raw, 0, sizeof(*ustack_raw));
+
+	if (collect_ustack && (__s32)ustack_raw->stack_id < 0)
+		return 0;
+	if (!user_stacks_only && (__s32)key->kern_stack_raw < 0)
+		return 0;
+
 	key->user_stack_id = ustack_raw->stack_id;
 
 	if (key->kern_stack_raw >= 0) {


### PR DESCRIPTION
## Summary

- discard failed user-stack IDs before aggregation
- discard failed kernel-stack IDs before aggregation
- preserve only map-resolvable profile samples instead of exporting unsigned errno values as stack IDs

## Why

`bpf_get_stackid()` returns a negative errno on unwind failure, but both stack fields are unsigned. `profile_cpu` currently aggregates those values, after which the stack operators attempt lookups such as `4294967282` (`-EFAULT`) and emit repeated `stack with ID ... is lost` warnings. This makes otherwise exact-PID profiles appear to have map loss.

## Validation

- gadget builds successfully for both architectures with the pinned gadget builder
- source-built v0.53-compatible equivalent tested against a real KVM/Rust Criterion workload
- before: repeated unsigned `-EFAULT`/`-E2BIG` lookup warnings
- after: 175 exact-PID samples, zero malformed records, zero stack-loss markers
