### PR TITLE
replace sudo -E with portable ways to pass the environment

### DIFF
--- a/docs/gadget-devel/building.md
+++ b/docs/gadget-devel/building.md
@@ -114,14 +114,15 @@ In order to compile the in-tree gadgets (gadgets shipped in the Inspektor gadget
 repository) that use Wasm, it's necessary to define the `IG_SOURCE_PATH` env
 variable with the absolute path to the root of the Inspektor Gadget source code.
 This is needed to use the latest changes to the Wasm API when building the gadget.
-Also, `sudo` needs to be run with `-E` to pass this variable.
+Since `sudo` resets the environment, the variable has to be passed on the `sudo`
+command line.
 
 ```bash
 # Path where the inspektor-gadget folder is
 $ export IG_SOURCE_PATH=/home/ig/inspektor-gadget
 
 # Build an in-tree gadget that uses Wasm
-$ sudo -E ig image build $IG_SOURCE_PATH/gadgets/trace_open -t trace_open
+$ sudo IG_SOURCE_PATH=$IG_SOURCE_PATH ig image build $IG_SOURCE_PATH/gadgets/trace_open -t trace_open
 Pulling builder image ghcr.io/inspektor-gadget/gadget-builder:%IG_TAG%
 latest: Pulling from inspektor-gadget/gadget-builder
 Digest: sha256:5deec444ea81b866f135430f62b2a580374b7bbcfa5961298cb292546395e3b4

--- a/docs/gadget-devel/testing.md
+++ b/docs/gadget-devel/testing.md
@@ -132,5 +132,10 @@ $ export GADGET_REPOSITORY=ghcr.io/my-org GADGET_TAG=latest
 We are all set now to run the test.
 
 ```bash
-$ go test -exec 'sudo -E' -v ./mygadget_test.go
+$ go test -exec 'sudo --preserve-env=GADGET_REPOSITORY,GADGET_TAG' -v ./mygadget_test.go
 ```
+
+`sudo` resets the environment, so the variables the test needs have to be named
+in `--preserve-env`. Do not use `sudo -E`: it is silently ignored by
+[sudo-rs](https://github.com/trifectatechfoundation/sudo-rs), which is the
+default `sudo` implementation since Ubuntu 25.10.

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -17,6 +17,29 @@ and you haven't specified one using either the `--authfile PATH` parameter for e
 command or the environment variable `REGISTRY_AUTH_FILE`, your docker credentials
 (`~/.docker/config.json`) will be used as fallback.
 
+Note that `ig` needs to run as root and that `sudo` resets `HOME` to `/root`, so
+the docker credentials fallback resolves to `/root/.docker/config.json` rather
+than to those of the user invoking `sudo`. To use your own credentials, ask
+`sudo` to preserve `HOME`, and `DOCKER_CONFIG` too if you set it: it overrides
+`~/.docker` and is likewise dropped by `sudo`. Variables of the list that are
+not set are simply ignored.
+
+```bash
+$ sudo --preserve-env=HOME,DOCKER_CONFIG ig image push ghcr.io/my-org/my-gadget:latest
+```
+
+Alternatively, point `ig` at the file explicitly. This does not depend on the
+`sudo` configuration at all:
+
+```bash
+$ sudo ig image push --authfile $HOME/.docker/config.json ghcr.io/my-org/my-gadget:latest
+```
+
+Do not use `sudo -E` for this: it is silently ignored by
+[sudo-rs](https://github.com/trifectatechfoundation/sudo-rs), the default `sudo`
+implementation since Ubuntu 25.10, so `HOME` stays `/root` and the credentials
+are not found.
+
 ## Commands
 
 ### `login`

--- a/docs/reference/install-linux.md
+++ b/docs/reference/install-linux.md
@@ -53,9 +53,14 @@ $ sudo IG_EXPERIMENTAL=true ig run trace_exec
 INFO[0000] Experimental features enabled
 ...
 
-# pass -E if using export and sudo
+# if the variable is already exported, ask sudo to preserve it
 $ export IG_EXPERIMENTAL=true
-$ sudo -E ig run trace_exec
+$ sudo --preserve-env=IG_EXPERIMENTAL ig run trace_exec
 INFO[0000] Experimental features enabled
 ...
 ```
