### PR TITLE
fix(oci): make signature pull failures actionable

### DIFF
--- a/docs/gadget-devel/signing.md
+++ b/docs/gadget-devel/signing.md
@@ -8,3 +8,14 @@ It's highly recommended to sign your gadget images for security reasons. Signed
 images ensure integrity and authenticity, adding an extra layer of trust. Tools
 like [cosign](https://docs.sigstore.dev/cosign/signing/signing_with_containers/)
 can be used for this purpose.
+
+If you publish a gadget without signing it, users running it with the default
+settings get the following error:
+
+```bash
+no signature found for gadget ghcr.io/your-repo/gadget/trace_open:latest
+If the gadget is not signed and you are sure you want to skip signature verification, run or deploy Inspektor Gadget with --verify-image=false
+```
+
+See [Verifying Gadget Images](../reference/verify-gadgets.mdx) for the ways
+users can verify your gadget once it is signed.

--- a/docs/reference/verify-gadgets.mdx
+++ b/docs/reference/verify-gadgets.mdx
@@ -85,10 +85,13 @@ Let's try to run an image-based gadget which was not signed:
 
 ```bash
 $ sudo ig run ghcr.io/inspektor-gadget/gadget/trace_open:v0.27.0
-Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": ensuring image: verifying image "ghcr.io/inspektor-gadget/gadget/trace_open:v0.27.0": getting signing information: getting signature: getting signature bytes: ghcr.io/inspektor-gadget/gadget/trace_open:sha256-0c0e2fa72ae70e65351ab7a48a1cd5a68752a94d9c36e7b51e8764a1b7be3d7a.sig: not found
+WARN[0000] no signature found for gadget ghcr.io/inspektor-gadget/gadget/trace_open:v0.27.0
+Error: fetching gadget information: initializing and preparing operators: instantiating operator "oci": verifying image: no signature found for gadget ghcr.io/inspektor-gadget/gadget/trace_open:v0.27.0
+If the gadget is not signed and you are sure you want to skip signature verification, run or deploy Inspektor Gadget with --verify-image=false
 ```
 
 As the image was not signed, no signature was found in the repository, so the execution is denied.
+Run with `-v` to see which signature formats were tried and why each one failed.
 
 You can set your own public keys with `--public-keys`:
 

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -154,7 +154,9 @@ func VerifyGadgetImage(ctx context.Context, image string, imgOpts *ImageOptions)
 				return fmt.Errorf("verifying gadget signature %q: %w", image, err)
 			}
 
