### PR TITLE
feat(runtime-finder): add runc path for custom CAPI images built with kubernetes-sigs/image-builder

### DIFF
--- a/pkg/container-hook/runtime-finder/finder.go
+++ b/pkg/container-hook/runtime-finder/finder.go
@@ -39,11 +39,12 @@ var RuntimePaths = []string{
 	"/usr/local/sbin/runc",
 	"/usr/lib/cri-o-runc/sbin/runc",
 	"/usr/bin/crun",
-	"/var/lib/rancher/k3s/data/current/bin/runc", // Used in k3s
-	"/var/lib/rancher/rke2/bin/runc",             // Used in RKE2
-	"/usr/libexec/crio/runc",                     // Used in kubeadm on Debian, upstream crio
-	"/usr/libexec/crio/crun",                     // Used by upstream CRI-O
-	"/var/lib/k0s/bin/runc",                      // Used in k0s
+	"/opt/bin/runc", // Used in custom CAPI images built with kubernetes-sigs/image-builder
+	"/var/lib/rancher/k3s/data/current/bin/runc",            // Used in k3s
+	"/var/lib/rancher/rke2/bin/runc",                        // Used in RKE2
+	"/usr/libexec/crio/runc",                                // Used in kubeadm on Debian, upstream crio
+	"/usr/libexec/crio/crun",                                // Used by upstream CRI-O
+	"/var/lib/k0s/bin/runc",                                 // Used in k0s
 	"/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/runc", // Used in Bottlerocket OS
 	"/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/runc",  // Used in Bottlerocket OS
 	"/snap/microk8s/current/bin/runc",


### PR DESCRIPTION
Adds a custom runc path for custom CAPI images built with kubernetes-sigs/image-builder