+
+`sudo` resets the environment, so the variable has to be passed on the `sudo`
+command line or named in `--preserve-env`. Do not use `sudo -E`: it is silently
+ignored by [sudo-rs](https://github.com/trifectatechfoundation/sudo-rs), which
+is the default `sudo` implementation since Ubuntu 25.10.

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -28,7 +28,80 @@ CRANE ?= crane
 VIMTO ?= vimto
 VIMTO_VM_MEMORY ?= 4096M
 DOCKER ?= docker
-SUDO ?= sudo -E
+# sudo resets the environment, so anything the command needs has to be passed
+# on the sudo command line or named in --preserve-env. `sudo -E` is not usable
+# here: sudo-rs, the default sudo implementation since Ubuntu 25.10, does not
+# implement it. It prints a warning and runs the command with a reset
+# environment, which makes the gadget tests skip themselves rather than fail.
+SUDO ?= sudo
+#
+# The variables that used to be carried over by `sudo -E`, enumerated:
+#
+# - HOME, because a lot of things are derived from it. The commands talking to
+#   a registry (push, pull, inspect) fall back to the docker credentials of
+#   ~/.docker/config.json, which is how the CI authenticates: it logs in with
+#   docker/login-action, which writes the config file of the runner user.
+#   DOCKER_CONFIG overrides that path, so it is needed as well.
+# - The DOCKER_* variables, because `ig image build` runs the builder in a
+#   container through a docker client configured from the environment.
+# - XDG_CACHE_HOME and HOME, because vimto caches the kernel images it pulls in
+#   $XDG_CACHE_HOME/vimto, falling back to ~/.cache.
+# - The GO* variables, because the unit tests run go under sudo inside vimto.
+# - The IG_*, GADGET_* and TEST_* variables that the gadget tests read from
+#   their environment. They are exported by the test recipes below, and vimto
+#   passes its own environment to the command it runs in the VM.
+# - KERNEL_VERSION, which the workflow sets and some tests read to skip
+#   themselves on the ci-kernels images, e.g. trace_fsslower, whose filesystem
+#   is not present there. Dropping it makes those tests run and fail rather
+#   than skip.
+#
+# sudo silently ignores the variables of the list that are not set, so a single
+# list can serve every command. Keeping one list rather than a tailored one per
+# command is deliberate: `-E` passed everything, so anything left out here is a
+# silent behaviour change rather than an error.
+#
+# --preserve-env takes a comma separated list, which keeps this a single
+# whitespace free token. That matters for `go test -exec`, which splits its
+# argument on whitespace with no quote handling: an `env VAR=value` prefix
+# could not carry a value containing spaces, such as an IG_FLAGS with more than
+# one flag.
+#
+# The list is written one variable per line for readability and joined
+# afterwards: a backslash continuation expands to a space, so the names are
+# collected whitespace separated and the spaces are then turned into commas.
+# "$() " below is a literal space; the comma needs a variable because a literal
+# one would be taken as an argument separator by $(subst ...).
+SUDO_ENV_COMMA := ,
+SUDO_ENV_VARS = \
+	HOME \
+	DOCKER_CONFIG \
+	DOCKER_HOST \
+	DOCKER_TLS_VERIFY \
+	DOCKER_CERT_PATH \
+	DOCKER_API_VERSION \
+	XDG_CACHE_HOME \
+	GOFLAGS \
+	GOPATH \
+	GOCACHE \
+	GOMODCACHE \
+	IG_PATH \
+	IG_RUNTIME \
+	IG_FLAGS \
+	IG_SOURCE_PATH \
+	IG_EXPERIMENTAL \
+	IG_VERIFY_IMAGE \
+	IG_DEBUG_LOGS \
+	GPU_EBPF_BRIDGE_PATH \
+	GADGET_REPOSITORY \
+	GADGET_TAG \
+	TEST_DNS_SERVER_IMAGE \
+	TEST_DNS_CLIENT_IMAGE \
+	KUBERNETES_DISTRIBUTION \
+	KERNEL_VERSION
+SUDO_ENV = $(subst $() ,$(SUDO_ENV_COMMA),$(strip $(SUDO_ENV_VARS)))
+# Empty when SUDO is overridden to nothing, e.g. when running as root, so that
+# the option string is not mistaken for the command to run.
+SUDO_E ?= $(if $(SUDO),$(SUDO) --preserve-env=$(SUDO_ENV))
 
 UNIT_TEST_DIR = test/unit
 INTEGRATION_TEST_DIR = test/integration
@@ -124,7 +197,7 @@ pull-builder-image:
 .PHONY: $(GADGETS)
 $(GADGETS): pull-builder-image
 	@echo "Building $@"
-	@$(SUDO) \
+	@$(SUDO_E) \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -143,7 +216,7 @@ DOCS_GADGETS = \
 .PHONY: $(DOCS_GADGETS)
 $(DOCS_GADGETS): pull-builder-image
 	@echo "Building $@"
-	@$(SUDO) \
+	@$(SUDO_E) \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
@@ -189,7 +262,7 @@ $(GADGETS_README_DEV):
 
 %-push: %-build phony_explicit
 	@echo "Pushing $*"
-	@$(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	@$(SUDO_E) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY: push
 push: $(addsuffix -push,$(GADGETS))
@@ -197,7 +270,7 @@ push: $(addsuffix -push,$(GADGETS))
 %-push-existing: % phony_explicit
 	@echo "Pushing existing $*"
 	@n=0; \
-	until $(SUDO) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS); do \
+	until $(SUDO_E) $(IG) image push $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) $(IG_FLAGS); do \
 		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
 			echo "Push of $* failed after $$n retries"; \
 			exit 1; \