-			log.Warn("signature not found, will pull signing information and try verification again")
+			// The signing information is simply not in the local store yet;
+			// this is the normal path the first time an image is verified.
+			log.Debug("signature not found locally, will pull signing information and try verification again")
 
 			if imageStore.readOnly {
 				return fmt.Errorf("disabling signature pull for %q as --oci-store-user opens the user's store as read only", image)
@@ -174,7 +176,9 @@ func VerifyGadgetImage(ctx context.Context, image string, imgOpts *ImageOptions)
 			// again.
 			err = puller.DefaultSignaturePuller.PullSigningInformation(ctx, repo, imageStore, desc.Digest.String())
 			if err != nil {
-				return fmt.Errorf("pulling gadget signature %q: %w", image, err)
+				log.Debugf("pulling signing information for %q: %v", image, err)
+
+				return signaturePullError(imageRef, err)
 			}
 
 			if err := imageStore.saveIndexWithLock(); err != nil {
@@ -273,8 +277,12 @@ func pullImage(ctx context.Context, targetImage reference.Named, imageStore oras
 
 	imageDigest := desc.Digest.String()
 	if err := puller.DefaultSignaturePuller.PullSigningInformation(ctx, repo, imageStore, imageDigest); err != nil {
-		log.Warnf("error pulling signature: %v", err)
-		// it's not a requirement to have a signature for pulling the image
+		// It's not a requirement to have a signature for pulling the image, so
+		// only warn about it. Keep the warning to a single line and leave the
+		// per-puller detail to the debug log.
+		log.Debugf("pulling signing information for %q: %v", targetImage.String(), err)
+		log.Warnf("%s", signaturePullWarning(targetImage, err))
+
 		return &desc, nil
 	}
 

--- a/pkg/oci/signature_error.go
+++ b/pkg/oci/signature_error.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/distribution/reference"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/signature/puller"
+)
+
+const skipVerificationHint = "If the gadget is not signed and you are sure you want to skip signature " +
+	"verification, run or deploy Inspektor Gadget with --verify-image=false"
+
+// signaturePullError turns the error returned by the signature puller into a
+// message a user can act on. The three cases below look identical in the raw
+// output of the pullers, but call for very different fixes. Anything we cannot
+// classify keeps its original wording so no detail is lost.
+//
+// The caller is expected to log err at debug level: the returned error
+// deliberately drops the per-puller detail.
+func signaturePullError(imageRef reference.Named, err error) error {
+	image := imageRef.String()
+
+	switch {
+	case errors.Is(err, puller.ErrSignatureNotFound):
+		return fmt.Errorf("no signature found for gadget %s\n%s", image, skipVerificationHint)
+	case errors.Is(err, puller.ErrRegistryUnreachable):
+		return fmt.Errorf("fetching the signature for gadget %s: %s is unreachable\n"+
+			"If you are running air-gapped, pull the gadget while online, as its signature is pulled along with it. "+
+			"Otherwise, run or deploy Inspektor Gadget with --verify-image=false",
+			image, reference.Domain(imageRef))
+	case errors.Is(err, puller.ErrSignatureUnauthorized):
+		return fmt.Errorf("not authorized to fetch the signature for gadget %s\n"+
+			"Log in to %s, or run or deploy Inspektor Gadget with --verify-image=false",
+			image, reference.Domain(imageRef))
+	}
+
+	return fmt.Errorf("pulling gadget signature %q: %w", image, err)
+}
+
+// signaturePullWarning is the non-fatal counterpart of signaturePullError, used
+// while pulling an image. Verification is not being asked for here, so the
+// message states what happened without suggesting how to bypass anything.
+func signaturePullWarning(imageRef reference.Named, err error) string {
+	image := imageRef.String()
+
+	switch {
+	case errors.Is(err, puller.ErrSignatureNotFound):
+		return fmt.Sprintf("no signature found for gadget %s", image)
+	case errors.Is(err, puller.ErrRegistryUnreachable):
+		return fmt.Sprintf("fetching the signature for gadget %s: %s is unreachable",
+			image, reference.Domain(imageRef))
+	case errors.Is(err, puller.ErrSignatureUnauthorized):
+		return fmt.Sprintf("not authorized to fetch the signature for gadget %s", image)
+	}
+
+	return fmt.Sprintf("error pulling signature for gadget %s: %v", image, err)
+}

--- a/pkg/oci/signature_error_test.go
+++ b/pkg/oci/signature_error_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/signature/puller"
+)
+
+const testImage = "ghcr.io/inspektor-gadget/gadget/trace_open:latest"
+
+// errDetail stands in for the raw, multi-line error the pullers produce; none of
+// it should reach the user-facing message.
+var errDetail = errors.New(`pulling signing information with cosign: not found
+pulling signing information with oci 1.1: not found
+pulling signing information with bundle: no referrers found`)
+
+func TestSignaturePullError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err          error
+		wantContains []string
+		wantHint     bool
+	}{
+		"not_found": {
+			err:          fmt.Errorf("%w: %w", puller.ErrSignatureNotFound, errDetail),
+			wantContains: []string{"no signature found for gadget", testImage},
+			wantHint:     true,
+		},
+		"unreachable": {
+			err:          fmt.Errorf("%w: %w", puller.ErrRegistryUnreachable, errDetail),
+			wantContains: []string{"ghcr.io is unreachable", "air-gapped", testImage},
+			wantHint:     true,
+		},
+		"unauthorized": {
+			err:          fmt.Errorf("%w: %w", puller.ErrSignatureUnauthorized, errDetail),
+			wantContains: []string{"not authorized", "Log in to ghcr.io", testImage},
+			wantHint:     true,
+		},
+		"unclassified_keeps_detail": {
+			err:          errDetail,
+			wantContains: []string{"pulling gadget signature", "no referrers found"},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ref, err := normalizeImageName(testImage)
+			require.NoError(t, err)
+
+			got := signaturePullError(ref, test.err).Error()
+
+			for _, want := range test.wantContains {
+				require.Contains(t, got, want)
+			}
+
+			if test.wantHint {
+				require.Contains(t, got, "--verify-image=false")
+				// The raw per-puller dump is what confuses users; it belongs
+				// in the debug log, not in the message they are shown.
+				require.NotContains(t, got, "pulling signing information with cosign")
+			}
+		})
+	}
+}
+
+func TestSignaturePullWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  error
+		want string
+	}{
+		"not_found": {
+			err:  fmt.Errorf("%w: %w", puller.ErrSignatureNotFound, errDetail),
+			want: "no signature found for gadget " + testImage,
+		},
+		"unreachable": {
+			err:  fmt.Errorf("%w: %w", puller.ErrRegistryUnreachable, errDetail),
+			want: "fetching the signature for gadget " + testImage + ": ghcr.io is unreachable",
+		},
+		"unauthorized": {
+			err:  fmt.Errorf("%w: %w", puller.ErrSignatureUnauthorized, errDetail),
+			want: "not authorized to fetch the signature for gadget " + testImage,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ref, err := normalizeImageName(testImage)
+			require.NoError(t, err)
+
+			got := signaturePullWarning(ref, test.err)
+
+			require.Equal(t, test.want, got)
+			// Pulling is not verifying, so the message must not tell the user
+			// to turn verification off.
+			require.NotContains(t, got, "--verify-image")
+		})
+	}
+}

