### PR TITLE
operators/ebpf: Hide Parent Tid

### DIFF
--- a/pkg/operators/ebpf/struct.go
+++ b/pkg/operators/ebpf/struct.go
@@ -153,6 +153,7 @@ func applyAnnotationsTemplateForType(typeName string, dst map[string]string) boo
 		ebpftypes.NetNsTypeName,
 		ebpftypes.PcommTypeName,
 		ebpftypes.PpidTypeName,
+		ebpftypes.PtidTypeName,
 		ebpftypes.UserStackTypeName:
 		return metadatav1.ApplyAnnotationsTemplate(strings.TrimPrefix(typeName, "gadget_"), dst)
 	case ebpftypes.ProcessTypeName,


### PR DESCRIPTION
When introducing tid in gadget_parent we missed handling it via applyAnnotationsTemplateForType which results in parent tid not hidden by default

Fixes: #5580 

## Testing Done

`trace_exec` after these changes:

```
→ sudo ig run trace_exec 
RUNTIME.CONTAINERNAME                                                             COMM                    PID        TID TTY         ARGS                                                ERROR
minikube-docker                                                                   bridge              1279244    1279244 0           /opt/cni/bin/bridge                                      
minikube-docker                                                                   portmap             1279250    1279250 0           /opt/cni/bin/portmap                                     
minikube-docker                                                                   firewall            1279255    1279255 0           /opt/cni/bin/firewall                                    
minikube-docker                                                                   runc                1279259    1279259 0           runc\u00a0--root\u00a0/var/run/docker/runt…              
minikube-docker                                                                   6                   1279268    1279268 0           runc\u00a0init                                           
minikube-docker                                                                   runc                1279286    1279286 0           runc\u00a0--root\u00a0/var/run/docker/runt…              
minikube-docker                                                                   6                   1279296    1279296 0           runc\u00a0init     
```