@@ -212,7 +285,7 @@ push-existing: $(addsuffix -push-existing,$(GADGETS))
 
 %-sign: %-push phony_explicit
 	@echo "Signing $*"
-	digest=$$($(SUDO) $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
+	digest=$$($(SUDO_E) $(IG) image inspect $(GADGET_REPOSITORY)/$*:$(GADGET_TAG) -o json | jq -r .Digest) ; \
 	$(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest
 
 .PHONY: sign
@@ -220,7 +293,7 @@ sign: $(addsuffix -sign,$(GADGETS))
 
 %-sign-existing: phony_explicit
 	@echo "Signing existing $*"
-	@digest=$$($(SUDO) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
+	@digest=$$($(SUDO_E) $(IG) image list --no-trunc | grep "$* " | awk '{ print $$3 }') ; \
 	n=0; \
 	until $(COSIGN) sign $(COSIGN_FLAGS) --key env://COSIGN_PRIVATE_KEY --yes --recursive $(GADGET_REPOSITORY)/$*@$$digest; do \
 		if [ $$n -ge $(GADGET_PUSH_RETRIES) ]; then \
@@ -236,7 +309,7 @@ sign: $(addsuffix -sign,$(GADGETS))
 sign-existing: $(addsuffix -sign-existing,$(GADGETS))
 
 %-clean: phony_explicit
-	$(SUDO) $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO_E) $(IG) image remove $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY: clean
 clean: $(addsuffix -clean,$(GADGETS))
@@ -246,13 +319,13 @@ pull:
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) && \
 	for GADGET in $(GADGETS); do \
-		$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
+		$(SUDO_E) $(IG) image pull $(GADGET_REPOSITORY)/$$GADGET:$(GADGET_TAG); \
 	done
 
 %/pull: phony_explicit
 	GADGET_TAG=$(GADGET_TAG) \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
-	$(SUDO) $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
+	$(SUDO_E) $(IG) image pull $(GADGET_REPOSITORY)/$*:$(GADGET_TAG)
 
 .PHONY: test-unit
 test-unit: build
@@ -264,9 +337,9 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO_E) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./.../$(UNIT_TEST_DIR)/..., \
-		go test -v -exec '$(SUDO)' ./.../$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO_E)' ./.../$(UNIT_TEST_DIR)/...)
 
 %/test-unit: % phony_explicit
 	# use PATH preservation to find **right** go binary inside vimto as it's run as sudo
@@ -277,19 +350,20 @@ test-unit: build
 	VIMTO=$(VIMTO) \
 	VIMTO_VM_MEMORY=$(VIMTO_VM_MEMORY) \
 	$(if $(KERNEL_VERSION), \
-		$(SUDO) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
+		$(SUDO_E) PATH="$$PATH" $(VIMTO) -kernel $(KERNEL_REPOSITORY):$(KERNEL_VERSION) \
 		-memory $(VIMTO_VM_MEMORY) -- go test -v ./$*/$(UNIT_TEST_DIR)/..., \
-		go test -v -exec '$(SUDO)' ./$*/$(UNIT_TEST_DIR)/...)
+		go test -v -exec '$(SUDO_E)' ./$*/$(UNIT_TEST_DIR)/...)
 
 %/test-integration: % phony_explicit
 	IG_PATH=$(IG_PATH) \
+	IG_RUNTIME=$(IG_RUNTIME) \
 	GPU_EBPF_BRIDGE_PATH=$(GPU_EBPF_BRIDGE_PATH) \
 	CGO_ENABLED=0 \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec '$(SUDO)' ./$*/$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO_E)' ./$*/$(INTEGRATION_TEST_DIR)/...
 
 # CI-only gadgets can ship a workload container image built locally from
 # ci/<gadget>/workload/Dockerfile. It is tagged ig-<gadget>:test, e.g.