--- a/pkg/signature/helpers/helpers.go
+++ b/pkg/signature/helpers/helpers.go
@@ -16,11 +16,11 @@ package helpers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -111,7 +111,9 @@ func findReferrerTag(ctx context.Context, imageStore oras.ReadOnlyGraphTarget, i
 	}
 
 	if len(descriptors) == 0 {
-		return "", errors.New("no referrers found")
+		// Report this the same way a registry reports a missing signature tag,
+		// so callers can tell "nothing is signed here" from a real failure.
+		return "", fmt.Errorf("no referrers found: %w", errdef.ErrNotFound)
 	}
 
 	if len(descriptors) > 1 {

--- a/pkg/signature/puller/errors.go
+++ b/pkg/signature/puller/errors.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+// Every puller fails on its own terms when there is nothing to pull, which
+// makes the joined error unreadable. These sentinels let callers tell the
+// three interesting situations apart and phrase an actionable message.
+var (
+	// ErrSignatureNotFound means the registry was reachable and readable, but
+	// holds no signing information for the image: the gadget is not signed.
+	ErrSignatureNotFound = errors.New("signature not found")
+
+	// ErrRegistryUnreachable means the registry could not be contacted at all,
+	// typically because the host is running air-gapped.
+	ErrRegistryUnreachable = errors.New("registry unreachable")
+
+	// ErrSignatureUnauthorized means the registry refused to serve the signing
+	// information, typically because the repository is private and no
+	// credentials were provided.
+	ErrSignatureUnauthorized = errors.New("signature not accessible")
+)
+
+// classify turns the errors collected from the pullers into a single error
+// tagged with the sentinel that best describes them. The original errors stay
+// reachable through errors.Is and errors.As, so callers can still log the full
+// detail at debug level. Errors we do not recognise are returned as they are
+// rather than being forced into a category.
+func classify(errs []error) error {
+	joined := errors.Join(errs...)
+	if joined == nil {
+		return nil
+	}
+
+	// Unauthorized is checked first, and unreachable before not found: a 404
+	// from one puller next to a 401 from another means the registry is hiding
+	// the repository, not that the image is unsigned.
+	switch {
+	case anyIs(errs, isUnauthorized):
+		return fmt.Errorf("%w: %w", ErrSignatureUnauthorized, joined)
+	case anyIs(errs, isUnreachable):
+		return fmt.Errorf("%w: %w", ErrRegistryUnreachable, joined)
+	case allAre(errs, isNotFound):
+		return fmt.Errorf("%w: %w", ErrSignatureNotFound, joined)
+	}
+
+	return joined
+}
+
+func anyIs(errs []error, pred func(error) bool) bool {
+	for _, err := range errs {
+		if pred(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func allAre(errs []error, pred func(error) bool) bool {
+	for _, err := range errs {
+		if !pred(err) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, errdef.ErrNotFound)
+}
+
+func isUnauthorized(err error) bool {
+	if errors.Is(err, auth.ErrBasicCredentialNotFound) {
+		return true
+	}
+
+	var resp *errcode.ErrorResponse
+	if !errors.As(err, &resp) {
+		return false
+	}
+
+	return resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden
+}
+
+func isUnreachable(err error) bool {
+	// An error response, however unhelpful, still proves we reached the
+	// registry, so it must never be reported as a connectivity problem.
+	var resp *errcode.ErrorResponse
+	if errors.As(err, &resp) {
+		return false
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}

--- a/pkg/signature/puller/errors_test.go
+++ b/pkg/signature/puller/errors_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package puller
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+func notFoundErr(tag string) error {
+	return fmt.Errorf("pulling signing information with cosign: %s: %w", tag, errdef.ErrNotFound)
+}
+
+func statusErr(code int) error {
+	u, _ := url.Parse("https://ghcr.io/v2/inspektor-gadget/gadget/trace_open/manifests/latest")
+	return &errcode.ErrorResponse{Method: "GET", URL: u, StatusCode: code}
+}
+
+func dnsErr() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "https://ghcr.io/v2/",
+		Err: &net.DNSError{Err: "no such host", Name: "ghcr.io", IsNotFound: true},
+	}
+}
+
+func refusedErr() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "https://registry.local/v2/",
+		Err: &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+	}
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		errs []error
+		want error
+	}{
+		"no_errors": {
+			errs: nil,
+			want: nil,
+		},
+		"all_not_found": {
+			// The common case: the gadget is simply not signed, so each
+			// puller gets a 404 (or finds no referrer) in turn.
+			errs: []error{notFoundErr("sha256-abc.sig"), notFoundErr("sha256-abc"), notFoundErr("sha256-abc")},
+			want: ErrSignatureNotFound,
+		},
+		"unauthorized": {
+			errs: []error{statusErr(401), statusErr(401), statusErr(401)},
+			want: ErrSignatureUnauthorized,
+		},
+		"denied": {
+			errs: []error{statusErr(403)},
+			want: ErrSignatureUnauthorized,
+		},
+		"missing_credentials": {
+			errs: []error{fmt.Errorf("fetching token: %w", auth.ErrBasicCredentialNotFound)},
+			want: ErrSignatureUnauthorized,
+		},
+		"dns_failure": {
+			errs: []error{dnsErr(), dnsErr(), dnsErr()},
+			want: ErrRegistryUnreachable,
+		},
+		"connection_refused": {
+			errs: []error{refusedErr()},
+			want: ErrRegistryUnreachable,
+		},
+		"unauthorized_wins_over_not_found": {
+			// A 404 from one puller next to a 401 from another means the
+			// registry is hiding the repository, not that it is unsigned.
+			errs: []error{notFoundErr("sha256-abc.sig"), statusErr(401), notFoundErr("sha256-abc")},
+			want: ErrSignatureUnauthorized,
+		},
+		"unauthorized_wins_over_unreachable": {
+			errs: []error{dnsErr(), statusErr(403)},
+			want: ErrSignatureUnauthorized,
+		},
+		"unreachable_wins_over_not_found": {
+			errs: []error{notFoundErr("sha256-abc.sig"), dnsErr()},
+			want: ErrRegistryUnreachable,
+		},
+		"unknown_error_is_not_classified": {
+			// Anything we do not recognise must keep its original wording
+			// instead of being mislabelled as a missing signature.
+			errs: []error{notFoundErr("sha256-abc.sig"), errors.New("images with several referrers are not supported")},
+			want: nil,
+		},
+		"server_error_is_not_classified": {
+			errs: []error{statusErr(500)},
+			want: nil,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := classify(test.errs)
+
+			if len(test.errs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+
+			if test.want != nil {
+				require.ErrorIs(t, err, test.want)
+			} else {
+				for _, sentinel := range []error{ErrSignatureNotFound, ErrRegistryUnreachable, ErrSignatureUnauthorized} {
+					require.NotErrorIs(t, err, sentinel)
+				}
+			}
+
+			// Whatever the classification, the underlying errors must stay
+			// reachable so they can still be logged at debug level.
+			for _, e := range test.errs {
+				require.ErrorIs(t, err, e)
+			}
+		})
+	}
+}