@@ -312,13 +386,14 @@ $(foreach gadget,$(CI_WORKLOAD_GADGETS),$(eval $(call CI_WORKLOAD_INTEGRATION_PR
 .PHONY: test-integration
 test-integration: build $(addsuffix /workload-image,$(filter $(GADGETS),$(CI_WORKLOAD_GADGETS)))
 	IG_PATH=$(IG_PATH) \
+	IG_RUNTIME=$(IG_RUNTIME) \
 	GPU_EBPF_BRIDGE_PATH=$(GPU_EBPF_BRIDGE_PATH) \
 	CGO_ENABLED=0 \
 	GADGET_REPOSITORY=$(GADGET_REPOSITORY) \
 	GADGET_TAG=$(GADGET_TAG) \
 	IG_FLAGS=$(IG_FLAGS) \
 	TEST_DNS_SERVER_IMAGE=$(DNSTESTER_IMAGE) \
-	go test -v -exec '$(SUDO)' ./.../$(INTEGRATION_TEST_DIR)/...
+	go test -v -exec '$(SUDO_E)' ./.../$(INTEGRATION_TEST_DIR)/...
 
 .PHONY: test-local
 test-local: IG_PATH=$(IG)

--- a/gadgets/audit_seccomp/README.mdx
+++ b/gadgets/audit_seccomp/README.mdx
@@ -152,7 +152,7 @@ minikube-docker   default         mypod           container1      unshare     60
 <TabItem value="ig" label="ig">
 
 ```bash
-$ sudo -E ig run audit_seccomp:%IG_TAG%
+$ sudo ig run audit_seccomp:%IG_TAG%
 RUNTIME.CONTAINERNAME COMM                  PID         TID         CODE          SYSCALL
 test-audit-seccomp    unshare            485855      485855         …_KILL_THREAD SYS_UNSHARE
 test-audit-seccomp    unshare            485865      485865         …_KILL_THREAD SYS_UNSHARE
@@ -188,7 +188,7 @@ $ kubectl gadget run audit_seccomp:%IG_TAG% --collect-ustack -o jsonpretty
 <TabItem value="ig" label="ig">
 
 ```bash
-$ sudo -E ig run audit_seccomp:%IG_TAG% --collect-ustack -o jsonpretty
+$ sudo ig run audit_seccomp:%IG_TAG% --collect-ustack -o jsonpretty
 ...
   "ustack": {
     "addresses": "[0]0x000000000040332e; [1]0x00000000004771e6; [2]0x000000000047752e; [3]0x000000000048250b; [4]0x00000000004829ae; [5]0x0000000000482a7e; [6]0x0000000000482afe; [7]0x0000000000482b7e; [8]0x0000000000435a9d; [9]0x00000000004625a1; ",

--- a/tools/monitoring/README.md
+++ b/tools/monitoring/README.md
@@ -10,7 +10,7 @@ go run -exec sudo ../../cmd/ig daemon --tls-insecure --otel-metrics-listen=true
 then start the gadget with
 
 ```bash
-go run -exec 'sudo -E' ../../cmd/gadgetctl run ghcr.io/inspektor-gadget/gadget/profile_blockio:latest \
+go run -exec sudo ../../cmd/gadgetctl run ghcr.io/inspektor-gadget/gadget/profile_blockio:latest \
         --annotate=blockio:metrics.collect=true \
         --otel-metrics-name=blockio:blockio-metrics \
         --detach


### PR DESCRIPTION
Makefiles and docs in this repo pass the environment to `ig` with `sudo -E`.
That does not work everywhere anymore: [sudo-rs], the default `sudo`
implementation since Ubuntu 25.10, does not implement `-E`. It prints a
warning and runs the command with a reset environment.

The failure is silent rather than loud. `gadgets/Makefile` runs the gadget
tests as `go test -exec 'sudo -E'`, so with sudo-rs the test binary no longer
sees `IG_PATH`, and `RequireEnvironmentVariables` skips every test
(`gadgets/testing/testing.go:71`). The suite passes without running anything:

```
$ go test -v -exec 'sudo -E' -run TestTraceOpen ./trace_open/test/integration/...
sudo: preserving the entire environment is not supported, '-E' is ignored
=== RUN   TestTraceOpen
    testing.go:71: environment variable IG_PATH undefined
--- SKIP: TestTraceOpen (0.00s)
PASS
ok  	github.com/.../gadgets/trace_open/test/integration	0.071s
```

Without `-v`, that is just a green `ok` in 0.07s.

After this PR, on the same machine:

```
--- PASS: TestTraceOpen (9.00s)
```

## What is used instead

`sudo --preserve-env=<list>`, which both sudo and sudo-rs implement. It has
been available since sudo 1.8.21 (2017), so it is safe for the distros we care
about. Where the variable is not already exported, setting it on the `sudo`
command line is enough, which is what most of the tree already does.

Note that `-E` never needed a special sudoers configuration here only because
`SETENV` is implied when the sudoers command match is `ALL`, as with the stock
`%sudo ALL=(ALL:ALL) ALL`. `--preserve-env=<list>` is fine under the same rule.

## Commit 1, docs

Replaces `sudo -E` in `building.md`, `testing.md` and `install-linux.md`.

In `gadgets/audit_seccomp/README.mdx` and `tools/monitoring/README.md`, `-E`
was not needed at all: those commands take everything on their command line,
and the 43 other gadget READMEs, as well as the synopsis of `audit_seccomp`
itself, already use a plain `sudo ig run`.

Also documents something that bites people independently of sudo-rs: `sudo`
resets `HOME` to `/root`, so the docker credentials fallback of
`ig image push` resolves to `/root/.docker/config.json` rather than to the
credentials of the user who ran `sudo`.

## Commit 2, gadgets/Makefile

`SUDO ?= sudo -E` becomes:

```make
SUDO ?= sudo
SUDO_ENV = HOME,DOCKER_CONFIG,DOCKER_HOST,...,GADGET_TAG,KUBERNETES_DISTRIBUTION
SUDO_E ?= $(if $(SUDO),$(SUDO) --preserve-env=$(SUDO_ENV))
```

`$(SUDO_E)` is a drop-in for the old `sudo -E` and is used at every call site.

**One list for every command, on purpose.** My first attempt tailored a list
per command, and it introduced two silent regressions, which is exactly the
class of bug this PR is fixing. `-E` passed everything, so anything left out
of a per-command list is a behaviour change with nothing to catch it, while
`sudo` simply ignores the entries of the list that are not set. The two I had
broken:

- **vimto** caches the kernel images it pulls in `$XDG_CACHE_HOME/vimto`,
  falling back to `~/.cache` ([`image.go:33`][vimto-cache]), so it needs `HOME`.
  Without it the cache silently moves to `/root/.cache` and every run
  re-downloads. This path runs in CI, at `inspektor-gadget.yml:2114`. vimto also
  clones its own environment into the guest, stripping only `TMPDIR`, so the
  test variables have to reach vimto itself.
- **`ig image build`** builds through a docker client configured from the
  environment, `client.New(client.FromEnv)` in `cmd/common/image/build.go:473`,
  so it needs `DOCKER_HOST` and friends. A bare `sudo` breaks anyone whose
  docker endpoint is not the default.

Two details worth flagging for review:

- `PATH` is deliberately **not** in the list, because a sudoers `secure_path`
  takes precedence over preserving it. The vimto recipes keep passing
  `PATH="$$PATH"` explicitly, as they already did.
- the list is comma separated rather than an `env VAR=value` prefix because
  `go test -exec` splits its argument on whitespace with no quote handling, so
  a value containing spaces, such as an `IG_FLAGS` with more than one flag,
  could not survive that way.

`$(if $(SUDO),...)` keeps `make SUDO=` working for anyone running as root;
without it the recipe expanded to `until  --preserve-env=... ig image push`,
using the option string as the command.

### Unrelated fix in the same commit

`IG_RUNTIME` was never forwarded to the integration tests. Make does not export
variables that only have a `?=` default, so `IG_RUNTIME ?= docker` never
reached the test binary. CI does not notice because it passes `IG_RUNTIME` on
the command line, but a local `make test-local` skipped every test.

## Testing

- `TestTraceOpen` goes from SKIP to PASS on Ubuntu 25.10 with sudo-rs 0.2.13,
  as shown above.
- The vimto expansion that CI uses was checked with
  `make -C gadgets --dry-run test-unit KERNEL_VERSION=6.6`.
- `make -C gadgets --dry-run ... SUDO=` still yields the plain command.
- Ordering is valid on sudo-rs too:
  `sudo --preserve-env=HOME FOO=bar printenv FOO` prints `bar`.

CI should be the real check for the push, pull and vimto paths, since those
need registry credentials and KVM.

AIL:3

[sudo-rs]: https://github.com/trifectatechfoundation/sudo-rs
[vimto-cache]: https://github.com/lmb/vimto/blob/fc25e09ed4cd35afaa77eb340cc5879397aa484d/image.go#L33