--- a/pkg/signature/puller/puller.go
+++ b/pkg/signature/puller/puller.go
@@ -59,5 +59,5 @@ func (p *SignaturePuller) PullSigningInformation(ctx context.Context, repo *remo
 		errs = append(errs, fmt.Errorf("pulling signing information with %s: %w", puller.Name(), err))
 	}
 
-	return errors.Join(errs...)
+	return classify(errs)
 }

--- a/pkg/signature/puller/puller_test.go
+++ b/pkg/signature/puller/puller_test.go
@@ -80,7 +80,7 @@ func TestPullSigningInformation(t *testing.T) {
 
 			err = DefaultSignaturePuller.PullSigningInformation(ctx, repo, store, desc.Digest.String())
 			if test.shouldErr {
-				require.Error(t, err)
+				require.ErrorIs(t, err, ErrSignatureNotFound)
 				return
 			}
 


### PR DESCRIPTION
Fixes #5605

<!-- armosec-pr: v=1 via=manual -->

## Summary

The three signature pullers each fail differently when there is nothing to pull, and the joined error was printed verbatim, twice. Users got nine lines of oras internals instead of the fact that matters: the gadget is not signed. This classifies those errors and renders a message users can act on.

## Change

`PullSigningInformation` now classifies the errors it collects:

| Sentinel | Meaning |
| --- | --- |
| `ErrSignatureNotFound` | registry reachable and readable, nothing signed |
| `ErrRegistryUnreachable` | registry could not be contacted, typically air-gapped |
| `ErrSignatureUnauthorized` | registry refused, typically a private repo with no credentials |

Unauthorized is checked before unreachable, both before not-found: a 404 from one puller next to a 401 from another means the registry is hiding the repository, not that the image is unsigned. Unrecognised errors keep their original wording, and the originals stay reachable via `errors.Is`, so the full detail is still logged at debug level.

`no referrers found` now wraps `errdef.ErrNotFound` so all three pullers signal "nothing here" the same way. The WARN on the normal first-verification path (signing info simply not in the local store yet) becomes a debug message.

## Result

Unsigned gadget:

```
no signature found for gadget ghcr.io/inspektor-gadget/gadget/trace_open:v0.25.0
If the gadget is not signed and you are sure you want to skip signature verification, run or deploy Inspektor Gadget with --verify-image=false
```

Air-gapped:

```
fetching the signature for gadget ghcr.io/inspektor-gadget/gadget/trace_open:v0.25.0: ghcr.io is unreachable
If you are running air-gapped, pull the gadget while online, as its signature is pulled along with it. Otherwise, run or deploy Inspektor Gadget with --verify-image=false
```

`ig image pull`, where a missing signature is not fatal:

```
WARN no signature found for gadget ghcr.io/inspektor-gadget/gadget/trace_open:v0.25.0
```

The issue suggests `--verify-image=true`; the value that skips verification is `false`, so that is what the messages say.

## Testing

Unit tests for `classify` and both renderers. The existing live-registry case in `puller_test.go` now asserts `ErrorIs(ErrSignatureNotFound)`.

The not-found and unreachable outputs above were copied from real runs through `VerifyGadgetImage` (the latter behind an unreachable proxy). The unauthorized path is unit tested only, since I had no private repo to hit, so that wording is worth a check from someone who does.

## Docs

`docs/reference/verify-gadgets.mdx` had a stale example predating the current wrapping, now updated. Added a short note to `docs/gadget-devel/signing.md` showing what users see when a published gadget is unsigned.

## Not included

The outer wrapping chain (`fetching gadget information: initializing and preparing operators: ...`) still precedes the message. Left for a separate change to keep this one reviewable.
